### PR TITLE
Add Phase 2 shard runtime with multi-core, pools, route table, Expected errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 build-cov/
 .cache/
+build-release/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,11 @@ endif()
 # Core compiler flags per DESIGN.md: no exceptions, no RTTI, no C++ stdlib
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti -fno-unwind-tables -fno-asynchronous-unwind-tables")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -Wall -Wextra -Wpedantic")
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG -flto")
+# Use CMake's native LTO support — handles llvm-ar/gcc-ar automatically.
+# Applied to both C and C++ so mixed-language targets (bench/llhttp) link correctly.
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG")
 
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")

--- a/TODO.md
+++ b/TODO.md
@@ -13,8 +13,11 @@ Outstanding work items, tracked from code TODOs and Copilot review findings.
 - [x] **Provided buffer return** — `wait()` copies recv data from provided buffer into `Connection::recv_buf` via `write_ptr()`/`commit()`, then immediately calls `return_buffer(buf_id)`. Events reach dispatch with `has_buf=0`.
 
 ## Phase 2 (shard integration)
-- [ ] **Shard: memory pools** — Arena, SlabPool, SlicePool per shard (`include/rout/runtime/shard.h:14`)
-- [ ] **Shard: connection table** — SlabPool<Connection> (`shard.h:15`)
-- [ ] **Shard: timer wheel integration** — wire into shard lifecycle (`shard.h:16`)
-- [ ] **Shard: upstream connection pools** — per-upstream, per-shard (`shard.h:17`)
-- [ ] **Shard: route table** — atomically swappable for hot reload (`shard.h:18`)
+- [x] **Shard: per-core runtime** — Shard<Backend> wraps EventLoop (mmap'd), Arena (per-request scratch), listen_fd (SO_REUSEPORT), pthread with CPU affinity. Multi-shard main with signal-based graceful shutdown.
+- [x] **Shard: connection table** — EventLoop owns Connection[16384] with free-stack pool (inherited from Phase 1). SlabPool deferred to when Connection moves off fixed array.
+- [x] **Shard: timer wheel integration** — EventLoop owns TimerWheel, driven by timerfd. Shard lifecycle: shutdown drains via EventLoop::shutdown().
+- [x] **Shard: upstream connection pools** — UpstreamPool per shard (mmap'd, 4096 slots), alloc/free/find_idle/return_idle/shutdown. UpstreamConn tracks fd + upstream_id + idle state.
+- [x] **Shard: route table** — RouteConfig with RouteEntry[] (prefix match) + UpstreamTarget[] (addr:port). Supports Static/Proxy actions, method filter, first-match-wins. Shard holds const RouteConfig* (swappable for hot reload).
+- [x] **SlicePool** — 16KB slice allocator, mmap-backed, O(1) alloc/free via free-stack. Per-shard, for on-demand network I/O buffers (idle connections hold 0 slices).
+- [x] **SlabPool\<T, Cap\>** — generic fixed-size object pool, mmap-backed. alloc/free by pointer or index, index_of, capacity/available/in_use stats. Generalizes EventLoop's Connection free-stack.
+- [ ] **Integration**: replace Connection inline storage with SlicePool slices (idle connections → zero buffer memory)

--- a/include/rout/runtime/arena.h
+++ b/include/rout/runtime/arena.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "rout/common/types.h"
+#include "rout/runtime/error.h"
+
+#include "core/expected.h"
 
 #include <errno.h>
 #include <sys/mman.h>  // mmap, munmap
@@ -38,11 +41,12 @@ struct Arena {
     u64 block_size = 0;
     u64 total_allocated = 0;
 
-    i32 init(u64 initial_block_size) {
+    core::Expected<void, Error> init(u64 initial_block_size) {
         block_size = initial_block_size < 256 ? 256 : initial_block_size;
         total_allocated = 0;
         current = alloc_block(block_size, nullptr);
-        return current ? 0 : -errno;
+        if (!current) return core::make_unexpected(Error::from_errno(Error::Source::Arena));
+        return {};
     }
 
     // Bump allocate, 8-byte aligned.

--- a/include/rout/runtime/epoll_backend.h
+++ b/include/rout/runtime/epoll_backend.h
@@ -2,7 +2,10 @@
 
 #include "rout/common/types.h"
 #include "rout/runtime/connection.h"
+#include "rout/runtime/error.h"
 #include "rout/runtime/io_backend.h"
+
+#include "core/expected.h"
 
 #include <sys/epoll.h>
 #include <sys/timerfd.h>
@@ -51,8 +54,7 @@ struct EpollBackend {
     // --- Interface methods ---
 
     // Initialize epoll and timerfd for this shard.
-    // Returns 0 on success, -errno on failure.
-    i32 init(u32 shard_id, i32 listen_fd);
+    core::Expected<void, Error> init(u32 shard_id, i32 listen_fd);
 
     // Register listen socket for accept events.
     void add_accept();

--- a/include/rout/runtime/error.h
+++ b/include/rout/runtime/error.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "rout/common/types.h"
+
+#include <errno.h>
+
+namespace rout {
+
+// Runtime error — carries errno + context about where the error occurred.
+// Used as the E type in Expected<T, Error> for init/setup functions.
+struct Error {
+    i32 code;  // errno value (positive, e.g., ENOMEM=12)
+
+    enum class Source : u8 {
+        Mmap,       // mmap failed
+        Epoll,      // epoll_create/ctl failed
+        IoUring,    // io_uring_setup/register failed
+        Timerfd,    // timerfd_create/settime failed
+        Socket,     // socket/bind/listen failed
+        Thread,     // pthread_create failed
+        Arena,      // Arena block allocation failed
+        SlicePool,  // SlicePool init failed
+        SlabPool,   // SlabPool init failed
+    };
+    Source source;
+
+    static Error from_errno(Source src) { return {static_cast<i32>(errno), src}; }
+    static Error make(i32 code, Source src) { return {code, src}; }
+};
+
+}  // namespace rout

--- a/include/rout/runtime/event_loop.h
+++ b/include/rout/runtime/event_loop.h
@@ -58,9 +58,9 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
     u32 shard_id;
 
 private:
-    bool running_;  // cross-thread: stop() from main, while loop in shard thread.
-                    // Accessed only via __atomic_* in stop()/is_running() to satisfy
-                    // C++ memory model (no UB on concurrent access).
+    volatile bool running_;  // stop() from main thread, while loop in shard thread.
+                             // volatile prevents compiler from hoisting read out of loop.
+
 public:
     static constexpr u32 kMaxConns = 16384;
     Connection conns[kMaxConns];
@@ -71,7 +71,7 @@ public:
 
     core::Expected<void, Error> init(u32 id, i32 listen_fd) {
         shard_id = id;
-        __atomic_store_n(&running_, true, __ATOMIC_RELEASE);
+        running_ = true;
         keepalive_timeout = 60;  // explicit: mmap zeroes memory, skipping default member init
         free_top = kMaxConns;
         timer.init();
@@ -97,8 +97,8 @@ public:
         }
     }
 
-    void stop() { __atomic_store_n(&running_, false, __ATOMIC_RELEASE); }
-    bool is_running() const { return __atomic_load_n(&running_, __ATOMIC_ACQUIRE); }
+    void stop() { running_ = false; }
+    bool is_running() const { return running_; }
     void shutdown() { backend.shutdown(); }
 
     // --- CRTP implementations ---

--- a/include/rout/runtime/event_loop.h
+++ b/include/rout/runtime/event_loop.h
@@ -3,9 +3,12 @@
 #include "rout/common/types.h"
 #include "rout/runtime/callbacks.h"
 #include "rout/runtime/connection.h"
+#include "rout/runtime/error.h"
 #include "rout/runtime/io_backend.h"
 #include "rout/runtime/io_event.h"
 #include "rout/runtime/timer_wheel.h"
+
+#include "core/expected.h"
 
 #include <unistd.h>  // close()
 
@@ -62,7 +65,7 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
 
     u32 keepalive_timeout = 60;
 
-    i32 init(u32 id, i32 listen_fd) {
+    core::Expected<void, Error> init(u32 id, i32 listen_fd) {
         shard_id = id;
         running = true;
         keepalive_timeout = 60;  // explicit: mmap zeroes memory, skipping default member init
@@ -74,7 +77,8 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
             conns[i].shard_id = static_cast<u8>(id);
             free_stack[i] = i;
         }
-        return backend.init(id, listen_fd);
+        TRY_VOID(backend.init(id, listen_fd));
+        return {};
     }
 
     void run() {

--- a/include/rout/runtime/event_loop.h
+++ b/include/rout/runtime/event_loop.h
@@ -58,9 +58,9 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
     u32 shard_id;
 
 private:
-    volatile bool running_;  // volatile: prevent compiler hoisting out of loop.
-                             // Single writer (stop from main thread after sigwait),
-                             // single reader (shard thread's while loop). No atomic needed.
+    bool running_;  // cross-thread: stop() from main, while loop in shard thread.
+                    // Accessed only via __atomic_* in stop()/is_running() to satisfy
+                    // C++ memory model (no UB on concurrent access).
 public:
     static constexpr u32 kMaxConns = 16384;
     Connection conns[kMaxConns];
@@ -71,7 +71,7 @@ public:
 
     core::Expected<void, Error> init(u32 id, i32 listen_fd) {
         shard_id = id;
-        running_ = true;
+        __atomic_store_n(&running_, true, __ATOMIC_RELEASE);
         keepalive_timeout = 60;  // explicit: mmap zeroes memory, skipping default member init
         free_top = kMaxConns;
         timer.init();
@@ -89,7 +89,7 @@ public:
         backend.add_accept();
         IoEvent events[kMaxEventsPerWait];
 
-        while (running_) {
+        while (is_running()) {
             u32 n = backend.wait(events, kMaxEventsPerWait, conns, kMaxConns);
             for (u32 i = 0; i < n; i++) {
                 dispatch(events[i]);
@@ -97,8 +97,8 @@ public:
         }
     }
 
-    void stop() { running_ = false; }
-    bool is_running() const { return running_; }
+    void stop() { __atomic_store_n(&running_, false, __ATOMIC_RELEASE); }
+    bool is_running() const { return __atomic_load_n(&running_, __ATOMIC_ACQUIRE); }
     void shutdown() { backend.shutdown(); }
 
     // --- CRTP implementations ---

--- a/include/rout/runtime/event_loop.h
+++ b/include/rout/runtime/event_loop.h
@@ -72,7 +72,7 @@ public:
     core::Expected<void, Error> init(u32 id, i32 listen_fd) {
         shard_id = id;
         running_ = true;
-        keepalive_timeout = 60;  // explicit: mmap zeroes memory, skipping default member init
+        keepalive_timeout = 60;
         free_top = kMaxConns;
         timer.init();
         for (u32 i = 0; i < kMaxConns; i++) {

--- a/include/rout/runtime/event_loop.h
+++ b/include/rout/runtime/event_loop.h
@@ -56,7 +56,7 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
     Backend backend;
     TimerWheel timer;
     u32 shard_id;
-    bool running;
+    volatile bool running;
 
     static constexpr u32 kMaxConns = 16384;
     Connection conns[kMaxConns];

--- a/include/rout/runtime/event_loop.h
+++ b/include/rout/runtime/event_loop.h
@@ -58,8 +58,9 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
     u32 shard_id;
 
 private:
-    bool running_;  // access only via is_running()/stop() with atomics
-
+    volatile bool running_;  // volatile: prevent compiler hoisting out of loop.
+                             // Single writer (stop from main thread after sigwait),
+                             // single reader (shard thread's while loop). No atomic needed.
 public:
     static constexpr u32 kMaxConns = 16384;
     Connection conns[kMaxConns];
@@ -70,7 +71,7 @@ public:
 
     core::Expected<void, Error> init(u32 id, i32 listen_fd) {
         shard_id = id;
-        __atomic_store_n(&running_, true, __ATOMIC_RELAXED);
+        running_ = true;
         keepalive_timeout = 60;  // explicit: mmap zeroes memory, skipping default member init
         free_top = kMaxConns;
         timer.init();
@@ -88,7 +89,7 @@ public:
         backend.add_accept();
         IoEvent events[kMaxEventsPerWait];
 
-        while (__atomic_load_n(&running_, __ATOMIC_RELAXED)) {
+        while (running_) {
             u32 n = backend.wait(events, kMaxEventsPerWait, conns, kMaxConns);
             for (u32 i = 0; i < n; i++) {
                 dispatch(events[i]);
@@ -96,8 +97,8 @@ public:
         }
     }
 
-    void stop() { __atomic_store_n(&running_, false, __ATOMIC_RELAXED); }
-    bool is_running() const { return __atomic_load_n(&running_, __ATOMIC_RELAXED); }
+    void stop() { running_ = false; }
+    bool is_running() const { return running_; }
     void shutdown() { backend.shutdown(); }
 
     // --- CRTP implementations ---

--- a/include/rout/runtime/event_loop.h
+++ b/include/rout/runtime/event_loop.h
@@ -56,8 +56,11 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
     Backend backend;
     TimerWheel timer;
     u32 shard_id;
-    volatile bool running;
 
+private:
+    bool running_;  // access only via is_running()/stop() with atomics
+
+public:
     static constexpr u32 kMaxConns = 16384;
     Connection conns[kMaxConns];
     u32 free_stack[kMaxConns];
@@ -67,7 +70,7 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
 
     core::Expected<void, Error> init(u32 id, i32 listen_fd) {
         shard_id = id;
-        __atomic_store_n(&running, true, __ATOMIC_RELAXED);
+        __atomic_store_n(&running_, true, __ATOMIC_RELAXED);
         keepalive_timeout = 60;  // explicit: mmap zeroes memory, skipping default member init
         free_top = kMaxConns;
         timer.init();
@@ -85,7 +88,7 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
         backend.add_accept();
         IoEvent events[kMaxEventsPerWait];
 
-        while (__atomic_load_n(&running, __ATOMIC_RELAXED)) {
+        while (__atomic_load_n(&running_, __ATOMIC_RELAXED)) {
             u32 n = backend.wait(events, kMaxEventsPerWait, conns, kMaxConns);
             for (u32 i = 0; i < n; i++) {
                 dispatch(events[i]);
@@ -93,7 +96,8 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
         }
     }
 
-    void stop() { __atomic_store_n(&running, false, __ATOMIC_RELAXED); }
+    void stop() { __atomic_store_n(&running_, false, __ATOMIC_RELAXED); }
+    bool is_running() const { return __atomic_load_n(&running_, __ATOMIC_RELAXED); }
     void shutdown() { backend.shutdown(); }
 
     // --- CRTP implementations ---

--- a/include/rout/runtime/event_loop.h
+++ b/include/rout/runtime/event_loop.h
@@ -67,7 +67,7 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
 
     core::Expected<void, Error> init(u32 id, i32 listen_fd) {
         shard_id = id;
-        running = true;
+        __atomic_store_n(&running, true, __ATOMIC_RELAXED);
         keepalive_timeout = 60;  // explicit: mmap zeroes memory, skipping default member init
         free_top = kMaxConns;
         timer.init();
@@ -85,7 +85,7 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
         backend.add_accept();
         IoEvent events[kMaxEventsPerWait];
 
-        while (running) {
+        while (__atomic_load_n(&running, __ATOMIC_RELAXED)) {
             u32 n = backend.wait(events, kMaxEventsPerWait, conns, kMaxConns);
             for (u32 i = 0; i < n; i++) {
                 dispatch(events[i]);
@@ -93,7 +93,7 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
         }
     }
 
-    void stop() { running = false; }
+    void stop() { __atomic_store_n(&running, false, __ATOMIC_RELAXED); }
     void shutdown() { backend.shutdown(); }
 
     // --- CRTP implementations ---

--- a/include/rout/runtime/io_uring_backend.h
+++ b/include/rout/runtime/io_uring_backend.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "rout/common/types.h"
+#include "rout/runtime/error.h"
 #include "rout/runtime/io_backend.h"
+
+#include "core/expected.h"
 
 #include <linux/io_uring.h>
 #include <sys/mman.h>
@@ -81,8 +84,7 @@ struct IoUringBackend {
     // --- Interface methods ---
 
     // Initialize the io_uring instance for this shard.
-    // Returns 0 on success, -errno on failure.
-    i32 init(u32 shard_id, i32 listen_fd);
+    core::Expected<void, Error> init(u32 shard_id, i32 listen_fd);
 
     // Submit a multishot accept on the listen socket.
     void add_accept();
@@ -123,7 +125,7 @@ private:
     static void decode_user_data(u64 data, u32& conn_id, IoEventType& type);
 
     // Setup provided buffer ring via io_uring_register.
-    i32 setup_buf_ring();
+    core::Expected<void, Error> setup_buf_ring();
 
     // Submit IORING_OP_READ on timer_fd to receive next tick.
     void submit_timer_read();

--- a/include/rout/runtime/route_table.h
+++ b/include/rout/runtime/route_table.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "rout/common/types.h"
+
+#include <netinet/in.h>
+#include <string.h>
+
+namespace rout {
+
+// Action for a matched route.
+enum class RouteAction : u8 {
+    Static,  // respond with fixed status (e.g., 200 OK, 404)
+    Proxy,   // forward to upstream target
+};
+
+// Upstream target — address:port for a backend server.
+struct UpstreamTarget {
+    struct sockaddr_in addr;
+    // Short name for logging/debugging (e.g., "api-v1")
+    char name[32];
+    u32 name_len;
+
+    void set_name(const char* n) {
+        name_len = 0;
+        while (n[name_len] && name_len < sizeof(name) - 1) {
+            name[name_len] = n[name_len];
+            name_len++;
+        }
+        name[name_len] = '\0';
+    }
+
+    // Helper: set address from IP (host order) + port (host order)
+    void set_addr(u32 ip, u16 port) {
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = __builtin_bswap32(ip);
+        addr.sin_port = __builtin_bswap16(port);
+    }
+};
+
+// Single route entry: matches method + path prefix → action.
+struct RouteEntry {
+    // Match criteria
+    char path[128];  // path prefix (e.g., "/api/v1/")
+    u32 path_len;
+    u8 method;  // 0 = any, 'G' = GET, 'P' = POST, etc. (first char)
+
+    // Action
+    RouteAction action;
+    u16 upstream_id;  // index into RouteConfig::upstreams (if action == Proxy)
+    u16 status_code;  // status code (if action == Static, e.g., 200, 404)
+};
+
+// RouteConfig — immutable after construction, atomically swappable.
+// Contains route entries + upstream targets. The entire config is replaced
+// on hot reload (RCU pattern: new config built, atomic swap, old reclaimed).
+//
+// Phase 2: simple linear scan (adequate for <100 routes).
+// Phase 3: radix trie from Rue compiler (O(path_length) lookup).
+struct RouteConfig {
+    static constexpr u32 kMaxRoutes = 128;
+    static constexpr u32 kMaxUpstreams = 64;
+
+    RouteEntry routes[kMaxRoutes];
+    u32 route_count = 0;
+
+    UpstreamTarget upstreams[kMaxUpstreams];
+    u32 upstream_count = 0;
+
+    // Add a proxy route: path prefix → upstream target.
+    // Returns true on success.
+    bool add_proxy(const char* path, u8 method, u16 upstream_id) {
+        if (route_count >= kMaxRoutes) return false;
+        auto& r = routes[route_count];
+        r.path_len = 0;
+        while (path[r.path_len] && r.path_len < sizeof(r.path) - 1) {
+            r.path[r.path_len] = path[r.path_len];
+            r.path_len++;
+        }
+        r.path[r.path_len] = '\0';
+        r.method = method;
+        r.action = RouteAction::Proxy;
+        r.upstream_id = upstream_id;
+        r.status_code = 0;
+        route_count++;
+        return true;
+    }
+
+    // Add a static response route.
+    bool add_static(const char* path, u8 method, u16 status) {
+        if (route_count >= kMaxRoutes) return false;
+        auto& r = routes[route_count];
+        r.path_len = 0;
+        while (path[r.path_len] && r.path_len < sizeof(r.path) - 1) {
+            r.path[r.path_len] = path[r.path_len];
+            r.path_len++;
+        }
+        r.path[r.path_len] = '\0';
+        r.method = method;
+        r.action = RouteAction::Static;
+        r.upstream_id = 0;
+        r.status_code = status;
+        route_count++;
+        return true;
+    }
+
+    // Add an upstream target. Returns its index.
+    i32 add_upstream(const char* name, u32 ip, u16 port) {
+        if (upstream_count >= kMaxUpstreams) return -1;
+        u32 idx = upstream_count++;
+        upstreams[idx].set_name(name);
+        upstreams[idx].set_addr(ip, port);
+        return static_cast<i32>(idx);
+    }
+
+    // Match a request path (prefix match, first match wins).
+    // method_char: first char of HTTP method ('G'=GET, 'P'=POST, etc.), 0=any.
+    // Returns pointer to matching entry, or nullptr for no match (→ default 200 OK).
+    const RouteEntry* match(const u8* path_data, u32 path_len, u8 method_char) const {
+        for (u32 i = 0; i < route_count; i++) {
+            auto& r = routes[i];
+            // Method filter: 0 = any
+            if (r.method != 0 && r.method != method_char) continue;
+            // Prefix match
+            if (path_len < r.path_len) continue;
+            bool matched = true;
+            for (u32 j = 0; j < r.path_len; j++) {
+                if (path_data[j] != static_cast<u8>(r.path[j])) {
+                    matched = false;
+                    break;
+                }
+            }
+            if (matched) return &r;
+        }
+        return nullptr;  // no match → default handler
+    }
+};
+
+}  // namespace rout

--- a/include/rout/runtime/route_table.h
+++ b/include/rout/runtime/route_table.h
@@ -68,15 +68,17 @@ struct RouteConfig {
     u32 upstream_count = 0;
 
     // Add a proxy route: path prefix → upstream target.
-    // Returns true on success.
+    // Returns false if table full, upstream_id invalid, or path too long.
     bool add_proxy(const char* path, u8 method, u16 upstream_id) {
         if (route_count >= kMaxRoutes) return false;
+        if (upstream_id >= upstream_count) return false;
         auto& r = routes[route_count];
         r.path_len = 0;
         while (path[r.path_len] && r.path_len < sizeof(r.path) - 1) {
             r.path[r.path_len] = path[r.path_len];
             r.path_len++;
         }
+        if (path[r.path_len] != '\0') return false;  // path too long (truncated)
         r.path[r.path_len] = '\0';
         r.method = method;
         r.action = RouteAction::Proxy;
@@ -86,7 +88,7 @@ struct RouteConfig {
         return true;
     }
 
-    // Add a static response route.
+    // Add a static response route. Returns false if table full or path too long.
     bool add_static(const char* path, u8 method, u16 status) {
         if (route_count >= kMaxRoutes) return false;
         auto& r = routes[route_count];
@@ -95,6 +97,7 @@ struct RouteConfig {
             r.path[r.path_len] = path[r.path_len];
             r.path_len++;
         }
+        if (path[r.path_len] != '\0') return false;  // path too long
         r.path[r.path_len] = '\0';
         r.method = method;
         r.action = RouteAction::Static;

--- a/include/rout/runtime/shard.h
+++ b/include/rout/runtime/shard.h
@@ -113,6 +113,8 @@ struct Shard {
     // pin_cpu: -1 = no pinning, >=0 = pin to that core.
     core::Expected<void, Error> spawn(i32 pin_cpu = -1) {
         if (!loop) return core::make_unexpected(Error::make(EINVAL, Error::Source::Thread));
+        if (thread_spawned)
+            return core::make_unexpected(Error::make(EEXIST, Error::Source::Thread));
 
         pthread_attr_t attr;
         pthread_attr_init(&attr);
@@ -153,8 +155,10 @@ struct Shard {
         }
     }
 
-    // Release all resources.
+    // Release all resources. Stops and joins thread if still running.
     void shutdown() {
+        stop();
+        join();
         if (upstream) {
             upstream->shutdown();
             munmap(upstream, sizeof(UpstreamPool));

--- a/include/rout/runtime/shard.h
+++ b/include/rout/runtime/shard.h
@@ -16,6 +16,9 @@
 
 namespace rout {
 
+// Forward declaration (defined below Shard).
+inline u32 detect_cpu_count();
+
 // Shard — per-core share-nothing runtime unit.
 //
 // Each Shard owns:
@@ -116,10 +119,19 @@ struct Shard {
 
         // Pin to CPU if requested
         if (pin_cpu >= 0) {
+            u32 ncpus = detect_cpu_count();
+            if (static_cast<u32>(pin_cpu) >= ncpus) {
+                pthread_attr_destroy(&attr);
+                return core::make_unexpected(Error::make(EINVAL, Error::Source::Thread));
+            }
             cpu_set_t cpuset;
             CPU_ZERO(&cpuset);
             CPU_SET(pin_cpu, &cpuset);
-            pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset);
+            i32 aff_rc = pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset);
+            if (aff_rc != 0) {
+                pthread_attr_destroy(&attr);
+                return core::make_unexpected(Error::make(aff_rc, Error::Source::Thread));
+            }
         }
 
         i32 rc = pthread_create(&thread, &attr, thread_entry, this);

--- a/include/rout/runtime/shard.h
+++ b/include/rout/runtime/shard.h
@@ -2,9 +2,12 @@
 
 #include "rout/common/types.h"
 #include "rout/runtime/arena.h"
+#include "rout/runtime/error.h"
 #include "rout/runtime/event_loop.h"
 #include "rout/runtime/route_table.h"
 #include "rout/runtime/upstream_pool.h"
+
+#include "core/expected.h"
 
 #include <pthread.h>
 #include <sched.h>
@@ -53,8 +56,7 @@ struct Shard {
 
     // Initialize shard: mmap EventLoop, init backend + arena.
     // listen_fd must already be created with SO_REUSEPORT.
-    // Returns 0 on success, -errno on failure.
-    i32 init(u32 shard_id, i32 lfd) {
+    core::Expected<void, Error> init(u32 shard_id, i32 lfd) {
         id = shard_id;
         listen_fd = lfd;
 
@@ -65,23 +67,23 @@ struct Shard {
                          MAP_PRIVATE | MAP_ANONYMOUS,
                          -1,
                          0);
-        if (mem == MAP_FAILED) return -errno;
+        if (mem == MAP_FAILED) return core::make_unexpected(Error::from_errno(Error::Source::Mmap));
         loop = static_cast<EventLoop<Backend>*>(mem);
 
-        i32 rc = loop->init(shard_id, listen_fd);
-        if (rc < 0) {
+        auto loop_result = loop->init(shard_id, listen_fd);
+        if (!loop_result) {
             munmap(loop, sizeof(EventLoop<Backend>));
             loop = nullptr;
-            return rc;
+            return loop_result;
         }
 
         // Init scratch arena (64KB initial block, grows on demand)
-        rc = scratch.init(65536);
-        if (rc < 0) {
+        auto arena_result = scratch.init(65536);
+        if (!arena_result) {
             loop->shutdown();
             munmap(loop, sizeof(EventLoop<Backend>));
             loop = nullptr;
-            return rc;
+            return arena_result;
         }
 
         // mmap upstream pool (UpstreamConn[4096] is ~50KB)
@@ -96,19 +98,18 @@ struct Shard {
             loop->shutdown();
             munmap(loop, sizeof(EventLoop<Backend>));
             loop = nullptr;
-            return -errno;
+            return core::make_unexpected(Error::from_errno(Error::Source::Mmap));
         }
         upstream = static_cast<UpstreamPool*>(up_mem);
         upstream->init();
 
-        return 0;
+        return {};
     }
 
     // Spawn the shard's thread. Optionally pin to CPU core.
     // pin_cpu: -1 = no pinning, >=0 = pin to that core.
-    // Returns 0 on success, -errno on failure.
-    i32 spawn(i32 pin_cpu = -1) {
-        if (!loop) return -EINVAL;
+    core::Expected<void, Error> spawn(i32 pin_cpu = -1) {
+        if (!loop) return core::make_unexpected(Error::make(EINVAL, Error::Source::Thread));
 
         pthread_attr_t attr;
         pthread_attr_init(&attr);
@@ -123,9 +124,9 @@ struct Shard {
 
         i32 rc = pthread_create(&thread, &attr, thread_entry, this);
         pthread_attr_destroy(&attr);
-        if (rc != 0) return -rc;
+        if (rc != 0) return core::make_unexpected(Error::make(rc, Error::Source::Thread));
         thread_spawned = true;
-        return 0;
+        return {};
     }
 
     // Signal the shard to stop (safe to call from any thread).

--- a/include/rout/runtime/shard.h
+++ b/include/rout/runtime/shard.h
@@ -117,21 +117,20 @@ struct Shard {
         pthread_attr_t attr;
         pthread_attr_init(&attr);
 
-        // Pin to CPU if requested
+        // Pin to CPU if requested. Use sched_getaffinity to check allowed CPUs
+        // (respects cpuset/cgroup restrictions). Fall back to unpinned on failure.
         if (pin_cpu >= 0) {
-            u32 ncpus = detect_cpu_count();
-            if (static_cast<u32>(pin_cpu) >= ncpus) {
-                pthread_attr_destroy(&attr);
-                return core::make_unexpected(Error::make(EINVAL, Error::Source::Thread));
+            cpu_set_t allowed;
+            CPU_ZERO(&allowed);
+            if (sched_getaffinity(0, sizeof(allowed), &allowed) == 0 &&
+                CPU_ISSET(pin_cpu, &allowed)) {
+                cpu_set_t cpuset;
+                CPU_ZERO(&cpuset);
+                CPU_SET(pin_cpu, &cpuset);
+                // Best-effort: if setaffinity fails, continue unpinned
+                (void)pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset);
             }
-            cpu_set_t cpuset;
-            CPU_ZERO(&cpuset);
-            CPU_SET(pin_cpu, &cpuset);
-            i32 aff_rc = pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset);
-            if (aff_rc != 0) {
-                pthread_attr_destroy(&attr);
-                return core::make_unexpected(Error::make(aff_rc, Error::Source::Thread));
-            }
+            // If CPU not in allowed set or getaffinity failed, spawn unpinned
         }
 
         i32 rc = pthread_create(&thread, &attr, thread_entry, this);

--- a/include/rout/runtime/shard.h
+++ b/include/rout/runtime/shard.h
@@ -120,7 +120,8 @@ struct Shard {
             return core::make_unexpected(Error::make(EEXIST, Error::Source::Thread));
 
         pthread_attr_t attr;
-        pthread_attr_init(&attr);
+        i32 attr_rc = pthread_attr_init(&attr);
+        if (attr_rc != 0) return core::make_unexpected(Error::make(attr_rc, Error::Source::Thread));
 
         // Pin to CPU if requested. Use sched_getaffinity to check allowed CPUs
         // (respects cpuset/cgroup restrictions). Fall back to unpinned on failure.

--- a/include/rout/runtime/shard.h
+++ b/include/rout/runtime/shard.h
@@ -1,21 +1,177 @@
 #pragma once
 
 #include "rout/common/types.h"
-#include "rout/runtime/connection.h"
-#include "rout/runtime/io_event.h"
+#include "rout/runtime/arena.h"
+#include "rout/runtime/event_loop.h"
+#include "rout/runtime/route_table.h"
+#include "rout/runtime/upstream_pool.h"
+
+#include <pthread.h>
+#include <sched.h>
+#include <sys/mman.h>
+#include <unistd.h>
 
 namespace rout {
 
-// Per-shard state — one per CPU core, share-nothing
-struct Shard {
-    u32 id;
-    i32 listen_fd;
+// Shard — per-core share-nothing runtime unit.
+//
+// Each Shard owns:
+//   - One EventLoop (mmap'd, ~130MB) with backend, connections, timer wheel
+//   - One listen socket (SO_REUSEPORT, kernel distributes across shards)
+//   - One Arena (per-request scratch memory, reset between requests)
+//   - One OS thread, optionally pinned to a CPU core
+//
+// Lifecycle: init() → spawn() → [running] → stop() → join() → shutdown()
+//
+// Thread safety: each Shard is single-threaded. Cross-shard communication
+// is lock-free (atomics, per-shard counters). Only stop() is called from
+// outside the shard's thread.
 
-    // TODO: memory pools (Arena, SlabPool, SlicePool)
-    // TODO: connection table
-    // TODO: timer wheel
-    // TODO: upstream connection pools
-    // TODO: route table pointer (atomically swappable)
+template <typename Backend>
+struct Shard {
+    u32 id = 0;
+    i32 listen_fd = -1;
+    bool owns_listen_fd = false;  // if true, close on shutdown
+
+    // EventLoop — mmap'd due to size (~130MB from Connection[16384])
+    EventLoop<Backend>* loop = nullptr;
+
+    // Per-request scratch arena (reset after each request cycle)
+    Arena scratch;
+
+    // Upstream connection pool (per-shard, mmap'd due to size)
+    UpstreamPool* upstream = nullptr;
+
+    // Route config — atomically swappable for hot reload.
+    // Shared across all shards (read-only after construction).
+    // Pointer swapped via atomic store; old config reclaimed after epoch drain.
+    const RouteConfig* route_config = nullptr;
+
+    // Thread
+    pthread_t thread = 0;
+    bool thread_spawned = false;
+
+    // Initialize shard: mmap EventLoop, init backend + arena.
+    // listen_fd must already be created with SO_REUSEPORT.
+    // Returns 0 on success, -errno on failure.
+    i32 init(u32 shard_id, i32 lfd) {
+        id = shard_id;
+        listen_fd = lfd;
+
+        // mmap the EventLoop (too large for stack)
+        void* mem = mmap(nullptr,
+                         sizeof(EventLoop<Backend>),
+                         PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS,
+                         -1,
+                         0);
+        if (mem == MAP_FAILED) return -errno;
+        loop = static_cast<EventLoop<Backend>*>(mem);
+
+        i32 rc = loop->init(shard_id, listen_fd);
+        if (rc < 0) {
+            munmap(loop, sizeof(EventLoop<Backend>));
+            loop = nullptr;
+            return rc;
+        }
+
+        // Init scratch arena (64KB initial block, grows on demand)
+        rc = scratch.init(65536);
+        if (rc < 0) {
+            loop->shutdown();
+            munmap(loop, sizeof(EventLoop<Backend>));
+            loop = nullptr;
+            return rc;
+        }
+
+        // mmap upstream pool (UpstreamConn[4096] is ~50KB)
+        void* up_mem = mmap(nullptr,
+                            sizeof(UpstreamPool),
+                            PROT_READ | PROT_WRITE,
+                            MAP_PRIVATE | MAP_ANONYMOUS,
+                            -1,
+                            0);
+        if (up_mem == MAP_FAILED) {
+            scratch.destroy();
+            loop->shutdown();
+            munmap(loop, sizeof(EventLoop<Backend>));
+            loop = nullptr;
+            return -errno;
+        }
+        upstream = static_cast<UpstreamPool*>(up_mem);
+        upstream->init();
+
+        return 0;
+    }
+
+    // Spawn the shard's thread. Optionally pin to CPU core.
+    // pin_cpu: -1 = no pinning, >=0 = pin to that core.
+    // Returns 0 on success, -errno on failure.
+    i32 spawn(i32 pin_cpu = -1) {
+        if (!loop) return -EINVAL;
+
+        pthread_attr_t attr;
+        pthread_attr_init(&attr);
+
+        // Pin to CPU if requested
+        if (pin_cpu >= 0) {
+            cpu_set_t cpuset;
+            CPU_ZERO(&cpuset);
+            CPU_SET(pin_cpu, &cpuset);
+            pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset);
+        }
+
+        i32 rc = pthread_create(&thread, &attr, thread_entry, this);
+        pthread_attr_destroy(&attr);
+        if (rc != 0) return -rc;
+        thread_spawned = true;
+        return 0;
+    }
+
+    // Signal the shard to stop (safe to call from any thread).
+    void stop() {
+        if (loop) loop->stop();
+    }
+
+    // Wait for the shard's thread to finish.
+    void join() {
+        if (thread_spawned) {
+            pthread_join(thread, nullptr);
+            thread_spawned = false;
+        }
+    }
+
+    // Release all resources.
+    void shutdown() {
+        if (upstream) {
+            upstream->shutdown();
+            munmap(upstream, sizeof(UpstreamPool));
+            upstream = nullptr;
+        }
+        if (loop) {
+            loop->shutdown();
+            munmap(loop, sizeof(EventLoop<Backend>));
+            loop = nullptr;
+        }
+        scratch.destroy();
+        if (owns_listen_fd && listen_fd >= 0) {
+            close(listen_fd);
+            listen_fd = -1;
+        }
+    }
+
+private:
+    static void* thread_entry(void* arg) {
+        auto* self = static_cast<Shard*>(arg);
+        self->loop->run();
+        return nullptr;
+    }
 };
+
+// Detect CPU count (online cores).
+inline u32 detect_cpu_count() {
+    long n = sysconf(_SC_NPROCESSORS_ONLN);
+    return (n > 0) ? static_cast<u32>(n) : 1;
+}
 
 }  // namespace rout

--- a/include/rout/runtime/shard.h
+++ b/include/rout/runtime/shard.h
@@ -48,9 +48,9 @@ struct Shard {
     // Upstream connection pool (per-shard, mmap'd due to size)
     UpstreamPool* upstream = nullptr;
 
-    // Route config — atomically swappable for hot reload.
-    // Shared across all shards (read-only after construction).
-    // Pointer swapped via atomic store; old config reclaimed after epoch drain.
+    // Route config — set before spawning threads, read-only during runtime.
+    // Phase 3 hot reload will use __atomic_load_n/__atomic_store_n for
+    // cross-thread swap + epoch-based reclamation. Currently immutable.
     const RouteConfig* route_config = nullptr;
 
     // Thread

--- a/include/rout/runtime/shard.h
+++ b/include/rout/runtime/shard.h
@@ -75,6 +75,7 @@ struct Shard {
 
         auto loop_result = loop->init(shard_id, listen_fd);
         if (!loop_result) {
+            loop->~EventLoop();
             munmap(loop, sizeof(EventLoop<Backend>));
             loop = nullptr;
             return loop_result;
@@ -84,6 +85,7 @@ struct Shard {
         auto arena_result = scratch.init(65536);
         if (!arena_result) {
             loop->shutdown();
+            loop->~EventLoop();
             munmap(loop, sizeof(EventLoop<Backend>));
             loop = nullptr;
             return arena_result;
@@ -99,6 +101,7 @@ struct Shard {
         if (up_mem == MAP_FAILED) {
             scratch.destroy();
             loop->shutdown();
+            loop->~EventLoop();
             munmap(loop, sizeof(EventLoop<Backend>));
             loop = nullptr;
             return core::make_unexpected(Error::from_errno(Error::Source::Mmap));

--- a/include/rout/runtime/shard.h
+++ b/include/rout/runtime/shard.h
@@ -71,7 +71,7 @@ struct Shard {
                          -1,
                          0);
         if (mem == MAP_FAILED) return core::make_unexpected(Error::from_errno(Error::Source::Mmap));
-        loop = static_cast<EventLoop<Backend>*>(mem);
+        loop = new (mem) EventLoop<Backend>();
 
         auto loop_result = loop->init(shard_id, listen_fd);
         if (!loop_result) {
@@ -103,7 +103,7 @@ struct Shard {
             loop = nullptr;
             return core::make_unexpected(Error::from_errno(Error::Source::Mmap));
         }
-        upstream = static_cast<UpstreamPool*>(up_mem);
+        upstream = new (up_mem) UpstreamPool();
         upstream->init();
 
         return {};
@@ -161,11 +161,13 @@ struct Shard {
         join();
         if (upstream) {
             upstream->shutdown();
+            upstream->~UpstreamPool();
             munmap(upstream, sizeof(UpstreamPool));
             upstream = nullptr;
         }
         if (loop) {
             loop->shutdown();
+            loop->~EventLoop();
             munmap(loop, sizeof(EventLoop<Backend>));
             loop = nullptr;
         }

--- a/include/rout/runtime/slab_pool.h
+++ b/include/rout/runtime/slab_pool.h
@@ -14,6 +14,11 @@ namespace rout {
 
 template <typename T, u32 Cap>
 struct SlabPool {
+    static_assert(__is_trivially_constructible(T),
+                  "SlabPool<T>: T must be trivially constructible (mmap zeroes memory)");
+    static_assert(__is_trivially_destructible(T),
+                  "SlabPool<T>: T must be trivially destructible (no destructors called)");
+
     T* objects = nullptr;
     u32* free_stack = nullptr;
     u8* in_use_map = nullptr;  // 1 byte per slot: 0=free, 1=allocated

--- a/include/rout/runtime/slab_pool.h
+++ b/include/rout/runtime/slab_pool.h
@@ -14,10 +14,17 @@ namespace rout {
 
 template <typename T, u32 Cap>
 struct SlabPool {
+    // T must be trivially constructible (mmap zeroes) and destructible (no dtors called).
+    // GCC uses __has_trivial_constructor/__has_trivial_destructor;
+    // Clang uses __is_trivially_constructible/__is_trivially_destructible.
+#if defined(__clang__)
     static_assert(__is_trivially_constructible(T),
-                  "SlabPool<T>: T must be trivially constructible (mmap zeroes memory)");
-    static_assert(__is_trivially_destructible(T),
-                  "SlabPool<T>: T must be trivially destructible (no destructors called)");
+                  "SlabPool<T>: T must be trivially constructible");
+    static_assert(__is_trivially_destructible(T), "SlabPool<T>: T must be trivially destructible");
+#elif defined(__GNUC__)
+    static_assert(__has_trivial_constructor(T), "SlabPool<T>: T must be trivially constructible");
+    static_assert(__has_trivial_destructor(T), "SlabPool<T>: T must be trivially destructible");
+#endif
 
     T* objects = nullptr;
     u32* free_stack = nullptr;

--- a/include/rout/runtime/slab_pool.h
+++ b/include/rout/runtime/slab_pool.h
@@ -72,11 +72,16 @@ struct SlabPool {
     }
 
     // Free an object by index.
-    void free(u32 idx) { free_stack[free_top++] = idx; }
+    void free(u32 idx) {
+        if (idx >= Cap || free_top >= Cap || !free_stack) return;
+        free_stack[free_top++] = idx;
+    }
 
     // Free an object by pointer.
     void free(T* obj) {
+        if (!obj || !objects || obj < objects || obj >= objects + Cap) return;
         u32 idx = static_cast<u32>(obj - objects);
+        if (free_top >= Cap) return;
         free_stack[free_top++] = idx;
     }
 

--- a/include/rout/runtime/slab_pool.h
+++ b/include/rout/runtime/slab_pool.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "rout/common/types.h"
+
+#include <errno.h>
+#include <sys/mman.h>
+
+namespace rout {
+
+// SlabPool<T, Cap> — fixed-size object pool, O(1) alloc/free.
+//
+// All objects are pre-allocated in a single mmap'd region. Free-stack
+// tracks available slots. No malloc, no fragmentation, cache-friendly.
+//
+// This is the generalized version of EventLoop's Connection[16384]+free_stack
+// and UpstreamPool's UpstreamConn[4096]+free_stack.
+//
+// T must be trivially constructible (mmap zeroes memory).
+// Caller is responsible for initializing objects after alloc.
+//
+// Usage:
+//   SlabPool<Connection, 16384> pool;
+//   pool.init();
+//   auto [obj, idx] = pool.alloc();
+//   // ... use obj ...
+//   pool.free(idx);
+//   pool.destroy();
+
+template <typename T, u32 Cap>
+struct SlabPool {
+    T* objects = nullptr;       // mmap'd: Cap * sizeof(T)
+    u32* free_stack = nullptr;  // mmap'd: Cap * sizeof(u32)
+    u32 free_top = 0;
+    u64 objects_size = 0;
+    u64 stack_size = 0;
+
+    // Initialize pool. mmap's objects + free stack.
+    // Returns 0 on success, -errno on failure.
+    i32 init() {
+        free_top = Cap;
+
+        // mmap objects
+        objects_size = static_cast<u64>(Cap) * sizeof(T);
+        void* obj_mem =
+            mmap(nullptr, objects_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (obj_mem == MAP_FAILED) return -errno;
+        objects = static_cast<T*>(obj_mem);
+
+        // mmap free stack
+        stack_size = static_cast<u64>(Cap) * sizeof(u32);
+        void* stk_mem =
+            mmap(nullptr, stack_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (stk_mem == MAP_FAILED) {
+            munmap(objects, objects_size);
+            objects = nullptr;
+            return -errno;
+        }
+        free_stack = static_cast<u32*>(stk_mem);
+
+        // Fill free stack
+        for (u32 i = 0; i < Cap; i++) free_stack[i] = i;
+
+        return 0;
+    }
+
+    // Allocate an object. Returns pointer + index, or {nullptr, 0} if full.
+    T* alloc() {
+        if (free_top == 0) return nullptr;
+        u32 idx = free_stack[--free_top];
+        return &objects[idx];
+    }
+
+    // Allocate and return index as well.
+    T* alloc_with_id(u32& out_idx) {
+        if (free_top == 0) {
+            out_idx = 0;
+            return nullptr;
+        }
+        out_idx = free_stack[--free_top];
+        return &objects[out_idx];
+    }
+
+    // Free an object by index.
+    void free(u32 idx) { free_stack[free_top++] = idx; }
+
+    // Free an object by pointer.
+    void free(T* obj) {
+        u32 idx = static_cast<u32>(obj - objects);
+        free_stack[free_top++] = idx;
+    }
+
+    // Get object by index.
+    T& operator[](u32 idx) { return objects[idx]; }
+    const T& operator[](u32 idx) const { return objects[idx]; }
+
+    // Get index from pointer.
+    u32 index_of(const T* obj) const { return static_cast<u32>(obj - objects); }
+
+    // Stats.
+    u32 capacity() const { return Cap; }
+    u32 available() const { return free_top; }
+    u32 in_use() const { return Cap - free_top; }
+
+    // Release all mmap'd memory.
+    void destroy() {
+        if (free_stack) {
+            munmap(free_stack, stack_size);
+            free_stack = nullptr;
+        }
+        if (objects) {
+            munmap(objects, objects_size);
+            objects = nullptr;
+        }
+        free_top = 0;
+    }
+};
+
+}  // namespace rout

--- a/include/rout/runtime/slab_pool.h
+++ b/include/rout/runtime/slab_pool.h
@@ -28,8 +28,10 @@ struct SlabPool {
         objects_size = static_cast<u64>(Cap) * sizeof(T);
         void* obj_mem =
             mmap(nullptr, objects_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (obj_mem == MAP_FAILED)
+        if (obj_mem == MAP_FAILED) {
+            free_top = 0;
             return core::make_unexpected(Error::from_errno(Error::Source::SlabPool));
+        }
         objects = static_cast<T*>(obj_mem);
 
         stack_size = static_cast<u64>(Cap) * sizeof(u32);
@@ -38,6 +40,7 @@ struct SlabPool {
         if (stk_mem == MAP_FAILED) {
             munmap(objects, objects_size);
             objects = nullptr;
+            free_top = 0;
             return core::make_unexpected(Error::from_errno(Error::Source::SlabPool));
         }
         free_stack = static_cast<u32*>(stk_mem);
@@ -51,6 +54,7 @@ struct SlabPool {
             free_stack = nullptr;
             munmap(objects, objects_size);
             objects = nullptr;
+            free_top = 0;
             return core::make_unexpected(err);
         }
         in_use_map = static_cast<u8*>(map_mem);  // mmap zeroes = all free

--- a/include/rout/runtime/slab_pool.h
+++ b/include/rout/runtime/slab_pool.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "rout/common/types.h"
+#include "rout/runtime/error.h"
 
-#include <errno.h>
+#include "core/expected.h"
+
 #include <sys/mman.h>
 
 namespace rout {
@@ -12,19 +14,8 @@ namespace rout {
 // All objects are pre-allocated in a single mmap'd region. Free-stack
 // tracks available slots. No malloc, no fragmentation, cache-friendly.
 //
-// This is the generalized version of EventLoop's Connection[16384]+free_stack
-// and UpstreamPool's UpstreamConn[4096]+free_stack.
-//
 // T must be trivially constructible (mmap zeroes memory).
 // Caller is responsible for initializing objects after alloc.
-//
-// Usage:
-//   SlabPool<Connection, 16384> pool;
-//   pool.init();
-//   auto [obj, idx] = pool.alloc();
-//   // ... use obj ...
-//   pool.free(idx);
-//   pool.destroy();
 
 template <typename T, u32 Cap>
 struct SlabPool {
@@ -35,15 +26,15 @@ struct SlabPool {
     u64 stack_size = 0;
 
     // Initialize pool. mmap's objects + free stack.
-    // Returns 0 on success, -errno on failure.
-    i32 init() {
+    core::Expected<void, Error> init() {
         free_top = Cap;
 
         // mmap objects
         objects_size = static_cast<u64>(Cap) * sizeof(T);
         void* obj_mem =
             mmap(nullptr, objects_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (obj_mem == MAP_FAILED) return -errno;
+        if (obj_mem == MAP_FAILED)
+            return core::make_unexpected(Error::from_errno(Error::Source::SlabPool));
         objects = static_cast<T*>(obj_mem);
 
         // mmap free stack
@@ -53,17 +44,17 @@ struct SlabPool {
         if (stk_mem == MAP_FAILED) {
             munmap(objects, objects_size);
             objects = nullptr;
-            return -errno;
+            return core::make_unexpected(Error::from_errno(Error::Source::SlabPool));
         }
         free_stack = static_cast<u32*>(stk_mem);
 
         // Fill free stack
         for (u32 i = 0; i < Cap; i++) free_stack[i] = i;
 
-        return 0;
+        return {};
     }
 
-    // Allocate an object. Returns pointer + index, or {nullptr, 0} if full.
+    // Allocate an object. Returns pointer, or nullptr if full.
     T* alloc() {
         if (free_top == 0) return nullptr;
         u32 idx = free_stack[--free_top];

--- a/include/rout/runtime/slab_pool.h
+++ b/include/rout/runtime/slab_pool.h
@@ -10,26 +10,21 @@
 namespace rout {
 
 // SlabPool<T, Cap> — fixed-size object pool, O(1) alloc/free.
-//
-// All objects are pre-allocated in a single mmap'd region. Free-stack
-// tracks available slots. No malloc, no fragmentation, cache-friendly.
-//
-// T must be trivially constructible (mmap zeroes memory).
-// Caller is responsible for initializing objects after alloc.
+// Double-free detected via per-slot in_use tracking.
 
 template <typename T, u32 Cap>
 struct SlabPool {
-    T* objects = nullptr;       // mmap'd: Cap * sizeof(T)
-    u32* free_stack = nullptr;  // mmap'd: Cap * sizeof(u32)
+    T* objects = nullptr;
+    u32* free_stack = nullptr;
+    u8* in_use_map = nullptr;  // 1 byte per slot: 0=free, 1=allocated
     u32 free_top = 0;
     u64 objects_size = 0;
     u64 stack_size = 0;
+    u64 map_size = 0;
 
-    // Initialize pool. mmap's objects + free stack.
     core::Expected<void, Error> init() {
         free_top = Cap;
 
-        // mmap objects
         objects_size = static_cast<u64>(Cap) * sizeof(T);
         void* obj_mem =
             mmap(nullptr, objects_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -37,7 +32,6 @@ struct SlabPool {
             return core::make_unexpected(Error::from_errno(Error::Source::SlabPool));
         objects = static_cast<T*>(obj_mem);
 
-        // mmap free stack
         stack_size = static_cast<u64>(Cap) * sizeof(u32);
         void* stk_mem =
             mmap(nullptr, stack_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -48,57 +42,69 @@ struct SlabPool {
         }
         free_stack = static_cast<u32*>(stk_mem);
 
-        // Fill free stack
-        for (u32 i = 0; i < Cap; i++) free_stack[i] = i;
+        map_size = static_cast<u64>(Cap);
+        void* map_mem =
+            mmap(nullptr, map_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (map_mem == MAP_FAILED) {
+            auto err = Error::from_errno(Error::Source::SlabPool);
+            munmap(free_stack, stack_size);
+            free_stack = nullptr;
+            munmap(objects, objects_size);
+            objects = nullptr;
+            return core::make_unexpected(err);
+        }
+        in_use_map = static_cast<u8*>(map_mem);  // mmap zeroes = all free
 
+        for (u32 i = 0; i < Cap; i++) free_stack[i] = i;
         return {};
     }
 
-    // Allocate an object. Returns pointer, or nullptr if full.
     T* alloc() {
         if (free_top == 0) return nullptr;
         u32 idx = free_stack[--free_top];
+        if (in_use_map) in_use_map[idx] = 1;
         return &objects[idx];
     }
 
-    // Allocate and return index as well.
     T* alloc_with_id(u32& out_idx) {
         if (free_top == 0) {
             out_idx = 0;
             return nullptr;
         }
         out_idx = free_stack[--free_top];
+        if (in_use_map) in_use_map[out_idx] = 1;
         return &objects[out_idx];
     }
 
-    // Free an object by index.
     void free(u32 idx) {
         if (idx >= Cap || free_top >= Cap || !free_stack) return;
+        if (in_use_map && !in_use_map[idx]) return;  // double-free
+        if (in_use_map) in_use_map[idx] = 0;
         free_stack[free_top++] = idx;
     }
 
-    // Free an object by pointer.
     void free(T* obj) {
         if (!obj || !objects || obj < objects || obj >= objects + Cap) return;
         u32 idx = static_cast<u32>(obj - objects);
         if (free_top >= Cap) return;
+        if (in_use_map && !in_use_map[idx]) return;  // double-free
+        if (in_use_map) in_use_map[idx] = 0;
         free_stack[free_top++] = idx;
     }
 
-    // Get object by index.
     T& operator[](u32 idx) { return objects[idx]; }
     const T& operator[](u32 idx) const { return objects[idx]; }
-
-    // Get index from pointer.
     u32 index_of(const T* obj) const { return static_cast<u32>(obj - objects); }
 
-    // Stats.
     u32 capacity() const { return Cap; }
     u32 available() const { return free_top; }
     u32 in_use() const { return Cap - free_top; }
 
-    // Release all mmap'd memory.
     void destroy() {
+        if (in_use_map) {
+            munmap(in_use_map, map_size);
+            in_use_map = nullptr;
+        }
         if (free_stack) {
             munmap(free_stack, stack_size);
             free_stack = nullptr;

--- a/include/rout/runtime/slice_pool.h
+++ b/include/rout/runtime/slice_pool.h
@@ -47,8 +47,11 @@ struct SlicePool {
         base_size = static_cast<u64>(n) * kSliceSize;
         void* data_mem =
             mmap(nullptr, base_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (data_mem == MAP_FAILED)
+        if (data_mem == MAP_FAILED) {
+            count = 0;
+            free_top = 0;
             return core::make_unexpected(Error::from_errno(Error::Source::SlicePool));
+        }
         base = static_cast<u8*>(data_mem);
 
         // mmap free stack
@@ -58,6 +61,8 @@ struct SlicePool {
         if (stack_mem == MAP_FAILED) {
             munmap(base, base_size);
             base = nullptr;
+            count = 0;
+            free_top = 0;
             return core::make_unexpected(Error::from_errno(Error::Source::SlicePool));
         }
         free_stack = static_cast<u32*>(stack_mem);
@@ -72,6 +77,8 @@ struct SlicePool {
             free_stack = nullptr;
             munmap(base, base_size);
             base = nullptr;
+            count = 0;
+            free_top = 0;
             return core::make_unexpected(err);
         }
         in_use_map = static_cast<u8*>(map_mem);  // mmap zeroes = all free

--- a/include/rout/runtime/slice_pool.h
+++ b/include/rout/runtime/slice_pool.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "rout/common/types.h"
+
+#include <errno.h>
+#include <sys/mman.h>
+
+namespace rout {
+
+// SlicePool — fixed-size (16KB) memory slice allocator.
+//
+// Per-shard pool of pre-allocated 16KB slices for network I/O buffers.
+// Connections borrow slices on demand (recv/send), return them when done.
+// Idle connections hold 0 slices → zero memory overhead at C100K.
+//
+// All memory is mmap'd upfront (no malloc/free). Free-stack gives O(1)
+// alloc/free with zero fragmentation.
+//
+// Usage:
+//   SlicePool pool;
+//   pool.init(1024);       // 1024 × 16KB = 16MB
+//   u8* buf = pool.alloc();  // get a 16KB slice
+//   // ... use buf for recv/send ...
+//   pool.free(buf);          // return to pool
+//   pool.destroy();          // unmap everything
+
+struct SlicePool {
+    static constexpr u32 kSliceSize = 16384;  // 16KB per slice
+
+    u8* base = nullptr;         // mmap'd region: count * kSliceSize bytes
+    u32* free_stack = nullptr;  // mmap'd: free slice indices
+    u32 free_top = 0;
+    u32 count = 0;       // total number of slices
+    u64 base_size = 0;   // size of mmap'd base region
+    u64 stack_size = 0;  // size of mmap'd free_stack region
+
+    // Initialize pool with `n` slices. Total memory: n * 16KB + n * 4 bytes.
+    // Returns 0 on success, -errno on failure.
+    i32 init(u32 n) {
+        count = n;
+        free_top = n;
+
+        // mmap slice data
+        base_size = static_cast<u64>(n) * kSliceSize;
+        void* data_mem =
+            mmap(nullptr, base_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (data_mem == MAP_FAILED) return -errno;
+        base = static_cast<u8*>(data_mem);
+
+        // mmap free stack
+        stack_size = static_cast<u64>(n) * sizeof(u32);
+        void* stack_mem =
+            mmap(nullptr, stack_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (stack_mem == MAP_FAILED) {
+            munmap(base, base_size);
+            base = nullptr;
+            return -errno;
+        }
+        free_stack = static_cast<u32*>(stack_mem);
+
+        // Fill free stack: all slices available
+        for (u32 i = 0; i < n; i++) free_stack[i] = i;
+
+        return 0;
+    }
+
+    // Allocate one 16KB slice. Returns pointer to slice, or nullptr if exhausted.
+    u8* alloc() {
+        if (free_top == 0) return nullptr;
+        u32 idx = free_stack[--free_top];
+        return base + static_cast<u64>(idx) * kSliceSize;
+    }
+
+    // Free a slice back to the pool. ptr must have been returned by alloc().
+    void free(u8* ptr) {
+        if (!ptr || !base) return;
+        u64 offset = static_cast<u64>(ptr - base);
+        u32 idx = static_cast<u32>(offset / kSliceSize);
+        free_stack[free_top++] = idx;
+    }
+
+    // Number of available (free) slices.
+    u32 available() const { return free_top; }
+
+    // Number of in-use slices.
+    u32 in_use() const { return count - free_top; }
+
+    // Release all mmap'd memory.
+    void destroy() {
+        if (free_stack) {
+            munmap(free_stack, stack_size);
+            free_stack = nullptr;
+        }
+        if (base) {
+            munmap(base, base_size);
+            base = nullptr;
+        }
+        free_top = 0;
+        count = 0;
+    }
+};
+
+}  // namespace rout

--- a/include/rout/runtime/slice_pool.h
+++ b/include/rout/runtime/slice_pool.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "rout/common/types.h"
+#include "rout/runtime/error.h"
 
-#include <errno.h>
+#include "core/expected.h"
+
 #include <sys/mman.h>
 
 namespace rout {
@@ -18,11 +20,11 @@ namespace rout {
 //
 // Usage:
 //   SlicePool pool;
-//   pool.init(1024);       // 1024 × 16KB = 16MB
-//   u8* buf = pool.alloc();  // get a 16KB slice
-//   // ... use buf for recv/send ...
-//   pool.free(buf);          // return to pool
-//   pool.destroy();          // unmap everything
+//   auto rc = pool.init(1024);  // 1024 × 16KB = 16MB
+//   if (!rc) handle(rc.error());
+//   u8* buf = pool.alloc();
+//   pool.free(buf);
+//   pool.destroy();
 
 struct SlicePool {
     static constexpr u32 kSliceSize = 16384;  // 16KB per slice
@@ -35,8 +37,7 @@ struct SlicePool {
     u64 stack_size = 0;  // size of mmap'd free_stack region
 
     // Initialize pool with `n` slices. Total memory: n * 16KB + n * 4 bytes.
-    // Returns 0 on success, -errno on failure.
-    i32 init(u32 n) {
+    core::Expected<void, Error> init(u32 n) {
         count = n;
         free_top = n;
 
@@ -44,7 +45,8 @@ struct SlicePool {
         base_size = static_cast<u64>(n) * kSliceSize;
         void* data_mem =
             mmap(nullptr, base_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (data_mem == MAP_FAILED) return -errno;
+        if (data_mem == MAP_FAILED)
+            return core::make_unexpected(Error::from_errno(Error::Source::SlicePool));
         base = static_cast<u8*>(data_mem);
 
         // mmap free stack
@@ -54,14 +56,14 @@ struct SlicePool {
         if (stack_mem == MAP_FAILED) {
             munmap(base, base_size);
             base = nullptr;
-            return -errno;
+            return core::make_unexpected(Error::from_errno(Error::Source::SlicePool));
         }
         free_stack = static_cast<u32*>(stack_mem);
 
         // Fill free stack: all slices available
         for (u32 i = 0; i < n; i++) free_stack[i] = i;
 
-        return 0;
+        return {};
     }
 
     // Allocate one 16KB slice. Returns pointer to slice, or nullptr if exhausted.

--- a/include/rout/runtime/slice_pool.h
+++ b/include/rout/runtime/slice_pool.h
@@ -31,10 +31,12 @@ struct SlicePool {
 
     u8* base = nullptr;         // mmap'd region: count * kSliceSize bytes
     u32* free_stack = nullptr;  // mmap'd: free slice indices
+    u8* in_use_map = nullptr;   // mmap'd: 1 byte per slice (0=free, 1=in-use)
     u32 free_top = 0;
     u32 count = 0;       // total number of slices
     u64 base_size = 0;   // size of mmap'd base region
     u64 stack_size = 0;  // size of mmap'd free_stack region
+    u64 map_size = 0;    // size of mmap'd in_use_map
 
     // Initialize pool with `n` slices. Total memory: n * 16KB + n * 4 bytes.
     core::Expected<void, Error> init(u32 n) {
@@ -60,6 +62,20 @@ struct SlicePool {
         }
         free_stack = static_cast<u32*>(stack_mem);
 
+        // mmap in-use tracking map (1 byte per slice, 0=free)
+        map_size = static_cast<u64>(n);
+        void* map_mem =
+            mmap(nullptr, map_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (map_mem == MAP_FAILED) {
+            auto err = Error::from_errno(Error::Source::SlicePool);
+            munmap(free_stack, stack_size);
+            free_stack = nullptr;
+            munmap(base, base_size);
+            base = nullptr;
+            return core::make_unexpected(err);
+        }
+        in_use_map = static_cast<u8*>(map_mem);  // mmap zeroes = all free
+
         // Fill free stack: all slices available
         for (u32 i = 0; i < n; i++) free_stack[i] = i;
 
@@ -70,6 +86,7 @@ struct SlicePool {
     u8* alloc() {
         if (free_top == 0) return nullptr;
         u32 idx = free_stack[--free_top];
+        if (in_use_map) in_use_map[idx] = 1;
         return base + static_cast<u64>(idx) * kSliceSize;
     }
 
@@ -79,8 +96,10 @@ struct SlicePool {
         if (ptr < base || ptr >= base + base_size) return;  // out of range
         u64 offset = static_cast<u64>(ptr - base);
         if (offset % kSliceSize != 0) return;  // not slice-aligned
-        if (free_top >= count) return;         // overflow (double-free)
+        if (free_top >= count) return;         // overflow guard
         u32 idx = static_cast<u32>(offset / kSliceSize);
+        if (in_use_map && !in_use_map[idx]) return;  // double-free detection
+        if (in_use_map) in_use_map[idx] = 0;
         free_stack[free_top++] = idx;
     }
 
@@ -92,6 +111,10 @@ struct SlicePool {
 
     // Release all mmap'd memory.
     void destroy() {
+        if (in_use_map) {
+            munmap(in_use_map, map_size);
+            in_use_map = nullptr;
+        }
         if (free_stack) {
             munmap(free_stack, stack_size);
             free_stack = nullptr;

--- a/include/rout/runtime/slice_pool.h
+++ b/include/rout/runtime/slice_pool.h
@@ -75,8 +75,11 @@ struct SlicePool {
 
     // Free a slice back to the pool. ptr must have been returned by alloc().
     void free(u8* ptr) {
-        if (!ptr || !base) return;
+        if (!ptr || !base || !free_stack || count == 0) return;
+        if (ptr < base || ptr >= base + base_size) return;  // out of range
         u64 offset = static_cast<u64>(ptr - base);
+        if (offset % kSliceSize != 0) return;  // not slice-aligned
+        if (free_top >= count) return;         // overflow (double-free)
         u32 idx = static_cast<u32>(offset / kSliceSize);
         free_stack[free_top++] = idx;
     }

--- a/include/rout/runtime/socket.h
+++ b/include/rout/runtime/socket.h
@@ -1,15 +1,18 @@
 #pragma once
 
 #include "rout/common/types.h"
+#include "rout/runtime/error.h"
+
+#include "core/expected.h"
 
 namespace rout {
 
 // Create a non-blocking, reusable listen socket.
-// Returns fd on success, -errno on failure.
+// Returns fd on success, Error on failure.
 // Uses SO_REUSEPORT so each shard can bind the same port.
-i32 create_listen_socket(u16 port);
+core::Expected<i32, Error> create_listen_socket(u16 port);
 
-// Set fd to non-blocking mode.
+// Set fd to non-blocking mode. (kept as i32 — internal helper, error is rare)
 i32 set_nonblocking(i32 fd);
 
 }  // namespace rout

--- a/include/rout/runtime/upstream_pool.h
+++ b/include/rout/runtime/upstream_pool.h
@@ -85,14 +85,20 @@ struct UpstreamPool {
         c->idle = true;
     }
 
-    // Close all connections and reset.
+    // Close all connections and fully reset to initial state.
     void shutdown() {
         for (u32 i = 0; i < kMaxConns; i++) {
             if (conns[i].fd >= 0) {
                 close(conns[i].fd);
                 conns[i].fd = -1;
             }
+            conns[i].idle = false;
+            conns[i].allocated = false;
+            conns[i].upstream_id = 0;
         }
+        // Rebuild free stack (all slots available)
+        free_top = kMaxConns;
+        for (u32 i = 0; i < kMaxConns; i++) free_stack[i] = i;
     }
 
     // Create a non-blocking socket for upstream connection.

--- a/include/rout/runtime/upstream_pool.h
+++ b/include/rout/runtime/upstream_pool.h
@@ -46,6 +46,7 @@ struct UpstreamPool {
         if (free_top == 0) return nullptr;
         u32 idx = free_stack[--free_top];
         conns[idx].fd = -1;
+        conns[idx].upstream_id = 0;
         conns[idx].idle = false;
         conns[idx].allocated = true;
         return &conns[idx];

--- a/include/rout/runtime/upstream_pool.h
+++ b/include/rout/runtime/upstream_pool.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "rout/common/types.h"
+
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace rout {
+
+// Per-shard upstream connection pool.
+//
+// Manages idle (reusable) upstream connections grouped by upstream target.
+// Each shard owns one UpstreamPool — no cross-shard sharing.
+//
+// Phase 2: simple fixed-array pool with free-stack.
+// Phase 3: SlabPool-backed, health checking, weighted load balancing.
+
+struct UpstreamConn {
+    i32 fd = -1;
+    u16 upstream_id = 0;  // which upstream target this connects to
+    bool idle = false;    // true = available for reuse
+};
+
+struct UpstreamPool {
+    static constexpr u32 kMaxConns = 4096;
+
+    UpstreamConn conns[kMaxConns];
+    u32 free_stack[kMaxConns];
+    u32 free_top = 0;
+
+    void init() {
+        free_top = kMaxConns;
+        for (u32 i = 0; i < kMaxConns; i++) {
+            conns[i].fd = -1;
+            conns[i].upstream_id = 0;
+            conns[i].idle = false;
+            free_stack[i] = i;
+        }
+    }
+
+    // Allocate a new upstream connection slot.
+    // Caller must create the socket and initiate connect.
+    UpstreamConn* alloc() {
+        if (free_top == 0) return nullptr;
+        u32 idx = free_stack[--free_top];
+        conns[idx].fd = -1;
+        conns[idx].idle = false;
+        return &conns[idx];
+    }
+
+    // Free an upstream connection slot.
+    void free(UpstreamConn* c) {
+        if (c->fd >= 0) {
+            close(c->fd);
+            c->fd = -1;
+        }
+        c->idle = false;
+        u32 idx = static_cast<u32>(c - conns);
+        free_stack[free_top++] = idx;
+    }
+
+    // Find an idle connection for the given upstream target.
+    // Returns nullptr if none available (caller should allocate + connect).
+    UpstreamConn* find_idle(u16 upstream_id) {
+        for (u32 i = 0; i < kMaxConns; i++) {
+            if (conns[i].idle && conns[i].upstream_id == upstream_id && conns[i].fd >= 0) {
+                conns[i].idle = false;  // mark as busy
+                return &conns[i];
+            }
+        }
+        return nullptr;
+    }
+
+    // Return a connection to the idle pool for reuse.
+    void return_idle(UpstreamConn* c) { c->idle = true; }
+
+    // Close all connections and reset.
+    void shutdown() {
+        for (u32 i = 0; i < kMaxConns; i++) {
+            if (conns[i].fd >= 0) {
+                close(conns[i].fd);
+                conns[i].fd = -1;
+            }
+        }
+    }
+
+    // Create a non-blocking socket for upstream connection.
+    // Returns fd on success, -1 on failure.
+    static i32 create_socket() {
+        i32 fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+        return fd;
+    }
+};
+
+}  // namespace rout

--- a/include/rout/runtime/upstream_pool.h
+++ b/include/rout/runtime/upstream_pool.h
@@ -17,8 +17,9 @@ namespace rout {
 
 struct UpstreamConn {
     i32 fd = -1;
-    u16 upstream_id = 0;  // which upstream target this connects to
-    bool idle = false;    // true = available for reuse
+    u16 upstream_id = 0;     // which upstream target this connects to
+    bool idle = false;       // true = available for reuse
+    bool allocated = false;  // true = slot in use (guards double-free)
 };
 
 struct UpstreamPool {
@@ -34,6 +35,7 @@ struct UpstreamPool {
             conns[i].fd = -1;
             conns[i].upstream_id = 0;
             conns[i].idle = false;
+            conns[i].allocated = false;
             free_stack[i] = i;
         }
     }
@@ -45,17 +47,20 @@ struct UpstreamPool {
         u32 idx = free_stack[--free_top];
         conns[idx].fd = -1;
         conns[idx].idle = false;
+        conns[idx].allocated = true;
         return &conns[idx];
     }
 
     // Free an upstream connection slot.
     void free(UpstreamConn* c) {
         if (!c || c < conns || c >= conns + kMaxConns) return;
+        if (!c->allocated) return;  // double-free detection
         if (c->fd >= 0) {
             close(c->fd);
             c->fd = -1;
         }
         c->idle = false;
+        c->allocated = false;
         u32 idx = static_cast<u32>(c - conns);
         if (free_top >= kMaxConns) return;
         free_stack[free_top++] = idx;
@@ -74,7 +79,11 @@ struct UpstreamPool {
     }
 
     // Return a connection to the idle pool for reuse.
-    void return_idle(UpstreamConn* c) { c->idle = true; }
+    void return_idle(UpstreamConn* c) {
+        if (!c || c < conns || c >= conns + kMaxConns) return;
+        if (!c->allocated || c->fd < 0) return;
+        c->idle = true;
+    }
 
     // Close all connections and reset.
     void shutdown() {

--- a/include/rout/runtime/upstream_pool.h
+++ b/include/rout/runtime/upstream_pool.h
@@ -50,12 +50,14 @@ struct UpstreamPool {
 
     // Free an upstream connection slot.
     void free(UpstreamConn* c) {
+        if (!c || c < conns || c >= conns + kMaxConns) return;
         if (c->fd >= 0) {
             close(c->fd);
             c->fd = -1;
         }
         c->idle = false;
         u32 idx = static_cast<u32>(c - conns);
+        if (free_top >= kMaxConns) return;
         free_stack[free_top++] = idx;
     }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -54,11 +54,11 @@ static bool detect_io_uring() {
 
 // --- Signal handling for graceful shutdown ---
 
-// Signal handler only sets a flag; main thread calls stop() outside signal context.
-static volatile sig_atomic_t g_stop_requested = 0;
-
-static void signal_handler(int /*sig*/) {
-    g_stop_requested = 1;
+static void write_error(const char* prefix, const rout::Error& err) {
+    write_str(prefix);
+    write_str(" (errno=");
+    write_u32(static_cast<u32>(err.code));
+    write_str(")\n");
 }
 
 template <typename Backend>
@@ -80,7 +80,7 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
         if (!lfd_result) {
             write_str("Failed to create listen socket for shard ");
             write_u32(i);
-            write_str("\n");
+            write_error("", lfd_result.error());
             // Cleanup already-initialized shards
             for (u32 j = 0; j < i; j++) {
                 shards[j].stop();
@@ -96,7 +96,7 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
         if (!rc) {
             write_str("Failed to init shard ");
             write_u32(i);
-            write_str("\n");
+            write_error("", rc.error());
             close(lfd);
             for (u32 j = 0; j < i; j++) {
                 shards[j].stop();
@@ -124,12 +124,13 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
     write_u32(shard_count);
     write_str(" shard(s)\n");
 
-    // Install signal handlers for graceful shutdown
-    struct sigaction sa;
-    memset(&sa, 0, sizeof(sa));
-    sa.sa_handler = signal_handler;
-    sigaction(SIGINT, &sa, nullptr);
-    sigaction(SIGTERM, &sa, nullptr);
+    // Block SIGINT/SIGTERM so sigwait() can catch them race-free.
+    // Must block before spawning threads (threads inherit the mask).
+    sigset_t wait_set;
+    sigemptyset(&wait_set);
+    sigaddset(&wait_set, SIGINT);
+    sigaddset(&wait_set, SIGTERM);
+    pthread_sigmask(SIG_BLOCK, &wait_set, nullptr);
 
     // Spawn shard threads
     for (u32 i = 0; i < shard_count; i++) {
@@ -138,7 +139,7 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
         if (!rc) {
             write_str("Failed to spawn shard ");
             write_u32(i);
-            write_str("\n");
+            write_error("", rc.error());
             // Stop all already-spawned shards
             for (u32 j = 0; j < i; j++) shards[j].stop();
             for (u32 j = 0; j < i; j++) shards[j].join();
@@ -147,8 +148,9 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
         }
     }
 
-    // Wait for signal, then stop all shards from main thread (async-signal-safe).
-    while (!g_stop_requested) pause();
+    // Wait for SIGINT/SIGTERM — sigwait() is race-free (signal is blocked).
+    i32 sig = 0;
+    sigwait(&wait_set, &sig);
 
     // Stop all shards from main thread (not signal context)
     for (u32 i = 0; i < shard_count; i++) shards[i].stop();

--- a/src/main.cc
+++ b/src/main.cc
@@ -58,6 +58,8 @@ static void write_error(const char* prefix, const rout::Error& err) {
     write_str(prefix);
     write_str(" (errno=");
     write_u32(static_cast<u32>(err.code));
+    write_str(", source=");
+    write_u32(static_cast<u32>(err.source));
     write_str(")\n");
 }
 
@@ -74,7 +76,11 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
         if (i == 0 && port == 0 && lfd_result) {
             struct sockaddr_in a;
             socklen_t al = sizeof(a);
-            getsockname(lfd_result.value(), reinterpret_cast<struct sockaddr*>(&a), &al);
+            if (getsockname(lfd_result.value(), reinterpret_cast<struct sockaddr*>(&a), &al) < 0) {
+                write_str("Failed to resolve ephemeral port\n");
+                close(lfd_result.value());
+                return 1;
+            }
             port = __builtin_bswap16(a.sin_port);
         }
         if (!lfd_result) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -54,17 +54,11 @@ static bool detect_io_uring() {
 
 // --- Signal handling for graceful shutdown ---
 
-// Store pointers to each shard's loop->running flag for signal handler.
-// Use atomic store for cross-thread + signal safety.
-static volatile bool* g_running_flags[kMaxShards];
-static volatile sig_atomic_t g_shard_count = 0;
+// Signal handler only sets a flag; main thread calls stop() outside signal context.
+static volatile sig_atomic_t g_stop_requested = 0;
 
 static void signal_handler(int /*sig*/) {
-    sig_atomic_t count = g_shard_count;
-    for (sig_atomic_t i = 0; i < count && i < static_cast<sig_atomic_t>(kMaxShards); i++) {
-        volatile bool* flag = g_running_flags[i];
-        if (flag) __atomic_store_n(flag, false, __ATOMIC_RELAXED);
-    }
+    g_stop_requested = 1;
 }
 
 template <typename Backend>
@@ -72,9 +66,17 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
     Shard<Backend> shards[kMaxShards];
 
     // Create one SO_REUSEPORT listen socket per shard.
-    // Kernel distributes incoming connections across sockets.
+    // If port==0 (ephemeral), create shard 0 first to get the assigned port,
+    // then create remaining sockets on that concrete port.
     for (u32 i = 0; i < shard_count; i++) {
         auto lfd_result = create_listen_socket(port);
+        // After shard 0, resolve ephemeral port so remaining shards bind the same port.
+        if (i == 0 && port == 0 && lfd_result) {
+            struct sockaddr_in a;
+            socklen_t al = sizeof(a);
+            getsockname(lfd_result.value(), reinterpret_cast<struct sockaddr*>(&a), &al);
+            port = __builtin_bswap16(a.sin_port);
+        }
         if (!lfd_result) {
             write_str("Failed to create listen socket for shard ");
             write_u32(i);
@@ -117,12 +119,6 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
     write_u32(shard_count);
     write_str(" shard(s)\n");
 
-    // Register running flags for signal handler (before spawning threads)
-    for (u32 i = 0; i < shard_count; i++) {
-        g_running_flags[i] = &shards[i].loop->running;
-    }
-    g_shard_count = static_cast<sig_atomic_t>(shard_count);
-
     // Install signal handlers for graceful shutdown
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
@@ -146,13 +142,12 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
         }
     }
 
-    // Wait for all shard threads to finish (blocked by signal or stop)
+    // Wait for signal, then stop all shards from main thread (async-signal-safe).
+    while (!g_stop_requested) pause();
+
+    // Stop all shards from main thread (not signal context)
+    for (u32 i = 0; i < shard_count; i++) shards[i].stop();
     for (u32 i = 0; i < shard_count; i++) shards[i].join();
-
-    // Clear signal handler state before shutdown to prevent dangling pointer access
-    g_shard_count = 0;
-    for (u32 i = 0; i < shard_count; i++) g_running_flags[i] = nullptr;
-
     for (u32 i = 0; i < shard_count; i++) shards[i].shutdown();
 
     return 0;

--- a/src/main.cc
+++ b/src/main.cc
@@ -63,8 +63,8 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
     // Create one SO_REUSEPORT listen socket per shard.
     // Kernel distributes incoming connections across sockets.
     for (u32 i = 0; i < shard_count; i++) {
-        i32 lfd = create_listen_socket(port);
-        if (lfd < 0) {
+        auto lfd_result = create_listen_socket(port);
+        if (!lfd_result) {
             write_str("Failed to create listen socket for shard ");
             write_u32(i);
             write_str("\n");
@@ -76,10 +76,11 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
             }
             return 1;
         }
+        i32 lfd = lfd_result.value();
         shards[i].owns_listen_fd = true;
 
-        i32 rc = shards[i].init(i, lfd);
-        if (rc < 0) {
+        auto rc = shards[i].init(i, lfd);
+        if (!rc) {
             write_str("Failed to init shard ");
             write_u32(i);
             write_str("\n");
@@ -121,8 +122,8 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
     // Spawn shard threads
     for (u32 i = 0; i < shard_count; i++) {
         i32 pin = pin_cpus ? static_cast<i32>(i) : -1;
-        i32 rc = shards[i].spawn(pin);
-        if (rc < 0) {
+        auto rc = shards[i].spawn(pin);
+        if (!rc) {
             write_str("Failed to spawn shard ");
             write_u32(i);
             write_str("\n");

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,10 +1,11 @@
 #include "rout/runtime/epoll_backend.h"
-#include "rout/runtime/event_loop.h"
 #include "rout/runtime/io_uring_backend.h"
+#include "rout/runtime/shard.h"
 #include "rout/runtime/socket.h"
 
 #include <linux/io_uring.h>
 #include <netinet/in.h>
+#include <signal.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/syscall.h>
@@ -12,10 +13,23 @@
 
 using namespace rout;
 
+static constexpr u32 kMaxShards = 64;
+
 static void write_str(const char* s) {
     u32 len = 0;
     while (s[len]) len++;
     (void)write(1, s, len);
+}
+
+static void write_u32(u32 val) {
+    char buf[12];
+    i32 n = 0;
+    u32 tmp = val;
+    do {
+        buf[n++] = static_cast<char>('0' + tmp % 10);
+        tmp /= 10;
+    } while (tmp);
+    for (i32 i = n - 1; i >= 0; i--) (void)write(1, &buf[i], 1);
 }
 
 static bool detect_io_uring() {
@@ -29,89 +43,152 @@ static bool detect_io_uring() {
     return false;
 }
 
-int main(int argc, char** argv) {
-    u16 port = 8080;
-    if (argc > 1) {
-        port = 0;
-        for (const char* p = argv[1]; *p >= '0' && *p <= '9'; p++)
-            port = port * 10 + static_cast<u16>(*p - '0');
+// --- Signal handling for graceful shutdown ---
+
+// Store pointers to each shard's loop->running flag for signal handler.
+// Writing false to a bool is async-signal-safe.
+static bool* g_running_flags[kMaxShards];
+static u32 g_shard_count = 0;
+
+static void signal_handler(int /*sig*/) {
+    for (u32 i = 0; i < g_shard_count; i++) {
+        if (g_running_flags[i]) *g_running_flags[i] = false;
+    }
+}
+
+template <typename Backend>
+static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
+    Shard<Backend> shards[kMaxShards];
+
+    // Create one SO_REUSEPORT listen socket per shard.
+    // Kernel distributes incoming connections across sockets.
+    for (u32 i = 0; i < shard_count; i++) {
+        i32 lfd = create_listen_socket(port);
+        if (lfd < 0) {
+            write_str("Failed to create listen socket for shard ");
+            write_u32(i);
+            write_str("\n");
+            // Cleanup already-initialized shards
+            for (u32 j = 0; j < i; j++) {
+                shards[j].stop();
+                shards[j].join();
+                shards[j].shutdown();
+            }
+            return 1;
+        }
+        shards[i].owns_listen_fd = true;
+
+        i32 rc = shards[i].init(i, lfd);
+        if (rc < 0) {
+            write_str("Failed to init shard ");
+            write_u32(i);
+            write_str("\n");
+            close(lfd);
+            for (u32 j = 0; j < i; j++) {
+                shards[j].stop();
+                shards[j].join();
+                shards[j].shutdown();
+            }
+            return 1;
+        }
     }
 
-    i32 listen_fd = create_listen_socket(port);
-    if (listen_fd < 0) {
-        write_str("Failed to create listen socket\n");
-        return 1;
-    }
-
-    // Get actual port (kernel may assign ephemeral if port==0)
+    // Get actual port from first shard's socket
     struct sockaddr_in bound_addr;
     socklen_t addr_len = sizeof(bound_addr);
-    getsockname(listen_fd, reinterpret_cast<struct sockaddr*>(&bound_addr), &addr_len);
+    getsockname(shards[0].listen_fd, reinterpret_cast<struct sockaddr*>(&bound_addr), &addr_len);
     port = __builtin_bswap16(bound_addr.sin_port);
 
     write_str("Listening on port ");
-    char buf[8];
-    i32 n = 0;
-    u16 tmp = port;
-    do {
-        buf[n++] = static_cast<char>('0' + tmp % 10);
-        tmp /= 10;
-    } while (tmp);
-    for (i32 i = n - 1; i >= 0; i--) {
-        (void)write(1, &buf[i], 1);
-    }
-    write_str("\n");
+    write_u32(port);
+    write_str(" with ");
+    write_u32(shard_count);
+    write_str(" shard(s)\n");
 
-    // EventLoop contains large arrays (Connection[16384] × ~8KB each ≈ 130MB).
-    // Must be mmap'd, not stack-allocated.
+    // Register running flags for signal handler (before spawning threads)
+    for (u32 i = 0; i < shard_count; i++) {
+        g_running_flags[i] = &shards[i].loop->running;
+    }
+    g_shard_count = shard_count;
+
+    // Install signal handlers for graceful shutdown
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = signal_handler;
+    sigaction(SIGINT, &sa, nullptr);
+    sigaction(SIGTERM, &sa, nullptr);
+
+    // Spawn shard threads
+    for (u32 i = 0; i < shard_count; i++) {
+        i32 pin = pin_cpus ? static_cast<i32>(i) : -1;
+        i32 rc = shards[i].spawn(pin);
+        if (rc < 0) {
+            write_str("Failed to spawn shard ");
+            write_u32(i);
+            write_str("\n");
+            // Stop all already-spawned shards
+            for (u32 j = 0; j < i; j++) shards[j].stop();
+            for (u32 j = 0; j < i; j++) shards[j].join();
+            for (u32 j = 0; j < shard_count; j++) shards[j].shutdown();
+            return 1;
+        }
+    }
+
+    // Wait for all shard threads to finish (blocked by signal or stop)
+    for (u32 i = 0; i < shard_count; i++) shards[i].join();
+    for (u32 i = 0; i < shard_count; i++) shards[i].shutdown();
+
+    return 0;
+}
+
+int main(int argc, char** argv) {
+    u16 port = 8080;
+    u32 shard_count = 0;  // 0 = auto-detect
+    bool pin_cpus = true;
+
+    // Simple arg parsing: [port] [--shards N] [--no-pin]
+    for (int i = 1; i < argc; i++) {
+        if (argv[i][0] >= '0' && argv[i][0] <= '9') {
+            port = 0;
+            for (const char* p = argv[i]; *p >= '0' && *p <= '9'; p++)
+                port = port * 10 + static_cast<u16>(*p - '0');
+        }
+        // Check --shards
+        if (i + 1 < argc) {
+            bool is_shards = true;
+            const char* expect = "--shards";
+            for (int k = 0; expect[k]; k++) {
+                if (argv[i][k] != expect[k]) {
+                    is_shards = false;
+                    break;
+                }
+            }
+            if (is_shards) {
+                i++;
+                shard_count = 0;
+                for (const char* p = argv[i]; *p >= '0' && *p <= '9'; p++)
+                    shard_count = shard_count * 10 + static_cast<u32>(*p - '0');
+            }
+        }
+        // Check --no-pin
+        bool is_nopin = true;
+        const char* expect_np = "--no-pin";
+        for (int k = 0; expect_np[k]; k++) {
+            if (argv[i][k] != expect_np[k]) {
+                is_nopin = false;
+                break;
+            }
+        }
+        if (is_nopin) pin_cpus = false;
+    }
+
+    if (shard_count == 0) shard_count = detect_cpu_count();
+    if (shard_count > kMaxShards) shard_count = kMaxShards;
+
     if (detect_io_uring()) {
         write_str("Backend: io_uring\n");
-        auto* loop = static_cast<EventLoop<IoUringBackend>*>(mmap(nullptr,
-                                                                  sizeof(EventLoop<IoUringBackend>),
-                                                                  PROT_READ | PROT_WRITE,
-                                                                  MAP_PRIVATE | MAP_ANONYMOUS,
-                                                                  -1,
-                                                                  0));
-        if (loop == MAP_FAILED) {
-            write_str("Failed to mmap io_uring loop\n");
-            close(listen_fd);
-            return 1;
-        }
-        if (loop->init(0, listen_fd) < 0) {
-            write_str("Failed to init io_uring\n");
-            loop->shutdown();
-            munmap(loop, sizeof(EventLoop<IoUringBackend>));
-            close(listen_fd);
-            return 1;
-        }
-        loop->run();
-        loop->shutdown();
-        munmap(loop, sizeof(EventLoop<IoUringBackend>));
-    } else {
-        write_str("Backend: epoll\n");
-        auto* loop = static_cast<EventLoop<EpollBackend>*>(mmap(nullptr,
-                                                                sizeof(EventLoop<EpollBackend>),
-                                                                PROT_READ | PROT_WRITE,
-                                                                MAP_PRIVATE | MAP_ANONYMOUS,
-                                                                -1,
-                                                                0));
-        if (loop == MAP_FAILED) {
-            write_str("Failed to mmap epoll loop\n");
-            close(listen_fd);
-            return 1;
-        }
-        if (loop->init(0, listen_fd) < 0) {
-            write_str("Failed to init epoll\n");
-            loop->shutdown();
-            munmap(loop, sizeof(EventLoop<EpollBackend>));
-            close(listen_fd);
-            return 1;
-        }
-        loop->run();
-        loop->shutdown();
-        munmap(loop, sizeof(EventLoop<EpollBackend>));
+        return run_shards<IoUringBackend>(port, shard_count, pin_cpus);
     }
-
-    close(listen_fd);
-    return 0;
+    write_str("Backend: epoll\n");
+    return run_shards<EpollBackend>(port, shard_count, pin_cpus);
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -110,7 +110,12 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
     // Get actual port from first shard's socket
     struct sockaddr_in bound_addr;
     socklen_t addr_len = sizeof(bound_addr);
-    getsockname(shards[0].listen_fd, reinterpret_cast<struct sockaddr*>(&bound_addr), &addr_len);
+    if (getsockname(
+            shards[0].listen_fd, reinterpret_cast<struct sockaddr*>(&bound_addr), &addr_len) < 0) {
+        write_str("Failed to get bound address\n");
+        for (u32 j = 0; j < shard_count; j++) shards[j].shutdown();
+        return 1;
+    }
     port = __builtin_bswap16(bound_addr.sin_port);
 
     write_str("Listening on port ");

--- a/src/main.cc
+++ b/src/main.cc
@@ -55,13 +55,15 @@ static bool detect_io_uring() {
 // --- Signal handling for graceful shutdown ---
 
 // Store pointers to each shard's loop->running flag for signal handler.
-// Writing false to a bool is async-signal-safe.
+// Use atomic store for cross-thread + signal safety.
 static volatile bool* g_running_flags[kMaxShards];
-static u32 g_shard_count = 0;
+static volatile sig_atomic_t g_shard_count = 0;
 
 static void signal_handler(int /*sig*/) {
-    for (u32 i = 0; i < g_shard_count; i++) {
-        if (g_running_flags[i]) *g_running_flags[i] = false;
+    sig_atomic_t count = g_shard_count;
+    for (sig_atomic_t i = 0; i < count && i < static_cast<sig_atomic_t>(kMaxShards); i++) {
+        volatile bool* flag = g_running_flags[i];
+        if (flag) __atomic_store_n(flag, false, __ATOMIC_RELAXED);
     }
 }
 
@@ -119,7 +121,7 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
     for (u32 i = 0; i < shard_count; i++) {
         g_running_flags[i] = &shards[i].loop->running;
     }
-    g_shard_count = shard_count;
+    g_shard_count = static_cast<sig_atomic_t>(shard_count);
 
     // Install signal handlers for graceful shutdown
     struct sigaction sa;

--- a/src/main.cc
+++ b/src/main.cc
@@ -32,6 +32,15 @@ static void write_u32(u32 val) {
     for (i32 i = n - 1; i >= 0; i--) (void)write(1, &buf[i], 1);
 }
 
+static bool str_eq(const char* a, const char* b) {
+    while (*a && *b) {
+        if (*a != *b) return false;
+        a++;
+        b++;
+    }
+    return *a == *b;
+}
+
 static bool detect_io_uring() {
     struct io_uring_params params;
     memset(&params, 0, sizeof(params));
@@ -47,7 +56,7 @@ static bool detect_io_uring() {
 
 // Store pointers to each shard's loop->running flag for signal handler.
 // Writing false to a bool is async-signal-safe.
-static bool* g_running_flags[kMaxShards];
+static volatile bool* g_running_flags[kMaxShards];
 static u32 g_shard_count = 0;
 
 static void signal_handler(int /*sig*/) {
@@ -137,6 +146,11 @@ static i32 run_shards(u16 port, u32 shard_count, bool pin_cpus) {
 
     // Wait for all shard threads to finish (blocked by signal or stop)
     for (u32 i = 0; i < shard_count; i++) shards[i].join();
+
+    // Clear signal handler state before shutdown to prevent dangling pointer access
+    g_shard_count = 0;
+    for (u32 i = 0; i < shard_count; i++) g_running_flags[i] = nullptr;
+
     for (u32 i = 0; i < shard_count; i++) shards[i].shutdown();
 
     return 0;
@@ -156,15 +170,7 @@ int main(int argc, char** argv) {
         }
         // Check --shards
         if (i + 1 < argc) {
-            bool is_shards = true;
-            const char* expect = "--shards";
-            for (int k = 0; expect[k]; k++) {
-                if (argv[i][k] != expect[k]) {
-                    is_shards = false;
-                    break;
-                }
-            }
-            if (is_shards) {
+            if (str_eq(argv[i], "--shards")) {
                 i++;
                 shard_count = 0;
                 for (const char* p = argv[i]; *p >= '0' && *p <= '9'; p++)
@@ -172,15 +178,7 @@ int main(int argc, char** argv) {
             }
         }
         // Check --no-pin
-        bool is_nopin = true;
-        const char* expect_np = "--no-pin";
-        for (int k = 0; expect_np[k]; k++) {
-            if (argv[i][k] != expect_np[k]) {
-                is_nopin = false;
-                break;
-            }
-        }
-        if (is_nopin) pin_cpus = false;
+        if (str_eq(argv[i], "--no-pin")) pin_cpus = false;
     }
 
     if (shard_count == 0) shard_count = detect_cpu_count();

--- a/src/runtime/epoll_backend.cc
+++ b/src/runtime/epoll_backend.cc
@@ -65,8 +65,9 @@ core::Expected<void, Error> EpollBackend::init(u32 /*shard_id*/, i32 lfd) {
     ev.events = EPOLLIN;
     ev.data.u64 = encode_data(kTimerConnId, IoEventType::Timeout);
     if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, timer_fd, &ev) < 0) {
+        i32 err = errno;
         shutdown();
-        return core::make_unexpected(Error::from_errno(Error::Source::Epoll));
+        return core::make_unexpected(Error::make(err, Error::Source::Epoll));
     }
 
     return {};

--- a/src/runtime/epoll_backend.cc
+++ b/src/runtime/epoll_backend.cc
@@ -1,5 +1,9 @@
 #include "rout/runtime/epoll_backend.h"
 
+#include "rout/runtime/error.h"
+
+#include "core/expected.h"
+
 #include <errno.h>
 #include <string.h>  // memset
 #include <sys/epoll.h>
@@ -28,7 +32,7 @@ void EpollBackend::decode_data(u64 data, u32& conn_id, IoEventType& type) {
 
 // --- Init ---
 
-i32 EpollBackend::init(u32 /*shard_id*/, i32 lfd) {
+core::Expected<void, Error> EpollBackend::init(u32 /*shard_id*/, i32 lfd) {
     listen_fd = lfd;
     epoll_fd = -1;
     timer_fd = -1;
@@ -39,7 +43,7 @@ i32 EpollBackend::init(u32 /*shard_id*/, i32 lfd) {
     }
 
     epoll_fd = epoll_create1(EPOLL_CLOEXEC);
-    if (epoll_fd < 0) return -errno;
+    if (epoll_fd < 0) return core::make_unexpected(Error::from_errno(Error::Source::Epoll));
 
     // Create timerfd for 1-second ticks (drives timer wheel)
     timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
@@ -47,7 +51,7 @@ i32 EpollBackend::init(u32 /*shard_id*/, i32 lfd) {
         i32 err = errno;
         close(epoll_fd);
         epoll_fd = -1;
-        return -err;
+        return core::make_unexpected(Error::make(err, Error::Source::Timerfd));
     }
 
     struct itimerspec ts;
@@ -62,10 +66,10 @@ i32 EpollBackend::init(u32 /*shard_id*/, i32 lfd) {
     ev.data.u64 = encode_data(kTimerConnId, IoEventType::Timeout);
     if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, timer_fd, &ev) < 0) {
         shutdown();
-        return -errno;
+        return core::make_unexpected(Error::from_errno(Error::Source::Epoll));
     }
 
-    return 0;
+    return {};
 }
 
 // --- Operations ---

--- a/src/runtime/io_uring_backend.cc
+++ b/src/runtime/io_uring_backend.cc
@@ -120,7 +120,7 @@ core::Expected<void, Error> IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
     if (sq_ring_ptr == MAP_FAILED) {
         i32 err = errno;
         shutdown();
-        return core::make_unexpected(Error::make(err, Error::Source::IoUring));
+        return core::make_unexpected(Error::make(err, Error::Source::Mmap));
     }
 
     auto* sq_base = static_cast<u8*>(sq_ring_ptr);
@@ -140,7 +140,7 @@ core::Expected<void, Error> IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
     if (sqes_ptr == MAP_FAILED) {
         i32 err = errno;
         shutdown();
-        return core::make_unexpected(Error::make(err, Error::Source::IoUring));
+        return core::make_unexpected(Error::make(err, Error::Source::Mmap));
     }
     sq_entries = static_cast<io_uring_sqe*>(sqes_ptr);
 
@@ -155,7 +155,7 @@ core::Expected<void, Error> IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
     if (cq_ring_ptr == MAP_FAILED) {
         i32 err = errno;
         shutdown();
-        return core::make_unexpected(Error::make(err, Error::Source::IoUring));
+        return core::make_unexpected(Error::make(err, Error::Source::Mmap));
     }
 
     auto* cq_base = static_cast<u8*>(cq_ring_ptr);

--- a/src/runtime/io_uring_backend.cc
+++ b/src/runtime/io_uring_backend.cc
@@ -118,8 +118,9 @@ core::Expected<void, Error> IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
                        ring_fd,
                        IORING_OFF_SQ_RING);
     if (sq_ring_ptr == MAP_FAILED) {
+        i32 err = errno;
         shutdown();
-        return core::make_unexpected(Error::from_errno(Error::Source::IoUring));
+        return core::make_unexpected(Error::make(err, Error::Source::IoUring));
     }
 
     auto* sq_base = static_cast<u8*>(sq_ring_ptr);
@@ -137,8 +138,9 @@ core::Expected<void, Error> IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
                     ring_fd,
                     IORING_OFF_SQES);
     if (sqes_ptr == MAP_FAILED) {
+        i32 err = errno;
         shutdown();
-        return core::make_unexpected(Error::from_errno(Error::Source::IoUring));
+        return core::make_unexpected(Error::make(err, Error::Source::IoUring));
     }
     sq_entries = static_cast<io_uring_sqe*>(sqes_ptr);
 
@@ -151,8 +153,9 @@ core::Expected<void, Error> IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
                        ring_fd,
                        IORING_OFF_CQ_RING);
     if (cq_ring_ptr == MAP_FAILED) {
+        i32 err = errno;
         shutdown();
-        return core::make_unexpected(Error::from_errno(Error::Source::IoUring));
+        return core::make_unexpected(Error::make(err, Error::Source::IoUring));
     }
 
     auto* cq_base = static_cast<u8*>(cq_ring_ptr);
@@ -199,8 +202,9 @@ core::Expected<void, Error> IoUringBackend::setup_buf_ring() {
                                      -1,
                                      0));
     if (buf_base == MAP_FAILED) {
+        i32 err = errno;
         shutdown();
-        return core::make_unexpected(Error::from_errno(Error::Source::Mmap));
+        return core::make_unexpected(Error::make(err, Error::Source::Mmap));
     }
 
     // Allocate the buf_ring structure itself
@@ -212,8 +216,9 @@ core::Expected<void, Error> IoUringBackend::setup_buf_ring() {
                           -1,
                           0);
     if (ring_mem == MAP_FAILED) {
+        i32 err = errno;
         shutdown();
-        return core::make_unexpected(Error::from_errno(Error::Source::Mmap));
+        return core::make_unexpected(Error::make(err, Error::Source::Mmap));
     }
     buf_ring = static_cast<io_uring_buf_ring*>(ring_mem);
 

--- a/src/runtime/io_uring_backend.cc
+++ b/src/runtime/io_uring_backend.cc
@@ -1,6 +1,9 @@
 #include "rout/runtime/io_uring_backend.h"
 
 #include "rout/runtime/connection.h"
+#include "rout/runtime/error.h"
+
+#include "core/expected.h"
 
 #include <errno.h>
 #include <linux/io_uring.h>
@@ -82,7 +85,7 @@ static void sqe_advance_tail(u32* sq_tail) {
 
 // --- Init ---
 
-i32 IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
+core::Expected<void, Error> IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
     listen_fd = lfd;
     // Explicitly init fds to -1: mmap-zeroed memory skips default member initializers,
     // so timer_fd/ring_fd could be 0. If init fails early and calls shutdown(), closing
@@ -101,7 +104,7 @@ i32 IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
 
     constexpr u32 kRingEntries = 16384;
     ring_fd = io_uring_setup(kRingEntries, &params);
-    if (ring_fd < 0) return ring_fd;
+    if (ring_fd < 0) return core::make_unexpected(Error::make(-ring_fd, Error::Source::IoUring));
 
     sq_ring_entries = params.sq_entries;
     cq_ring_entries = params.cq_entries;
@@ -116,7 +119,7 @@ i32 IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
                        IORING_OFF_SQ_RING);
     if (sq_ring_ptr == MAP_FAILED) {
         shutdown();
-        return -errno;
+        return core::make_unexpected(Error::from_errno(Error::Source::IoUring));
     }
 
     auto* sq_base = static_cast<u8*>(sq_ring_ptr);
@@ -135,7 +138,7 @@ i32 IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
                     IORING_OFF_SQES);
     if (sqes_ptr == MAP_FAILED) {
         shutdown();
-        return -errno;
+        return core::make_unexpected(Error::from_errno(Error::Source::IoUring));
     }
     sq_entries = static_cast<io_uring_sqe*>(sqes_ptr);
 
@@ -149,7 +152,7 @@ i32 IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
                        IORING_OFF_CQ_RING);
     if (cq_ring_ptr == MAP_FAILED) {
         shutdown();
-        return -errno;
+        return core::make_unexpected(Error::from_errno(Error::Source::IoUring));
     }
 
     auto* cq_base = static_cast<u8*>(cq_ring_ptr);
@@ -159,15 +162,14 @@ i32 IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
     cq_entries = reinterpret_cast<io_uring_cqe*>(cq_base + params.cq_off.cqes);
 
     // Setup provided buffer ring for zero-copy recv
-    i32 rc = setup_buf_ring();
-    if (rc < 0) return rc;
+    TRY_VOID(setup_buf_ring());
 
     // Create timerfd for 1-second ticks (drives timer wheel)
     timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
     if (timer_fd < 0) {
         i32 err = errno;
         shutdown();
-        return -err;
+        return core::make_unexpected(Error::make(err, Error::Source::Timerfd));
     }
     struct itimerspec ts;
     memset(&ts, 0, sizeof(ts));
@@ -176,18 +178,18 @@ i32 IoUringBackend::init(u32 /*shard_id*/, i32 lfd) {
     if (timerfd_settime(timer_fd, 0, &ts, nullptr) < 0) {
         i32 err = errno;
         shutdown();
-        return -err;
+        return core::make_unexpected(Error::make(err, Error::Source::Timerfd));
     }
 
     // Submit initial read on timerfd
     submit_timer_read();
 
-    return 0;
+    return {};
 }
 
 // --- Provided buffer ring ---
 
-i32 IoUringBackend::setup_buf_ring() {
+core::Expected<void, Error> IoUringBackend::setup_buf_ring() {
     // Allocate buffer memory: kProvidedBufCount * kProvidedBufSize
     u64 total_buf_sz = static_cast<u64>(kProvidedBufCount) * kProvidedBufSize;
     buf_base = static_cast<u8*>(mmap(nullptr,
@@ -198,7 +200,7 @@ i32 IoUringBackend::setup_buf_ring() {
                                      0));
     if (buf_base == MAP_FAILED) {
         shutdown();
-        return -errno;
+        return core::make_unexpected(Error::from_errno(Error::Source::Mmap));
     }
 
     // Allocate the buf_ring structure itself
@@ -211,7 +213,7 @@ i32 IoUringBackend::setup_buf_ring() {
                           0);
     if (ring_mem == MAP_FAILED) {
         shutdown();
-        return -errno;
+        return core::make_unexpected(Error::from_errno(Error::Source::Mmap));
     }
     buf_ring = static_cast<io_uring_buf_ring*>(ring_mem);
 
@@ -225,7 +227,7 @@ i32 IoUringBackend::setup_buf_ring() {
     i32 rc = io_uring_register(ring_fd, IORING_REGISTER_PBUF_RING, &reg, 1);
     if (rc < 0) {
         shutdown();
-        return rc;
+        return core::make_unexpected(Error::make(-rc, Error::Source::IoUring));
     }
 
     // Fill the ring with buffer entries
@@ -238,7 +240,7 @@ i32 IoUringBackend::setup_buf_ring() {
     // Advance the ring tail to make all buffers available
     __atomic_store_n(&buf_ring->tail, static_cast<u16>(kProvidedBufCount), __ATOMIC_RELEASE);
 
-    return 0;
+    return {};
 }
 
 void IoUringBackend::return_buffer(u16 buf_id) {

--- a/src/runtime/shard.cc
+++ b/src/runtime/shard.cc
@@ -1,7 +1,11 @@
+// Shard implementation — template instantiations live in shard.h (header-only).
+// This file is kept for future non-template shard utilities.
+
 #include "rout/runtime/shard.h"
 
 namespace rout {
 
-// Shard implementation — Phase 1 stub
+// Explicit template instantiations are not needed since Shard<Backend>
+// is fully defined in the header and instantiated in main.cc.
 
 }  // namespace rout

--- a/src/runtime/socket.cc
+++ b/src/runtime/socket.cc
@@ -17,9 +17,9 @@ i32 set_nonblocking(i32 fd) {
     return 0;
 }
 
-i32 create_listen_socket(u16 port) {
+core::Expected<i32, Error> create_listen_socket(u16 port) {
     i32 fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
-    if (fd < 0) return -errno;
+    if (fd < 0) return core::make_unexpected(Error::from_errno(Error::Source::Socket));
 
     i32 one = 1;
     setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
@@ -33,15 +33,15 @@ i32 create_listen_socket(u16 port) {
     addr.sin_addr.s_addr = 0;                 // INADDR_ANY
 
     if (bind(fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0) {
-        i32 err = errno;
+        auto err = Error::from_errno(Error::Source::Socket);
         close(fd);
-        return -err;
+        return core::make_unexpected(err);
     }
 
     if (listen(fd, 4096) < 0) {
-        i32 err = errno;
+        auto err = Error::from_errno(Error::Source::Socket);
         close(fd);
-        return -err;
+        return core::make_unexpected(err);
     }
 
     return fd;

--- a/tests/mock_backend.h
+++ b/tests/mock_backend.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "rout/common/types.h"
+#include "rout/runtime/error.h"
 #include "rout/runtime/io_event.h"
+
+#include "core/expected.h"
 
 namespace rout {
 
@@ -31,10 +34,10 @@ struct MockBackend {
     IoEvent pending[kMaxEvents];
     u32 pending_count = 0;
 
-    i32 init(u32 /*shard_id*/, i32 /*listen_fd*/) {
+    core::Expected<void, Error> init(u32 /*shard_id*/, i32 /*listen_fd*/) {
         op_count = 0;
         pending_count = 0;
-        return 0;
+        return {};
     }
 
     void add_accept() {

--- a/tests/test_arena.cc
+++ b/tests/test_arena.cc
@@ -13,7 +13,7 @@ using namespace rout;
 
 TEST(block, data_starts_after_header) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     auto* b = a.current;
     u64 hdr = (sizeof(Arena::Block) + 15) & ~u64(15);
     u8* expected = reinterpret_cast<u8*>(b) + hdr;
@@ -23,7 +23,7 @@ TEST(block, data_starts_after_header) {
 
 TEST(block, capacity_equals_size_minus_header) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     auto* b = a.current;
     u64 hdr = (sizeof(Arena::Block) + 15) & ~u64(15);
     CHECK_EQ(b->capacity(), b->size - hdr);
@@ -32,7 +32,7 @@ TEST(block, capacity_equals_size_minus_header) {
 
 TEST(block, remaining_decreases_after_alloc) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     u64 r0 = a.current->remaining();
     a.alloc(100);
     u64 r1 = a.current->remaining();
@@ -42,7 +42,7 @@ TEST(block, remaining_decreases_after_alloc) {
 
 TEST(block, chain_integrity) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     Arena::Block* first = a.current;
     CHECK(first->prev == nullptr);
 
@@ -59,7 +59,7 @@ TEST(block, chain_integrity) {
 
 TEST(block, three_block_chain) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     Arena::Block* b0 = a.current;
 
     // Force 3 blocks by allocating more than one block can hold each time
@@ -84,7 +84,7 @@ TEST(block, three_block_chain) {
 
 TEST(arena, init_succeeds) {
     Arena a;
-    CHECK_EQ(a.init(4096), 0);
+    CHECK(a.init(4096).has_value());
     CHECK(a.current != nullptr);
     CHECK_GT(a.space_allocated(), 0u);
     a.destroy();
@@ -92,14 +92,14 @@ TEST(arena, init_succeeds) {
 
 TEST(arena, init_min_256) {
     Arena a;
-    REQUIRE_EQ(a.init(1), 0);
+    REQUIRE(a.init(1).has_value());
     CHECK_GE(a.current->size, 256u);
     a.destroy();
 }
 
 TEST(arena, small_alloc) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     void* p = a.alloc(64);
     CHECK(p != nullptr);
     CHECK_EQ(a.space_used(), 64u);
@@ -108,7 +108,7 @@ TEST(arena, small_alloc) {
 
 TEST(arena, alloc_returns_sequential_addresses) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     u8* p1 = static_cast<u8*>(a.alloc(16));
     u8* p2 = static_cast<u8*>(a.alloc(32));
     u8* p3 = static_cast<u8*>(a.alloc(8));
@@ -119,7 +119,7 @@ TEST(arena, alloc_returns_sequential_addresses) {
 
 TEST(arena, multiple_allocs_in_one_block) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     void* p1 = a.alloc(100);
     void* p2 = a.alloc(200);
     void* p3 = a.alloc(300);
@@ -137,7 +137,7 @@ TEST(arena, multiple_allocs_in_one_block) {
 
 TEST(arena, alignment_8byte) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     void* p1 = a.alloc(1);
     void* p2 = a.alloc(1);
     CHECK_EQ(reinterpret_cast<u64>(p1) % 8, 0u);
@@ -148,7 +148,7 @@ TEST(arena, alignment_8byte) {
 
 TEST(arena, alignment_various_sizes) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     for (u64 sz = 1; sz <= 64; sz++) {
         void* p = a.alloc(sz);
         CHECK_EQ(reinterpret_cast<u64>(p) % 8, 0u);
@@ -158,7 +158,7 @@ TEST(arena, alignment_various_sizes) {
 
 TEST(arena, zero_size_alloc) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     void* p = a.alloc(0);
     CHECK(p != nullptr);
     a.destroy();
@@ -170,7 +170,7 @@ TEST(arena, zero_size_alloc) {
 
 TEST(arena, overflow_to_new_block) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     u64 cap = a.current->capacity();
     a.alloc(cap);
     a.alloc(64);
@@ -181,7 +181,7 @@ TEST(arena, overflow_to_new_block) {
 
 TEST(arena, large_alloc_gets_own_block) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     void* p = a.alloc(1024);
     CHECK(p != nullptr);
     CHECK_GE(a.current->size, 1024u + sizeof(Arena::Block));
@@ -190,7 +190,7 @@ TEST(arena, large_alloc_gets_own_block) {
 
 TEST(arena, many_blocks) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     for (int i = 0; i < 100; i++) CHECK(a.alloc(200) != nullptr);
     int blocks = 0;
     for (Arena::Block* b = a.current; b; b = b->prev) blocks++;
@@ -200,7 +200,7 @@ TEST(arena, many_blocks) {
 
 TEST(arena, alloc_exact_block_capacity) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     u64 cap = a.current->capacity();
     u64 aligned_cap = cap & ~static_cast<u64>(7);
     void* p = a.alloc(aligned_cap);
@@ -215,7 +215,7 @@ TEST(arena, alloc_exact_block_capacity) {
 
 TEST(arena, reset_single_block_only) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     Arena::Block* first = a.current;
     a.alloc(100);
     a.alloc(200);
@@ -229,7 +229,7 @@ TEST(arena, reset_single_block_only) {
 
 TEST(arena, reset_reuses_first_block) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     Arena::Block* first = a.current;
     a.alloc(100);
     a.reset();
@@ -242,7 +242,7 @@ TEST(arena, reset_reuses_first_block) {
 
 TEST(arena, reset_frees_extra_blocks) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     u64 initial = a.space_allocated();
     for (int i = 0; i < 10; i++) a.alloc(4000);
     CHECK_GT(a.space_allocated(), initial);
@@ -254,7 +254,7 @@ TEST(arena, reset_frees_extra_blocks) {
 
 TEST(arena, reset_total_allocated_tracking) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     u64 initial = a.space_allocated();
     // Create 3 extra blocks
     for (int i = 0; i < 3; i++) {
@@ -270,7 +270,7 @@ TEST(arena, reset_total_allocated_tracking) {
 
 TEST(arena, reset_then_alloc_10_cycles) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     for (int cycle = 0; cycle < 10; cycle++) {
         for (int i = 0; i < 20; i++) CHECK(a.alloc(100) != nullptr);
         a.reset();
@@ -289,7 +289,7 @@ struct Point {
 
 TEST(arena, alloc_t_pod) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     auto* p = a.alloc_t<Point>(10, 20);
     CHECK(p != nullptr);
     CHECK_EQ(p->x, 10);
@@ -304,7 +304,7 @@ struct Counter {
 
 TEST(arena, alloc_t_with_constructor) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     auto* c = a.alloc_t<Counter>();
     CHECK(c != nullptr);
     CHECK_EQ(c->value, 42);
@@ -317,7 +317,7 @@ struct Large {
 
 TEST(arena, alloc_t_large_struct) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     auto* l = a.alloc_t<Large>();
     CHECK(l != nullptr);
     // Write pattern and verify
@@ -328,7 +328,7 @@ TEST(arena, alloc_t_large_struct) {
 
 TEST(arena, alloc_t_multiple_types) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     auto* p = a.alloc_t<Point>(1, 2);
     auto* c = a.alloc_t<Counter>();
     auto* l = a.alloc_t<Large>();
@@ -340,7 +340,7 @@ TEST(arena, alloc_t_multiple_types) {
 
 TEST(arena, alloc_array_int) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     auto* arr = a.alloc_array<i32>(10);
     CHECK(arr != nullptr);
     for (int i = 0; i < 10; i++) CHECK_EQ(arr[i], 0);
@@ -351,7 +351,7 @@ TEST(arena, alloc_array_int) {
 
 TEST(arena, alloc_array_struct) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     auto* arr = a.alloc_array<Point>(5);
     CHECK(arr != nullptr);
     for (int i = 0; i < 5; i++) {
@@ -363,7 +363,7 @@ TEST(arena, alloc_array_struct) {
 
 TEST(arena, alloc_array_zero_count) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     auto* arr = a.alloc_array<i32>(0);
     CHECK(arr != nullptr);  // zero-count returns valid pointer
     a.destroy();
@@ -375,7 +375,7 @@ TEST(arena, alloc_array_zero_count) {
 
 TEST(arena, destroy_frees_all) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     for (int i = 0; i < 20; i++) a.alloc(200);
     a.destroy();
     CHECK(a.current == nullptr);
@@ -384,7 +384,7 @@ TEST(arena, destroy_frees_all) {
 
 TEST(arena, double_destroy_safe) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     a.alloc(100);
     a.destroy();
     a.destroy();
@@ -393,7 +393,7 @@ TEST(arena, double_destroy_safe) {
 
 TEST(arena, destroy_single_block) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     a.alloc(64);
     a.destroy();
     CHECK(a.current == nullptr);
@@ -406,7 +406,7 @@ TEST(arena, destroy_single_block) {
 
 TEST(arena, space_used_single_block) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     a.alloc(100);  // → 104
     a.alloc(8);
     CHECK_EQ(a.space_used(), 104u + 8u);
@@ -415,7 +415,7 @@ TEST(arena, space_used_single_block) {
 
 TEST(arena, space_used_across_blocks) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     u64 cap = a.current->capacity();
     a.alloc(cap);  // fill first block
     a.alloc(64);   // second block
@@ -426,7 +426,7 @@ TEST(arena, space_used_across_blocks) {
 
 TEST(arena, space_allocated_grows_with_blocks) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     u64 a0 = a.space_allocated();
     a.alloc(a.current->capacity());
     a.alloc(64);
@@ -437,7 +437,7 @@ TEST(arena, space_allocated_grows_with_blocks) {
 
 TEST(arena, space_used_zero_after_reset) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     a.alloc(500);
     CHECK_GT(a.space_used(), 0u);
     a.reset();
@@ -451,7 +451,7 @@ TEST(arena, space_used_zero_after_reset) {
 
 TEST(arena, stress_10k_small_allocs) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     for (int i = 0; i < 10000; i++) CHECK(a.alloc(8) != nullptr);
     CHECK_EQ(a.space_used(), 80000u);
     a.destroy();
@@ -459,7 +459,7 @@ TEST(arena, stress_10k_small_allocs) {
 
 TEST(arena, stress_mixed_sizes) {
     Arena a;
-    REQUIRE_EQ(a.init(1024), 0);
+    REQUIRE(a.init(1024).has_value());
     for (int i = 0; i < 1000; i++) {
         u64 sz = static_cast<u64>((i % 7 + 1) * 8);  // 8,16,24,32,40,48,56
         CHECK(a.alloc(sz) != nullptr);
@@ -469,7 +469,7 @@ TEST(arena, stress_mixed_sizes) {
 
 TEST(arena, stress_alloc_reset_1000_cycles) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     for (int cycle = 0; cycle < 1000; cycle++) {
         a.alloc(128);
         a.alloc(256);
@@ -482,7 +482,7 @@ TEST(arena, stress_alloc_reset_1000_cycles) {
 
 TEST(arena, stress_large_allocs_across_blocks) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     // Each alloc forces a new block
     for (int i = 0; i < 50; i++) CHECK(a.alloc(4000) != nullptr);
     int blocks = 0;
@@ -493,7 +493,7 @@ TEST(arena, stress_large_allocs_across_blocks) {
 
 TEST(arena, stress_reset_preserves_first_block_across_cycles) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     Arena::Block* first = a.current;
     for (int cycle = 0; cycle < 100; cycle++) {
         for (int i = 0; i < 10; i++) a.alloc(100);
@@ -509,7 +509,7 @@ TEST(arena, stress_reset_preserves_first_block_across_cycles) {
 
 TEST(arena, data_integrity_after_alloc) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     auto* buf = static_cast<u8*>(a.alloc(256));
     REQUIRE(buf != nullptr);
     for (int i = 0; i < 256; i++) buf[i] = static_cast<u8>(i);
@@ -519,7 +519,7 @@ TEST(arena, data_integrity_after_alloc) {
 
 TEST(arena, data_integrity_across_blocks) {
     Arena a;
-    REQUIRE_EQ(a.init(256), 0);
+    REQUIRE(a.init(256).has_value());
     // Fill first block, force second
     u64 cap = a.current->capacity();
     auto* buf1 = static_cast<u8*>(a.alloc(cap));
@@ -548,7 +548,7 @@ TEST(arena, alloc_before_init_returns_null) {
 // alloc() after destroy (current==nullptr) must return nullptr.
 TEST(arena, alloc_after_destroy_returns_null) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     a.destroy();
     CHECK(a.alloc(64) == nullptr);
 }
@@ -556,7 +556,7 @@ TEST(arena, alloc_after_destroy_returns_null) {
 // reset() after destroy (current==nullptr) must not crash.
 TEST(arena, reset_after_destroy_no_crash) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     a.destroy();
     a.reset();  // must be a no-op, not a crash
     CHECK(a.current == nullptr);

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -239,13 +239,14 @@ struct TestServer {
     bool setup(i32 iters) {
         loop = create_real_loop();
         if (!loop) return false;
-        listen_fd = create_listen_socket(0);
-        if (listen_fd < 0) {
+        auto lfd_result = create_listen_socket(0);
+        if (!lfd_result) {
             destroy_real_loop(loop);
             return false;
         }
+        listen_fd = lfd_result.value();
         port = get_port(listen_fd);
-        if (loop->init(0, listen_fd) < 0) {
+        if (!loop->init(0, listen_fd)) {
             close(listen_fd);
             destroy_real_loop(loop);
             return false;

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -216,7 +216,7 @@ struct LoopThread {
         lp->backend.add_accept();
         IoEvent events[256];
         i32 iters = 0;
-        while (lp->running) {
+        while (lp->is_running()) {
             u32 n = lp->backend.wait(events, 256, lp->conns, RealLoop::kMaxConns);
             for (u32 i = 0; i < n; i++) lp->dispatch(events[i]);
             if (++iters >= lt->max_iters) break;
@@ -225,7 +225,7 @@ struct LoopThread {
     }
     void start() { pthread_create(&thread, nullptr, run, this); }
     void stop() {
-        loop->running = false;
+        loop->stop();
         pthread_join(thread, nullptr);
     }
 };

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -152,11 +152,15 @@ using RealLoop = EventLoop<EpollBackend>;
 inline RealLoop* create_real_loop() {
     void* p =
         mmap(nullptr, sizeof(RealLoop), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    return p == MAP_FAILED ? nullptr : static_cast<RealLoop*>(p);
+    if (p == MAP_FAILED) return nullptr;
+    return new (p) RealLoop();
 }
 
 inline void destroy_real_loop(RealLoop* l) {
-    if (l) munmap(l, sizeof(RealLoop));
+    if (l) {
+        l->~RealLoop();
+        munmap(l, sizeof(RealLoop));
+    }
 }
 
 inline u16 get_port(i32 fd) {

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -8,14 +8,14 @@
 // === Socket Setup (libuv: test-tcp-bind-error, test-tcp-flags, test-tcp-reuseport) ===
 
 TEST(socket, nonblocking) {
-    i32 fd = create_listen_socket(0);
+    i32 fd = create_listen_socket(0).value_or(-1);
     REQUIRE(fd >= 0);
     CHECK(fcntl(fd, F_GETFL, 0) & O_NONBLOCK);
     close(fd);
 }
 
 TEST(socket, reuseport) {
-    i32 fd = create_listen_socket(0);
+    i32 fd = create_listen_socket(0).value_or(-1);
     REQUIRE(fd >= 0);
     i32 val = 0;
     socklen_t len = sizeof(val);
@@ -25,7 +25,7 @@ TEST(socket, reuseport) {
 }
 
 TEST(socket, nodelay) {
-    i32 fd = create_listen_socket(0);
+    i32 fd = create_listen_socket(0).value_or(-1);
     REQUIRE(fd >= 0);
     i32 val = 0;
     socklen_t len = sizeof(val);
@@ -35,9 +35,9 @@ TEST(socket, nodelay) {
 }
 
 TEST(socket, two_listeners_same_port) {
-    i32 fd1 = create_listen_socket(0);
+    i32 fd1 = create_listen_socket(0).value_or(-1);
     REQUIRE(fd1 >= 0);
-    i32 fd2 = create_listen_socket(get_port(fd1));
+    i32 fd2 = create_listen_socket(get_port(fd1)).value_or(-1);
     CHECK(fd2 >= 0);
     if (fd2 >= 0) close(fd2);
     close(fd1);
@@ -71,7 +71,7 @@ TEST(socket, double_bind_error) {
 }
 
 TEST(socket, double_listen_ok) {
-    i32 fd = create_listen_socket(0);
+    i32 fd = create_listen_socket(0).value_or(-1);
     REQUIRE(fd >= 0);
     CHECK_EQ(listen(fd, 4096), 0);
     close(fd);
@@ -290,7 +290,7 @@ TEST(error, server_shutdown_with_clients) {
 }
 
 TEST(error, double_close_no_crash) {
-    i32 fd = create_listen_socket(0);
+    i32 fd = create_listen_socket(0).value_or(-1);
     REQUIRE(fd >= 0);
     close(fd);
     CHECK(close(fd) < 0);
@@ -350,9 +350,9 @@ TEST(loop, stop_from_outside) {
 TEST(partial_send, state_initialized) {
     auto* loop = create_real_loop();
     REQUIRE(loop != nullptr);
-    i32 fd = create_listen_socket(0);
+    i32 fd = create_listen_socket(0).value_or(-1);
     REQUIRE(fd >= 0);
-    REQUIRE_EQ(loop->init(0, fd), 0);
+    REQUIRE(loop->init(0, fd).has_value());
     // EpollBackend send_state should be zero-initialized
     for (u32 i = 0; i < EpollBackend::kMaxFdMap; i++) {
         CHECK_EQ(loop->backend.send_state[i].remaining, 0u);
@@ -381,7 +381,7 @@ TEST(partial_send, real_epollout_completion) {
     // Use init() so timerfd is created — gives wait() a bounded 1-second wakeup
     // to prevent indefinite hangs if EPOLLOUT doesn't fire immediately.
     EpollBackend backend;
-    REQUIRE_EQ(backend.init(0, -1), 0);
+    REQUIRE(backend.init(0, -1).has_value());
     backend.fd_map[0] = fds[0];
 
     Connection conn;
@@ -448,7 +448,7 @@ TEST(partial_send, socketpair_full_send) {
     REQUIRE_EQ(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fds), 0);
 
     EpollBackend backend;
-    REQUIRE_EQ(backend.init(0, -1), 0);
+    REQUIRE(backend.init(0, -1).has_value());
     backend.fd_map[0] = fds[0];
 
     Connection conn;
@@ -492,7 +492,7 @@ TEST(partial_send, send_to_closed_peer) {
     close(fds[1]);
 
     EpollBackend backend;
-    REQUIRE_EQ(backend.init(0, -1), 0);
+    REQUIRE(backend.init(0, -1).has_value());
 
     Connection conn;
     conn.reset();
@@ -522,7 +522,7 @@ TEST(partial_send, send_to_closed_peer) {
 // Verify send_state is zeroed per connection after init
 TEST(partial_send, state_zeroed_per_conn) {
     EpollBackend backend;
-    REQUIRE_EQ(backend.init(0, -1), 0);
+    REQUIRE(backend.init(0, -1).has_value());
     // Spot check several entries
     CHECK_EQ(backend.send_state[0].offset, 0u);
     CHECK_EQ(backend.send_state[0].remaining, 0u);
@@ -539,7 +539,7 @@ TEST(partial_send, epollout_no_pending_switches_to_epollin) {
     REQUIRE_EQ(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fds), 0);
 
     EpollBackend backend;
-    REQUIRE_EQ(backend.init(0, -1), 0);
+    REQUIRE(backend.init(0, -1).has_value());
     backend.fd_map[0] = fds[0];
 
     Connection conn;
@@ -593,10 +593,10 @@ TEST(partial_send, epollout_no_pending_switches_to_epollin) {
 TEST(uring, init_creates_timerfd) {
     // io_uring requires Linux 6.0+. If init fails, skip gracefully.
     IoUringBackend backend;
-    i32 lfd = create_listen_socket(0);
+    i32 lfd = create_listen_socket(0).value_or(-1);
     REQUIRE(lfd >= 0);
-    i32 rc = backend.init(0, lfd);
-    if (rc < 0) {
+    auto rc = backend.init(0, lfd);
+    if (!rc) {
         // io_uring not available — skip
         close(lfd);
         CHECK(true);
@@ -610,10 +610,10 @@ TEST(uring, init_creates_timerfd) {
 // Verify return_buffer doesn't crash (ring structure test)
 TEST(uring, return_buffer_no_crash) {
     IoUringBackend backend;
-    i32 lfd = create_listen_socket(0);
+    i32 lfd = create_listen_socket(0).value_or(-1);
     REQUIRE(lfd >= 0);
-    i32 rc = backend.init(0, lfd);
-    if (rc < 0) {
+    auto rc = backend.init(0, lfd);
+    if (!rc) {
         close(lfd);
         CHECK(true);
         return;
@@ -631,9 +631,9 @@ TEST(uring, return_buffer_no_crash) {
 // Shard init + shutdown without spawning a thread
 TEST(shard, init_shutdown) {
     Shard<EpollBackend> shard;
-    i32 lfd = create_listen_socket(0);
+    i32 lfd = create_listen_socket(0).value_or(-1);
     REQUIRE(lfd >= 0);
-    REQUIRE_EQ(shard.init(0, lfd), 0);
+    REQUIRE(shard.init(0, lfd).has_value());
     CHECK(shard.loop != nullptr);
     CHECK_EQ(shard.id, 0u);
     CHECK_EQ(shard.listen_fd, lfd);
@@ -645,10 +645,10 @@ TEST(shard, init_shutdown) {
 // Shard spawn + stop + join
 TEST(shard, spawn_stop_join) {
     Shard<EpollBackend> shard;
-    i32 lfd = create_listen_socket(0);
+    i32 lfd = create_listen_socket(0).value_or(-1);
     REQUIRE(lfd >= 0);
-    REQUIRE_EQ(shard.init(0, lfd), 0);
-    REQUIRE_EQ(shard.spawn(-1), 0);  // no CPU pinning
+    REQUIRE(shard.init(0, lfd).has_value());
+    REQUIRE(shard.spawn(-1).has_value());  // no CPU pinning
     CHECK(shard.thread_spawned);
 
     // Let the shard run briefly, then stop
@@ -663,11 +663,11 @@ TEST(shard, spawn_stop_join) {
 // Shard handles requests while running
 TEST(shard, serves_requests) {
     Shard<EpollBackend> shard;
-    i32 lfd = create_listen_socket(0);
+    i32 lfd = create_listen_socket(0).value_or(-1);
     REQUIRE(lfd >= 0);
     u16 port = get_port(lfd);
-    REQUIRE_EQ(shard.init(0, lfd), 0);
-    REQUIRE_EQ(shard.spawn(-1), 0);
+    REQUIRE(shard.init(0, lfd).has_value());
+    REQUIRE(shard.spawn(-1).has_value());
 
     usleep(50000);  // let shard start
     i32 c = connect_to(port);
@@ -687,17 +687,17 @@ TEST(shard, serves_requests) {
 
 // Two shards on same port (SO_REUSEPORT)
 TEST(shard, two_shards_same_port) {
-    i32 lfd1 = create_listen_socket(0);
+    i32 lfd1 = create_listen_socket(0).value_or(-1);
     REQUIRE(lfd1 >= 0);
     u16 port = get_port(lfd1);
-    i32 lfd2 = create_listen_socket(port);
+    i32 lfd2 = create_listen_socket(port).value_or(-1);
     REQUIRE(lfd2 >= 0);
 
     Shard<EpollBackend> s1, s2;
-    REQUIRE_EQ(s1.init(0, lfd1), 0);
-    REQUIRE_EQ(s2.init(1, lfd2), 0);
-    REQUIRE_EQ(s1.spawn(-1), 0);
-    REQUIRE_EQ(s2.spawn(-1), 0);
+    REQUIRE(s1.init(0, lfd1).has_value());
+    REQUIRE(s2.init(1, lfd2).has_value());
+    REQUIRE(s1.spawn(-1).has_value());
+    REQUIRE(s2.spawn(-1).has_value());
 
     usleep(50000);
 
@@ -732,9 +732,9 @@ TEST(shard, detect_cpu_count) {
 // Shard with owns_listen_fd closes it on shutdown
 TEST(shard, owns_listen_fd) {
     Shard<EpollBackend> shard;
-    i32 lfd = create_listen_socket(0);
+    i32 lfd = create_listen_socket(0).value_or(-1);
     REQUIRE(lfd >= 0);
-    REQUIRE_EQ(shard.init(0, lfd), 0);
+    REQUIRE(shard.init(0, lfd).has_value());
     shard.owns_listen_fd = true;
     shard.shutdown();
     // lfd should be closed now — verify by trying to close again
@@ -744,9 +744,9 @@ TEST(shard, owns_listen_fd) {
 // Shard has upstream pool after init
 TEST(shard, upstream_pool_initialized) {
     Shard<EpollBackend> shard;
-    i32 lfd = create_listen_socket(0);
+    i32 lfd = create_listen_socket(0).value_or(-1);
     REQUIRE(lfd >= 0);
-    REQUIRE_EQ(shard.init(0, lfd), 0);
+    REQUIRE(shard.init(0, lfd).has_value());
     CHECK(shard.upstream != nullptr);
     // Pool should be fresh (all free)
     auto* c = shard.upstream->alloc();
@@ -764,9 +764,9 @@ TEST(shard, route_config_attached) {
     cfg.add_proxy("/api/", 0, 0);
 
     Shard<EpollBackend> shard;
-    i32 lfd = create_listen_socket(0);
+    i32 lfd = create_listen_socket(0).value_or(-1);
     REQUIRE(lfd >= 0);
-    REQUIRE_EQ(shard.init(0, lfd), 0);
+    REQUIRE(shard.init(0, lfd).has_value());
     shard.route_config = &cfg;
     CHECK(shard.route_config != nullptr);
     CHECK_EQ(shard.route_config->route_count, 2u);
@@ -816,14 +816,14 @@ TEST(copilot, keepalive_20_cycles_eexist_regression) {
 // Regression: listen_fd must be closeable after server teardown.
 // Proves the fd isn't leaked or double-closed.
 TEST(copilot6, listen_fd_not_leaked) {
-    i32 fd1 = create_listen_socket(0);
+    i32 fd1 = create_listen_socket(0).value_or(-1);
     REQUIRE(fd1 >= 0);
     u16 port = get_port(fd1);
 
     // Use the fd in a server, tear it down
     auto* loop = create_real_loop();
     REQUIRE(loop != nullptr);
-    REQUIRE_EQ(loop->init(0, fd1), 0);
+    REQUIRE(loop->init(0, fd1).has_value());
     // Don't run the loop, just init + shutdown
     loop->shutdown();
     destroy_real_loop(loop);
@@ -833,7 +833,7 @@ TEST(copilot6, listen_fd_not_leaked) {
     CHECK_EQ(close(fd1), 0);
 
     // Now the port should be reusable
-    i32 fd2 = create_listen_socket(port);
+    i32 fd2 = create_listen_socket(port).value_or(-1);
     CHECK(fd2 >= 0);
     if (fd2 >= 0) close(fd2);
 }
@@ -843,9 +843,9 @@ TEST(copilot6, listen_fd_not_leaked) {
 TEST(copilot6, real_loop_keepalive_timeout) {
     auto* loop = create_real_loop();
     REQUIRE(loop != nullptr);
-    i32 fd = create_listen_socket(0);
+    i32 fd = create_listen_socket(0).value_or(-1);
     REQUIRE(fd >= 0);
-    REQUIRE_EQ(loop->init(0, fd), 0);
+    REQUIRE(loop->init(0, fd).has_value());
     CHECK_EQ(loop->keepalive_timeout, 60u);
     loop->shutdown();
     close(fd);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -338,7 +338,7 @@ TEST(loop, stop_from_outside) {
     send_all(c, HTTP_REQ, HTTP_REQ_LEN);
     char buf[4096];
     recv_timeout(c, buf, sizeof(buf), 1000);
-    srv.loop->running = false;
+    srv.loop->stop();
     close(c);
     srv.teardown();
 }

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1,5 +1,6 @@
 // Real-socket integration tests. Ported from libuv/libevent2 scenarios.
 #include "rout/runtime/io_uring_backend.h"
+#include "rout/runtime/shard.h"
 
 #include "test.h"
 #include "test_helpers.h"
@@ -622,6 +623,155 @@ TEST(uring, return_buffer_no_crash) {
     // Return buffer at boundary
     backend.return_buffer(static_cast<u16>(kProvidedBufCount - 1));
     backend.shutdown();
+    close(lfd);
+}
+
+// === Shard lifecycle ===
+
+// Shard init + shutdown without spawning a thread
+TEST(shard, init_shutdown) {
+    Shard<EpollBackend> shard;
+    i32 lfd = create_listen_socket(0);
+    REQUIRE(lfd >= 0);
+    REQUIRE_EQ(shard.init(0, lfd), 0);
+    CHECK(shard.loop != nullptr);
+    CHECK_EQ(shard.id, 0u);
+    CHECK_EQ(shard.listen_fd, lfd);
+    shard.shutdown();
+    CHECK(shard.loop == nullptr);
+    close(lfd);
+}
+
+// Shard spawn + stop + join
+TEST(shard, spawn_stop_join) {
+    Shard<EpollBackend> shard;
+    i32 lfd = create_listen_socket(0);
+    REQUIRE(lfd >= 0);
+    REQUIRE_EQ(shard.init(0, lfd), 0);
+    REQUIRE_EQ(shard.spawn(-1), 0);  // no CPU pinning
+    CHECK(shard.thread_spawned);
+
+    // Let the shard run briefly, then stop
+    usleep(50000);  // 50ms
+    shard.stop();
+    shard.join();
+    CHECK(!shard.thread_spawned);
+    shard.shutdown();
+    close(lfd);
+}
+
+// Shard handles requests while running
+TEST(shard, serves_requests) {
+    Shard<EpollBackend> shard;
+    i32 lfd = create_listen_socket(0);
+    REQUIRE(lfd >= 0);
+    u16 port = get_port(lfd);
+    REQUIRE_EQ(shard.init(0, lfd), 0);
+    REQUIRE_EQ(shard.spawn(-1), 0);
+
+    usleep(50000);  // let shard start
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    char buf[4096];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+    CHECK(n > 0);
+    CHECK(has_200(buf, n));
+    close(c);
+
+    shard.stop();
+    shard.join();
+    shard.shutdown();
+    close(lfd);
+}
+
+// Two shards on same port (SO_REUSEPORT)
+TEST(shard, two_shards_same_port) {
+    i32 lfd1 = create_listen_socket(0);
+    REQUIRE(lfd1 >= 0);
+    u16 port = get_port(lfd1);
+    i32 lfd2 = create_listen_socket(port);
+    REQUIRE(lfd2 >= 0);
+
+    Shard<EpollBackend> s1, s2;
+    REQUIRE_EQ(s1.init(0, lfd1), 0);
+    REQUIRE_EQ(s2.init(1, lfd2), 0);
+    REQUIRE_EQ(s1.spawn(-1), 0);
+    REQUIRE_EQ(s2.spawn(-1), 0);
+
+    usleep(50000);
+
+    // Send requests — kernel distributes across shards
+    for (int i = 0; i < 5; i++) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+        char buf[4096];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK(n > 0);
+        close(c);
+    }
+
+    s1.stop();
+    s2.stop();
+    s1.join();
+    s2.join();
+    s1.shutdown();
+    s2.shutdown();
+    close(lfd1);
+    close(lfd2);
+}
+
+// detect_cpu_count returns > 0
+TEST(shard, detect_cpu_count) {
+    u32 cpus = detect_cpu_count();
+    CHECK(cpus > 0);
+    CHECK(cpus <= 1024);  // sanity upper bound
+}
+
+// Shard with owns_listen_fd closes it on shutdown
+TEST(shard, owns_listen_fd) {
+    Shard<EpollBackend> shard;
+    i32 lfd = create_listen_socket(0);
+    REQUIRE(lfd >= 0);
+    REQUIRE_EQ(shard.init(0, lfd), 0);
+    shard.owns_listen_fd = true;
+    shard.shutdown();
+    // lfd should be closed now — verify by trying to close again
+    CHECK(close(lfd) < 0);
+}
+
+// Shard has upstream pool after init
+TEST(shard, upstream_pool_initialized) {
+    Shard<EpollBackend> shard;
+    i32 lfd = create_listen_socket(0);
+    REQUIRE(lfd >= 0);
+    REQUIRE_EQ(shard.init(0, lfd), 0);
+    CHECK(shard.upstream != nullptr);
+    // Pool should be fresh (all free)
+    auto* c = shard.upstream->alloc();
+    CHECK(c != nullptr);
+    shard.upstream->free(c);
+    shard.shutdown();
+    close(lfd);
+}
+
+// Shard can hold a route config
+TEST(shard, route_config_attached) {
+    RouteConfig cfg;
+    cfg.add_static("/health", 0, 200);
+    cfg.add_upstream("api", 0x7F000001, 8080);
+    cfg.add_proxy("/api/", 0, 0);
+
+    Shard<EpollBackend> shard;
+    i32 lfd = create_listen_socket(0);
+    REQUIRE(lfd >= 0);
+    REQUIRE_EQ(shard.init(0, lfd), 0);
+    shard.route_config = &cfg;
+    CHECK(shard.route_config != nullptr);
+    CHECK_EQ(shard.route_config->route_count, 2u);
+    CHECK_EQ(shard.route_config->upstream_count, 1u);
+    shard.shutdown();
     close(lfd);
 }
 

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -729,6 +729,43 @@ TEST(shard, detect_cpu_count) {
     CHECK(cpus <= 1024);  // sanity upper bound
 }
 
+// Two shards with ephemeral port (port=0) bind the same port
+TEST(shard, ephemeral_port_two_shards) {
+    // First shard gets ephemeral port
+    i32 lfd1 = create_listen_socket(0).value_or(-1);
+    REQUIRE(lfd1 >= 0);
+    u16 port = get_port(lfd1);
+    CHECK(port > 0);
+
+    // Second shard should bind the same port (SO_REUSEPORT)
+    i32 lfd2 = create_listen_socket(port).value_or(-1);
+    REQUIRE(lfd2 >= 0);
+    CHECK_EQ(get_port(lfd2), port);
+
+    Shard<EpollBackend> s1, s2;
+    REQUIRE(s1.init(0, lfd1).has_value());
+    REQUIRE(s2.init(1, lfd2).has_value());
+    REQUIRE(s1.spawn(-1).has_value());
+    REQUIRE(s2.spawn(-1).has_value());
+
+    usleep(50000);
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    char buf[4096];
+    CHECK(recv_timeout(c, buf, sizeof(buf), 2000) > 0);
+    close(c);
+
+    s1.stop();
+    s2.stop();
+    s1.join();
+    s2.join();
+    s1.shutdown();
+    s2.shutdown();
+    close(lfd1);
+    close(lfd2);
+}
+
 // Shard with owns_listen_fd closes it on shutdown
 TEST(shard, owns_listen_fd) {
     Shard<EpollBackend> shard;

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -1,5 +1,6 @@
 // Mock tests — no real sockets. Ported from libuv/libevent scenarios.
 #include "rout/runtime/arena.h"
+#include "rout/runtime/error.h"
 #include "rout/runtime/route_table.h"
 #include "rout/runtime/slab_pool.h"
 #include "rout/runtime/slice_pool.h"
@@ -2008,8 +2009,6 @@ TEST(route, add_route_at_capacity) {
 }
 
 // === Error source ===
-
-#include "rout/runtime/error.h"
 
 TEST(error, from_errno_captures_source) {
     errno = ENOMEM;

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -1,5 +1,9 @@
 // Mock tests — no real sockets. Ported from libuv/libevent scenarios.
 #include "rout/runtime/arena.h"
+#include "rout/runtime/route_table.h"
+#include "rout/runtime/slab_pool.h"
+#include "rout/runtime/slice_pool.h"
+#include "rout/runtime/upstream_pool.h"
 
 #include "test.h"
 #include "test_helpers.h"
@@ -1369,8 +1373,6 @@ TEST(copilot6, keepalive_timeout_is_60) {
 
 // === RouteTable ===
 
-#include "rout/runtime/route_table.h"
-
 TEST(route, match_prefix) {
     RouteConfig cfg;
     i32 up = cfg.add_upstream("backend", 0x7F000001, 8080);
@@ -1439,8 +1441,6 @@ TEST(route, upstream_target_addr) {
 
 // === UpstreamPool ===
 
-#include "rout/runtime/upstream_pool.h"
-
 TEST(upstream_pool, alloc_free) {
     UpstreamPool pool;
     pool.init();
@@ -1493,8 +1493,6 @@ TEST(upstream_pool, shutdown_closes_fds) {
 }
 
 // === SlicePool ===
-
-#include "rout/runtime/slice_pool.h"
 
 TEST(slice_pool, init_destroy) {
     SlicePool pool;
@@ -1657,8 +1655,6 @@ TEST(slice_pool, large_pool) {
 }
 
 // === SlabPool ===
-
-#include "rout/runtime/slab_pool.h"
 
 struct TestObj {
     i32 value;

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -1857,6 +1857,173 @@ TEST(slab_pool, small_object) {
     pool.destroy();
 }
 
+// === Double-free detection ===
+
+TEST(slice_pool, double_free_rejected) {
+    SlicePool pool;
+    REQUIRE(pool.init(4));
+    u8* s = pool.alloc();
+    REQUIRE(s != nullptr);
+    CHECK_EQ(pool.available(), 3u);
+    pool.free(s);
+    CHECK_EQ(pool.available(), 4u);
+    pool.free(s);                    // double-free: should be silently rejected
+    CHECK_EQ(pool.available(), 4u);  // unchanged
+    pool.destroy();
+}
+
+TEST(slab_pool, double_free_by_ptr_rejected) {
+    SlabPool<TestObj, 4> pool;
+    REQUIRE(pool.init());
+    TestObj* a = pool.alloc();
+    REQUIRE(a != nullptr);
+    CHECK_EQ(pool.in_use(), 1u);
+    pool.free(a);
+    CHECK_EQ(pool.in_use(), 0u);
+    pool.free(a);                 // double-free
+    CHECK_EQ(pool.in_use(), 0u);  // unchanged
+    pool.destroy();
+}
+
+TEST(slab_pool, double_free_by_idx_rejected) {
+    SlabPool<TestObj, 4> pool;
+    REQUIRE(pool.init());
+    u32 idx = 0;
+    pool.alloc_with_id(idx);
+    pool.free(idx);
+    CHECK_EQ(pool.available(), 4u);
+    pool.free(idx);                  // double-free
+    CHECK_EQ(pool.available(), 4u);  // unchanged
+    pool.destroy();
+}
+
+TEST(upstream_pool, double_free_rejected) {
+    UpstreamPool pool;
+    pool.init();
+    auto* c = pool.alloc();
+    REQUIRE(c != nullptr);
+    u32 before = pool.free_top;
+    c->fd = -1;  // no real fd to close
+    pool.free(c);
+    CHECK_EQ(pool.free_top, before + 1);
+    pool.free(c);                         // double-free: allocated=false now
+    CHECK_EQ(pool.free_top, before + 1);  // unchanged
+}
+
+// === UpstreamPool validation ===
+
+TEST(upstream_pool, return_idle_null_safe) {
+    UpstreamPool pool;
+    pool.init();
+    pool.return_idle(nullptr);  // should not crash
+}
+
+TEST(upstream_pool, return_idle_requires_allocated) {
+    UpstreamPool pool;
+    pool.init();
+    auto* c = pool.alloc();
+    REQUIRE(c != nullptr);
+    c->fd = -1;
+    pool.free(c);
+    // c is now free — return_idle should reject
+    pool.return_idle(c);
+    CHECK(!c->idle);  // not marked idle (allocated=false)
+}
+
+TEST(upstream_pool, shutdown_is_idempotent) {
+    UpstreamPool pool;
+    pool.init();
+    auto* c = pool.alloc();
+    REQUIRE(c != nullptr);
+    c->fd = UpstreamPool::create_socket();
+    pool.shutdown();
+    CHECK_EQ(pool.free_top, UpstreamPool::kMaxConns);
+    pool.shutdown();  // second shutdown
+    CHECK_EQ(pool.free_top, UpstreamPool::kMaxConns);
+}
+
+TEST(upstream_pool, alloc_resets_upstream_id) {
+    UpstreamPool pool;
+    pool.init();
+    auto* c = pool.alloc();
+    REQUIRE(c != nullptr);
+    c->upstream_id = 42;
+    c->fd = -1;
+    pool.free(c);
+    auto* c2 = pool.alloc();
+    CHECK_EQ(c2->upstream_id, 0u);  // reset on alloc
+    c2->fd = -1;
+    pool.free(c2);
+}
+
+// === RouteTable validation ===
+
+TEST(route, add_proxy_invalid_upstream_id) {
+    RouteConfig cfg;
+    // No upstreams added — upstream_id 0 is invalid
+    CHECK(!cfg.add_proxy("/api/", 0, 0));
+    CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, add_proxy_path_too_long) {
+    RouteConfig cfg;
+    cfg.add_upstream("x", 0x7F000001, 80);
+    char long_path[256];
+    for (u32 i = 0; i < 255; i++) long_path[i] = 'a';
+    long_path[255] = '\0';
+    CHECK(!cfg.add_proxy(long_path, 0, 0));  // exceeds 128-char RouteEntry::path
+    CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, add_static_path_too_long) {
+    RouteConfig cfg;
+    char long_path[256];
+    for (u32 i = 0; i < 255; i++) long_path[i] = 'b';
+    long_path[255] = '\0';
+    CHECK(!cfg.add_static(long_path, 0, 200));
+    CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, add_upstream_at_capacity) {
+    RouteConfig cfg;
+    for (u32 i = 0; i < RouteConfig::kMaxUpstreams; i++) {
+        CHECK(cfg.add_upstream("x", 0x7F000001, static_cast<u16>(8080 + i)) >= 0);
+    }
+    CHECK(cfg.add_upstream("overflow", 0x7F000001, 9999) < 0);  // full
+}
+
+TEST(route, add_route_at_capacity) {
+    RouteConfig cfg;
+    cfg.add_upstream("x", 0x7F000001, 80);
+    for (u32 i = 0; i < RouteConfig::kMaxRoutes; i++) {
+        char path[8];
+        path[0] = '/';
+        path[1] = static_cast<char>('0' + (i / 100) % 10);
+        path[2] = static_cast<char>('0' + (i / 10) % 10);
+        path[3] = static_cast<char>('0' + i % 10);
+        path[4] = '\0';
+        CHECK(cfg.add_proxy(path, 0, 0));
+    }
+    CHECK(!cfg.add_proxy("/overflow", 0, 0));  // full
+}
+
+// === Error source ===
+
+#include "rout/runtime/error.h"
+
+TEST(error, from_errno_captures_source) {
+    errno = ENOMEM;
+    Error e = Error::from_errno(Error::Source::Mmap);
+    CHECK_EQ(e.code, ENOMEM);
+    CHECK_EQ(static_cast<u8>(e.source), static_cast<u8>(Error::Source::Mmap));
+}
+
+TEST(error, make_with_code) {
+    Error e = Error::make(EINVAL, Error::Source::Socket);
+    CHECK_EQ(e.code, EINVAL);
+    CHECK_EQ(static_cast<u8>(e.source), static_cast<u8>(Error::Source::Socket));
+}
+
 int main(int argc, char** argv) {
     return rout::test::run_all(argc, argv);
 }

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -490,11 +490,11 @@ TEST(copilot, timer_wheel_has_64_slots) {
 
 // Copilot #4: io_backend.h documented init as void, but it returns i32.
 // Verify MockBackend.init returns 0 on success.
-TEST(copilot, backend_init_returns_zero) {
+TEST(copilot, backend_init_returns_success) {
     SmallLoop loop;
     loop.setup();
-    // setup() calls backend.init which returns i32
-    CHECK_EQ(loop.backend.init(0, -1), 0);
+    // setup() calls backend.init which returns Expected<void, Error>
+    CHECK(loop.backend.init(0, -1).has_value());
 }
 
 // === Proxy (mock) ===
@@ -1090,35 +1090,35 @@ TEST(timer_clamp, zero_tick_coerced_to_one) {
 
 // io_uring init returns -errno (not -1) on failure.
 // We can't easily make mmap fail, but verify the convention:
-// successful MockBackend init returns 0.
-TEST(copilot4, init_returns_zero_on_success) {
+// successful MockBackend init returns success.
+TEST(copilot4, init_returns_success) {
     SmallLoop loop;
     loop.setup();
-    CHECK_EQ(loop.backend.init(0, -1), 0);
+    CHECK(loop.backend.init(0, -1).has_value());
 }
 
-// Arena init returns -errno on failure (not -1).
-// Verify success returns 0.
-TEST(copilot4, arena_init_returns_zero) {
+// Arena init returns Expected on failure.
+// Verify success returns has_value().
+TEST(copilot4, arena_init_returns_success) {
     Arena a;
-    CHECK_EQ(a.init(4096), 0);
+    CHECK(a.init(4096).has_value());
     a.destroy();
 }
 
 // Arena init with absurdly large size should fail gracefully.
-// mmap of near-max u64 will fail → should return negative errno.
+// mmap of near-max u64 will fail → should return error.
 TEST(copilot4, arena_init_huge_fails) {
     Arena a;
-    i32 rc = a.init(static_cast<u64>(-1));  // ~18 exabytes
-    CHECK(rc < 0);
-    // Should be -ENOMEM or similar, not -1
-    CHECK_NE(rc, -1);  // -errno convention, not raw -1
+    auto rc = a.init(static_cast<u64>(-1));  // ~18 exabytes
+    CHECK(!rc);
+    // Should carry a real errno code
+    CHECK(rc.error().code > 0);
 }
 
 // Arena alloc overflow protection
 TEST(copilot4, arena_alloc_overflow_returns_null) {
     Arena a;
-    REQUIRE_EQ(a.init(4096), 0);
+    REQUIRE(a.init(4096).has_value());
     // size close to u64 max → overflow in (size+7) alignment
     void* p = a.alloc(static_cast<u64>(-1));
     CHECK(p == nullptr);
@@ -1498,7 +1498,7 @@ TEST(upstream_pool, shutdown_closes_fds) {
 
 TEST(slice_pool, init_destroy) {
     SlicePool pool;
-    REQUIRE_EQ(pool.init(64), 0);
+    REQUIRE(pool.init(64).has_value());
     CHECK_EQ(pool.count, 64u);
     CHECK_EQ(pool.available(), 64u);
     CHECK_EQ(pool.in_use(), 0u);
@@ -1507,7 +1507,7 @@ TEST(slice_pool, init_destroy) {
 
 TEST(slice_pool, alloc_free) {
     SlicePool pool;
-    REQUIRE_EQ(pool.init(4), 0);
+    REQUIRE(pool.init(4).has_value());
 
     u8* s1 = pool.alloc();
     u8* s2 = pool.alloc();
@@ -1534,7 +1534,7 @@ TEST(slice_pool, alloc_free) {
 
 TEST(slice_pool, exhaust_and_recover) {
     SlicePool pool;
-    REQUIRE_EQ(pool.init(2), 0);
+    REQUIRE(pool.init(2).has_value());
 
     u8* s1 = pool.alloc();
     u8* s2 = pool.alloc();
@@ -1555,7 +1555,7 @@ TEST(slice_pool, exhaust_and_recover) {
 
 TEST(slice_pool, slice_size) {
     SlicePool pool;
-    REQUIRE_EQ(pool.init(1), 0);
+    REQUIRE(pool.init(1).has_value());
     CHECK_EQ(SlicePool::kSliceSize, 16384u);
     u8* s = pool.alloc();
     REQUIRE(s != nullptr);
@@ -1570,7 +1570,7 @@ TEST(slice_pool, slice_size) {
 
 TEST(slice_pool, free_null_safe) {
     SlicePool pool;
-    REQUIRE_EQ(pool.init(2), 0);
+    REQUIRE(pool.init(2).has_value());
     pool.free(nullptr);              // should not crash
     CHECK_EQ(pool.available(), 2u);  // unchanged
     pool.destroy();
@@ -1579,7 +1579,7 @@ TEST(slice_pool, free_null_safe) {
 // SlicePool: out-of-order free
 TEST(slice_pool, out_of_order_free) {
     SlicePool pool;
-    REQUIRE_EQ(pool.init(4), 0);
+    REQUIRE(pool.init(4).has_value());
     u8* s1 = pool.alloc();
     u8* s2 = pool.alloc();
     u8* s3 = pool.alloc();
@@ -1604,7 +1604,7 @@ TEST(slice_pool, out_of_order_free) {
 // SlicePool: multiple alloc-free cycles don't corrupt free-stack
 TEST(slice_pool, stress_cycles) {
     SlicePool pool;
-    REQUIRE_EQ(pool.init(8), 0);
+    REQUIRE(pool.init(8).has_value());
     for (int cycle = 0; cycle < 100; cycle++) {
         u8* ptrs[8];
         for (int j = 0; j < 8; j++) {
@@ -1621,7 +1621,7 @@ TEST(slice_pool, stress_cycles) {
 // SlicePool: destroy is idempotent
 TEST(slice_pool, destroy_idempotent) {
     SlicePool pool;
-    REQUIRE_EQ(pool.init(4), 0);
+    REQUIRE(pool.init(4).has_value());
     pool.destroy();
     pool.destroy();  // second destroy should not crash
     CHECK(pool.base == nullptr);
@@ -1631,7 +1631,7 @@ TEST(slice_pool, destroy_idempotent) {
 // SlicePool: alloc after destroy returns nullptr
 TEST(slice_pool, alloc_after_destroy) {
     SlicePool pool;
-    REQUIRE_EQ(pool.init(4), 0);
+    REQUIRE(pool.init(4).has_value());
     pool.destroy();
     CHECK(pool.alloc() == nullptr);
 }
@@ -1639,7 +1639,7 @@ TEST(slice_pool, alloc_after_destroy) {
 // SlicePool: large pool (verify mmap works at scale)
 TEST(slice_pool, large_pool) {
     SlicePool pool;
-    REQUIRE_EQ(pool.init(1024), 0);  // 1024 * 16KB = 16MB
+    REQUIRE(pool.init(1024).has_value());  // 1024 * 16KB = 16MB
     CHECK_EQ(pool.available(), 1024u);
 
     // Alloc a few, verify they don't overlap
@@ -1667,7 +1667,7 @@ struct TestObj {
 
 TEST(slab_pool, init_destroy) {
     SlabPool<TestObj, 128> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
     CHECK_EQ(pool.capacity(), 128u);
     CHECK_EQ(pool.available(), 128u);
     CHECK_EQ(pool.in_use(), 0u);
@@ -1676,7 +1676,7 @@ TEST(slab_pool, init_destroy) {
 
 TEST(slab_pool, alloc_free_by_ptr) {
     SlabPool<TestObj, 4> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
 
     TestObj* a = pool.alloc();
     TestObj* b = pool.alloc();
@@ -1698,7 +1698,7 @@ TEST(slab_pool, alloc_free_by_ptr) {
 
 TEST(slab_pool, alloc_with_id) {
     SlabPool<TestObj, 8> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
 
     u32 idx = 0;
     TestObj* obj = pool.alloc_with_id(idx);
@@ -1714,7 +1714,7 @@ TEST(slab_pool, alloc_with_id) {
 
 TEST(slab_pool, exhaust) {
     SlabPool<TestObj, 2> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
 
     TestObj* a = pool.alloc();
     TestObj* b = pool.alloc();
@@ -1733,7 +1733,7 @@ TEST(slab_pool, exhaust) {
 
 TEST(slab_pool, index_of) {
     SlabPool<TestObj, 16> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
 
     TestObj* a = pool.alloc();
     TestObj* b = pool.alloc();
@@ -1751,7 +1751,7 @@ TEST(slab_pool, index_of) {
 // SlabPool: capacity 1
 TEST(slab_pool, capacity_one) {
     SlabPool<TestObj, 1> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
     CHECK_EQ(pool.capacity(), 1u);
 
     TestObj* a = pool.alloc();
@@ -1772,7 +1772,7 @@ TEST(slab_pool, capacity_one) {
 // SlabPool: free by index vs free by pointer consistency
 TEST(slab_pool, free_by_index_vs_ptr) {
     SlabPool<TestObj, 4> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
 
     u32 idx1 = 0;
     TestObj* a = pool.alloc_with_id(idx1);
@@ -1799,7 +1799,7 @@ TEST(slab_pool, free_by_index_vs_ptr) {
 // SlabPool: alloc_with_id when empty returns nullptr
 TEST(slab_pool, alloc_with_id_empty) {
     SlabPool<TestObj, 1> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
 
     u32 idx = 999;
     pool.alloc();  // take the only slot
@@ -1816,7 +1816,7 @@ TEST(slab_pool, alloc_with_id_empty) {
 // SlabPool: destroy idempotent
 TEST(slab_pool, destroy_idempotent) {
     SlabPool<TestObj, 4> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
     pool.destroy();
     pool.destroy();  // second destroy should not crash
     CHECK(pool.objects == nullptr);
@@ -1826,7 +1826,7 @@ TEST(slab_pool, destroy_idempotent) {
 // SlabPool: stress alloc-free cycles
 TEST(slab_pool, stress_cycles) {
     SlabPool<TestObj, 16> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
     for (int cycle = 0; cycle < 50; cycle++) {
         TestObj* ptrs[16];
         for (int j = 0; j < 16; j++) {
@@ -1851,7 +1851,7 @@ struct SmallObj {
 
 TEST(slab_pool, small_object) {
     SlabPool<SmallObj, 32> pool;
-    REQUIRE_EQ(pool.init(), 0);
+    REQUIRE(pool.init().has_value());
     SmallObj* a = pool.alloc();
     REQUIRE(a != nullptr);
     a->tag = 0xAB;

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -1852,7 +1852,7 @@ TEST(slab_pool, small_object) {
     SmallObj* a = pool.alloc();
     REQUIRE(a != nullptr);
     a->tag = 0xAB;
-    CHECK_EQ(pool.index_of(a), pool.index_of(a));  // consistent
+    CHECK_EQ(&pool[pool.index_of(a)], a);  // index_of round-trips to same pointer
     CHECK_EQ(a->tag, 0xABu);
     pool.free(a);
     pool.destroy();

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -1367,6 +1367,500 @@ TEST(copilot6, keepalive_timeout_is_60) {
     CHECK_EQ(loop.keepalive_timeout, 60u);
 }
 
+// === RouteTable ===
+
+#include "rout/runtime/route_table.h"
+
+TEST(route, match_prefix) {
+    RouteConfig cfg;
+    i32 up = cfg.add_upstream("backend", 0x7F000001, 8080);
+    REQUIRE(up >= 0);
+    cfg.add_proxy("/api/", 0, static_cast<u16>(up));
+
+    const u8 path1[] = "/api/users";
+    auto* r = cfg.match(path1, sizeof(path1) - 1, 0);
+    REQUIRE(r != nullptr);
+    CHECK_EQ(r->action, RouteAction::Proxy);
+    CHECK_EQ(r->upstream_id, static_cast<u16>(up));
+
+    const u8 path2[] = "/health";
+    CHECK(cfg.match(path2, sizeof(path2) - 1, 0) == nullptr);
+}
+
+TEST(route, method_filter) {
+    RouteConfig cfg;
+    cfg.add_static("/status", 'G', 200);
+
+    const u8 path[] = "/status";
+    CHECK(cfg.match(path, sizeof(path) - 1, 'G') != nullptr);
+    CHECK(cfg.match(path, sizeof(path) - 1, 'P') == nullptr);
+}
+
+TEST(route, first_match_wins) {
+    RouteConfig cfg;
+    i32 up1 = cfg.add_upstream("v1", 0x7F000001, 8081);
+    i32 up2 = cfg.add_upstream("v2", 0x7F000001, 8082);
+    cfg.add_proxy("/api/v1/", 0, static_cast<u16>(up1));
+    cfg.add_proxy("/api/", 0, static_cast<u16>(up2));
+
+    const u8 path[] = "/api/v1/users";
+    auto* r = cfg.match(path, sizeof(path) - 1, 0);
+    REQUIRE(r != nullptr);
+    CHECK_EQ(r->upstream_id, static_cast<u16>(up1));
+}
+
+TEST(route, static_response) {
+    RouteConfig cfg;
+    cfg.add_static("/health", 0, 200);
+
+    const u8 path[] = "/health";
+    auto* r = cfg.match(path, sizeof(path) - 1, 0);
+    REQUIRE(r != nullptr);
+    CHECK_EQ(r->action, RouteAction::Static);
+    CHECK_EQ(r->status_code, 200u);
+}
+
+TEST(route, empty_config_no_match) {
+    RouteConfig cfg;
+    const u8 path[] = "/anything";
+    CHECK(cfg.match(path, sizeof(path) - 1, 0) == nullptr);
+}
+
+TEST(route, upstream_target_addr) {
+    RouteConfig cfg;
+    i32 idx = cfg.add_upstream("api", 0x0A000101, 9090);
+    REQUIRE(idx >= 0);
+    auto& t = cfg.upstreams[idx];
+    CHECK_EQ(t.addr.sin_family, AF_INET);
+    CHECK_EQ(__builtin_bswap16(t.addr.sin_port), 9090u);
+    CHECK_EQ(__builtin_bswap32(t.addr.sin_addr.s_addr), 0x0A000101u);
+    CHECK_EQ(t.name[0], 'a');
+}
+
+// === UpstreamPool ===
+
+#include "rout/runtime/upstream_pool.h"
+
+TEST(upstream_pool, alloc_free) {
+    UpstreamPool pool;
+    pool.init();
+    auto* c = pool.alloc();
+    REQUIRE(c != nullptr);
+    CHECK_EQ(c->fd, -1);
+    CHECK(!c->idle);
+    pool.free(c);
+}
+
+TEST(upstream_pool, find_idle) {
+    UpstreamPool pool;
+    pool.init();
+    auto* c = pool.alloc();
+    REQUIRE(c != nullptr);
+    c->fd = 42;
+    c->upstream_id = 5;
+
+    CHECK(pool.find_idle(5) == nullptr);
+    pool.return_idle(c);
+    CHECK(c->idle);
+
+    auto* found = pool.find_idle(5);
+    CHECK_EQ(found, c);
+    CHECK(!found->idle);
+
+    pool.return_idle(c);
+    CHECK(pool.find_idle(99) == nullptr);
+
+    c->fd = -1;
+    pool.free(c);
+}
+
+TEST(upstream_pool, create_socket) {
+    i32 fd = UpstreamPool::create_socket();
+    CHECK(fd >= 0);
+    if (fd >= 0) close(fd);
+}
+
+TEST(upstream_pool, shutdown_closes_fds) {
+    UpstreamPool pool;
+    pool.init();
+    auto* c = pool.alloc();
+    REQUIRE(c != nullptr);
+    c->fd = UpstreamPool::create_socket();
+    REQUIRE(c->fd >= 0);
+    i32 saved_fd = c->fd;
+    pool.shutdown();
+    CHECK(close(saved_fd) < 0);
+}
+
+// === SlicePool ===
+
+#include "rout/runtime/slice_pool.h"
+
+TEST(slice_pool, init_destroy) {
+    SlicePool pool;
+    REQUIRE_EQ(pool.init(64), 0);
+    CHECK_EQ(pool.count, 64u);
+    CHECK_EQ(pool.available(), 64u);
+    CHECK_EQ(pool.in_use(), 0u);
+    pool.destroy();
+}
+
+TEST(slice_pool, alloc_free) {
+    SlicePool pool;
+    REQUIRE_EQ(pool.init(4), 0);
+
+    u8* s1 = pool.alloc();
+    u8* s2 = pool.alloc();
+    REQUIRE(s1 != nullptr);
+    REQUIRE(s2 != nullptr);
+    CHECK_NE(s1, s2);
+    CHECK_EQ(pool.available(), 2u);
+    CHECK_EQ(pool.in_use(), 2u);
+
+    // Write to slices — verify no overlap (16KB apart)
+    s1[0] = 'A';
+    s1[SlicePool::kSliceSize - 1] = 'Z';
+    s2[0] = 'B';
+    CHECK_EQ(s1[0], 'A');
+    CHECK_EQ(s1[SlicePool::kSliceSize - 1], 'Z');
+    CHECK_EQ(s2[0], 'B');
+
+    pool.free(s1);
+    CHECK_EQ(pool.available(), 3u);
+    pool.free(s2);
+    CHECK_EQ(pool.available(), 4u);
+    pool.destroy();
+}
+
+TEST(slice_pool, exhaust_and_recover) {
+    SlicePool pool;
+    REQUIRE_EQ(pool.init(2), 0);
+
+    u8* s1 = pool.alloc();
+    u8* s2 = pool.alloc();
+    REQUIRE(s1 != nullptr);
+    REQUIRE(s2 != nullptr);
+    CHECK(pool.alloc() == nullptr);  // exhausted
+    CHECK_EQ(pool.available(), 0u);
+
+    pool.free(s1);
+    u8* s3 = pool.alloc();
+    CHECK(s3 != nullptr);  // recovered
+    CHECK_EQ(s3, s1);      // reuses same slice
+
+    pool.free(s2);
+    pool.free(s3);
+    pool.destroy();
+}
+
+TEST(slice_pool, slice_size) {
+    SlicePool pool;
+    REQUIRE_EQ(pool.init(1), 0);
+    CHECK_EQ(SlicePool::kSliceSize, 16384u);
+    u8* s = pool.alloc();
+    REQUIRE(s != nullptr);
+    // Verify we can write to the full 16KB without crash
+    for (u32 i = 0; i < SlicePool::kSliceSize; i++) s[i] = static_cast<u8>(i & 0xFF);
+    CHECK_EQ(s[0], 0u);
+    CHECK_EQ(s[255], 255u);
+    CHECK_EQ(s[16383], static_cast<u8>(16383 & 0xFF));
+    pool.free(s);
+    pool.destroy();
+}
+
+TEST(slice_pool, free_null_safe) {
+    SlicePool pool;
+    REQUIRE_EQ(pool.init(2), 0);
+    pool.free(nullptr);              // should not crash
+    CHECK_EQ(pool.available(), 2u);  // unchanged
+    pool.destroy();
+}
+
+// SlicePool: out-of-order free
+TEST(slice_pool, out_of_order_free) {
+    SlicePool pool;
+    REQUIRE_EQ(pool.init(4), 0);
+    u8* s1 = pool.alloc();
+    u8* s2 = pool.alloc();
+    u8* s3 = pool.alloc();
+    REQUIRE(s1 && s2 && s3);
+
+    // Free in non-LIFO order
+    pool.free(s2);
+    pool.free(s1);
+    pool.free(s3);
+    CHECK_EQ(pool.available(), 4u);
+
+    // Re-alloc should still work
+    u8* r1 = pool.alloc();
+    u8* r2 = pool.alloc();
+    CHECK(r1 != nullptr);
+    CHECK(r2 != nullptr);
+    pool.free(r1);
+    pool.free(r2);
+    pool.destroy();
+}
+
+// SlicePool: multiple alloc-free cycles don't corrupt free-stack
+TEST(slice_pool, stress_cycles) {
+    SlicePool pool;
+    REQUIRE_EQ(pool.init(8), 0);
+    for (int cycle = 0; cycle < 100; cycle++) {
+        u8* ptrs[8];
+        for (int j = 0; j < 8; j++) {
+            ptrs[j] = pool.alloc();
+            REQUIRE(ptrs[j] != nullptr);
+        }
+        CHECK(pool.alloc() == nullptr);  // exhausted each cycle
+        for (int j = 7; j >= 0; j--) pool.free(ptrs[j]);
+        CHECK_EQ(pool.available(), 8u);
+    }
+    pool.destroy();
+}
+
+// SlicePool: destroy is idempotent
+TEST(slice_pool, destroy_idempotent) {
+    SlicePool pool;
+    REQUIRE_EQ(pool.init(4), 0);
+    pool.destroy();
+    pool.destroy();  // second destroy should not crash
+    CHECK(pool.base == nullptr);
+    CHECK(pool.free_stack == nullptr);
+}
+
+// SlicePool: alloc after destroy returns nullptr
+TEST(slice_pool, alloc_after_destroy) {
+    SlicePool pool;
+    REQUIRE_EQ(pool.init(4), 0);
+    pool.destroy();
+    CHECK(pool.alloc() == nullptr);
+}
+
+// SlicePool: large pool (verify mmap works at scale)
+TEST(slice_pool, large_pool) {
+    SlicePool pool;
+    REQUIRE_EQ(pool.init(1024), 0);  // 1024 * 16KB = 16MB
+    CHECK_EQ(pool.available(), 1024u);
+
+    // Alloc a few, verify they don't overlap
+    u8* first = pool.alloc();
+    u8* last = pool.alloc();
+    REQUIRE(first != nullptr);
+    REQUIRE(last != nullptr);
+    // Must be at least 16KB apart
+    u64 dist = (first > last) ? static_cast<u64>(first - last) : static_cast<u64>(last - first);
+    CHECK(dist >= SlicePool::kSliceSize);
+
+    pool.free(first);
+    pool.free(last);
+    pool.destroy();
+}
+
+// === SlabPool ===
+
+#include "rout/runtime/slab_pool.h"
+
+struct TestObj {
+    i32 value;
+    u8 data[60];  // pad to 64 bytes
+};
+
+TEST(slab_pool, init_destroy) {
+    SlabPool<TestObj, 128> pool;
+    REQUIRE_EQ(pool.init(), 0);
+    CHECK_EQ(pool.capacity(), 128u);
+    CHECK_EQ(pool.available(), 128u);
+    CHECK_EQ(pool.in_use(), 0u);
+    pool.destroy();
+}
+
+TEST(slab_pool, alloc_free_by_ptr) {
+    SlabPool<TestObj, 4> pool;
+    REQUIRE_EQ(pool.init(), 0);
+
+    TestObj* a = pool.alloc();
+    TestObj* b = pool.alloc();
+    REQUIRE(a != nullptr);
+    REQUIRE(b != nullptr);
+    CHECK_NE(a, b);
+    CHECK_EQ(pool.in_use(), 2u);
+
+    a->value = 42;
+    b->value = 99;
+    CHECK_EQ(a->value, 42);
+    CHECK_EQ(b->value, 99);
+
+    pool.free(a);
+    pool.free(b);
+    CHECK_EQ(pool.available(), 4u);
+    pool.destroy();
+}
+
+TEST(slab_pool, alloc_with_id) {
+    SlabPool<TestObj, 8> pool;
+    REQUIRE_EQ(pool.init(), 0);
+
+    u32 idx = 0;
+    TestObj* obj = pool.alloc_with_id(idx);
+    REQUIRE(obj != nullptr);
+    obj->value = 7;
+    CHECK_EQ(pool[idx].value, 7);
+    CHECK_EQ(pool.index_of(obj), idx);
+
+    pool.free(idx);
+    CHECK_EQ(pool.available(), 8u);
+    pool.destroy();
+}
+
+TEST(slab_pool, exhaust) {
+    SlabPool<TestObj, 2> pool;
+    REQUIRE_EQ(pool.init(), 0);
+
+    TestObj* a = pool.alloc();
+    TestObj* b = pool.alloc();
+    REQUIRE(a != nullptr);
+    REQUIRE(b != nullptr);
+    CHECK(pool.alloc() == nullptr);
+
+    pool.free(a);
+    TestObj* c = pool.alloc();
+    CHECK_EQ(c, a);
+
+    pool.free(b);
+    pool.free(c);
+    pool.destroy();
+}
+
+TEST(slab_pool, index_of) {
+    SlabPool<TestObj, 16> pool;
+    REQUIRE_EQ(pool.init(), 0);
+
+    TestObj* a = pool.alloc();
+    TestObj* b = pool.alloc();
+    u32 ia = pool.index_of(a);
+    u32 ib = pool.index_of(b);
+    CHECK_NE(ia, ib);
+    CHECK_EQ(&pool[ia], a);
+    CHECK_EQ(&pool[ib], b);
+
+    pool.free(a);
+    pool.free(b);
+    pool.destroy();
+}
+
+// SlabPool: capacity 1
+TEST(slab_pool, capacity_one) {
+    SlabPool<TestObj, 1> pool;
+    REQUIRE_EQ(pool.init(), 0);
+    CHECK_EQ(pool.capacity(), 1u);
+
+    TestObj* a = pool.alloc();
+    REQUIRE(a != nullptr);
+    CHECK(pool.alloc() == nullptr);  // full
+
+    a->value = 77;
+    CHECK_EQ(pool[0].value, 77);
+
+    pool.free(a);
+    TestObj* b = pool.alloc();
+    CHECK_EQ(b, a);  // reused
+
+    pool.free(b);
+    pool.destroy();
+}
+
+// SlabPool: free by index vs free by pointer consistency
+TEST(slab_pool, free_by_index_vs_ptr) {
+    SlabPool<TestObj, 4> pool;
+    REQUIRE_EQ(pool.init(), 0);
+
+    u32 idx1 = 0;
+    TestObj* a = pool.alloc_with_id(idx1);
+    u32 idx2 = 0;
+    TestObj* b = pool.alloc_with_id(idx2);
+    REQUIRE(a && b);
+
+    // Free a by index, b by pointer
+    pool.free(idx1);
+    pool.free(b);
+    CHECK_EQ(pool.available(), 4u);
+
+    // Both slots reusable
+    TestObj* c = pool.alloc();
+    TestObj* d = pool.alloc();
+    CHECK(c != nullptr);
+    CHECK(d != nullptr);
+
+    pool.free(c);
+    pool.free(d);
+    pool.destroy();
+}
+
+// SlabPool: alloc_with_id when empty returns nullptr
+TEST(slab_pool, alloc_with_id_empty) {
+    SlabPool<TestObj, 1> pool;
+    REQUIRE_EQ(pool.init(), 0);
+
+    u32 idx = 999;
+    pool.alloc();  // take the only slot
+
+    TestObj* obj = pool.alloc_with_id(idx);
+    CHECK(obj == nullptr);
+    CHECK_EQ(idx, 0u);  // idx set to 0 on failure
+
+    // Cleanup
+    pool.free(static_cast<u32>(0));
+    pool.destroy();
+}
+
+// SlabPool: destroy idempotent
+TEST(slab_pool, destroy_idempotent) {
+    SlabPool<TestObj, 4> pool;
+    REQUIRE_EQ(pool.init(), 0);
+    pool.destroy();
+    pool.destroy();  // second destroy should not crash
+    CHECK(pool.objects == nullptr);
+    CHECK(pool.free_stack == nullptr);
+}
+
+// SlabPool: stress alloc-free cycles
+TEST(slab_pool, stress_cycles) {
+    SlabPool<TestObj, 16> pool;
+    REQUIRE_EQ(pool.init(), 0);
+    for (int cycle = 0; cycle < 50; cycle++) {
+        TestObj* ptrs[16];
+        for (int j = 0; j < 16; j++) {
+            ptrs[j] = pool.alloc();
+            REQUIRE(ptrs[j] != nullptr);
+            ptrs[j]->value = cycle * 16 + j;
+        }
+        CHECK(pool.alloc() == nullptr);
+        // Verify values
+        for (int j = 0; j < 16; j++) CHECK_EQ(ptrs[j]->value, cycle * 16 + j);
+        // Free all
+        for (int j = 0; j < 16; j++) pool.free(ptrs[j]);
+        CHECK_EQ(pool.available(), 16u);
+    }
+    pool.destroy();
+}
+
+// SlabPool: different object type (small)
+struct SmallObj {
+    u8 tag;
+};
+
+TEST(slab_pool, small_object) {
+    SlabPool<SmallObj, 32> pool;
+    REQUIRE_EQ(pool.init(), 0);
+    SmallObj* a = pool.alloc();
+    REQUIRE(a != nullptr);
+    a->tag = 0xAB;
+    CHECK_EQ(pool.index_of(a), pool.index_of(a));  // consistent
+    CHECK_EQ(a->tag, 0xABu);
+    pool.free(a);
+    pool.destroy();
+}
+
 int main(int argc, char** argv) {
     return rout::test::run_all(argc, argv);
 }


### PR DESCRIPTION
## Summary

Phase 2 shard integration: lifts the single-threaded runtime into a per-core share-nothing architecture.

### Per-core Shard runtime (`shard.h`)
- `Shard<Backend>` wraps EventLoop (mmap'd ~130MB), Arena (64KB scratch), UpstreamPool, RouteConfig*
- pthread with CPU affinity (`--no-pin` to disable), SO_REUSEPORT listen sockets
- Lifecycle: init → spawn → stop → join → shutdown
- Multi-shard `main.cc`: auto-detects cores, `--shards N` CLI arg, SIGINT/SIGTERM graceful shutdown

### Route table (`route_table.h`)
- `RouteConfig`: RouteEntry[] (prefix match, first-match-wins) + UpstreamTarget[] (addr:port)
- Static (status code) and Proxy (upstream_id) actions with method filter
- Immutable after construction, `const RouteConfig*` in Shard for atomic hot reload swap

### Upstream connection pool (`upstream_pool.h`)
- Per-shard `UpstreamPool` (4096 slots), alloc/free/find_idle/return_idle
- `UpstreamConn`: fd + upstream_id + idle state for connection reuse

### Memory pools
- **SlicePool** (`slice_pool.h`): 16KB fixed-size slice allocator, mmap-backed, O(1) free-stack. Per-shard network I/O buffers — idle connections hold 0 slices.
- **SlabPool\<T, Cap\>** (`slab_pool.h`): generic fixed-size object pool template, mmap-backed. alloc/free by pointer or index, alloc_with_id, operator[], index_of.

### Structured errors with Expected (`error.h`)
- `rout::Error` carries errno + `Source` enum (Mmap, Epoll, IoUring, Timerfd, Socket, Thread, Arena, SlicePool, SlabPool)
- All init functions converted from `i32` (-errno) to `core::Expected<void, Error>` or `core::Expected<i32, Error>`
- `create_listen_socket`, Arena, SlicePool, SlabPool, EpollBackend, IoUringBackend, EventLoop, Shard init/spawn all return Expected
- Callers use `.has_value()`, `.value()`, `.value_or()`, `TRY_VOID()`

## Test plan
- [x] 510 tests across all suites (51 buffer + 22 types + 107 network + 45 integration + 47 arena + 56 expected + 182 parser)
- [x] Shard lifecycle: init/shutdown, spawn/stop/join, serves requests, two shards same port, CPU detection, owns_listen_fd, upstream pool init, route config attach
- [x] Route table: prefix match, method filter, first-match-wins, static response, empty config, upstream target addr
- [x] Upstream pool: alloc/free, find_idle, create_socket, shutdown closes fds
- [x] SlicePool: init, alloc/free, exhaust/recover, 16KB write, null safe, out-of-order free, stress cycles, destroy idempotent, alloc-after-destroy, large pool
- [x] SlabPool: init, alloc/free by ptr, alloc_with_id, exhaust, index_of, capacity=1, free by index vs ptr, alloc_with_id empty, destroy idempotent, stress, small obj
- [x] clang-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)