### PR TITLE
Add per-shard independent control for hot-reload

### DIFF
--- a/include/rut/runtime/access_log.h
+++ b/include/rut/runtime/access_log.h
@@ -3,6 +3,7 @@
 #include "core/expected.h"
 #include "rut/common/types.h"
 #include "rut/runtime/error.h"
+#include <atomic>
 
 #include <pthread.h>
 #include <time.h>
@@ -74,8 +75,8 @@ struct AccessLogRing {
     static constexpr u32 kMask = kCapacity - 1;
 
     // Cache-line aligned to prevent false sharing between producer and consumer.
-    alignas(64) u32 write_pos;  // written by shard thread only
-    alignas(64) u32 read_pos;   // written by flusher thread only
+    alignas(64) std::atomic<u32> write_pos;  // written by shard thread only
+    alignas(64) std::atomic<u32> read_pos;   // written by flusher thread only
     AccessLogEntry entries[kCapacity];
 
     void init() {
@@ -92,35 +93,35 @@ struct AccessLogRing {
     // Dropping newest under backpressure is acceptable for access logs —
     // the flusher will catch up and future entries will succeed.
     bool push(const AccessLogEntry& entry) {
-        u32 wp = __atomic_load_n(&write_pos, __ATOMIC_RELAXED);
-        u32 rp = __atomic_load_n(&read_pos, __ATOMIC_ACQUIRE);
+        u32 wp = write_pos.load(std::memory_order_relaxed);
+        u32 rp = read_pos.load(std::memory_order_acquire);
 
         if (wp - rp >= kCapacity) {
             return false;  // full — drop this entry
         }
 
         entries[wp & kMask] = entry;
-        __atomic_store_n(&write_pos, wp + 1, __ATOMIC_RELEASE);
+        write_pos.store(wp + 1, std::memory_order_release);
         return true;
     }
 
     // Consumer: read one entry. Returns false if empty.
     // Called from flusher thread only — no contention on read_pos.
     bool pop(AccessLogEntry& out) {
-        u32 rp = __atomic_load_n(&read_pos, __ATOMIC_RELAXED);
-        u32 wp = __atomic_load_n(&write_pos, __ATOMIC_ACQUIRE);
+        u32 rp = read_pos.load(std::memory_order_relaxed);
+        u32 wp = write_pos.load(std::memory_order_acquire);
 
         if (rp == wp) return false;  // empty
 
         out = entries[rp & kMask];
-        __atomic_store_n(&read_pos, rp + 1, __ATOMIC_RELEASE);
+        read_pos.store(rp + 1, std::memory_order_release);
         return true;
     }
 
     // Number of entries available to read.
     u32 available() const {
-        u32 wp = __atomic_load_n(&write_pos, __ATOMIC_ACQUIRE);
-        u32 rp = __atomic_load_n(&read_pos, __ATOMIC_RELAXED);
+        u32 wp = write_pos.load(std::memory_order_acquire);
+        u32 rp = read_pos.load(std::memory_order_relaxed);
         return wp - rp;
     }
 };
@@ -153,7 +154,7 @@ struct AccessLogFlusher {
     i32 compress_level;     // zstd level: 1-4 (fast/doubleFast only)
 
     pthread_t thread;
-    bool running;  // cross-thread: accessed via __atomic builtins
+    std::atomic<bool> running;  // cross-thread: accessed via std::atomic
 
     // Opaque zstd state (ZSTD_CStream*), managed in access_log.cc.
     void* zstd_ctx;

--- a/include/rut/runtime/callbacks.h
+++ b/include/rut/runtime/callbacks.h
@@ -251,6 +251,7 @@ void on_header_received(void* lp, Connection& conn, IoEvent ev) {
 
     conn.req_start_us = monotonic_us();
     capture_request_metadata(conn);
+    loop->epoch_enter();
     if (loop->metrics) loop->metrics->on_request_start();
     conn.state = ConnState::Sending;
     conn.resp_status = kStatusOK;
@@ -294,6 +295,7 @@ void on_response_sent(void* lp, Connection& conn, IoEvent ev) {
 
     // Record metrics + access log only after send is confirmed successful.
     on_request_complete(loop, conn, conn.resp_status, conn.send_buf.len());
+    loop->epoch_leave();
 
     if (!conn.keep_alive) {
         loop->close_conn(conn);
@@ -510,6 +512,7 @@ void on_proxy_response_sent(void* lp, Connection& conn, IoEvent ev) {
 
     // Record metrics + access log only after send is confirmed successful.
     on_request_complete(loop, conn, conn.resp_status, conn.recv_buf.len());
+    loop->epoch_leave();
 
     // During drain: close proxy connections instead of re-arming for next request.
     if (loop->is_draining()) {

--- a/include/rut/runtime/event_loop.h
+++ b/include/rut/runtime/event_loop.h
@@ -10,8 +10,10 @@
 #include "rut/runtime/io_backend.h"
 #include "rut/runtime/io_event.h"
 #include "rut/runtime/metrics.h"
+#include "rut/runtime/shard_control.h"
 #include "rut/runtime/slice_pool.h"
 #include "rut/runtime/timer_wheel.h"
+#include <atomic>
 
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -65,14 +67,14 @@ struct EventLoop : EventLoopCRTP<EventLoop<Backend>> {
 
 private:
     // Cross-thread state — main thread writes (stop/drain), shard thread reads.
-    // All access via __atomic builtins for portability (ARM weak memory model).
+    // All access via std::atomic for portability (ARM weak memory model).
     // draining_ is the release/acquire gate: drain_start_/drain_period_ are
     // written with relaxed ordering before draining_ is stored with release,
     // so the shard thread sees consistent values after acquiring draining_.
-    bool running_;
-    bool draining_;
-    u64 drain_start_;   // monotonic seconds when drain began
-    u32 drain_period_;  // seconds until force-close
+    std::atomic<bool> running_;
+    std::atomic<bool> draining_;
+    std::atomic<u64> drain_start_;   // monotonic seconds when drain began
+    std::atomic<u32> drain_period_;  // seconds until force-close
 
 public:
     static constexpr u32 kMaxConns = 16384;
@@ -105,14 +107,26 @@ public:
     // Per-shard metrics. Set by Shard before run(). Null = no metrics.
     ShardMetrics* metrics = nullptr;
 
+    // Per-shard control plane pointers. Set by Shard::init(), read by
+    // poll_command() / epoch_enter() / epoch_leave() on the shard thread.
+    // Null = no control plane (standalone EventLoop in tests).
+    const RouteConfig** config_ptr = nullptr;
+    ShardControlBlock* control = nullptr;
+    ShardEpoch* epoch = nullptr;
+    void** jit_code_ptr = nullptr;
+
     core::Expected<void, Error> init(u32 id, i32 lfd, u32 pool_prealloc = 0) {
         shard_id = id;
         listen_fd = lfd;
-        __atomic_store_n(&running_, true, __ATOMIC_RELAXED);
-        __atomic_store_n(&draining_, false, __ATOMIC_RELAXED);
-        __atomic_store_n(&drain_start_, static_cast<u64>(0), __ATOMIC_RELAXED);
-        __atomic_store_n(&drain_period_, static_cast<u32>(0), __ATOMIC_RELAXED);
+        running_.store(true, std::memory_order_relaxed);
+        draining_.store(false, std::memory_order_relaxed);
+        drain_start_.store(0, std::memory_order_relaxed);
+        drain_period_.store(0, std::memory_order_relaxed);
         keepalive_timeout = kDefaultKeepaliveTimeout;
+        config_ptr = nullptr;
+        control = nullptr;
+        epoch = nullptr;
+        jit_code_ptr = nullptr;
         free_top = kMaxConns;
         pending_free_count = 0;
         deferred_accept_count = 0;
@@ -148,27 +162,57 @@ public:
                 reclaim_pending();
                 retry_deferred_accepts();
             }
+            poll_command();
             // Close listen fd after dispatching the current batch so any
             // already-queued accepts (epoll backlog) get a proper response
             // with Connection: close, rather than being dropped/reset.
             // Idempotent — only effective on the first drain iteration.
-            if (__atomic_load_n(&draining_, __ATOMIC_ACQUIRE)) {
+            if (draining_.load(std::memory_order_acquire)) {
                 close_listen();
-                u64 start = __atomic_load_n(&drain_start_, __ATOMIC_RELAXED);
-                u32 period = __atomic_load_n(&drain_period_, __ATOMIC_RELAXED);
+                u64 start = drain_start_.load(std::memory_order_relaxed);
+                u32 period = drain_period_.load(std::memory_order_relaxed);
                 if (active_count() == 0) {
-                    __atomic_store_n(&running_, false, __ATOMIC_RELAXED);
+                    running_.store(false, std::memory_order_relaxed);
                 } else if (monotonic_secs() >= start + period) {
                     force_close_all();
-                    __atomic_store_n(&running_, false, __ATOMIC_RELAXED);
+                    running_.store(false, std::memory_order_relaxed);
                 }
             }
         }
     }
 
-    void stop() { __atomic_store_n(&running_, false, __ATOMIC_RELEASE); }
-    bool is_running() const { return __atomic_load_n(&running_, __ATOMIC_ACQUIRE); }
-    bool is_draining() const { return __atomic_load_n(&draining_, __ATOMIC_ACQUIRE); }
+    void stop() { running_.store(false, std::memory_order_release); }
+    bool is_running() const { return running_.load(std::memory_order_acquire); }
+    bool is_draining() const { return draining_.load(std::memory_order_acquire); }
+
+    // Poll the per-shard control block. Independent config + JIT slots.
+    // Zero-cost when neither flag is set (two atomic loads, both predicted
+    // not-taken).
+    void poll_command() {
+        if (!control) return;
+        // Single atomic exchange per slot: read + clear in one op.
+        // nullptr = no update; non-null = apply.
+        auto* cfg = control->pending_config.exchange(nullptr, std::memory_order_acq_rel);
+        if (cfg && config_ptr) *config_ptr = cfg;
+
+        auto* jit = control->pending_jit.exchange(nullptr, std::memory_order_acq_rel);
+        if (jit && jit_code_ptr) *jit_code_ptr = jit;
+    }
+
+    // RCU monotonic epoch. Both enter and leave increment, so the control
+    // plane can snapshot before a swap and wait for advancement.
+    // Zero-cost when epoch pointer is null (no control plane wired).
+    void epoch_enter() {
+        if (epoch)
+            epoch->epoch.store(epoch->epoch.load(std::memory_order_relaxed) + 1,
+                               std::memory_order_release);
+    }
+    void epoch_leave() {
+        if (epoch)
+            epoch->epoch.store(epoch->epoch.load(std::memory_order_relaxed) + 1,
+                               std::memory_order_release);
+    }
+
     void shutdown() {
         if constexpr (Backend::kAsyncIo) reclaim_pending();
         backend.shutdown();
@@ -231,9 +275,9 @@ public:
     // release store on draining_ — shard thread's acquire load on
     // draining_ guarantees it sees consistent period/start values.
     void drain(u32 period_secs) {
-        __atomic_store_n(&drain_period_, period_secs, __ATOMIC_RELAXED);
-        __atomic_store_n(&drain_start_, monotonic_secs(), __ATOMIC_RELAXED);
-        __atomic_store_n(&draining_, true, __ATOMIC_RELEASE);
+        drain_period_.store(period_secs, std::memory_order_relaxed);
+        drain_start_.store(monotonic_secs(), std::memory_order_relaxed);
+        draining_.store(true, std::memory_order_release);
 
         // Wake the shard thread if it's blocked in backend.wait().
         // timerfd_settime is async-signal-safe and thread-safe (POSIX).
@@ -357,6 +401,10 @@ public:
     }
 
     void close_conn_impl(Connection& c) {
+        // If a request was in flight (epoch_enter called), leave the epoch
+        // before closing. This covers timer wheel timeouts, force_close_all
+        // during drain, and any other path that bypasses normal callbacks.
+        if (c.req_start_us != 0) epoch_leave();
         if constexpr (Backend::kAsyncIo) {
             // Only cancel when ops are in flight. If pending_ops == 0,
             // the slot is freed immediately — no cancels needed.
@@ -413,9 +461,9 @@ public:
 
             // During drain: probabilistically close idle connections.
             // ReadingHeader = waiting for next request on keep-alive (effectively idle).
-            if (__atomic_load_n(&draining_, __ATOMIC_ACQUIRE)) {
-                u64 start = __atomic_load_n(&drain_start_, __ATOMIC_RELAXED);
-                u32 period = __atomic_load_n(&drain_period_, __ATOMIC_RELAXED);
+            if (draining_.load(std::memory_order_acquire)) {
+                u64 start = drain_start_.load(std::memory_order_relaxed);
+                u32 period = drain_period_.load(std::memory_order_relaxed);
                 u64 now = monotonic_secs();
                 for (u32 i = 0; i < kMaxConns; i++) {
                     if (conns[i].fd >= 0 && conns[i].state == ConnState::ReadingHeader &&
@@ -493,7 +541,7 @@ private:
         }
         c->state = ConnState::ReadingHeader;
         // During drain: mark new connections for close after first response.
-        c->keep_alive = !__atomic_load_n(&draining_, __ATOMIC_RELAXED);
+        c->keep_alive = !draining_.load(std::memory_order_relaxed);
         c->on_complete = &on_header_received<Self>;
         timer.add(c, keepalive_timeout);
         if (metrics) metrics->on_accept();
@@ -519,7 +567,7 @@ private:
                 c->peer_addr = peer.sin_addr.s_addr;
             }
             c->state = ConnState::ReadingHeader;
-            c->keep_alive = !__atomic_load_n(&draining_, __ATOMIC_RELAXED);
+            c->keep_alive = !draining_.load(std::memory_order_relaxed);
             c->on_complete = &on_header_received<Self>;
             timer.add(c, keepalive_timeout);
             if (metrics) metrics->on_accept();

--- a/include/rut/runtime/shard.h
+++ b/include/rut/runtime/shard.h
@@ -8,11 +8,13 @@
 #include "rut/runtime/event_loop.h"
 #include "rut/runtime/metrics.h"
 #include "rut/runtime/route_table.h"
+#include "rut/runtime/shard_control.h"
 #include "rut/runtime/upstream_pool.h"
 
 #include <pthread.h>
 #include <sched.h>
 #include <sys/mman.h>
+#include <sys/timerfd.h>
 #include <unistd.h>
 
 namespace rut {
@@ -57,13 +59,25 @@ struct Shard {
     ShardMetrics shard_metrics{};
 
     // Route config — set before spawning threads, read-only during runtime.
-    // Phase 3 hot reload will use __atomic_load_n/__atomic_store_n for
+    // Phase 3 hot reload will use std::atomic store/load for
     // cross-thread swap + epoch-based reclamation. Currently immutable.
     const RouteConfig* route_config = nullptr;
 
+    // Per-shard control block (control plane → shard thread).
+    ShardControlBlock control{};
+
+    // Per-shard RCU epoch (shard thread → control plane reads).
+    ShardEpoch epoch{};
+
+    // Active config pointer — updated atomically by poll_command().
+    const RouteConfig* active_config = nullptr;
+
+    // Active JIT code pointer — updated atomically by poll_command().
+    void* jit_code = nullptr;
+
     // Thread
     pthread_t thread = 0;
-    bool thread_spawned = false;
+    bool thread_spawned = false;  // true between spawn() and join()
 
     // Initialize shard: mmap EventLoop, init backend + arena.
     // listen_fd must already be created with SO_REUSEPORT.
@@ -124,6 +138,17 @@ struct Shard {
         shard_metrics.init();
         loop->metrics = &shard_metrics;
 
+        // Init per-shard control block and epoch.
+        control.pending_config.store(nullptr, std::memory_order_relaxed);
+        control.pending_jit.store(nullptr, std::memory_order_relaxed);
+        epoch.epoch.store(0, std::memory_order_relaxed);
+
+        // Wire control pointers into EventLoop for poll_command/epoch.
+        loop->config_ptr = &active_config;
+        loop->control = &control;
+        loop->epoch = &epoch;
+        loop->jit_code_ptr = &jit_code;
+
         return {};
     }
 
@@ -148,6 +173,9 @@ struct Shard {
     // pin_cpu: -1 = no pinning, >=0 = pin to that core.
     core::Expected<void, Error> spawn(i32 pin_cpu = -1) {
         if (!loop) return core::make_unexpected(Error::make(EINVAL, Error::Source::Thread));
+        // Seed from route_config only if active_config wasn't already set
+        // by a reload_config() call before spawn.
+        if (!active_config) active_config = route_config;
         if (thread_spawned)
             return core::make_unexpected(Error::make(EEXIST, Error::Source::Thread));
 
@@ -191,11 +219,40 @@ struct Shard {
         if (loop) loop->drain(period_secs);
     }
 
+    // Send a config reload to the shard (fire-and-forget).
+    // If the shard is running, writes to control block.
+    // If stopped/not spawned, applies directly (no thread to race with).
+    void reload_config(const RouteConfig* cfg) {
+        if (!thread_spawned) {
+            // No thread — direct apply.
+            active_config = cfg;
+            return;
+        }
+        // Thread may be running or exiting. Queue atomically.
+        // If thread consumes it — good. If not, join() applies it.
+        control.pending_config.store(cfg, std::memory_order_release);
+    }
+
+    // Send a JIT swap to the shard (fire-and-forget).
+    void swap_jit(void* code) {
+        if (!thread_spawned) {
+            jit_code = code;
+            return;
+        }
+        control.pending_jit.store(code, std::memory_order_release);
+    }
+
     // Wait for the shard's thread to finish.
     void join() {
         if (thread_spawned) {
             pthread_join(thread, nullptr);
             thread_spawned = false;
+            // Apply any pending updates the thread didn't consume.
+            // Thread is guaranteed gone — no race.
+            auto* cfg = control.pending_config.exchange(nullptr, std::memory_order_acq_rel);
+            if (cfg) active_config = cfg;
+            auto* jit = control.pending_jit.exchange(nullptr, std::memory_order_acq_rel);
+            if (jit) jit_code = jit;
         }
     }
 
@@ -236,6 +293,12 @@ private:
         self->loop->run();
         return nullptr;
     }
+
+    // No explicit wake — poll_command runs every event loop iteration,
+    // and the timerfd fires every 1 second. Perturbing the timerfd to
+    // wake the shard immediately would push out the next periodic tick
+    // and stall keepalive/drain processing. For admin operations (config
+    // reload, JIT swap), up to 1 second latency is acceptable.
 };
 
 // Detect CPU count (online cores).

--- a/include/rut/runtime/shard_control.h
+++ b/include/rut/runtime/shard_control.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "rut/common/types.h"
+#include <atomic>
+
+namespace rut {
+
+struct RouteConfig;  // forward declare
+
+// Per-shard control block. Config and JIT have independent atomic slots.
+// nullptr = no pending update. Non-null = fire-and-forget update.
+// Producer: pending_config.store(ptr, release)
+// Consumer: pending_config.exchange(nullptr, acq_rel)
+// Single atomic op per slot — no flag, no load-clear race.
+struct alignas(64) ShardControlBlock {
+    std::atomic<const RouteConfig*> pending_config{nullptr};
+    std::atomic<void*> pending_jit{nullptr};
+};
+
+// Per-shard monotonic epoch for RCU progress tracking.
+// Incremented on every request enter AND leave/close.
+//
+// LIMITATION: This epoch alone is NOT sufficient for safe reclamation
+// when multiple requests overlap on one shard. A long-running request
+// that started before a config swap can still be active while a newer
+// request advances the epoch past the control plane's snapshot.
+//
+// For safe reclamation, the control plane must ALSO ensure no request
+// that could reference the old config is still in flight. Options:
+//   1. Pin config per-request (Connection holds the config pointer it
+//      started with) — most precise, enables instant reclamation.
+//   2. Drain all connections before reclaiming (simplest, current plan
+//      for hot reload: drain old shard → swap config → re-accept).
+//
+// Shard thread writes, control plane reads via epoch.load(acquire).
+struct alignas(64) ShardEpoch {
+    std::atomic<u64> epoch{0};
+};
+
+}  // namespace rut

--- a/src/runtime/access_log.cc
+++ b/src/runtime/access_log.cc
@@ -1,5 +1,7 @@
 #include "rut/runtime/access_log.h"
 
+#include <atomic>
+
 #include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
@@ -173,7 +175,7 @@ u32 format_access_log_text(const AccessLogEntry& entry, char* buf, u32 buf_size)
 // buffer is full, write returns EAGAIN and we re-poll. Small chunks (4KB) ensure
 // write completes quickly even on pipes.
 static bool write_with_poll(
-    i32 fd, const u8* buf, u32 len, const bool* running_flag, u32 max_stall = 50) {
+    i32 fd, const u8* buf, u32 len, const std::atomic<bool>* running_flag, u32 max_stall = 50) {
     static constexpr u32 kChunkSize = 4096;  // bounded write size
     u32 written = 0;
     u32 stall_polls = 0;
@@ -185,7 +187,7 @@ static bool write_with_poll(
         i32 rc = poll(&pfd, 1, 100);
 
         if (rc == 0) {
-            if (!__atomic_load_n(running_flag, __ATOMIC_RELAXED)) {
+            if (!running_flag->load(std::memory_order_relaxed)) {
                 if (++stall_polls >= max_stall) return false;
             }
             continue;
@@ -217,7 +219,7 @@ static bool write_with_poll(
 // --- AccessLogFlusher ---
 
 core::Expected<void, Error> AccessLogFlusher::start() {
-    if (__atomic_load_n(&running, __ATOMIC_RELAXED)) return {};
+    if (running.load(std::memory_order_relaxed)) return {};
 
     // Set output fd non-blocking so write() never blocks the flusher thread.
     // Combined with poll(POLLOUT) + bounded 4KB chunks, this guarantees the
@@ -241,10 +243,10 @@ core::Expected<void, Error> AccessLogFlusher::start() {
         zstd_ctx = cstream;
     }
 
-    __atomic_store_n(&running, true, __ATOMIC_RELAXED);
+    running.store(true, std::memory_order_relaxed);
     i32 rc = pthread_create(&thread, nullptr, thread_entry, this);
     if (rc != 0) {
-        __atomic_store_n(&running, false, __ATOMIC_RELAXED);
+        running.store(false, std::memory_order_relaxed);
         if (zstd_ctx) {
             ZSTD_freeCStream(static_cast<ZSTD_CStream*>(zstd_ctx));
             zstd_ctx = nullptr;
@@ -255,8 +257,8 @@ core::Expected<void, Error> AccessLogFlusher::start() {
 }
 
 void AccessLogFlusher::stop() {
-    if (!__atomic_load_n(&running, __ATOMIC_RELAXED)) return;
-    __atomic_store_n(&running, false, __ATOMIC_RELEASE);
+    if (!running.load(std::memory_order_relaxed)) return;
+    running.store(false, std::memory_order_release);
     pthread_join(thread, nullptr);
 
     // Flush remaining zstd data and free context.
@@ -369,7 +371,7 @@ void* AccessLogFlusher::thread_entry(void* arg) {
     sleep_ts.tv_sec = self->flush_interval_ms / 1000;
     sleep_ts.tv_nsec = static_cast<long>(self->flush_interval_ms % 1000) * 1000000L;
 
-    while (__atomic_load_n(&self->running, __ATOMIC_ACQUIRE)) {
+    while (self->running.load(std::memory_order_acquire)) {
         self->flush_once();
         nanosleep(&sleep_ts, nullptr);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,16 @@ target_include_directories(test_metrics PRIVATE
 add_test(NAME test_metrics COMMAND test_metrics)
 set_tests_properties(test_metrics PROPERTIES LABELS "unit")
 
+add_executable(test_shard_control test_shard_control.cc)
+target_link_libraries(test_shard_control rue_runtime Threads::Threads)
+target_include_directories(test_shard_control PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_test(NAME test_shard_control COMMAND test_shard_control)
+set_tests_properties(test_shard_control PROPERTIES LABELS "unit")
+
 add_custom_target(check
     COMMAND $<TARGET_FILE:test_network>
     COMMAND $<TARGET_FILE:test_integration>
@@ -121,6 +131,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_drain>
     COMMAND $<TARGET_FILE:test_access_log>
     COMMAND $<TARGET_FILE:test_metrics>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_buffer test_types test_rir test_drain test_access_log test_metrics
+    COMMAND $<TARGET_FILE:test_shard_control>
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_buffer test_types test_rir test_drain test_access_log test_metrics test_shard_control
     COMMENT "Running all tests..."
 )

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -8,8 +8,11 @@
 #include "rut/runtime/epoll_backend.h"
 #include "rut/runtime/event_loop.h"
 #include "rut/runtime/io_event.h"
+#include "rut/runtime/route_table.h"
+#include "rut/runtime/shard_control.h"
 #include "rut/runtime/socket.h"
 #include "rut/runtime/timer_wheel.h"
+#include <atomic>
 
 #include <errno.h>
 #include <fcntl.h>
@@ -47,11 +50,42 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
 
     bool is_draining() const { return draining; }
 
+    // Per-shard control plane pointers (mirrors EventLoop for testing).
+    const RouteConfig** config_ptr = nullptr;
+    ShardControlBlock* control = nullptr;
+    ShardEpoch* epoch = nullptr;
+    void** jit_code_ptr = nullptr;
+
+    // Epoch helpers — functional when epoch pointer is wired.
+    void epoch_enter() {
+        if (epoch)
+            epoch->epoch.store(epoch->epoch.load(std::memory_order_relaxed) + 1,
+                               std::memory_order_release);
+    }
+    void epoch_leave() {
+        if (epoch)
+            epoch->epoch.store(epoch->epoch.load(std::memory_order_relaxed) + 1,
+                               std::memory_order_release);
+    }
+
+    // Poll the per-shard control block (mirrors EventLoop::poll_command).
+    void poll_command() {
+        if (!control) return;
+        auto* cfg = control->pending_config.exchange(nullptr, std::memory_order_acq_rel);
+        if (cfg && config_ptr) *config_ptr = cfg;
+        auto* jit = control->pending_jit.exchange(nullptr, std::memory_order_acq_rel);
+        if (jit && jit_code_ptr) *jit_code_ptr = jit;
+    }
+
     void setup() {
         running = true;
         draining = false;
         access_log = nullptr;
         metrics = nullptr;
+        config_ptr = nullptr;
+        control = nullptr;
+        epoch = nullptr;
+        jit_code_ptr = nullptr;
         keepalive_timeout = 60;
         free_top = kMaxConns;
         timer.init();
@@ -95,6 +129,7 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
         backend.add_connect(c.upstream_fd, c.id, addr, addr_len);
     }
     void close_conn_impl(Connection& c) {
+        if (c.req_start_us != 0) epoch_leave();
         // Mirror real EventLoop: cancel in-flight I/O before freeing.
         if (c.fd >= 0) {
             backend.cancel(c.fd, c.id);
@@ -317,11 +352,33 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
 
     bool is_draining() const { return draining; }
 
+    // Per-shard control plane pointers (mirrors EventLoop for testing).
+    const RouteConfig** config_ptr = nullptr;
+    ShardControlBlock* control = nullptr;
+    ShardEpoch* epoch = nullptr;
+    void** jit_code_ptr = nullptr;
+
+    // Epoch helpers — functional when epoch pointer is wired.
+    void epoch_enter() {
+        if (epoch)
+            epoch->epoch.store(epoch->epoch.load(std::memory_order_relaxed) + 1,
+                               std::memory_order_release);
+    }
+    void epoch_leave() {
+        if (epoch)
+            epoch->epoch.store(epoch->epoch.load(std::memory_order_relaxed) + 1,
+                               std::memory_order_release);
+    }
+
     void setup() {
         running = true;
         draining = false;
         access_log = nullptr;
         metrics = nullptr;
+        config_ptr = nullptr;
+        control = nullptr;
+        epoch = nullptr;
+        jit_code_ptr = nullptr;
         keepalive_timeout = 60;
         free_top = kMaxConns;
         pending_free_count = 0;
@@ -399,6 +456,7 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
     }
 
     void close_conn_impl(Connection& c) {
+        if (c.req_start_us != 0) epoch_leave();
         if (c.pending_ops > 0) {
             c.pending_ops += backend.cancel(c.fd,
                                             c.id,
@@ -535,11 +593,27 @@ struct FailRecvAsyncSmallLoop : EventLoopCRTP<FailRecvAsyncSmallLoop> {
 
     bool is_draining() const { return draining; }
 
+    // Per-shard control plane pointers (mirrors EventLoop for testing).
+    ShardEpoch* epoch = nullptr;
+
+    // Epoch helpers — functional when epoch pointer is wired.
+    void epoch_enter() {
+        if (epoch)
+            epoch->epoch.store(epoch->epoch.load(std::memory_order_relaxed) + 1,
+                               std::memory_order_release);
+    }
+    void epoch_leave() {
+        if (epoch)
+            epoch->epoch.store(epoch->epoch.load(std::memory_order_relaxed) + 1,
+                               std::memory_order_release);
+    }
+
     void setup() {
         running = true;
         draining = false;
         access_log = nullptr;
         metrics = nullptr;
+        epoch = nullptr;
         keepalive_timeout = 60;
         free_top = kMaxConns;
         timer.init();
@@ -594,6 +668,7 @@ struct FailRecvAsyncSmallLoop : EventLoopCRTP<FailRecvAsyncSmallLoop> {
         if (backend.add_connect(c.upstream_fd, c.id, addr, addr_len)) c.pending_ops++;
     }
     void close_conn_impl(Connection& c) {
+        if (c.req_start_us != 0) epoch_leave();
         c.fd = -1;
         c.upstream_fd = -1;
         this->free_conn(c);

--- a/tests/test_shard_control.cc
+++ b/tests/test_shard_control.cc
@@ -1,0 +1,1141 @@
+// Per-shard independent control system tests.
+#include "rut/runtime/epoll_backend.h"
+#include "rut/runtime/event_loop.h"
+#include "rut/runtime/route_table.h"
+#include "rut/runtime/shard.h"
+#include "rut/runtime/shard_control.h"
+#include "rut/runtime/socket.h"
+#include "test.h"
+#include "test_helpers.h"
+
+#include <sys/mman.h>
+#include <sys/timerfd.h>
+#include <time.h>
+#include <unistd.h>
+
+using namespace rut;
+
+// === ShardControlBlock tests ===
+
+TEST(shard_control, control_block_init_zero) {
+    ShardControlBlock cb{};
+    CHECK(cb.pending_config == nullptr);
+    CHECK(cb.pending_jit == nullptr);
+}
+
+TEST(shard_control, control_block_config_write_read) {
+    ShardControlBlock cb{};
+    RouteConfig cfg;
+    cfg.route_count = 42;
+
+    cb.pending_config.store(&cfg, std::memory_order_release);
+
+    CHECK(cb.pending_config.load(std::memory_order_acquire) == &cfg);
+    CHECK_EQ(cb.pending_config.load(std::memory_order_acquire)->route_count, 42u);
+}
+
+TEST(shard_control, control_block_jit_write_read) {
+    ShardControlBlock cb{};
+    u8 fake_code = 0xCC;
+
+    cb.pending_jit.store(static_cast<void*>(&fake_code), std::memory_order_release);
+
+    CHECK(cb.pending_jit.load(std::memory_order_acquire) == &fake_code);
+}
+
+TEST(shard_control, control_block_alignas) {
+    // Verify ShardControlBlock is cache-line aligned.
+    CHECK_EQ(alignof(ShardControlBlock), 64u);
+}
+
+// === ShardEpoch tests ===
+
+TEST(shard_control, epoch_starts_zero) {
+    ShardEpoch ep{};
+    CHECK_EQ(ep.epoch, 0u);
+}
+
+TEST(shard_control, epoch_enter_leave_increments) {
+    // Use a real EventLoop with epoll backend to test epoch_enter/leave.
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    REQUIRE(loop->init(0, lfd).has_value());
+
+    ShardEpoch ep{};
+    ep.epoch = 0;
+    loop->epoch = &ep;
+
+    loop->epoch_enter();
+    CHECK_EQ(ep.epoch, 1u);  // enter incremented
+
+    loop->epoch_leave();
+    CHECK_EQ(ep.epoch, 2u);  // leave incremented
+
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(shard_control, epoch_noop_when_null) {
+    // epoch_enter/leave must be zero-cost when epoch pointer is null.
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    REQUIRE(loop->init(0, lfd).has_value());
+
+    CHECK(loop->epoch == nullptr);
+    // Should not crash or modify anything.
+    loop->epoch_enter();
+    loop->epoch_leave();
+
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(shard_control, epoch_alignas) {
+    CHECK_EQ(alignof(ShardEpoch), 64u);
+}
+
+// === poll_command tests (using SmallLoop-style approach) ===
+
+TEST(shard_control, poll_command_noop_when_null) {
+    // When control is null, poll_command is a no-op.
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    REQUIRE(loop->init(0, lfd).has_value());
+
+    CHECK(loop->control == nullptr);
+    loop->poll_command();  // should not crash
+
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(shard_control, poll_command_reload) {
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    REQUIRE(loop->init(0, lfd).has_value());
+
+    const RouteConfig* active_config = nullptr;
+    ShardControlBlock cb{};
+    RouteConfig cfg;
+    cfg.route_count = 7;
+
+    loop->config_ptr = &active_config;
+    loop->control = &cb;
+
+    // Write config update.
+    cb.pending_config.store(&cfg, std::memory_order_release);
+
+    loop->poll_command();
+
+    CHECK(active_config == &cfg);
+    CHECK_EQ(active_config->route_count, 7u);
+    CHECK(cb.pending_config == nullptr);
+
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(shard_control, poll_command_swap_jit) {
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    REQUIRE(loop->init(0, lfd).has_value());
+
+    void* jit_code = nullptr;
+    ShardControlBlock cb{};
+    loop->control = &cb;
+    loop->jit_code_ptr = &jit_code;
+
+    u8 fake_code = 0xCC;
+    cb.pending_jit.store(static_cast<void*>(&fake_code), std::memory_order_release);
+
+    loop->poll_command();
+
+    CHECK(jit_code == &fake_code);
+    CHECK(cb.pending_jit == nullptr);
+
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(shard_control, poll_command_none_is_noop) {
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    REQUIRE(loop->init(0, lfd).has_value());
+
+    const RouteConfig* active_config = nullptr;
+    ShardControlBlock cb{};
+    loop->config_ptr = &active_config;
+    loop->control = &cb;
+
+    // Both pending are nullptr — poll_command should not modify active_config.
+    loop->poll_command();
+    CHECK(active_config == nullptr);
+
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(shard_control, poll_command_simultaneous_config_and_jit) {
+    // Both pending_config and pending_jit are set. Both should be applied in one poll.
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    REQUIRE(loop->init(0, lfd).has_value());
+
+    const RouteConfig* active_config = nullptr;
+    void* jit_code = nullptr;
+    ShardControlBlock cb{};
+
+    loop->config_ptr = &active_config;
+    loop->jit_code_ptr = &jit_code;
+    loop->control = &cb;
+
+    RouteConfig cfg;
+    cfg.route_count = 55;
+    u8 fake_jit = 0x90;
+
+    cb.pending_config.store(&cfg, std::memory_order_release);
+    cb.pending_jit.store(static_cast<void*>(&fake_jit), std::memory_order_release);
+
+    loop->poll_command();
+
+    CHECK(active_config == &cfg);
+    CHECK_EQ(active_config->route_count, 55u);
+    CHECK(jit_code == &fake_jit);
+    CHECK(cb.pending_config == nullptr);
+    CHECK(cb.pending_jit == nullptr);
+
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+// === Shard integration tests ===
+
+TEST(shard_control, shard_init_wiring) {
+    // Verify control block is initialized and wired into EventLoop.
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    Shard<EpollBackend> shard;
+    auto rc = shard.init(0, lfd);
+    REQUIRE(rc.has_value());
+
+    CHECK(shard.control.pending_config == nullptr);
+    CHECK(shard.control.pending_jit == nullptr);
+    CHECK(shard.loop->control == &shard.control);
+    CHECK(shard.loop->epoch == &shard.epoch);
+    CHECK(shard.loop->config_ptr == &shard.active_config);
+    CHECK(shard.loop->jit_code_ptr == &shard.jit_code);
+
+    shard.shutdown();
+    close(lfd);
+}
+
+TEST(shard_control, shard_reload_config) {
+    // Spawn a real shard, send ReloadConfig, verify active_config changes.
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    Shard<EpollBackend> shard;
+    auto rc = shard.init(0, lfd);
+    REQUIRE(rc.has_value());
+    CHECK(shard.active_config == nullptr);
+
+    auto spawn_rc = shard.spawn();
+    REQUIRE(spawn_rc.has_value());
+
+    // Allocate a RouteConfig via mmap (no malloc).
+    void* cfg_mem = mmap(
+        nullptr, sizeof(RouteConfig), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    REQUIRE(cfg_mem != MAP_FAILED);
+    auto* cfg = new (cfg_mem) RouteConfig();
+    cfg->route_count = 99;
+
+    shard.reload_config(cfg);
+
+    // Give the shard thread time to process the command.
+    // Poll until active_config is updated or timeout after ~100ms.
+    for (u32 i = 0; i < 2000; i++) {
+        const RouteConfig* cur = shard.active_config;
+        if (cur == cfg) break;
+        usleep(1000);
+    }
+
+    const RouteConfig* cur = shard.active_config;
+    CHECK(cur == cfg);
+
+    shard.stop();
+    shard.join();
+    shard.shutdown();
+    close(lfd);
+    munmap(cfg_mem, sizeof(RouteConfig));
+}
+
+TEST(shard_control, shard_swap_jit) {
+    // Spawn a real shard, send SwapJit, verify jit_code changes.
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    Shard<EpollBackend> shard;
+    auto rc = shard.init(0, lfd);
+    REQUIRE(rc.has_value());
+    CHECK(shard.jit_code == nullptr);
+
+    auto spawn_rc = shard.spawn();
+    REQUIRE(spawn_rc.has_value());
+
+    u8 fake_jit = 0x90;  // NOP
+    shard.swap_jit(&fake_jit);
+
+    // Poll until jit_code is updated.
+    for (u32 i = 0; i < 2000; i++) {
+        void* cur = shard.jit_code;
+        if (cur == &fake_jit) break;
+        usleep(1000);
+    }
+
+    void* cur = shard.jit_code;
+    CHECK(cur == &fake_jit);
+
+    shard.stop();
+    shard.join();
+    shard.shutdown();
+    close(lfd);
+}
+
+// === Epoch through real request cycles (SmallLoop) ===
+
+TEST(shard_control, epoch_odd_during_request) {
+    // Accept + recv triggers on_header_received which calls epoch_enter.
+    // Verify epoch is odd after recv (in-request), even after send (request done).
+    SmallLoop loop;
+    loop.setup();
+
+    ShardEpoch ep{};
+    ep.epoch = 0;
+    loop.epoch = &ep;
+
+    // Accept a connection.
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    CHECK_EQ(ep.epoch, 0u);  // no request yet
+
+    // Recv triggers on_header_received → epoch_enter.
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 50));
+    CHECK_EQ(ep.epoch, 1u);  // enter incremented
+    CHECK_EQ(c->state, ConnState::Sending);
+
+    // Send completion triggers on_response_sent → epoch_leave.
+    loop.inject_and_dispatch(
+        make_ev(c->id, IoEventType::Send, static_cast<i32>(c->send_buf.len())));
+    CHECK_EQ(ep.epoch, 2u);  // leave incremented
+    CHECK_EQ(c->state, ConnState::ReadingHeader);
+}
+
+TEST(shard_control, epoch_across_keepalive) {
+    // Two full request cycles. Monotonic epoch: each cycle = +2 (enter+leave).
+    SmallLoop loop;
+    loop.setup();
+
+    ShardEpoch ep{};
+    ep.epoch = 0;
+    loop.epoch = &ep;
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    // First request cycle: enter=1, leave=2.
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 50));
+    CHECK_EQ(ep.epoch, 1u);
+    loop.inject_and_dispatch(
+        make_ev(c->id, IoEventType::Send, static_cast<i32>(c->send_buf.len())));
+    CHECK_EQ(ep.epoch, 2u);
+
+    // Second request cycle: enter=3, leave=4.
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 50));
+    CHECK_EQ(ep.epoch, 3u);
+    loop.inject_and_dispatch(
+        make_ev(c->id, IoEventType::Send, static_cast<i32>(c->send_buf.len())));
+    CHECK_EQ(ep.epoch, 4u);
+}
+
+TEST(shard_control, epoch_on_error_close) {
+    // Accept, recv, inject a Send error (result < 0).
+    // Verify epoch_leave was called even on the error path (epoch goes back to even).
+    SmallLoop loop;
+    loop.setup();
+
+    ShardEpoch ep{};
+    ep.epoch = 0;
+    loop.epoch = &ep;
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    u32 cid = c->id;
+
+    // Recv → epoch_enter (epoch = 1).
+    loop.inject_and_dispatch(make_ev(cid, IoEventType::Recv, 50));
+    CHECK_EQ(ep.epoch, 1u);
+
+    // Send error → close_conn_impl calls epoch_leave (req_start_us != 0).
+    loop.inject_and_dispatch(make_ev(cid, IoEventType::Send, -32));
+    CHECK_EQ(ep.epoch, 2u);            // leave incremented (enter=1, leave=2)
+    CHECK_EQ(loop.conns[cid].fd, -1);  // connection closed
+}
+
+// === Config pointer through request cycle ===
+
+TEST(shard_control, config_ptr_readable_in_loop) {
+    // Set loop.config_ptr to point to a local RouteConfig*.
+    // Verify *loop.config_ptr reads the config.
+    SmallLoop loop;
+    loop.setup();
+
+    RouteConfig cfg;
+    cfg.route_count = 77;
+    const RouteConfig* active = &cfg;
+    loop.config_ptr = &active;
+
+    CHECK(loop.config_ptr != nullptr);
+    CHECK(*loop.config_ptr == &cfg);
+    CHECK_EQ((*loop.config_ptr)->route_count, 77u);
+}
+
+TEST(shard_control, reload_config_updates_ptr) {
+    // Set initial config, poll_command with pending_config pointing to a new config.
+    SmallLoop loop;
+    loop.setup();
+
+    RouteConfig cfg1;
+    cfg1.route_count = 10;
+    RouteConfig cfg2;
+    cfg2.route_count = 20;
+
+    const RouteConfig* active = &cfg1;
+    ShardControlBlock cb{};
+
+    loop.config_ptr = &active;
+    loop.control = &cb;
+
+    CHECK(active == &cfg1);
+
+    // Send config update.
+    cb.pending_config.store(&cfg2, std::memory_order_release);
+    loop.poll_command();
+
+    CHECK(active == &cfg2);
+    CHECK_EQ(active->route_count, 20u);
+    CHECK(cb.pending_config == nullptr);
+}
+
+// === Command sequencing ===
+
+TEST(shard_control, sequential_commands) {
+    // Send config update, consume it, then send JIT update, consume it.
+    SmallLoop loop;
+    loop.setup();
+
+    RouteConfig cfg;
+    cfg.route_count = 42;
+    const RouteConfig* active = nullptr;
+    void* jit_code = nullptr;
+    ShardControlBlock cb{};
+
+    loop.config_ptr = &active;
+    loop.jit_code_ptr = &jit_code;
+    loop.control = &cb;
+
+    // First: config reload.
+    cb.pending_config.store(&cfg, std::memory_order_release);
+    loop.poll_command();
+    CHECK(active == &cfg);
+    CHECK(cb.pending_config == nullptr);
+
+    // Second: JIT swap.
+    u8 fake_jit = 0x90;
+    cb.pending_jit.store(static_cast<void*>(&fake_jit), std::memory_order_release);
+    loop.poll_command();
+    CHECK(jit_code == &fake_jit);
+    CHECK(cb.pending_jit == nullptr);
+
+    // Both were applied.
+    CHECK(active == &cfg);
+    CHECK(jit_code == &fake_jit);
+}
+
+// === Stop behavior ===
+
+TEST(shard_control, stop_does_not_affect_other_shards) {
+    // Create two real shards. Stop one. Verify the other is still running.
+    auto lfd1_result = create_listen_socket(0);
+    REQUIRE(lfd1_result.has_value());
+    i32 lfd1 = lfd1_result.value();
+
+    auto lfd2_result = create_listen_socket(0);
+    REQUIRE(lfd2_result.has_value());
+    i32 lfd2 = lfd2_result.value();
+
+    Shard<EpollBackend> shard1;
+    Shard<EpollBackend> shard2;
+    REQUIRE(shard1.init(0, lfd1).has_value());
+    REQUIRE(shard2.init(1, lfd2).has_value());
+
+    REQUIRE(shard1.spawn().has_value());
+    REQUIRE(shard2.spawn().has_value());
+
+    // Stop shard1.
+    shard1.stop();
+    shard1.join();
+
+    // shard2 should still be running.
+    CHECK(!shard1.loop->is_running());
+    CHECK(shard2.loop->is_running());
+
+    shard2.stop();
+    shard2.join();
+
+    shard1.shutdown();
+    shard2.shutdown();
+    close(lfd1);
+    close(lfd2);
+}
+
+// === JIT pointer ===
+
+TEST(shard_control, jit_swap_updates_ptr) {
+    // Set jit_code_ptr, send JIT updates, verify the pointer was updated.
+    SmallLoop loop;
+    loop.setup();
+
+    void* jit_code = nullptr;
+    ShardControlBlock cb{};
+    loop.jit_code_ptr = &jit_code;
+    loop.control = &cb;
+
+    u8 code_a = 0xCC;
+    u8 code_b = 0x90;
+
+    // First swap.
+    cb.pending_jit.store(static_cast<void*>(&code_a), std::memory_order_release);
+    loop.poll_command();
+    CHECK(jit_code == &code_a);
+
+    // Second swap overwrites.
+    cb.pending_jit.store(static_cast<void*>(&code_b), std::memory_order_release);
+    loop.poll_command();
+    CHECK(jit_code == &code_b);
+}
+
+// === Wake timeliness (real shard) ===
+
+TEST(shard_control, command_processed_within_timer_tick) {
+    // Spawn a real shard, send ReloadConfig with known config pointer.
+    // Shard processes commands on each event loop iteration (timer tick = 1s).
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    Shard<EpollBackend> shard;
+    REQUIRE(shard.init(0, lfd).has_value());
+    CHECK(shard.active_config == nullptr);
+
+    REQUIRE(shard.spawn().has_value());
+
+    void* cfg_mem = mmap(
+        nullptr, sizeof(RouteConfig), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    REQUIRE(cfg_mem != MAP_FAILED);
+    auto* cfg = new (cfg_mem) RouteConfig();
+    cfg->route_count = 123;
+
+    shard.reload_config(cfg);
+
+    // Sleep 1.5s — shard processes on next timer tick (~1s interval).
+    struct timespec ts = {1, 500000000L};
+    nanosleep(&ts, nullptr);
+
+    const RouteConfig* cur = shard.active_config;
+    CHECK(cur == cfg);
+    CHECK_EQ(cur->route_count, 123u);
+
+    shard.stop();
+    shard.join();
+    shard.shutdown();
+    close(lfd);
+    munmap(cfg_mem, sizeof(RouteConfig));
+}
+
+// === Edge cases ===
+
+TEST(shard_control, poll_command_without_config_ptr) {
+    // control is set but config_ptr is null. Send config update.
+    // poll_command should not crash (null check on config_ptr).
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    REQUIRE(loop->init(0, lfd).has_value());
+
+    ShardControlBlock cb{};
+    loop->control = &cb;
+    loop->config_ptr = nullptr;  // explicitly null
+
+    RouteConfig cfg;
+    cfg.route_count = 50;
+    cb.pending_config.store(&cfg, std::memory_order_release);
+
+    // Should not crash — pending_config with null config_ptr is a no-op.
+    loop->poll_command();
+    CHECK(cb.pending_config == nullptr);
+
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(shard_control, poll_command_without_jit_ptr) {
+    // control is set but jit_code_ptr is null. Send JIT update.
+    // poll_command should not crash (null check on jit_code_ptr).
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    REQUIRE(loop->init(0, lfd).has_value());
+
+    ShardControlBlock cb{};
+    loop->control = &cb;
+    loop->jit_code_ptr = nullptr;  // explicitly null
+
+    u8 fake_code = 0xCC;
+    cb.pending_jit.store(static_cast<void*>(&fake_code), std::memory_order_release);
+
+    // Should not crash — pending_jit with null jit_code_ptr is a no-op.
+    loop->poll_command();
+    CHECK(cb.pending_jit == nullptr);
+
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+// === Direct apply when shard not running ===
+
+TEST(shard_control, reload_before_spawn_applies_directly) {
+    // reload_config before spawn should set active_config directly.
+    Shard<EpollBackend> s;
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    auto rc = s.init(0, lfd);
+    REQUIRE(rc.has_value());
+
+    RouteConfig cfg;
+    s.reload_config(&cfg);
+    CHECK_EQ(s.active_config, &cfg);  // applied directly
+
+    s.shutdown();
+    close(lfd);
+}
+
+TEST(shard_control, swap_jit_before_spawn_applies_directly) {
+    Shard<EpollBackend> s;
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    auto rc = s.init(0, lfd);
+    REQUIRE(rc.has_value());
+
+    i32 dummy = 42;
+    s.swap_jit(&dummy);
+    CHECK_EQ(s.jit_code, &dummy);  // applied directly
+
+    s.shutdown();
+    close(lfd);
+}
+
+TEST(shard_control, reload_after_stop_applies_directly) {
+    // Spawn, stop, join, then reload — should not hang.
+    Shard<EpollBackend> s;
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    auto rc = s.init(0, lfd);
+    REQUIRE(rc.has_value());
+
+    s.spawn(false);
+    s.stop();
+    s.join();
+
+    RouteConfig cfg;
+    s.reload_config(&cfg);  // must not hang
+    CHECK_EQ(s.active_config, &cfg);
+
+    s.shutdown();
+    close(lfd);
+}
+
+// === Seed active_config from route_config in spawn ===
+
+TEST(shard_control, spawn_seeds_active_config_from_route_config) {
+    // route_config is set after init(), before spawn().
+    // active_config should reflect it after spawn.
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    Shard<EpollBackend> s;
+    auto rc = s.init(0, lfd);
+    REQUIRE(rc.has_value());
+
+    // route_config set AFTER init, BEFORE spawn (standard pattern).
+    RouteConfig cfg;
+    cfg.route_count = 42;
+    s.route_config = &cfg;
+
+    REQUIRE(s.spawn(false).has_value());
+
+    // active_config should be seeded from route_config.
+    CHECK_EQ(s.active_config, &cfg);
+
+    s.stop();
+    s.join();
+    s.shutdown();
+    close(lfd);
+}
+
+// === Reload between stop and join ===
+
+TEST(shard_control, reload_after_stop_before_join) {
+    // stop() → reload_config() → join(): must not deadlock,
+    // and the reload must take effect.
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    Shard<EpollBackend> s;
+    REQUIRE(s.init(0, lfd).has_value());
+    REQUIRE(s.spawn(false).has_value());
+
+    s.stop();
+    // Shard thread is exiting or has exited.
+    // Sleep briefly to let it finish its final iteration.
+    struct timespec ts = {0, 100000000L};  // 100ms
+    nanosleep(&ts, nullptr);
+
+    RouteConfig new_cfg;
+    new_cfg.route_count = 99;
+    s.reload_config(&new_cfg);  // must not deadlock
+
+    s.join();
+
+    // After join, reload should have taken effect.
+    CHECK_EQ(s.active_config, &new_cfg);
+
+    s.shutdown();
+    close(lfd);
+}
+
+// === Stale command drained on join ===
+
+TEST(shard_control, join_clears_stale_pending_without_overwrite) {
+    // reload(A) → stop → reload(B) overwrites A in pending → join applies B.
+    // With atomic pointer exchange, B is the latest store. join() picks it up.
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    Shard<EpollBackend> s;
+    REQUIRE(s.init(0, lfd).has_value());
+    REQUIRE(s.spawn(false).has_value());
+
+    RouteConfig old_cfg;
+    old_cfg.route_count = 77;
+    s.reload_config(&old_cfg);  // queue via control block (thread_spawned=true)
+    s.stop();
+
+    // thread_spawned is still true, so this overwrites old_cfg in pending_config.
+    RouteConfig new_cfg;
+    new_cfg.route_count = 99;
+    s.reload_config(&new_cfg);
+
+    s.join();  // applies whatever is pending (new_cfg, since it overwrote old_cfg)
+
+    CHECK_EQ(s.active_config, &new_cfg);
+    CHECK_EQ(s.active_config->route_count, 99u);
+
+    s.shutdown();
+    close(lfd);
+}
+
+// === Epoch via timer close ===
+
+TEST(shard_control, epoch_leave_on_timer_close) {
+    // Accept a connection, recv (epoch_enter → epoch=1). Add connection to
+    // timer with timeout=0 (current slot). Dispatch a Timeout event to fire
+    // timer.tick(), which closes the connection via close_conn → epoch_leave.
+    // Verify epoch=2 (enter + leave).
+    SmallLoop loop;
+    loop.setup();
+
+    ShardEpoch ep{};
+    ep.epoch = 0;
+    loop.epoch = &ep;
+
+    // Accept a connection.
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    CHECK_EQ(ep.epoch, 0u);
+
+    // Recv triggers on_header_received → epoch_enter.
+    u32 cid = c->id;
+    loop.inject_and_dispatch(make_ev(cid, IoEventType::Recv, 50));
+    CHECK_EQ(ep.epoch, 1u);
+    CHECK_EQ(c->state, ConnState::Sending);
+
+    // Move the connection to the current timer slot (timeout=0 means current
+    // cursor slot). Refresh with 0 places it at cursor+0 = current slot.
+    loop.timer.refresh(c, 0);
+
+    // Dispatch a Timeout event. timer.tick() advances cursor, closing
+    // connections in the current slot via close_conn → epoch_leave.
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Timeout, 1));
+    CHECK_EQ(ep.epoch, 2u);
+
+    // Connection should be closed.
+    CHECK_EQ(loop.conns[cid].fd, -1);
+}
+
+// === Epoch with concurrent requests ===
+
+TEST(shard_control, epoch_with_concurrent_requests) {
+    // Accept two connections. Recv on both (two epoch_enters → epoch=2).
+    // Send complete on first (epoch_leave → epoch=3).
+    // Send complete on second (epoch_leave → epoch=4).
+    SmallLoop loop;
+    loop.setup();
+
+    ShardEpoch ep{};
+    ep.epoch = 0;
+    loop.epoch = &ep;
+
+    // Accept two connections.
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c1 = loop.find_fd(42);
+    REQUIRE(c1 != nullptr);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 43));
+    auto* c2 = loop.find_fd(43);
+    REQUIRE(c2 != nullptr);
+
+    CHECK_EQ(ep.epoch, 0u);
+
+    // Recv on first → epoch_enter (epoch=1).
+    loop.inject_and_dispatch(make_ev(c1->id, IoEventType::Recv, 50));
+    CHECK_EQ(ep.epoch, 1u);
+
+    // Recv on second → epoch_enter (epoch=2).
+    loop.inject_and_dispatch(make_ev(c2->id, IoEventType::Recv, 50));
+    CHECK_EQ(ep.epoch, 2u);
+
+    // Send complete on first → epoch_leave (epoch=3).
+    loop.inject_and_dispatch(
+        make_ev(c1->id, IoEventType::Send, static_cast<i32>(c1->send_buf.len())));
+    CHECK_EQ(ep.epoch, 3u);
+
+    // Send complete on second → epoch_leave (epoch=4).
+    loop.inject_and_dispatch(
+        make_ev(c2->id, IoEventType::Send, static_cast<i32>(c2->send_buf.len())));
+    CHECK_EQ(ep.epoch, 4u);
+}
+
+// === Epoch monotonic under load ===
+
+TEST(shard_control, epoch_monotonic_under_load) {
+    // Do 5 full request cycles (accept, recv, send). Verify epoch = 10 (5 * 2).
+    // Demonstrates monotonic advancement under steady traffic (the property
+    // that lets RCU work).
+    SmallLoop loop;
+    loop.setup();
+
+    ShardEpoch ep{};
+    ep.epoch = 0;
+    loop.epoch = &ep;
+
+    for (u32 i = 0; i < 5; i++) {
+        i32 fake_fd = static_cast<i32>(100 + i);
+        loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, fake_fd));
+        auto* c = loop.find_fd(fake_fd);
+        REQUIRE(c != nullptr);
+
+        // Recv → epoch_enter.
+        loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 50));
+        CHECK_EQ(ep.epoch, i * 2 + 1);
+
+        // Send → epoch_leave.
+        loop.inject_and_dispatch(
+            make_ev(c->id, IoEventType::Send, static_cast<i32>(c->send_buf.len())));
+        CHECK_EQ(ep.epoch, i * 2 + 2);
+    }
+
+    CHECK_EQ(ep.epoch, 10u);
+}
+
+// === Config pointer updates after multiple reloads ===
+
+TEST(shard_control, config_ptr_updates_after_reload) {
+    // Wire SmallLoop with config_ptr → local RouteConfig*. Set initial config.
+    // Send config update with new config. Call poll_command. Verify
+    // *config_ptr now points to new config. Send ANOTHER update. Verify
+    // updated again.
+    SmallLoop loop;
+    loop.setup();
+
+    RouteConfig cfg1;
+    cfg1.route_count = 10;
+    RouteConfig cfg2;
+    cfg2.route_count = 20;
+    RouteConfig cfg3;
+    cfg3.route_count = 30;
+
+    const RouteConfig* active = &cfg1;
+    ShardControlBlock cb{};
+
+    loop.config_ptr = &active;
+    loop.control = &cb;
+
+    CHECK(active == &cfg1);
+    CHECK_EQ(active->route_count, 10u);
+
+    // First reload: cfg1 → cfg2.
+    cb.pending_config.store(&cfg2, std::memory_order_release);
+    loop.poll_command();
+
+    CHECK(active == &cfg2);
+    CHECK_EQ(active->route_count, 20u);
+    CHECK(cb.pending_config == nullptr);
+
+    // Second reload: cfg2 → cfg3.
+    cb.pending_config.store(&cfg3, std::memory_order_release);
+    loop.poll_command();
+
+    CHECK(active == &cfg3);
+    CHECK_EQ(active->route_count, 30u);
+    CHECK(cb.pending_config == nullptr);
+}
+
+// === Swap JIT after stop before join ===
+
+TEST(shard_control, swap_jit_after_stop_before_join) {
+    // Create real shard, spawn, stop, sleep 100ms, swap_jit(new ptr), join.
+    // Verify jit_code == new ptr. (Mirrors reload_after_stop_before_join
+    // but for JIT.)
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    Shard<EpollBackend> shard;
+    REQUIRE(shard.init(0, lfd).has_value());
+    REQUIRE(shard.spawn(false).has_value());
+
+    shard.stop();
+    // Shard thread is exiting or has exited.
+    // Sleep briefly to let it finish its final iteration.
+    struct timespec ts = {0, 100000000L};  // 100ms
+    nanosleep(&ts, nullptr);
+
+    u8 fake_jit = 0x90;         // NOP
+    shard.swap_jit(&fake_jit);  // must not deadlock
+
+    shard.join();
+
+    // After join, swap should have taken effect.
+    CHECK(shard.jit_code == &fake_jit);
+
+    shard.shutdown();
+    close(lfd);
+}
+
+// === Fire-and-forget overwrite: last write wins ===
+
+TEST(shard_control, consecutive_reload_last_wins) {
+    // Two rapid reload_config calls before shard polls.
+    // Only the second config should be applied.
+    SmallLoop loop;
+    loop.setup();
+
+    const RouteConfig* active = nullptr;
+    ShardControlBlock cb{};
+    loop.config_ptr = &active;
+    loop.control = &cb;
+
+    RouteConfig cfg1;
+    cfg1.route_count = 11;
+    RouteConfig cfg2;
+    cfg2.route_count = 22;
+
+    // Two writes, no poll in between — second overwrites first.
+    cb.pending_config.store(&cfg1, std::memory_order_release);
+    cb.pending_config.store(&cfg2, std::memory_order_release);
+
+    loop.poll_command();
+    CHECK_EQ(active, &cfg2);
+    CHECK_EQ(active->route_count, 22u);
+}
+
+TEST(shard_control, consecutive_swap_jit_last_wins) {
+    SmallLoop loop;
+    loop.setup();
+
+    void* active_jit = nullptr;
+    ShardControlBlock cb{};
+    loop.jit_code_ptr = &active_jit;
+    loop.control = &cb;
+
+    i32 jit1 = 1;
+    i32 jit2 = 2;
+
+    cb.pending_jit.store(static_cast<void*>(&jit1), std::memory_order_release);
+    cb.pending_jit.store(static_cast<void*>(&jit2), std::memory_order_release);
+
+    loop.poll_command();
+    CHECK_EQ(active_jit, &jit2);
+}
+
+// === Lifecycle: reload after join applies directly ===
+
+TEST(shard_control, reload_after_join_applies_directly) {
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    Shard<EpollBackend> s;
+    REQUIRE(s.init(0, lfd).has_value());
+    REQUIRE(s.spawn(false).has_value());
+    s.stop();
+    s.join();
+
+    // After join, thread_spawned=false. reload should apply directly.
+    RouteConfig cfg;
+    cfg.route_count = 88;
+    s.reload_config(&cfg);
+    CHECK_EQ(s.active_config, &cfg);
+
+    s.shutdown();
+    close(lfd);
+}
+
+// === Epoch: force_close_all during drain deadline ===
+
+TEST(shard_control, epoch_leave_on_force_close_all) {
+    // Simulate drain deadline: force_close_all closes all connections.
+    // Each connection with req_start_us != 0 should get epoch_leave.
+    SmallLoop loop;
+    loop.setup();
+
+    ShardEpoch ep{};
+    ep.epoch = 0;
+    loop.epoch = &ep;
+
+    // Accept two connections, start requests on both.
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 43));
+    auto* c1 = loop.find_fd(42);
+    auto* c2 = loop.find_fd(43);
+    REQUIRE(c1 != nullptr);
+    REQUIRE(c2 != nullptr);
+
+    // Recv on both → epoch_enter on each (epoch = 2).
+    loop.inject_and_dispatch(make_ev(c1->id, IoEventType::Recv, 50));
+    loop.inject_and_dispatch(make_ev(c2->id, IoEventType::Recv, 50));
+    CHECK_EQ(ep.epoch, 2u);
+
+    // Force-close both (simulates drain deadline).
+    // close_conn_impl calls epoch_leave for each (req_start_us != 0).
+    loop.close_conn(*c1);
+    loop.close_conn(*c2);
+    CHECK_EQ(ep.epoch, 4u);  // 2 enters + 2 leaves
+    CHECK_EQ(loop.conns[c1->id].fd, -1);
+    CHECK_EQ(loop.conns[c2->id].fd, -1);
+}
+
+// === Fire-and-forget: real shard config+jit simultaneous ===
+
+TEST(shard_control, real_shard_simultaneous_config_and_jit) {
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+
+    Shard<EpollBackend> shard;
+    REQUIRE(shard.init(0, lfd).has_value());
+    REQUIRE(shard.spawn(false).has_value());
+
+    void* cfg_mem = mmap(
+        nullptr, sizeof(RouteConfig), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    REQUIRE(cfg_mem != MAP_FAILED);
+    auto* cfg = new (cfg_mem) RouteConfig();
+    cfg->route_count = 55;
+
+    i32 fake_jit = 99;
+
+    // Fire both simultaneously.
+    shard.reload_config(cfg);
+    shard.swap_jit(&fake_jit);
+
+    // Poll until both applied (up to 2s).
+    for (u32 i = 0; i < 2000; i++) {
+        const RouteConfig* cur_cfg = shard.active_config;
+        void* cur_jit = shard.jit_code;
+        if (cur_cfg == cfg && cur_jit == &fake_jit) break;
+        usleep(1000);
+    }
+
+    CHECK_EQ(shard.active_config, cfg);
+    CHECK_EQ(shard.jit_code, static_cast<void*>(&fake_jit));
+
+    shard.stop();
+    shard.join();
+    shard.shutdown();
+    close(lfd);
+    cfg->~RouteConfig();
+    munmap(cfg_mem, sizeof(RouteConfig));
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}


### PR DESCRIPTION
## Summary

Each shard now has an independent control block and RCU epoch, enabling per-shard hot-reload of config and JIT code without cross-core synchronization.

**Fire-and-forget protocol**:
- Two independent `std::atomic` pointer slots (config + JIT)
- Producer: `.store(ptr, release)` — returns immediately, no waiting
- Consumer: `.exchange(nullptr, acq_rel)` — atomic read+clear in one op
- No flags, no spin-wait, no cross-core blocking, no deadlock risk
- Last write wins (correct for config/JIT — latest is authoritative)

**RCU epoch**: monotonic counter for progress tracking. Documented limitation: not sufficient alone for safe reclamation with overlapping requests — drain-before-reclaim or per-request config pin needed.

**std::atomic migration**: replaced `__atomic` builtins with `std::atomic<T>` across all files except `io_uring_backend.cc` (kernel-mapped memory).

## Changed files
- `shard_control.h` — ShardControlBlock, ShardEpoch (new)
- `shard.h` — reload_config, swap_jit, join pending drain
- `event_loop.h` — poll_command, epoch_enter/leave, close_conn epoch safety
- `callbacks.h` — epoch_enter/leave in request lifecycle
- `access_log.h` + `access_log.cc` — std::atomic migration
- `test_helpers.h` — SmallLoop/AsyncSmallLoop control plane wiring
- `test_shard_control.cc` — 43 tests (new)

## Test plan
- [x] 43 shard control tests (control block, epoch, poll_command, lifecycle, real shard)
- [x] 701 total tests pass (no regressions)
- [x] `./dev.sh all` clean (build + test + tidy + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)