### PR TITLE
Add JIT infrastructure and refactor Arena to template backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,12 @@ set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG")
 
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--gc-sections")
 
+# LLVM — required for JIT compilation (ORC JIT via C API).
+# Only the rue_jit library links LLVM; rue_runtime stays LLVM-free.
+find_package(LLVM REQUIRED CONFIG)
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
 # Project include paths
 include_directories(include)
 

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -355,8 +355,8 @@ struct Module {
     u32 func_count;
     u32 func_cap;
 
-    // Arena that owns all IR memory.
-    Arena* arena;
+    // Arena that owns all IR memory (mmap-backed, compiler use).
+    MmapArena* arena;
 };
 
 }  // namespace rir

--- a/include/rut/jit/codegen.h
+++ b/include/rut/jit/codegen.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "rut/common/types.h"
+
+// Forward declarations — avoid pulling LLVM headers into other code.
+using LLVMModuleRef = struct LLVMOpaqueModule*;
+using LLVMContextRef = struct LLVMOpaqueContext*;
+
+namespace rut::rir {
+struct Module;
+}
+
+namespace rut::jit {
+
+// ── Codegen ────────────────────────────────────────────────────────
+// Translates an RIR Module into an LLVM IR Module via the LLVM C API.
+//
+// Phase 1: handles sync handlers only (no yields). Each RIR Function
+// becomes a single LLVM function with the HandlerFn signature.
+//
+// The returned LLVMModuleRef and LLVMContextRef are owned by the caller.
+// Pass both to JitEngine::compile() which takes ownership.
+
+struct CodegenResult {
+    LLVMModuleRef mod;
+    LLVMContextRef ctx;
+    bool ok;
+};
+
+// Translate all functions in the RIR module to LLVM IR.
+// Returns {module, context, true} on success, {null, null, false} on error.
+CodegenResult codegen(const rir::Module& rir_mod);
+
+}  // namespace rut::jit

--- a/include/rut/jit/handler_abi.h
+++ b/include/rut/jit/handler_abi.h
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "rut/common/types.h"
+
+namespace rut {
+namespace jit {
+
+// ── Handler Action ─────────────────────────────────────────────────
+// What the runtime should do after a JIT handler returns.
+
+enum class HandlerAction : u8 {
+    ReturnStatus = 0,  // Send HTTP response with status_code
+    Proxy = 1,         // Forward request to upstream_id
+    Yield = 2,         // Suspend: initiate I/O, resume at next_state
+};
+
+// ── Yield Kind ─────────────────────────────────────────────────────
+// Which I/O operation a Yield requests.
+
+enum class YieldKind : u8 {
+    HttpGet = 0,
+    HttpPost = 1,
+    Proxy = 2,
+    Extern = 3,
+};
+
+// ── Handler Result ─────────────────────────────────────────────────
+// Returned by every JIT handler call as a raw u64. Packed bit layout
+// (little-endian byte order):
+//
+//   byte 0:   action       (HandlerAction)
+//   byte 1-2: status_code  (u16, for ReturnStatus)
+//   byte 3-4: upstream_id  (u16, for Proxy)
+//   byte 5-6: next_state   (u16, for Yield)
+//   byte 7:   yield_kind   (YieldKind)
+//
+// IMPORTANT: We use u64 as the function return type (not a struct)
+// because clang uses sret (hidden pointer) for packed structs even
+// when they fit in a register. Returning u64 guarantees the value
+// goes in RAX, matching the LLVM IR `ret i64`.
+
+struct HandlerResult {
+    HandlerAction action;
+    u16 status_code;
+    u16 upstream_id;
+    u16 next_state;
+    YieldKind yield_kind;
+
+    // Pack into u64 for return from JIT.
+    u64 pack() const {
+        u64 v = 0;
+        v |= static_cast<u64>(action);
+        v |= static_cast<u64>(status_code) << 8;
+        v |= static_cast<u64>(upstream_id) << 24;
+        v |= static_cast<u64>(next_state) << 40;
+        v |= static_cast<u64>(yield_kind) << 56;
+        return v;
+    }
+
+    // Unpack from u64 returned by JIT.
+    static HandlerResult unpack(u64 v) {
+        HandlerResult r;
+        r.action = static_cast<HandlerAction>(v & 0xFF);
+        r.status_code = static_cast<u16>((v >> 8) & 0xFFFF);
+        r.upstream_id = static_cast<u16>((v >> 24) & 0xFFFF);
+        r.next_state = static_cast<u16>((v >> 40) & 0xFFFF);
+        r.yield_kind = static_cast<YieldKind>((v >> 56) & 0xFF);
+        return r;
+    }
+
+    static HandlerResult make_status(u16 code) {
+        return {HandlerAction::ReturnStatus, code, 0, 0, YieldKind::HttpGet};
+    }
+
+    static HandlerResult make_proxy(u16 upstream) {
+        return {HandlerAction::Proxy, 0, upstream, 0, YieldKind::HttpGet};
+    }
+
+    static HandlerResult make_yield(u16 state, YieldKind kind) {
+        return {HandlerAction::Yield, 0, 0, state, kind};
+    }
+};
+
+// ── Handler Context ────────────────────────────────────────────────
+// Per-request mutable context, allocated from the scratch Arena.
+// Holds the state machine index and live-across-yield values.
+//
+// Layout: [HandlerCtx header] [slot_0] [slot_1] ... [slot_N]
+// Each slot is 8-byte aligned. The number and types of slots are
+// determined at compile time by the state-splitting pass.
+
+struct HandlerCtx {
+    u16 state;        // current state machine state
+    u16 handler_idx;  // index into CompiledHandlers::handlers[]
+    u32 slot_count;   // number of 8-byte slots following this header
+
+    // Access slot storage (8-byte aligned, immediately after header).
+    u8* slots() { return reinterpret_cast<u8*>(this + 1); }
+    const u8* slots() const { return reinterpret_cast<const u8*>(this + 1); }
+
+    // Typed slot access.
+    template <typename T>
+    T load_slot(u32 idx) const {
+        static_assert(sizeof(T) <= 8, "Slot values must be <= 8 bytes");
+        T val{};
+        const u8* src = slots() + idx * 8;
+        __builtin_memcpy(&val, src, sizeof(T));
+        return val;
+    }
+
+    template <typename T>
+    void store_slot(u32 idx, T val) {
+        static_assert(sizeof(T) <= 8, "Slot values must be <= 8 bytes");
+        u8* dst = slots() + idx * 8;
+        u64 zero = 0;
+        __builtin_memcpy(dst, &zero, 8);
+        __builtin_memcpy(dst, &val, sizeof(T));
+    }
+};
+
+static_assert(sizeof(HandlerCtx) == 8, "HandlerCtx header must be 8 bytes");
+
+// ── Handler Function Pointer ───────────────────────────────────────
+// JIT-compiled handlers return u64 (not a struct) to guarantee
+// RAX return on x86-64. Use HandlerResult::unpack() to interpret.
+//
+// Parameters:
+//   conn      — the connection being processed (read peer_addr, etc.)
+//   ctx       — per-request context with state + yield slots
+//   req_data  — raw request bytes (recv_buf content)
+//   req_len   — request buffer length
+//   arena     — scratch arena for temporary allocations
+
+using HandlerFn = u64 (*)(void* conn,  // opaque: Connection* at runtime
+                          HandlerCtx* ctx,
+                          const u8* req_data,
+                          u32 req_len,
+                          void* arena  // opaque: SliceArena* at runtime
+);
+
+}  // namespace jit
+}  // namespace rut

--- a/include/rut/jit/jit_engine.h
+++ b/include/rut/jit/jit_engine.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "rut/common/types.h"
+
+// Forward-declare LLVM C API opaque types to avoid pulling LLVM headers
+// into runtime code. The actual LLVM headers are only included in
+// jit_engine.cc and codegen.cc.
+using LLVMOrcLLJITRef = struct LLVMOrcOpaqueLLJIT*;
+using LLVMModuleRef = struct LLVMOpaqueModule*;
+using LLVMContextRef = struct LLVMOpaqueContext*;
+
+namespace rut::jit {
+
+// ── JIT Engine ─────────────────────────────────────────────────────
+// Wraps LLVM ORC LLJIT via the C API. Compiles LLVM IR modules to
+// native code and resolves symbols (including runtime helpers).
+//
+// Thread safety:
+//   - init() / shutdown() on main thread only
+//   - compile() / lookup() are thread-safe (LLJIT uses internal locks)
+//   - JIT'd function pointers are plain C calls, no LLVM dependency
+//
+// Lifetime:
+//   - One JitEngine per process (not per shard)
+//   - Shard threads never touch JitEngine — only call JIT'd fn ptrs
+
+struct JitEngine {
+    LLVMOrcLLJITRef lljit = nullptr;
+
+    // Orphaned LLVMContextRefs from compile(). LLVM < 19 can't wrap an
+    // existing context into a ThreadSafeContext, so the module's context
+    // must be freed separately after LLJIT destroys the module.
+    static constexpr u32 kMaxContexts = 64;
+    LLVMContextRef contexts[kMaxContexts];
+    u32 ctx_count = 0;
+
+    bool init();
+
+    // Compile an LLVM IR module to native code.
+    // Always takes ownership of both mod and ctx regardless of return value.
+    bool compile(LLVMModuleRef mod, LLVMContextRef ctx);
+
+    void* lookup(const char* name);
+    void shutdown();
+};
+
+}  // namespace rut::jit

--- a/include/rut/jit/runtime_helpers.h
+++ b/include/rut/jit/runtime_helpers.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "rut/common/types.h"
+
+// Runtime helper functions callable from JIT'd code.
+// All use extern "C" linkage with rut_helper_ prefix to avoid
+// C++ name mangling. The JIT engine registers these via a custom
+// DefinitionGenerator so they're resolved on first use.
+//
+// These functions bridge the gap between JIT'd code (which operates
+// on raw pointers and primitives) and the runtime's parsed request
+// data. JIT'd code passes raw request bytes; helpers parse as needed.
+
+extern "C" {
+
+// ── Request Access ─────────────────────────────────────────────────
+
+// Extract request path from raw HTTP request.
+// Sets *out_ptr and *out_len to the path string (points into req_data).
+void rut_helper_req_path(const rut::u8* req_data,
+                         rut::u32 req_len,
+                         const char** out_ptr,
+                         rut::u32* out_len);
+
+// Extract HTTP method from raw request. Returns HttpMethod enum value.
+rut::u8 rut_helper_req_method(const rut::u8* req_data, rut::u32 req_len);
+
+// Look up a request header by name (case-insensitive).
+// Returns Optional(Str): *out_has_value = 1 if found, 0 if not.
+// If found, *out_ptr / *out_len point into req_data.
+void rut_helper_req_header(const rut::u8* req_data,
+                           rut::u32 req_len,
+                           const char* name,
+                           rut::u32 name_len,
+                           rut::u8* out_has_value,
+                           const char** out_ptr,
+                           rut::u32* out_len);
+
+// Get remote address from Connection. Returns IPv4 in network order.
+rut::u32 rut_helper_req_remote_addr(void* conn);
+
+// ── String Operations ──────────────────────────────────────────────
+
+// Check if string s has prefix pfx. Returns 1 (true) or 0 (false).
+rut::u8 rut_helper_str_has_prefix(const char* s, rut::u32 s_len, const char* pfx, rut::u32 pfx_len);
+
+// Trim prefix from string. If s starts with pfx, out = remainder.
+// Otherwise out = s unchanged.
+void rut_helper_str_trim_prefix(const char* s,
+                                rut::u32 s_len,
+                                const char* pfx,
+                                rut::u32 pfx_len,
+                                const char** out_ptr,
+                                rut::u32* out_len);
+
+}  // extern "C"

--- a/include/rut/runtime/arena.h
+++ b/include/rut/runtime/arena.h
@@ -9,41 +9,98 @@
 
 namespace rut {
 
-// Arena — bump allocator with block chaining. Zero stdlib, no malloc, no new.
+// Forward declaration — only needed by SlicePoolBackend.
+struct SlicePool;
+
+// ── Block Backends ─────────────────────────────────────────────────
+// Arena is parameterized on a backend that controls where blocks come
+// from. Two backends:
+//   MmapBackend      — mmap/munmap, variable-size blocks. For compiler.
+//   SlicePoolBackend — borrows 16KB slices from SlicePool. For runtime hot path.
+
+struct MmapBackend {
+    u64 default_block_size = 4096;
+
+    core::Expected<void, Error> init(u64 block_size) {
+        default_block_size = block_size < 256 ? 256 : block_size;
+        return {};
+    }
+
+    // Acquire a block of at least `needed` bytes. Returns raw ptr + actual size.
+    // The caller embeds a Block header at the start.
+    u8* acquire(u64 needed, u64* out_size) {
+        u64 size = default_block_size > needed ? default_block_size : needed;
+        // Page-align
+        if (size > static_cast<u64>(-1) - 4095) return nullptr;
+        size = (size + 4095) & ~static_cast<u64>(4095);
+        void* p = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (p == MAP_FAILED) return nullptr;
+        *out_size = size;
+        return static_cast<u8*>(p);
+    }
+
+    void release(u8* ptr, u64 size) { munmap(ptr, size); }
+};
+
+struct SlicePoolBackend {
+    SlicePool* pool = nullptr;
+
+    core::Expected<void, Error> init(SlicePool* p) {
+        pool = p;
+        return {};
+    }
+
+    // Acquire a 16KB slice from the pool. `needed` must fit in one slice.
+    u8* acquire(u64 needed, u64* out_size);
+    void release(u8* ptr, u64 size);
+};
+
+// ── Arena<Backend> ─────────────────────────────────────────────────
+// Bump allocator with block chaining. Zero stdlib, no malloc, no new.
 //
 // Pure bump allocation. No destructors, no cleanup, no ownership tracking.
 // Objects allocated from Arena must be trivially destructible, or the caller
 // is responsible for calling destructors manually before reset/destroy.
 //
-// Block memory comes from mmap/munmap. No malloc/free anywhere.
+// Block memory comes from the Backend (mmap or SlicePool).
 //
-// Typical usage: per-request temporaries.
-//   Arena arena;
-//   arena.init(4096);
+// Usage (runtime):
+//   Arena<SlicePoolBackend> arena;
+//   arena.init(&shard_pool);
 //   auto* hdr = arena.alloc_t<Header>();
-//   auto* params = arena.alloc_array<Param>(n);
-//   ... process request ...
-//   arena.reset();  // instant, reuses first block
+//   arena.reset();  // returns extra slices to pool
+//
+// Usage (compiler):
+//   Arena<MmapBackend> arena;
+//   arena.init(4096);
+//   auto* node = arena.alloc_t<AstNode>();
+//   arena.destroy();  // munmap all blocks
 
+template <typename Backend>
 struct Arena {
     struct Block {
         Block* prev;
-        u64 size;  // total mmap'd size (including this header)
+        u64 size;  // total block size (including this header)
         u64 used;  // bytes allocated after header
 
-        u8* data() { return reinterpret_cast<u8*>(this) + ((sizeof(Block) + 15) & ~u64(15)); }
-        u64 capacity() const { return size - ((sizeof(Block) + 15) & ~u64(15)); }
+        static constexpr u64 kHeaderSize = (sizeof(Block) + 15) & ~u64(15);
+        u8* data() { return reinterpret_cast<u8*>(this) + kHeaderSize; }
+        u64 capacity() const { return size - kHeaderSize; }
         u64 remaining() const { return capacity() - used; }
     };
 
     Block* current = nullptr;
-    u64 block_size = 0;
+    Backend backend{};
     u64 total_allocated = 0;
 
-    core::Expected<void, Error> init(u64 initial_block_size) {
-        block_size = initial_block_size < 256 ? 256 : initial_block_size;
+    // Initialize with backend-specific args (forwarded to Backend::init).
+    template <typename... Args>
+    core::Expected<void, Error> init(Args&&... args) {
         total_allocated = 0;
-        current = alloc_block(block_size, nullptr);
+        current = nullptr;
+        auto r = backend.init(static_cast<Args&&>(args)...);
+        if (!r) return r;
+        current = alloc_block(Block::kHeaderSize, nullptr);
         if (!current) return core::make_unexpected(Error::from_errno(Error::Source::Arena));
         return {};
     }
@@ -51,7 +108,6 @@ struct Arena {
     // Bump allocate, 8-byte aligned.
     void* alloc(u64 size) {
         if (!current) return nullptr;
-        // Overflow check: size + 7 must not wrap
         if (size > static_cast<u64>(-1) - 7) return nullptr;
         size = (size + 7) & ~static_cast<u64>(7);
         if (current->remaining() >= size) {
@@ -59,13 +115,12 @@ struct Arena {
             current->used += size;
             return p;
         }
-        // Use aligned header size, matching Block::data() offset
-        constexpr u64 kHdr = (sizeof(Block) + 15) & ~static_cast<u64>(15);
-        if (size > static_cast<u64>(-1) - kHdr) return nullptr;
-        u64 needed = size + kHdr;
-        u64 new_size = block_size > needed ? block_size : needed;
-        Block* b = alloc_block(new_size, current);
-        if (!b) return nullptr;
+        if (size > static_cast<u64>(-1) - Block::kHeaderSize) return nullptr;
+        Block* b = alloc_block(Block::kHeaderSize + size, current);
+        if (!b || b->capacity() < size) {
+            if (b) backend.release(reinterpret_cast<u8*>(b), b->size);
+            return nullptr;
+        }
         current = b;
         void* p = current->data() + current->used;
         current->used += size;
@@ -94,25 +149,22 @@ struct Arena {
     // Free all blocks except first, reset pointer. O(blocks).
     void reset() {
         if (!current) return;
-        Block* b = current;
-        while (b->prev) {
-            Block* prev = b->prev;
-            u64 sz = b->size;
-            munmap(b, sz);
+        while (current->prev) {
+            Block* prev = current->prev;
+            u64 sz = current->size;
+            backend.release(reinterpret_cast<u8*>(current), sz);
             total_allocated -= sz;
-            b = prev;
+            current = prev;
         }
-        b->used = 0;
-        current = b;
+        current->used = 0;
     }
 
     // Free everything.
     void destroy() {
-        Block* b = current;
-        while (b) {
-            Block* prev = b->prev;
-            munmap(b, b->size);
-            b = prev;
+        while (current) {
+            Block* prev = current->prev;
+            backend.release(reinterpret_cast<u8*>(current), current->size);
+            current = prev;
         }
         current = nullptr;
         total_allocated = 0;
@@ -127,26 +179,24 @@ struct Arena {
     u64 space_allocated() const { return total_allocated; }
 
 private:
-    static u64 page_align(u64 size) {
-        if (size > static_cast<u64>(-1) - 4095) return 0;  // overflow guard
-        return (size + 4095) & ~static_cast<u64>(4095);
-    }
-
-    Block* alloc_block(u64 size, Block* prev) {
-        size = page_align(size);
-        if (size == 0) {
-            errno = ENOMEM;  // overflow in page_align
-            return nullptr;
-        }
-        void* p = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        if (p == MAP_FAILED) return nullptr;
-        auto* b = static_cast<Block*>(p);
+    Block* alloc_block(u64 needed, Block* prev) {
+        u64 actual_size = 0;
+        u8* mem = backend.acquire(needed, &actual_size);
+        if (!mem) return nullptr;
+        auto* b = reinterpret_cast<Block*>(mem);
         b->prev = prev;
-        b->size = size;
+        b->size = actual_size;
         b->used = 0;
-        total_allocated += size;
+        total_allocated += actual_size;
         return b;
     }
 };
+
+// ── Type Aliases ───────────────────────────────────────────────────
+// MmapArena  — compiler/offline use (mmap-backed, variable-size blocks)
+// SliceArena — runtime hot path (SlicePool-backed, 16KB fixed blocks)
+
+using MmapArena = Arena<MmapBackend>;
+using SliceArena = Arena<SlicePoolBackend>;
 
 }  // namespace rut

--- a/include/rut/runtime/shard.h
+++ b/include/rut/runtime/shard.h
@@ -50,7 +50,7 @@ struct Shard {
     EventLoopType* loop = nullptr;
 
     // Per-request scratch arena (reset after each request cycle)
-    Arena scratch;
+    MmapArena scratch;
 
     // Upstream connection pool (per-shard, mmap'd due to size)
     UpstreamPool* upstream = nullptr;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,7 @@ target_compile_options(zstd_compress PRIVATE
 # Runtime library
 add_library(rue_runtime STATIC
     placement_new.cc
+    runtime/arena.cc
     runtime/shard.cc
     runtime/io_uring_backend.cc
     runtime/epoll_backend.cc
@@ -116,9 +117,37 @@ target_include_directories(rue_compiler PUBLIC
     ${PROJECT_SOURCE_DIR}/include
 )
 
+# JIT library — LLVM ORC JIT integration via C API.
+# Only this library links LLVM. rue_runtime stays LLVM-free so shard
+# threads never transitively depend on LLVM headers or libraries.
+add_library(rue_jit STATIC
+    jit/jit_engine.cc
+    jit/codegen.cc
+    jit/runtime_helpers.cc
+)
+
+target_include_directories(rue_jit PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+    ${LLVM_INCLUDE_DIRS}
+)
+
+# LLVM on this system is a single shared lib (-lLLVM-N).
+# llvm_map_components_to_libnames resolves to the shared lib automatically.
+llvm_map_components_to_libnames(LLVM_LIBS core orcjit native support)
+target_link_libraries(rue_jit ${LLVM_LIBS})
+
+# JIT .cc files may need LLVM definitions that conflict with -fno-rtti.
+# The LLVM C API is pure C so no RTTI issues, but LLVM's cmake may add
+# -fno-rtti to definitions. Add LLVM definitions selectively.
+target_compile_definitions(rue_jit PRIVATE ${LLVM_DEFINITIONS})
+
+# rue_jit also links rue_runtime for runtime_helpers (uses HttpParser, Connection)
+target_link_libraries(rue_jit rue_runtime)
+
 # Main executable
 add_executable(rue main.cc)
 target_link_libraries(rue
     rue_runtime
     rue_compiler
+    rue_jit
 )

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -1,0 +1,663 @@
+#include "rut/jit/codegen.h"
+
+#include "rut/compiler/rir.h"
+
+#include <llvm-c/Core.h>
+
+namespace rut::jit {
+
+// ── Codegen Context ────────────────────────────────────────────────
+// Per-compilation state. Holds LLVM context, module, builder, and
+// mapping tables from RIR IDs to LLVM values/blocks.
+
+struct Ctx {
+    LLVMContextRef llvm_ctx;
+    LLVMModuleRef llvm_mod;
+    LLVMBuilderRef builder;
+
+    // Per-function maps (sized to function's value_cap / block_cap).
+    LLVMValueRef* value_map;
+    u32 value_map_cap;
+    LLVMBasicBlockRef* block_map;
+    u32 block_map_cap;
+
+    // Cached LLVM types
+    LLVMTypeRef i1_ty;
+    LLVMTypeRef i8_ty;
+    LLVMTypeRef i16_ty;
+    LLVMTypeRef i32_ty;
+    LLVMTypeRef i64_ty;
+    LLVMTypeRef ptr_ty;
+    LLVMTypeRef void_ty;
+
+    // Str type: {ptr, i32} — matches rut::Str layout
+    LLVMTypeRef str_ty;
+
+    // Optional(Str): {i8, ptr, i32} — has_value byte + ptr + len
+    LLVMTypeRef opt_str_ty;
+
+    // HandlerResult: i64 (packed 8-byte struct, passed as integer)
+    LLVMTypeRef result_ty;
+
+    // Handler function type: i64 (ptr, ptr, ptr, i32, ptr)
+    LLVMTypeRef handler_fn_ty;
+
+    // Current RIR function (set per-function, for type lookups).
+    const rir::Function* cur_fn;
+
+    // Function parameters (set per-function)
+    LLVMValueRef param_conn;
+    LLVMValueRef param_ctx;
+    LLVMValueRef param_req_data;
+    LLVMValueRef param_req_len;
+    LLVMValueRef param_arena;
+
+    // Lazily declared runtime helpers
+    LLVMValueRef fn_req_path;
+    LLVMValueRef fn_req_method;
+    LLVMValueRef fn_req_header;
+    LLVMValueRef fn_req_remote_addr;
+    LLVMValueRef fn_str_has_prefix;
+    LLVMValueRef fn_str_trim_prefix;
+
+    void init_types() {
+        i1_ty = LLVMInt1TypeInContext(llvm_ctx);
+        i8_ty = LLVMInt8TypeInContext(llvm_ctx);
+        i16_ty = LLVMInt16TypeInContext(llvm_ctx);
+        i32_ty = LLVMInt32TypeInContext(llvm_ctx);
+        i64_ty = LLVMInt64TypeInContext(llvm_ctx);
+        ptr_ty = LLVMPointerTypeInContext(llvm_ctx, 0);
+        void_ty = LLVMVoidTypeInContext(llvm_ctx);
+
+        // Str: {ptr, i32}
+        LLVMTypeRef str_fields[] = {ptr_ty, i32_ty};
+        str_ty = LLVMStructTypeInContext(llvm_ctx, str_fields, 2, 0);
+
+        // Optional(Str): {i8, ptr, i32}
+        LLVMTypeRef opt_str_fields[] = {i8_ty, ptr_ty, i32_ty};
+        opt_str_ty = LLVMStructTypeInContext(llvm_ctx, opt_str_fields, 3, 0);
+
+        // HandlerResult is returned as i64 (8-byte packed struct)
+        result_ty = i64_ty;
+
+        // Handler fn: i64 (ptr %conn, ptr %ctx, ptr %req_data, i32 %req_len, ptr %arena)
+        LLVMTypeRef param_types[] = {ptr_ty, ptr_ty, ptr_ty, i32_ty, ptr_ty};
+        handler_fn_ty = LLVMFunctionType(result_ty, param_types, 5, 0);
+    }
+
+    // ── Lazy Helper Declaration ────────────────────────────────────
+
+    // void rut_helper_req_path(ptr, i32, ptr, ptr)
+    LLVMValueRef get_req_path() {
+        if (!fn_req_path) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(void_ty, params, 4, 0);
+            fn_req_path = LLVMAddFunction(llvm_mod, "rut_helper_req_path", ft);
+        }
+        return fn_req_path;
+    }
+
+    // u8 rut_helper_req_method(ptr, i32)
+    LLVMValueRef get_req_method() {
+        if (!fn_req_method) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty};
+            LLVMTypeRef ft = LLVMFunctionType(i8_ty, params, 2, 0);
+            fn_req_method = LLVMAddFunction(llvm_mod, "rut_helper_req_method", ft);
+        }
+        return fn_req_method;
+    }
+
+    // void rut_helper_req_header(ptr, i32, ptr, i32, ptr, ptr, ptr)
+    LLVMValueRef get_req_header() {
+        if (!fn_req_header) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty, ptr_ty, ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(void_ty, params, 7, 0);
+            fn_req_header = LLVMAddFunction(llvm_mod, "rut_helper_req_header", ft);
+        }
+        return fn_req_header;
+    }
+
+    // u32 rut_helper_req_remote_addr(ptr)
+    LLVMValueRef get_req_remote_addr() {
+        if (!fn_req_remote_addr) {
+            LLVMTypeRef params[] = {ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(i32_ty, params, 1, 0);
+            fn_req_remote_addr = LLVMAddFunction(llvm_mod, "rut_helper_req_remote_addr", ft);
+        }
+        return fn_req_remote_addr;
+    }
+
+    // u8 rut_helper_str_has_prefix(ptr, i32, ptr, i32)
+    LLVMValueRef get_str_has_prefix() {
+        if (!fn_str_has_prefix) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, i32_ty};
+            LLVMTypeRef ft = LLVMFunctionType(i8_ty, params, 4, 0);
+            fn_str_has_prefix = LLVMAddFunction(llvm_mod, "rut_helper_str_has_prefix", ft);
+        }
+        return fn_str_has_prefix;
+    }
+
+    // void rut_helper_str_trim_prefix(ptr, i32, ptr, i32, ptr, ptr)
+    LLVMValueRef get_str_trim_prefix() {
+        if (!fn_str_trim_prefix) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty, ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(void_ty, params, 6, 0);
+            fn_str_trim_prefix = LLVMAddFunction(llvm_mod, "rut_helper_str_trim_prefix", ft);
+        }
+        return fn_str_trim_prefix;
+    }
+
+    // ── RIR Type Queries ─────────────────────────────────────────────
+
+    // Check if an RIR value has unsigned integer semantics.
+    // Used to select signed vs unsigned LLVM comparison predicates.
+    bool is_unsigned_operand(rir::ValueId id) const {
+        if (!cur_fn || id.id >= cur_fn->value_cap) return false;
+        const rir::Type* ty = cur_fn->values[id.id].type;
+        if (!ty) return false;
+        switch (ty->kind) {
+            case rir::TypeKind::U32:
+            case rir::TypeKind::U64:
+            case rir::TypeKind::ByteSize:
+            case rir::TypeKind::Duration:
+            case rir::TypeKind::Time:
+            case rir::TypeKind::StatusCode:
+            case rir::TypeKind::IP:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    // ── String Globals ──────────────────────────────────────────────
+    // Create a global constant from a Str (which is NOT null-terminated).
+    // Returns a pointer to the first character. Uses LLVMConstStringInContext
+    // with explicit length instead of LLVMBuildGlobalStringPtr (which uses strlen).
+    LLVMValueRef make_global_str(Str s, const char* name) {
+        // Create constant with null terminator appended (for C compatibility)
+        LLVMValueRef str_const =
+            LLVMConstStringInContext(llvm_ctx, s.ptr, s.len, /*DontNullTerminate=*/0);
+        LLVMValueRef global = LLVMAddGlobal(llvm_mod, LLVMTypeOf(str_const), name);
+        LLVMSetInitializer(global, str_const);
+        LLVMSetGlobalConstant(global, 1);
+        LLVMSetLinkage(global, LLVMPrivateLinkage);
+        LLVMSetUnnamedAddress(global, LLVMGlobalUnnamedAddr);
+        // GEP to get ptr to first char
+        LLVMValueRef zero = LLVMConstInt(i32_ty, 0, 0);
+        LLVMValueRef indices[] = {zero, zero};
+        return LLVMBuildInBoundsGEP2(builder, LLVMTypeOf(str_const), global, indices, 2, name);
+    }
+
+    // ── Value / Block access ───────────────────────────────────────
+
+    void set_value(rir::ValueId id, LLVMValueRef val) {
+        if (id.id < value_map_cap) value_map[id.id] = val;
+    }
+
+    LLVMValueRef get_value(rir::ValueId id) {
+        if (id.id < value_map_cap) return value_map[id.id];
+        return nullptr;
+    }
+
+    LLVMBasicBlockRef get_block(rir::BlockId id) {
+        if (id.id < block_map_cap) return block_map[id.id];
+        return nullptr;
+    }
+
+    // ── HandlerResult construction ─────────────────────────────────
+    // Build an i64 from packed fields: {action:8, status:16, upstream:16, next_state:16,
+    // yield_kind:8} Layout (little-endian byte offsets): [0]=action [1-2]=status [3-4]=upstream
+    // [5-6]=next_state [7]=yield_kind
+
+    LLVMValueRef make_result_status(u16 code) {
+        // Pack: action=0 (ReturnStatus), status_code=code, rest=0
+        u64 packed = 0;
+        packed |= static_cast<u64>(0);          // action = ReturnStatus
+        packed |= static_cast<u64>(code) << 8;  // status_code
+        return LLVMConstInt(i64_ty, packed, 0);
+    }
+
+    LLVMValueRef make_result_proxy(u16 upstream) {
+        u64 packed = 0;
+        packed |= static_cast<u64>(1);               // action = Proxy
+        packed |= static_cast<u64>(upstream) << 24;  // upstream_id
+        return LLVMConstInt(i64_ty, packed, 0);
+    }
+
+    // ── Type mapping ───────────────────────────────────────────────
+
+    LLVMTypeRef map_type(const rir::Type* ty) {
+        if (!ty) return void_ty;
+        switch (ty->kind) {
+            case rir::TypeKind::Void:
+                return void_ty;
+            case rir::TypeKind::Bool:
+                return i1_ty;
+            case rir::TypeKind::I32:
+                return i32_ty;
+            case rir::TypeKind::I64:
+                return i64_ty;
+            case rir::TypeKind::U32:
+                return i32_ty;
+            case rir::TypeKind::U64:
+                return i64_ty;
+            case rir::TypeKind::F64:
+                return LLVMDoubleTypeInContext(llvm_ctx);
+            case rir::TypeKind::Str:
+                return str_ty;
+            case rir::TypeKind::ByteSize:
+            case rir::TypeKind::Duration:
+            case rir::TypeKind::Time:
+                return i64_ty;
+            case rir::TypeKind::IP:
+            case rir::TypeKind::StatusCode:
+                return i32_ty;
+            case rir::TypeKind::Method:
+                return i8_ty;
+            case rir::TypeKind::Optional:
+                return opt_str_ty;  // TODO: generic optional
+            default:
+                return ptr_ty;
+        }
+    }
+};
+
+// ── Instruction Emission ───────────────────────────────────────────
+
+static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
+    switch (inst.op) {
+        // ── Constants ──
+        case rir::Opcode::ConstI32: {
+            LLVMValueRef v = LLVMConstInt(c.i32_ty, static_cast<u64>(inst.imm.i32_val), 1);
+            c.set_value(inst.result, v);
+            break;
+        }
+        case rir::Opcode::ConstI64: {
+            LLVMValueRef v = LLVMConstInt(c.i64_ty, static_cast<u64>(inst.imm.i64_val), 1);
+            c.set_value(inst.result, v);
+            break;
+        }
+        case rir::Opcode::ConstBool: {
+            LLVMValueRef v = LLVMConstInt(c.i1_ty, inst.imm.bool_val ? 1 : 0, 0);
+            c.set_value(inst.result, v);
+            break;
+        }
+        case rir::Opcode::ConstStr: {
+            // Create a global constant string, then build {ptr, i32} struct.
+            // Uses make_global_str() with explicit length (Str is not null-terminated).
+            Str s = inst.imm.str_val;
+            LLVMValueRef gs = c.make_global_str(s, "str");
+            LLVMValueRef len = LLVMConstInt(c.i32_ty, s.len, 0);
+            LLVMValueRef strval = LLVMGetUndef(c.str_ty);
+            strval = LLVMBuildInsertValue(c.builder, strval, gs, 0, "str.ptr");
+            strval = LLVMBuildInsertValue(c.builder, strval, len, 1, "str.len");
+            c.set_value(inst.result, strval);
+            break;
+        }
+        case rir::Opcode::ConstDuration:
+        case rir::Opcode::ConstByteSize: {
+            LLVMValueRef v = LLVMConstInt(c.i64_ty, static_cast<u64>(inst.imm.i64_val), 1);
+            c.set_value(inst.result, v);
+            break;
+        }
+        case rir::Opcode::ConstMethod: {
+            LLVMValueRef v = LLVMConstInt(c.i8_ty, inst.imm.method_val, 0);
+            c.set_value(inst.result, v);
+            break;
+        }
+        case rir::Opcode::ConstStatus: {
+            LLVMValueRef v = LLVMConstInt(c.i32_ty, static_cast<u64>(inst.imm.i32_val), 0);
+            c.set_value(inst.result, v);
+            break;
+        }
+
+        // ── Request access ──
+        case rir::Opcode::ReqPath: {
+            // Alloca for out params, call helper, load result into Str struct.
+            LLVMValueRef out_ptr = LLVMBuildAlloca(c.builder, c.ptr_ty, "path.ptr");
+            LLVMValueRef out_len = LLVMBuildAlloca(c.builder, c.i32_ty, "path.len");
+            LLVMValueRef args[] = {c.param_req_data, c.param_req_len, out_ptr, out_len};
+            LLVMBuildCall2(
+                c.builder, LLVMGlobalGetValueType(c.get_req_path()), c.get_req_path(), args, 4, "");
+            LLVMValueRef p = LLVMBuildLoad2(c.builder, c.ptr_ty, out_ptr, "p");
+            LLVMValueRef l = LLVMBuildLoad2(c.builder, c.i32_ty, out_len, "l");
+            LLVMValueRef strval = LLVMGetUndef(c.str_ty);
+            strval = LLVMBuildInsertValue(c.builder, strval, p, 0, "path.s.ptr");
+            strval = LLVMBuildInsertValue(c.builder, strval, l, 1, "path.s.len");
+            c.set_value(inst.result, strval);
+            break;
+        }
+        case rir::Opcode::ReqMethod: {
+            LLVMValueRef args[] = {c.param_req_data, c.param_req_len};
+            LLVMValueRef v = LLVMBuildCall2(c.builder,
+                                            LLVMGlobalGetValueType(c.get_req_method()),
+                                            c.get_req_method(),
+                                            args,
+                                            2,
+                                            "method");
+            c.set_value(inst.result, v);
+            break;
+        }
+        case rir::Opcode::ReqHeader: {
+            Str name = inst.imm.str_val;
+            LLVMValueRef name_ptr = c.make_global_str(name, "hdr.name");
+            LLVMValueRef name_len = LLVMConstInt(c.i32_ty, name.len, 0);
+            LLVMValueRef out_has = LLVMBuildAlloca(c.builder, c.i8_ty, "hdr.has");
+            LLVMValueRef out_ptr = LLVMBuildAlloca(c.builder, c.ptr_ty, "hdr.ptr");
+            LLVMValueRef out_len = LLVMBuildAlloca(c.builder, c.i32_ty, "hdr.len");
+            LLVMValueRef args[] = {
+                c.param_req_data, c.param_req_len, name_ptr, name_len, out_has, out_ptr, out_len};
+            LLVMBuildCall2(c.builder,
+                           LLVMGlobalGetValueType(c.get_req_header()),
+                           c.get_req_header(),
+                           args,
+                           7,
+                           "");
+            LLVMValueRef h = LLVMBuildLoad2(c.builder, c.i8_ty, out_has, "h");
+            LLVMValueRef p = LLVMBuildLoad2(c.builder, c.ptr_ty, out_ptr, "p");
+            LLVMValueRef l = LLVMBuildLoad2(c.builder, c.i32_ty, out_len, "l");
+            LLVMValueRef opt = LLVMGetUndef(c.opt_str_ty);
+            opt = LLVMBuildInsertValue(c.builder, opt, h, 0, "opt.has");
+            opt = LLVMBuildInsertValue(c.builder, opt, p, 1, "opt.ptr");
+            opt = LLVMBuildInsertValue(c.builder, opt, l, 2, "opt.len");
+            c.set_value(inst.result, opt);
+            break;
+        }
+        case rir::Opcode::ReqRemoteAddr: {
+            LLVMValueRef args[] = {c.param_conn};
+            LLVMValueRef v = LLVMBuildCall2(c.builder,
+                                            LLVMGlobalGetValueType(c.get_req_remote_addr()),
+                                            c.get_req_remote_addr(),
+                                            args,
+                                            1,
+                                            "addr");
+            c.set_value(inst.result, v);
+            break;
+        }
+
+        // ── String operations ──
+        case rir::Opcode::StrHasPrefix: {
+            LLVMValueRef s = c.get_value(inst.operands[0]);
+            LLVMValueRef pfx = c.get_value(inst.operands[1]);
+            LLVMValueRef s_ptr = LLVMBuildExtractValue(c.builder, s, 0, "s.ptr");
+            LLVMValueRef s_len = LLVMBuildExtractValue(c.builder, s, 1, "s.len");
+            LLVMValueRef p_ptr = LLVMBuildExtractValue(c.builder, pfx, 0, "p.ptr");
+            LLVMValueRef p_len = LLVMBuildExtractValue(c.builder, pfx, 1, "p.len");
+            LLVMValueRef args[] = {s_ptr, s_len, p_ptr, p_len};
+            LLVMValueRef r = LLVMBuildCall2(c.builder,
+                                            LLVMGlobalGetValueType(c.get_str_has_prefix()),
+                                            c.get_str_has_prefix(),
+                                            args,
+                                            4,
+                                            "hp");
+            // Convert u8 result to i1 for branch usage
+            LLVMValueRef b =
+                LLVMBuildICmp(c.builder, LLVMIntNE, r, LLVMConstInt(c.i8_ty, 0, 0), "hp.bool");
+            c.set_value(inst.result, b);
+            break;
+        }
+        case rir::Opcode::StrTrimPrefix: {
+            LLVMValueRef s = c.get_value(inst.operands[0]);
+            LLVMValueRef pfx = c.get_value(inst.operands[1]);
+            LLVMValueRef s_ptr = LLVMBuildExtractValue(c.builder, s, 0, "s.ptr");
+            LLVMValueRef s_len = LLVMBuildExtractValue(c.builder, s, 1, "s.len");
+            LLVMValueRef p_ptr = LLVMBuildExtractValue(c.builder, pfx, 0, "p.ptr");
+            LLVMValueRef p_len = LLVMBuildExtractValue(c.builder, pfx, 1, "p.len");
+            LLVMValueRef out_ptr = LLVMBuildAlloca(c.builder, c.ptr_ty, "tp.ptr");
+            LLVMValueRef out_len = LLVMBuildAlloca(c.builder, c.i32_ty, "tp.len");
+            LLVMValueRef args[] = {s_ptr, s_len, p_ptr, p_len, out_ptr, out_len};
+            LLVMBuildCall2(c.builder,
+                           LLVMGlobalGetValueType(c.get_str_trim_prefix()),
+                           c.get_str_trim_prefix(),
+                           args,
+                           6,
+                           "");
+            LLVMValueRef rp = LLVMBuildLoad2(c.builder, c.ptr_ty, out_ptr, "tp.rp");
+            LLVMValueRef rl = LLVMBuildLoad2(c.builder, c.i32_ty, out_len, "tp.rl");
+            LLVMValueRef strval = LLVMGetUndef(c.str_ty);
+            strval = LLVMBuildInsertValue(c.builder, strval, rp, 0, "tp.s.ptr");
+            strval = LLVMBuildInsertValue(c.builder, strval, rl, 1, "tp.s.len");
+            c.set_value(inst.result, strval);
+            break;
+        }
+
+        // ── Comparisons ──
+        case rir::Opcode::CmpEq:
+        case rir::Opcode::CmpNe:
+        case rir::Opcode::CmpLt:
+        case rir::Opcode::CmpGt:
+        case rir::Opcode::CmpLe:
+        case rir::Opcode::CmpGe: {
+            LLVMValueRef a = c.get_value(inst.operands[0]);
+            LLVMValueRef b = c.get_value(inst.operands[1]);
+            // Eq/Ne are sign-agnostic. For ordered comparisons, pick
+            // signed vs unsigned predicates based on the RIR operand type.
+            bool uns = c.is_unsigned_operand(inst.operands[0]);
+            LLVMIntPredicate pred;
+            switch (inst.op) {
+                case rir::Opcode::CmpEq:
+                    pred = LLVMIntEQ;
+                    break;
+                case rir::Opcode::CmpNe:
+                    pred = LLVMIntNE;
+                    break;
+                case rir::Opcode::CmpLt:
+                    pred = uns ? LLVMIntULT : LLVMIntSLT;
+                    break;
+                case rir::Opcode::CmpGt:
+                    pred = uns ? LLVMIntUGT : LLVMIntSGT;
+                    break;
+                case rir::Opcode::CmpLe:
+                    pred = uns ? LLVMIntULE : LLVMIntSLE;
+                    break;
+                case rir::Opcode::CmpGe:
+                    pred = uns ? LLVMIntUGE : LLVMIntSGE;
+                    break;
+                default:
+                    pred = LLVMIntEQ;
+                    break;
+            }
+            LLVMValueRef v = LLVMBuildICmp(c.builder, pred, a, b, "cmp");
+            c.set_value(inst.result, v);
+            break;
+        }
+
+        // ── Optional operations ──
+        case rir::Opcode::OptIsNil: {
+            LLVMValueRef opt = c.get_value(inst.operands[0]);
+            LLVMValueRef has = LLVMBuildExtractValue(c.builder, opt, 0, "opt.has");
+            LLVMValueRef is_nil =
+                LLVMBuildICmp(c.builder, LLVMIntEQ, has, LLVMConstInt(c.i8_ty, 0, 0), "is_nil");
+            c.set_value(inst.result, is_nil);
+            break;
+        }
+        case rir::Opcode::OptUnwrap: {
+            // Extract the value fields (ptr, len) from Optional(Str).
+            LLVMValueRef opt = c.get_value(inst.operands[0]);
+            LLVMValueRef p = LLVMBuildExtractValue(c.builder, opt, 1, "uw.ptr");
+            LLVMValueRef l = LLVMBuildExtractValue(c.builder, opt, 2, "uw.len");
+            LLVMValueRef strval = LLVMGetUndef(c.str_ty);
+            strval = LLVMBuildInsertValue(c.builder, strval, p, 0, "uw.s.ptr");
+            strval = LLVMBuildInsertValue(c.builder, strval, l, 1, "uw.s.len");
+            c.set_value(inst.result, strval);
+            break;
+        }
+
+        // ── Terminators ──
+        case rir::Opcode::Br: {
+            LLVMValueRef cond = c.get_value(inst.operands[0]);
+            LLVMBasicBlockRef then_bb = c.get_block(inst.imm.block_targets[0]);
+            LLVMBasicBlockRef else_bb = c.get_block(inst.imm.block_targets[1]);
+            LLVMBuildCondBr(c.builder, cond, then_bb, else_bb);
+            break;
+        }
+        case rir::Opcode::Jmp: {
+            LLVMBasicBlockRef target = c.get_block(inst.imm.block_targets[0]);
+            LLVMBuildBr(c.builder, target);
+            break;
+        }
+        case rir::Opcode::RetStatus: {
+            // Pack HandlerResult as i64: action=0 (ReturnStatus), status_code from operand or
+            // immediate.
+            LLVMValueRef code;
+            if (inst.operand_count > 0) {
+                code = c.get_value(inst.operands[0]);
+                // Ensure it's i32
+                if (LLVMTypeOf(code) != c.i32_ty) {
+                    code = LLVMBuildZExt(c.builder, code, c.i32_ty, "code.ext");
+                }
+            } else {
+                code = LLVMConstInt(c.i32_ty, static_cast<u32>(inst.imm.i32_val), 0);
+            }
+            // Build packed i64: action(8) | status(16) | upstream(16) | next_state(16) |
+            // yield_kind(8) Byte layout (packed struct, little-endian):
+            //   byte 0: action = 0 (ReturnStatus)
+            //   byte 1-2: status_code (u16)
+            //   byte 3-7: zeros
+            LLVMValueRef action = LLVMConstInt(c.i64_ty, 0, 0);  // ReturnStatus
+            LLVMValueRef status_ext = LLVMBuildZExt(c.builder, code, c.i64_ty, "st.ext");
+            LLVMValueRef shifted =
+                LLVMBuildShl(c.builder, status_ext, LLVMConstInt(c.i64_ty, 8, 0), "st.shl");
+            LLVMValueRef result = LLVMBuildOr(c.builder, action, shifted, "result");
+            LLVMBuildRet(c.builder, result);
+            break;
+        }
+        case rir::Opcode::RetProxy: {
+            // Pack: action=1 (Proxy), upstream_id from operand or immediate.
+            LLVMValueRef upstream;
+            if (inst.operand_count > 0) {
+                upstream = c.get_value(inst.operands[0]);
+                if (LLVMTypeOf(upstream) != c.i32_ty) {
+                    upstream = LLVMBuildZExt(c.builder, upstream, c.i32_ty, "up.ext");
+                }
+            } else {
+                upstream = LLVMConstInt(c.i32_ty, 0, 0);
+            }
+            LLVMValueRef action = LLVMConstInt(c.i64_ty, 1, 0);  // Proxy
+            LLVMValueRef up_ext = LLVMBuildZExt(c.builder, upstream, c.i64_ty, "up.e");
+            LLVMValueRef shifted =
+                LLVMBuildShl(c.builder, up_ext, LLVMConstInt(c.i64_ty, 24, 0), "up.shl");
+            LLVMValueRef result = LLVMBuildOr(c.builder, action, shifted, "result");
+            LLVMBuildRet(c.builder, result);
+            break;
+        }
+
+        default:
+            // Unhandled opcode in Phase 1 — emit unreachable as a placeholder.
+            // The test should not exercise these paths.
+            if (inst.is_terminator()) {
+                LLVMBuildUnreachable(c.builder);
+            }
+            break;
+    }
+}
+
+// ── Function Codegen ───────────────────────────────────────────────
+
+static bool emit_function(Ctx& c, const rir::Function& fn) {
+    c.cur_fn = &fn;
+
+    // Build function name: "handler_<name>"
+    char fname[256] = "handler_";
+    u32 pos = 8;
+    for (u32 i = 0; i < fn.name.len && pos < 254; i++) {
+        fname[pos++] = fn.name.ptr[i];
+    }
+    fname[pos] = '\0';
+
+    LLVMValueRef func = LLVMAddFunction(c.llvm_mod, fname, c.handler_fn_ty);
+
+    // Name parameters for readability
+    c.param_conn = LLVMGetParam(func, 0);
+    c.param_ctx = LLVMGetParam(func, 1);
+    c.param_req_data = LLVMGetParam(func, 2);
+    c.param_req_len = LLVMGetParam(func, 3);
+    c.param_arena = LLVMGetParam(func, 4);
+    LLVMSetValueName2(c.param_conn, "conn", 4);
+    LLVMSetValueName2(c.param_ctx, "ctx", 3);
+    LLVMSetValueName2(c.param_req_data, "req_data", 8);
+    LLVMSetValueName2(c.param_req_len, "req_len", 7);
+    LLVMSetValueName2(c.param_arena, "arena", 5);
+
+    // Reset per-function maps
+    c.value_map_cap = fn.value_cap;
+    c.block_map_cap = fn.block_cap;
+
+    // Allocate maps (use alloca-style stack allocation for small functions,
+    // mmap for large ones). For Phase 1, stack is fine.
+    LLVMValueRef value_buf[512];
+    LLVMBasicBlockRef block_buf[64];
+
+    if (fn.value_cap > 512 || fn.block_cap > 64) return false;  // too large for Phase 1
+
+    for (u32 i = 0; i < fn.value_cap; i++) value_buf[i] = nullptr;
+    for (u32 i = 0; i < fn.block_cap; i++) block_buf[i] = nullptr;
+    c.value_map = value_buf;
+    c.block_map = block_buf;
+
+    // Create all basic blocks upfront (forward references from Br/Jmp).
+    for (u32 i = 0; i < fn.block_count; i++) {
+        auto& blk = fn.blocks[i];
+        const char* label = blk.label.ptr ? blk.label.ptr : "bb";
+        c.block_map[blk.id.id] = LLVMAppendBasicBlockInContext(c.llvm_ctx, func, label);
+    }
+
+    // Emit instructions block by block.
+    for (u32 i = 0; i < fn.block_count; i++) {
+        auto& blk = fn.blocks[i];
+        LLVMBasicBlockRef bb = c.block_map[blk.id.id];
+        LLVMPositionBuilderAtEnd(c.builder, bb);
+
+        for (u32 j = 0; j < blk.inst_count; j++) {
+            emit_instruction(c, blk.insts[j]);
+        }
+
+        // If block has no terminator, add unreachable (shouldn't happen in valid RIR).
+        if (!blk.terminator()) {
+            LLVMBuildUnreachable(c.builder);
+        }
+    }
+
+    return true;
+}
+
+// ── Module Codegen ─────────────────────────────────────────────────
+
+CodegenResult codegen(const rir::Module& rir_mod) {
+    Ctx c{};
+    c.llvm_ctx = LLVMContextCreate();
+    c.llvm_mod = LLVMModuleCreateWithNameInContext(
+        rir_mod.name.ptr ? rir_mod.name.ptr : "rue_module", c.llvm_ctx);
+    c.builder = LLVMCreateBuilderInContext(c.llvm_ctx);
+
+    // Zero out lazy helper pointers
+    c.fn_req_path = nullptr;
+    c.fn_req_method = nullptr;
+    c.fn_req_header = nullptr;
+    c.fn_req_remote_addr = nullptr;
+    c.fn_str_has_prefix = nullptr;
+    c.fn_str_trim_prefix = nullptr;
+    c.cur_fn = nullptr;
+
+    c.init_types();
+
+    // Set target triple + data layout from host
+    // (LLJIT will override, but setting these helps verification)
+
+    bool ok = true;
+    for (u32 i = 0; i < rir_mod.func_count && ok; i++) {
+        ok = emit_function(c, rir_mod.functions[i]);
+    }
+
+    LLVMDisposeBuilder(c.builder);
+
+    if (!ok) {
+        LLVMDisposeModule(c.llvm_mod);
+        LLVMContextDispose(c.llvm_ctx);
+        return {nullptr, nullptr, false};
+    }
+
+    return {c.llvm_mod, c.llvm_ctx, true};
+}
+
+}  // namespace rut::jit

--- a/src/jit/jit_engine.cc
+++ b/src/jit/jit_engine.cc
@@ -1,0 +1,169 @@
+#include "rut/jit/jit_engine.h"
+
+#include "rut/jit/runtime_helpers.h"
+
+#include <llvm-c/Core.h>
+#include <llvm-c/Error.h>
+#include <llvm-c/LLJIT.h>
+#include <llvm-c/Orc.h>
+#include <llvm-c/Target.h>
+#include <unistd.h>  // write (for error logging)
+
+namespace rut::jit {
+
+// ── Error logging (no stdlib) ──────────────────────────────────────
+
+static void log_error(const char* prefix, LLVMErrorRef err) {
+    char* msg = LLVMGetErrorMessage(err);
+    auto write_str = [](const char* s) {
+        int len = 0;
+        while (s[len]) len++;
+        (void)::write(2, s, len);
+    };
+    write_str(prefix);
+    write_str(": ");
+    write_str(msg);
+    write_str("\n");
+    LLVMDisposeErrorMessage(msg);
+}
+
+// ── Runtime Helper Symbol Table ────────────────────────────────────
+
+struct HelperEntry {
+    const char* name;
+    void* addr;
+};
+
+// Null-terminated table of runtime helper symbols.
+static const HelperEntry kHelpers[] = {
+    {"rut_helper_req_path", reinterpret_cast<void*>(&rut_helper_req_path)},
+    {"rut_helper_req_method", reinterpret_cast<void*>(&rut_helper_req_method)},
+    {"rut_helper_req_header", reinterpret_cast<void*>(&rut_helper_req_header)},
+    {"rut_helper_req_remote_addr", reinterpret_cast<void*>(&rut_helper_req_remote_addr)},
+    {"rut_helper_str_has_prefix", reinterpret_cast<void*>(&rut_helper_str_has_prefix)},
+    {"rut_helper_str_trim_prefix", reinterpret_cast<void*>(&rut_helper_str_trim_prefix)},
+    {nullptr, nullptr},
+};
+
+// ── JitEngine ──────────────────────────────────────────────────────
+
+bool JitEngine::init() {
+    // Initialize native target (required before creating LLJIT).
+    if (LLVMInitializeNativeTarget()) return false;
+    LLVMInitializeNativeAsmPrinter();
+    ctx_count = 0;
+
+    // Create LLJIT with default settings (auto-detects host target).
+    LLVMErrorRef err = LLVMOrcCreateLLJIT(&lljit, nullptr);
+    if (err) {
+        log_error("jit: LLJIT creation failed", err);
+        return false;
+    }
+
+    // Pre-register all runtime helper symbols as absolute addresses.
+    // MangleAndIntern produces correctly mangled names for the target.
+    LLVMOrcJITDylibRef main_jd = LLVMOrcLLJITGetMainJITDylib(lljit);
+
+    u32 count = 0;
+    for (const auto* h = kHelpers; h->name; h++) count++;
+
+    LLVMOrcCSymbolMapPair pairs[16];
+    for (u32 i = 0; i < count && i < 16; i++) {
+        pairs[i].Name = LLVMOrcLLJITMangleAndIntern(lljit, kHelpers[i].name);
+        pairs[i].Sym.Address = reinterpret_cast<LLVMOrcExecutorAddress>(kHelpers[i].addr);
+        pairs[i].Sym.Flags.GenericFlags = LLVMJITSymbolGenericFlagsExported;
+        pairs[i].Sym.Flags.TargetFlags = 0;
+    }
+
+    // LLVMOrcAbsoluteSymbols takes ownership of the Name fields in pairs.
+    // Do NOT release them after this call.
+    LLVMOrcMaterializationUnitRef mu = LLVMOrcAbsoluteSymbols(pairs, count);
+    err = LLVMOrcJITDylibDefine(main_jd, mu);
+    if (err) {
+        log_error("jit: helper registration failed", err);
+        // On failure, ownership of mu stays with us.
+        LLVMOrcDisposeMaterializationUnit(mu);
+        LLVMOrcDisposeLLJIT(lljit);
+        lljit = nullptr;
+        return false;
+    }
+
+    return true;
+}
+
+bool JitEngine::compile(LLVMModuleRef mod, LLVMContextRef ctx) {
+    // Always takes ownership of mod and ctx regardless of return value.
+    if (!lljit) {
+        LLVMDisposeModule(mod);
+        LLVMContextDispose(ctx);
+        return false;
+    }
+
+    // Set the module's data layout and target triple from LLJIT.
+    const char* dl = LLVMOrcLLJITGetDataLayoutStr(lljit);
+    if (dl) LLVMSetDataLayout(mod, dl);
+    const char* triple = LLVMOrcLLJITGetTripleString(lljit);
+    if (triple) LLVMSetTarget(mod, triple);
+
+    // Wrap module into a ThreadSafeModule for submission to LLJIT.
+    // We create a fresh ThreadSafeContext as the lock wrapper. Its internal
+    // context differs from the module's context, but LLJIT only uses it
+    // for synchronization — the module's own context is used for compilation.
+    // The module's original LLVMContext (ctx) is tracked for cleanup in
+    // shutdown() after LLJIT has destroyed the module.
+    LLVMOrcThreadSafeContextRef tsctx = LLVMOrcCreateNewThreadSafeContext();
+    LLVMOrcThreadSafeModuleRef tsm = LLVMOrcCreateNewThreadSafeModule(mod, tsctx);
+    LLVMOrcDisposeThreadSafeContext(tsctx);
+
+    // Track the orphaned context for cleanup.
+    if (ctx_count < kMaxContexts) {
+        contexts[ctx_count++] = ctx;
+    }
+
+    // Submit to the main JITDylib. On success, LLJIT owns tsm.
+    LLVMOrcJITDylibRef main_jd = LLVMOrcLLJITGetMainJITDylib(lljit);
+    LLVMErrorRef err = LLVMOrcLLJITAddLLVMIRModule(lljit, main_jd, tsm);
+    if (err) {
+        log_error("jit: module compilation failed", err);
+        // On failure, ownership of tsm stays with us.
+        LLVMOrcDisposeThreadSafeModule(tsm);
+        return false;
+    }
+
+    return true;
+}
+
+void* JitEngine::lookup(const char* name) {
+    if (!lljit) return nullptr;
+
+    LLVMOrcExecutorAddress addr = 0;
+    LLVMErrorRef err = LLVMOrcLLJITLookup(lljit, &addr, name);
+    if (err) {
+        log_error("jit: symbol lookup failed", err);
+        return nullptr;
+    }
+
+    // Cast via uintptr_t. The NOLINT suppresses performance-no-int-to-ptr
+    // which is unavoidable here — the LLVM C API returns addresses as u64.
+    return reinterpret_cast<void*>(  // NOLINT(performance-no-int-to-ptr)
+        static_cast<uintptr_t>(addr));
+}
+
+void JitEngine::shutdown() {
+    // Dispose LLJIT first — this destroys all compiled modules.
+    if (lljit) {
+        LLVMErrorRef err = LLVMOrcDisposeLLJIT(lljit);
+        if (err) {
+            log_error("jit: LLJIT disposal failed", err);
+        }
+        lljit = nullptr;
+    }
+    // Now safe to dispose orphaned contexts (modules that referenced
+    // them have been destroyed by LLJIT above).
+    for (u32 i = 0; i < ctx_count; i++) {
+        LLVMContextDispose(contexts[i]);
+    }
+    ctx_count = 0;
+}
+
+}  // namespace rut::jit

--- a/src/jit/runtime_helpers.cc
+++ b/src/jit/runtime_helpers.cc
@@ -1,0 +1,125 @@
+#include "rut/jit/runtime_helpers.h"
+
+#include "rut/runtime/connection.h"
+#include "rut/runtime/http_parser.h"
+
+using namespace rut;
+
+// ── Request Access ─────────────────────────────────────────────────
+
+void rut_helper_req_path(const u8* req_data, u32 req_len, const char** out_ptr, u32* out_len) {
+    // Fast path: parse just enough to extract the path.
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    if (parser.parse(req_data, req_len, &req) == ParseStatus::Complete) {
+        *out_ptr = req.path.ptr;
+        *out_len = req.path.len;
+        return;
+    }
+
+    // Fallback: minimal manual extraction.
+    // Skip method (find first space), extract path until next space.
+    u32 i = 0;
+    while (i < req_len && req_data[i] != ' ') i++;
+    if (i >= req_len) {
+        *out_ptr = "/";
+        *out_len = 1;
+        return;
+    }
+    i++;  // skip space
+    u32 path_start = i;
+    while (i < req_len && req_data[i] != ' ' && req_data[i] != '?' && req_data[i] != '\r') {
+        i++;
+    }
+    *out_ptr = reinterpret_cast<const char*>(req_data + path_start);
+    *out_len = i - path_start;
+}
+
+u8 rut_helper_req_method(const u8* req_data, u32 req_len) {
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    if (parser.parse(req_data, req_len, &req) == ParseStatus::Complete) {
+        return static_cast<u8>(req.method);
+    }
+
+    // Fallback: return Unknown
+    return static_cast<u8>(HttpMethod::Unknown);
+}
+
+void rut_helper_req_header(const u8* req_data,
+                           u32 req_len,
+                           const char* name,
+                           u32 name_len,
+                           u8* out_has_value,
+                           const char** out_ptr,
+                           u32* out_len) {
+    *out_has_value = 0;
+    *out_ptr = nullptr;
+    *out_len = 0;
+
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    if (parser.parse(req_data, req_len, &req) != ParseStatus::Complete) return;
+
+    // Linear scan through parsed headers (case-insensitive name match).
+    for (u32 i = 0; i < req.header_count; i++) {
+        auto& h = req.headers[i];
+        if (h.name.len != name_len) continue;
+        bool match = true;
+        for (u32 j = 0; j < name_len; j++) {
+            u8 a = static_cast<u8>(h.name.ptr[j]);
+            u8 b = static_cast<u8>(name[j]);
+            // ASCII case-insensitive comparison
+            if (a >= 'A' && a <= 'Z') a += 'a' - 'A';
+            if (b >= 'A' && b <= 'Z') b += 'a' - 'A';
+            if (a != b) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            *out_has_value = 1;
+            *out_ptr = h.value.ptr;
+            *out_len = h.value.len;
+            return;
+        }
+    }
+}
+
+u32 rut_helper_req_remote_addr(void* conn) {
+    auto* c = static_cast<Connection*>(conn);
+    return c->peer_addr;
+}
+
+// ── String Operations ──────────────────────────────────────────────
+
+u8 rut_helper_str_has_prefix(const char* s, u32 s_len, const char* pfx, u32 pfx_len) {
+    if (pfx_len > s_len) return 0;
+    for (u32 i = 0; i < pfx_len; i++) {
+        if (s[i] != pfx[i]) return 0;
+    }
+    return 1;
+}
+
+void rut_helper_str_trim_prefix(
+    const char* s, u32 s_len, const char* pfx, u32 pfx_len, const char** out_ptr, u32* out_len) {
+    if (pfx_len <= s_len) {
+        bool match = true;
+        for (u32 i = 0; i < pfx_len; i++) {
+            if (s[i] != pfx[i]) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            *out_ptr = s + pfx_len;
+            *out_len = s_len - pfx_len;
+            return;
+        }
+    }
+    *out_ptr = s;
+    *out_len = s_len;
+}

--- a/src/runtime/arena.cc
+++ b/src/runtime/arena.cc
@@ -1,0 +1,20 @@
+#include "rut/runtime/arena.h"
+
+#include "rut/runtime/slice_pool.h"
+
+namespace rut {
+
+u8* SlicePoolBackend::acquire(u64 needed, u64* out_size) {
+    if (!pool) return nullptr;
+    if (needed > SlicePool::kSliceSize) return nullptr;  // won't fit in one slice
+    u8* slice = pool->alloc();
+    if (!slice) return nullptr;
+    *out_size = SlicePool::kSliceSize;
+    return slice;
+}
+
+void SlicePoolBackend::release(u8* ptr, u64 /*size*/) {
+    if (pool) pool->free(ptr);
+}
+
+}  // namespace rut

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_test(NAME test_integration COMMAND test_integration)
 set_tests_properties(test_integration PROPERTIES LABELS "integration;network")
 
 add_executable(test_arena test_arena.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
+target_link_libraries(test_arena rue_runtime)
 target_include_directories(test_arena PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/testing
@@ -129,6 +130,17 @@ target_include_directories(test_shard_control PRIVATE
 add_test(NAME test_shard_control COMMAND test_shard_control)
 set_tests_properties(test_shard_control PROPERTIES LABELS "unit")
 
+add_executable(test_jit test_jit.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
+target_link_libraries(test_jit rue_jit rue_compiler)
+target_include_directories(test_jit PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+    ${LLVM_INCLUDE_DIRS}
+)
+target_compile_definitions(test_jit PRIVATE ${LLVM_DEFINITIONS})
+add_test(NAME test_jit COMMAND test_jit)
+set_tests_properties(test_jit PROPERTIES LABELS "unit;jit")
+
 add_custom_target(check
     COMMAND $<TARGET_FILE:test_network>
     COMMAND $<TARGET_FILE:test_integration>
@@ -143,6 +155,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_metrics>
     COMMAND $<TARGET_FILE:test_chunked_parser>
     COMMAND $<TARGET_FILE:test_shard_control>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_drain test_access_log test_metrics test_shard_control
+    COMMAND $<TARGET_FILE:test_jit>
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_drain test_access_log test_metrics test_shard_control test_jit
     COMMENT "Running all tests..."
 )

--- a/tests/test_arena.cc
+++ b/tests/test_arena.cc
@@ -1,7 +1,8 @@
-// Arena tests — comprehensive code path coverage.
-// Ported scenarios from clapdb/Arena test suite where applicable,
-// adapted to our no-stdlib Arena API.
+// Arena tests — comprehensive code path coverage for both backends.
+// MmapArena: mmap-backed, variable-size blocks (compiler use).
+// SliceArena: SlicePool-backed, fixed 16KB blocks (runtime hot path).
 #include "rut/runtime/arena.h"
+#include "rut/runtime/slice_pool.h"
 #include "test.h"
 
 using namespace rut;
@@ -11,26 +12,26 @@ using namespace rut;
 // ============================================================
 
 TEST(block, data_starts_after_header) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     auto* b = a.current;
-    u64 hdr = (sizeof(Arena::Block) + 15) & ~u64(15);
+    u64 hdr = (sizeof(MmapArena::Block) + 15) & ~u64(15);
     u8* expected = reinterpret_cast<u8*>(b) + hdr;
     CHECK_EQ(b->data(), expected);
     a.destroy();
 }
 
 TEST(block, capacity_equals_size_minus_header) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     auto* b = a.current;
-    u64 hdr = (sizeof(Arena::Block) + 15) & ~u64(15);
+    u64 hdr = (sizeof(MmapArena::Block) + 15) & ~u64(15);
     CHECK_EQ(b->capacity(), b->size - hdr);
     a.destroy();
 }
 
 TEST(block, remaining_decreases_after_alloc) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     u64 r0 = a.current->remaining();
     a.alloc(100);
@@ -40,16 +41,16 @@ TEST(block, remaining_decreases_after_alloc) {
 }
 
 TEST(block, chain_integrity) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
-    Arena::Block* first = a.current;
+    MmapArena::Block* first = a.current;
     CHECK(first->prev == nullptr);
 
     // Force new block
     a.alloc(first->capacity());
     a.alloc(64);
 
-    Arena::Block* second = a.current;
+    MmapArena::Block* second = a.current;
     CHECK(second != first);
     CHECK_EQ(second->prev, first);
     CHECK(first->prev == nullptr);
@@ -57,17 +58,17 @@ TEST(block, chain_integrity) {
 }
 
 TEST(block, three_block_chain) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
-    Arena::Block* b0 = a.current;
+    MmapArena::Block* b0 = a.current;
 
     // Force 3 blocks by allocating more than one block can hold each time
     a.alloc(b0->capacity() + 64);  // overflow → b1
-    Arena::Block* b1 = a.current;
+    MmapArena::Block* b1 = a.current;
     CHECK_NE(b1, b0);
 
     a.alloc(b1->capacity() + 64);  // overflow → b2
-    Arena::Block* b2 = a.current;
+    MmapArena::Block* b2 = a.current;
     CHECK_NE(b2, b1);
 
     // Verify chain: b2→b1→b0→nullptr
@@ -82,7 +83,7 @@ TEST(block, three_block_chain) {
 // ============================================================
 
 TEST(arena, init_succeeds) {
-    Arena a;
+    MmapArena a;
     CHECK(a.init(4096).has_value());
     CHECK(a.current != nullptr);
     CHECK_GT(a.space_allocated(), 0u);
@@ -90,14 +91,14 @@ TEST(arena, init_succeeds) {
 }
 
 TEST(arena, init_min_256) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(1).has_value());
     CHECK_GE(a.current->size, 256u);
     a.destroy();
 }
 
 TEST(arena, small_alloc) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     void* p = a.alloc(64);
     CHECK(p != nullptr);
@@ -106,7 +107,7 @@ TEST(arena, small_alloc) {
 }
 
 TEST(arena, alloc_returns_sequential_addresses) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     u8* p1 = static_cast<u8*>(a.alloc(16));
     u8* p2 = static_cast<u8*>(a.alloc(32));
@@ -117,7 +118,7 @@ TEST(arena, alloc_returns_sequential_addresses) {
 }
 
 TEST(arena, multiple_allocs_in_one_block) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     void* p1 = a.alloc(100);
     void* p2 = a.alloc(200);
@@ -135,7 +136,7 @@ TEST(arena, multiple_allocs_in_one_block) {
 // ============================================================
 
 TEST(arena, alignment_8byte) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     void* p1 = a.alloc(1);
     void* p2 = a.alloc(1);
@@ -146,7 +147,7 @@ TEST(arena, alignment_8byte) {
 }
 
 TEST(arena, alignment_various_sizes) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     for (u64 sz = 1; sz <= 64; sz++) {
         void* p = a.alloc(sz);
@@ -156,7 +157,7 @@ TEST(arena, alignment_various_sizes) {
 }
 
 TEST(arena, zero_size_alloc) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     void* p = a.alloc(0);
     CHECK(p != nullptr);
@@ -168,7 +169,7 @@ TEST(arena, zero_size_alloc) {
 // ============================================================
 
 TEST(arena, overflow_to_new_block) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
     u64 cap = a.current->capacity();
     a.alloc(cap);
@@ -179,26 +180,26 @@ TEST(arena, overflow_to_new_block) {
 }
 
 TEST(arena, large_alloc_gets_own_block) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
     void* p = a.alloc(1024);
     CHECK(p != nullptr);
-    CHECK_GE(a.current->size, 1024u + sizeof(Arena::Block));
+    CHECK_GE(a.current->size, 1024u + sizeof(MmapArena::Block));
     a.destroy();
 }
 
 TEST(arena, many_blocks) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
     for (int i = 0; i < 100; i++) CHECK(a.alloc(200) != nullptr);
     int blocks = 0;
-    for (Arena::Block* b = a.current; b; b = b->prev) blocks++;
+    for (MmapArena::Block* b = a.current; b; b = b->prev) blocks++;
     CHECK_GT(blocks, 1);
     a.destroy();
 }
 
 TEST(arena, alloc_exact_block_capacity) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     u64 cap = a.current->capacity();
     u64 aligned_cap = cap & ~static_cast<u64>(7);
@@ -213,9 +214,9 @@ TEST(arena, alloc_exact_block_capacity) {
 // ============================================================
 
 TEST(arena, reset_single_block_only) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
-    Arena::Block* first = a.current;
+    MmapArena::Block* first = a.current;
     a.alloc(100);
     a.alloc(200);
     CHECK_GT(a.space_used(), 0u);
@@ -227,9 +228,9 @@ TEST(arena, reset_single_block_only) {
 }
 
 TEST(arena, reset_reuses_first_block) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
-    Arena::Block* first = a.current;
+    MmapArena::Block* first = a.current;
     a.alloc(100);
     a.reset();
     // Alloc again — should use same first block
@@ -240,7 +241,7 @@ TEST(arena, reset_reuses_first_block) {
 }
 
 TEST(arena, reset_frees_extra_blocks) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
     u64 initial = a.space_allocated();
     for (int i = 0; i < 10; i++) a.alloc(4000);
@@ -252,7 +253,7 @@ TEST(arena, reset_frees_extra_blocks) {
 }
 
 TEST(arena, reset_total_allocated_tracking) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
     u64 initial = a.space_allocated();
     // Create 3 extra blocks
@@ -268,7 +269,7 @@ TEST(arena, reset_total_allocated_tracking) {
 }
 
 TEST(arena, reset_then_alloc_10_cycles) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     for (int cycle = 0; cycle < 10; cycle++) {
         for (int i = 0; i < 20; i++) CHECK(a.alloc(100) != nullptr);
@@ -287,7 +288,7 @@ struct Point {
 };
 
 TEST(arena, alloc_t_pod) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     auto* p = a.alloc_t<Point>(10, 20);
     CHECK(p != nullptr);
@@ -302,7 +303,7 @@ struct Counter {
 };
 
 TEST(arena, alloc_t_with_constructor) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     auto* c = a.alloc_t<Counter>();
     CHECK(c != nullptr);
@@ -315,7 +316,7 @@ struct Large {
 };
 
 TEST(arena, alloc_t_large_struct) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     auto* l = a.alloc_t<Large>();
     CHECK(l != nullptr);
@@ -326,7 +327,7 @@ TEST(arena, alloc_t_large_struct) {
 }
 
 TEST(arena, alloc_t_multiple_types) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     auto* p = a.alloc_t<Point>(1, 2);
     auto* c = a.alloc_t<Counter>();
@@ -338,7 +339,7 @@ TEST(arena, alloc_t_multiple_types) {
 }
 
 TEST(arena, alloc_array_int) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     auto* arr = a.alloc_array<i32>(10);
     CHECK(arr != nullptr);
@@ -349,7 +350,7 @@ TEST(arena, alloc_array_int) {
 }
 
 TEST(arena, alloc_array_struct) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     auto* arr = a.alloc_array<Point>(5);
     CHECK(arr != nullptr);
@@ -361,7 +362,7 @@ TEST(arena, alloc_array_struct) {
 }
 
 TEST(arena, alloc_array_zero_count) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     auto* arr = a.alloc_array<i32>(0);
     CHECK(arr != nullptr);  // zero-count returns valid pointer
@@ -373,7 +374,7 @@ TEST(arena, alloc_array_zero_count) {
 // ============================================================
 
 TEST(arena, destroy_frees_all) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
     for (int i = 0; i < 20; i++) a.alloc(200);
     a.destroy();
@@ -382,7 +383,7 @@ TEST(arena, destroy_frees_all) {
 }
 
 TEST(arena, double_destroy_safe) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     a.alloc(100);
     a.destroy();
@@ -391,7 +392,7 @@ TEST(arena, double_destroy_safe) {
 }
 
 TEST(arena, destroy_single_block) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     a.alloc(64);
     a.destroy();
@@ -404,7 +405,7 @@ TEST(arena, destroy_single_block) {
 // ============================================================
 
 TEST(arena, space_used_single_block) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     a.alloc(100);  // → 104
     a.alloc(8);
@@ -413,7 +414,7 @@ TEST(arena, space_used_single_block) {
 }
 
 TEST(arena, space_used_across_blocks) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
     u64 cap = a.current->capacity();
     a.alloc(cap);  // fill first block
@@ -424,7 +425,7 @@ TEST(arena, space_used_across_blocks) {
 }
 
 TEST(arena, space_allocated_grows_with_blocks) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
     u64 a0 = a.space_allocated();
     a.alloc(a.current->capacity());
@@ -435,7 +436,7 @@ TEST(arena, space_allocated_grows_with_blocks) {
 }
 
 TEST(arena, space_used_zero_after_reset) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     a.alloc(500);
     CHECK_GT(a.space_used(), 0u);
@@ -449,7 +450,7 @@ TEST(arena, space_used_zero_after_reset) {
 // ============================================================
 
 TEST(arena, stress_10k_small_allocs) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     for (int i = 0; i < 10000; i++) CHECK(a.alloc(8) != nullptr);
     CHECK_EQ(a.space_used(), 80000u);
@@ -457,7 +458,7 @@ TEST(arena, stress_10k_small_allocs) {
 }
 
 TEST(arena, stress_mixed_sizes) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(1024).has_value());
     for (int i = 0; i < 1000; i++) {
         u64 sz = static_cast<u64>((i % 7 + 1) * 8);  // 8,16,24,32,40,48,56
@@ -467,7 +468,7 @@ TEST(arena, stress_mixed_sizes) {
 }
 
 TEST(arena, stress_alloc_reset_1000_cycles) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     for (int cycle = 0; cycle < 1000; cycle++) {
         a.alloc(128);
@@ -480,20 +481,20 @@ TEST(arena, stress_alloc_reset_1000_cycles) {
 }
 
 TEST(arena, stress_large_allocs_across_blocks) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
     // Each alloc forces a new block
     for (int i = 0; i < 50; i++) CHECK(a.alloc(4000) != nullptr);
     int blocks = 0;
-    for (Arena::Block* b = a.current; b; b = b->prev) blocks++;
+    for (MmapArena::Block* b = a.current; b; b = b->prev) blocks++;
     CHECK_GE(blocks, 50);
     a.destroy();
 }
 
 TEST(arena, stress_reset_preserves_first_block_across_cycles) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
-    Arena::Block* first = a.current;
+    MmapArena::Block* first = a.current;
     for (int cycle = 0; cycle < 100; cycle++) {
         for (int i = 0; i < 10; i++) a.alloc(100);
         a.reset();
@@ -507,7 +508,7 @@ TEST(arena, stress_reset_preserves_first_block_across_cycles) {
 // ============================================================
 
 TEST(arena, data_integrity_after_alloc) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     auto* buf = static_cast<u8*>(a.alloc(256));
     REQUIRE(buf != nullptr);
@@ -517,7 +518,7 @@ TEST(arena, data_integrity_after_alloc) {
 }
 
 TEST(arena, data_integrity_across_blocks) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(256).has_value());
     // Fill first block, force second
     u64 cap = a.current->capacity();
@@ -536,17 +537,17 @@ TEST(arena, data_integrity_across_blocks) {
 
 // === Null guard tests (Copilot round 6) ===
 
-// alloc() on uninitialized Arena (current==nullptr) must return nullptr, not crash.
+// alloc() on uninitialized MmapArena (current==nullptr) must return nullptr, not crash.
 // Without the null guard, this would segfault.
 TEST(arena, alloc_before_init_returns_null) {
-    Arena a;
+    MmapArena a;
     a.current = nullptr;
     CHECK(a.alloc(64) == nullptr);
 }
 
 // alloc() after destroy (current==nullptr) must return nullptr.
 TEST(arena, alloc_after_destroy_returns_null) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     a.destroy();
     CHECK(a.alloc(64) == nullptr);
@@ -554,19 +555,281 @@ TEST(arena, alloc_after_destroy_returns_null) {
 
 // reset() after destroy (current==nullptr) must not crash.
 TEST(arena, reset_after_destroy_no_crash) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     a.destroy();
     a.reset();  // must be a no-op, not a crash
     CHECK(a.current == nullptr);
 }
 
-// reset() on uninitialized Arena must not crash.
+// reset() on uninitialized MmapArena must not crash.
 TEST(arena, reset_before_init_no_crash) {
-    Arena a;
+    MmapArena a;
     a.current = nullptr;
     a.reset();
     CHECK(a.current == nullptr);
+}
+
+// ============================================================
+// SliceArena tests (Arena<SlicePoolBackend>)
+// ============================================================
+
+// Helper: create a small SlicePool for tests.
+// 16 slices = 256KB — enough for arena tests.
+struct PoolCtx {
+    SlicePool pool;
+
+    bool init() {
+        return pool.init(16, 16).has_value();  // 16 slices, all precommitted
+    }
+    void destroy() { pool.destroy(); }
+};
+
+TEST(slice_arena, basic_alloc) {
+    PoolCtx pc;
+    REQUIRE(pc.init());
+
+    SliceArena a;
+    REQUIRE(a.init(&pc.pool).has_value());
+    CHECK(a.current != nullptr);
+
+    void* p = a.alloc(64);
+    CHECK(p != nullptr);
+
+    a.destroy();
+    pc.destroy();
+}
+
+TEST(slice_arena, alloc_t) {
+    PoolCtx pc;
+    REQUIRE(pc.init());
+
+    SliceArena a;
+    REQUIRE(a.init(&pc.pool).has_value());
+
+    struct Foo {
+        u32 x;
+        u32 y;
+    };
+    auto* f = a.alloc_t<Foo>(42, 99);
+    REQUIRE(f != nullptr);
+    CHECK_EQ(f->x, 42u);
+    CHECK_EQ(f->y, 99u);
+
+    a.destroy();
+    pc.destroy();
+}
+
+TEST(slice_arena, alloc_array) {
+    PoolCtx pc;
+    REQUIRE(pc.init());
+
+    SliceArena a;
+    REQUIRE(a.init(&pc.pool).has_value());
+
+    auto* arr = a.alloc_array<u64>(100);
+    REQUIRE(arr != nullptr);
+    // Value-initialized to zero
+    for (u32 i = 0; i < 100; i++) CHECK_EQ(arr[i], 0ull);
+
+    // Write and read back
+    arr[0] = 42;
+    arr[99] = 99;
+    CHECK_EQ(arr[0], 42ull);
+    CHECK_EQ(arr[99], 99ull);
+
+    a.destroy();
+    pc.destroy();
+}
+
+TEST(slice_arena, chain_to_second_slice) {
+    PoolCtx pc;
+    REQUIRE(pc.init());
+
+    SliceArena a;
+    REQUIRE(a.init(&pc.pool).has_value());
+
+    auto* first_block = a.current;
+    u64 cap = first_block->capacity();
+
+    // Fill the first slice almost completely
+    void* p1 = a.alloc(cap - 8);
+    REQUIRE(p1 != nullptr);
+    CHECK(a.current == first_block);  // still on first slice
+
+    // This allocation should overflow to a second slice
+    void* p2 = a.alloc(64);
+    REQUIRE(p2 != nullptr);
+    CHECK(a.current != first_block);         // new slice
+    CHECK_EQ(a.current->prev, first_block);  // chained
+
+    a.destroy();
+    pc.destroy();
+}
+
+TEST(slice_arena, chain_three_slices) {
+    PoolCtx pc;
+    REQUIRE(pc.init());
+
+    SliceArena a;
+    REQUIRE(a.init(&pc.pool).has_value());
+
+    u64 cap = a.current->capacity();
+
+    // Force 3 slices
+    a.alloc(cap);  // fill slice 0
+    auto* s1 = a.current;
+    a.alloc(cap);  // fill slice 1 → allocates slice 2
+    auto* s2 = a.current;
+
+    CHECK_NE(s1, s2);
+    CHECK_EQ(s2->prev, s1);
+
+    a.destroy();
+    pc.destroy();
+}
+
+TEST(slice_arena, reset_returns_slices_to_pool) {
+    PoolCtx pc;
+    REQUIRE(pc.init());
+
+    u32 free_before = pc.pool.available();
+
+    SliceArena a;
+    REQUIRE(a.init(&pc.pool).has_value());
+    u32 after_init = pc.pool.available();
+    CHECK_EQ(after_init, free_before - 1);  // took 1 slice
+
+    // Force overflow to a second slice
+    u64 cap = a.current->capacity();
+    a.alloc(cap);  // fills slice 0 exactly
+    a.alloc(64);   // overflows → takes slice 1
+    u32 after_chain = pc.pool.available();
+    CHECK_EQ(after_chain, free_before - 2);  // 2 slices total
+
+    // Reset should return extra slices, keep first
+    a.reset();
+    u32 after_reset = pc.pool.available();
+    CHECK_EQ(after_reset, free_before - 1);  // back to 1 slice
+    CHECK(a.current != nullptr);
+    CHECK(a.current->prev == nullptr);
+    CHECK_EQ(a.current->used, 0ull);
+
+    // Can still alloc after reset
+    void* p = a.alloc(32);
+    CHECK(p != nullptr);
+
+    a.destroy();
+    u32 after_destroy = pc.pool.available();
+    CHECK_EQ(after_destroy, free_before);  // all returned
+    pc.destroy();
+}
+
+TEST(slice_arena, destroy_returns_all_slices) {
+    PoolCtx pc;
+    REQUIRE(pc.init());
+
+    u32 free_before = pc.pool.available();
+
+    SliceArena a;
+    REQUIRE(a.init(&pc.pool).has_value());
+
+    u64 cap = a.current->capacity();
+    a.alloc(cap);
+    a.alloc(64);
+    // 3 slices in use
+
+    a.destroy();
+    CHECK_EQ(pc.pool.available(), free_before);  // all returned
+    CHECK(a.current == nullptr);
+
+    pc.destroy();
+}
+
+TEST(slice_arena, single_alloc_exceeding_slice_fails) {
+    PoolCtx pc;
+    REQUIRE(pc.init());
+
+    SliceArena a;
+    REQUIRE(a.init(&pc.pool).has_value());
+
+    // 16KB slice minus header ≈ 16368 bytes usable.
+    // Allocating more than that in one call should fail.
+    void* p = a.alloc(SlicePool::kSliceSize);  // 16384 > usable capacity
+    CHECK(p == nullptr);
+
+    // Arena should still be usable after failed alloc
+    void* p2 = a.alloc(32);
+    CHECK(p2 != nullptr);
+
+    a.destroy();
+    pc.destroy();
+}
+
+TEST(slice_arena, pool_exhaustion) {
+    // Pool with only 2 slices
+    SlicePool pool;
+    REQUIRE(pool.init(2, 2).has_value());
+
+    SliceArena a;
+    REQUIRE(a.init(&pool).has_value());  // takes slice 1
+
+    u64 cap = a.current->capacity();
+    a.alloc(cap);           // fill slice 1
+    void* p = a.alloc(64);  // overflows → takes slice 2
+    CHECK(p != nullptr);
+
+    // Slice 2 has cap-64 remaining. Fill it to force next overflow.
+    a.alloc(cap - 64);       // fill slice 2 completely
+    void* p2 = a.alloc(64);  // pool empty → nullptr
+    CHECK(p2 == nullptr);
+
+    a.destroy();
+    pool.destroy();
+}
+
+TEST(slice_arena, multiple_arenas_same_pool) {
+    PoolCtx pc;
+    REQUIRE(pc.init());
+
+    SliceArena a1, a2;
+    REQUIRE(a1.init(&pc.pool).has_value());
+    REQUIRE(a2.init(&pc.pool).has_value());
+
+    // Both arenas can alloc independently
+    auto* p1 = a1.alloc_t<u64>(111);
+    auto* p2 = a2.alloc_t<u64>(222);
+    REQUIRE(p1 != nullptr);
+    REQUIRE(p2 != nullptr);
+    CHECK_EQ(*p1, 111ull);
+    CHECK_EQ(*p2, 222ull);
+
+    // They don't interfere
+    a1.reset();
+    CHECK_EQ(*p2, 222ull);  // a2's data still valid
+
+    a1.destroy();
+    a2.destroy();
+    pc.destroy();
+}
+
+TEST(slice_arena, reset_then_reuse) {
+    PoolCtx pc;
+    REQUIRE(pc.init());
+
+    SliceArena a;
+    REQUIRE(a.init(&pc.pool).has_value());
+
+    // Alloc, reset, alloc again — simulates request cycle
+    for (int cycle = 0; cycle < 10; cycle++) {
+        auto* v = a.alloc_t<u32>(static_cast<u32>(cycle));
+        REQUIRE(v != nullptr);
+        CHECK_EQ(*v, static_cast<u32>(cycle));
+        a.reset();
+    }
+
+    a.destroy();
+    pc.destroy();
 }
 
 int main(int argc, char** argv) {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -1,0 +1,1251 @@
+#include "rut/compiler/rir.h"
+#include "rut/compiler/rir_builder.h"
+#include "rut/jit/codegen.h"
+#include "rut/jit/handler_abi.h"
+#include "rut/jit/jit_engine.h"
+#include "rut/jit/runtime_helpers.h"
+#include "rut/runtime/connection.h"
+#include "test.h"
+
+using namespace rut;
+using namespace rut::rir;
+using namespace rut::jit;
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+static Str lit(const char* s) {
+    u32 n = 0;
+    while (s[n]) n++;
+    return {s, n};
+}
+
+// Unwrap Expected.
+#define V(expr)                                                \
+    __extension__({                                            \
+        auto&& _v_result = (expr);                             \
+        REQUIRE(static_cast<bool>(_v_result));                 \
+        static_cast<decltype(_v_result)&&>(_v_result).value(); \
+    })
+
+#define VOK(expr) REQUIRE(static_cast<bool>(expr))
+
+// MmapArena-backed module initialization (same pattern as test_rir.cc).
+struct TestContext {
+    MmapArena arena;
+    Module mod;
+
+    bool init() {
+        if (!arena.init(4096)) return false;
+        mod.name = lit("test_jit.rue");
+        mod.arena = &arena;
+
+        static constexpr u32 kMaxFuncs = 8;
+        mod.functions = arena.alloc_array<Function>(kMaxFuncs);
+        if (!mod.functions) {
+            arena.destroy();
+            return false;
+        }
+        mod.func_count = 0;
+        mod.func_cap = kMaxFuncs;
+        static constexpr u32 kMaxStructs = 8;
+        mod.struct_defs = arena.alloc_array<StructDef*>(kMaxStructs);
+        if (!mod.struct_defs) {
+            arena.destroy();
+            return false;
+        }
+        mod.struct_count = 0;
+        mod.struct_cap = kMaxStructs;
+        return true;
+    }
+
+    void destroy() { arena.destroy(); }
+};
+
+// A minimal HTTP GET request for testing.
+static const char kGetApiRequest[] =
+    "GET /api/users HTTP/1.1\r\n"
+    "Host: localhost\r\n"
+    "\r\n";
+
+static const char kGetRootRequest[] =
+    "GET / HTTP/1.1\r\n"
+    "Host: localhost\r\n"
+    "\r\n";
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+// Test: runtime helpers work from C++ (sanity check)
+TEST(jit, helpers_sanity) {
+    const char* out_ptr = nullptr;
+    u32 out_len = 0;
+    rut_helper_req_path(reinterpret_cast<const u8*>(kGetApiRequest),
+                        sizeof(kGetApiRequest) - 1,
+                        &out_ptr,
+                        &out_len);
+    rut::test::out("  path: ");
+    if (out_ptr) {
+        for (u32 i = 0; i < out_len; i++) {
+            char ch = out_ptr[i];
+            (void)::write(1, &ch, 1);
+        }
+    }
+    rut::test::out(" len=");
+    rut::test::out_int(static_cast<int>(out_len));
+    rut::test::out("\n");
+    CHECK(out_ptr != nullptr);
+    CHECK(out_len > 0);
+}
+
+// Test: Simple handler that always returns 200.
+// RIR equivalent: return 200
+TEST(jit, return_200) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("always_200"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_ret_status(200));
+
+    // Codegen
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    // JIT compile
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    // Lookup
+    void* addr = engine.lookup("handler_always_200");
+    REQUIRE(addr != nullptr);
+
+    auto handler = reinterpret_cast<HandlerFn>(addr);
+    auto result = HandlerResult::unpack(handler(nullptr,
+                                                nullptr,
+                                                reinterpret_cast<const u8*>(kGetApiRequest),
+                                                sizeof(kGetApiRequest) - 1,
+                                                nullptr));
+
+    CHECK(result.action == HandlerAction::ReturnStatus);
+    CHECK(result.status_code == 200);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// Test: Handler with path prefix guard.
+// RIR equivalent:
+//   %path = req.path
+//   %prefix = const.str "/api"
+//   %has = str.has_prefix %path, %prefix
+//   br %has, ok_block, reject_block
+//   reject_block: ret.status 404
+//   ok_block: ret.status 200
+TEST(jit, guard_path_prefix) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("path_guard"), lit("/api"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok_blk = V(b.create_block(fn, lit("ok")));
+    auto reject_blk = V(b.create_block(fn, lit("reject")));
+
+    // Entry block: check path prefix
+    b.set_insert_point(fn, entry);
+    auto path = V(b.emit_req_path());
+    auto prefix = V(b.emit_const_str(lit("/api")));
+    auto has = V(b.emit_str_has_prefix(path, prefix));
+    VOK(b.emit_br(has, ok_blk, reject_blk));
+
+    // Reject block: 404
+    b.set_insert_point(fn, reject_blk);
+    VOK(b.emit_ret_status(404));
+
+    // OK block: 200
+    b.set_insert_point(fn, ok_blk);
+    VOK(b.emit_ret_status(200));
+
+    // Codegen + JIT
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto* addr = engine.lookup("handler_path_guard");
+    REQUIRE(addr != nullptr);
+    auto handler = reinterpret_cast<HandlerFn>(addr);
+
+    // Test with /api path — should return 200
+    {
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetApiRequest),
+                                               sizeof(kGetApiRequest) - 1,
+                                               nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 200);
+    }
+
+    // Test with / path — should return 404
+    {
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetRootRequest),
+                                               sizeof(kGetRootRequest) - 1,
+                                               nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 404);
+    }
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// Test: Handler that reads a header.
+// RIR equivalent:
+//   %auth = req.header "Authorization"
+//   %is_nil = opt.is_nil %auth
+//   br %is_nil, no_auth, has_auth
+//   no_auth: ret.status 401
+//   has_auth: ret.status 200
+TEST(jit, header_check) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("auth_check"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto no_auth = V(b.create_block(fn, lit("no_auth")));
+    auto has_auth = V(b.create_block(fn, lit("has_auth")));
+
+    b.set_insert_point(fn, entry);
+    auto auth = V(b.emit_req_header(lit("Authorization")));
+    auto is_nil = V(b.emit_opt_is_nil(auth));
+    VOK(b.emit_br(is_nil, no_auth, has_auth));
+
+    b.set_insert_point(fn, no_auth);
+    VOK(b.emit_ret_status(401));
+
+    b.set_insert_point(fn, has_auth);
+    VOK(b.emit_ret_status(200));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto* addr = engine.lookup("handler_auth_check");
+    REQUIRE(addr != nullptr);
+    auto handler = reinterpret_cast<HandlerFn>(addr);
+
+    // Request without Authorization → 401
+    {
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetApiRequest),
+                                               sizeof(kGetApiRequest) - 1,
+                                               nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 401);
+    }
+
+    // Request with Authorization → 200
+    {
+        static const char req[] =
+            "GET /api HTTP/1.1\r\n"
+            "Host: localhost\r\n"
+            "Authorization: Bearer token123\r\n"
+            "\r\n";
+        auto r = HandlerResult::unpack(
+            handler(nullptr, nullptr, reinterpret_cast<const u8*>(req), sizeof(req) - 1, nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 200);
+    }
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// Test: Handler with comparison.
+// RIR equivalent:
+//   %method = req.method
+//   %get = const.method 'G'
+//   %is_get = cmp.eq %method, %get
+//   br %is_get, ok, reject
+//   reject: ret.status 405
+//   ok: ret.status 200
+TEST(jit, method_check) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("method_check"), lit("/"), 0));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto reject = V(b.create_block(fn, lit("reject")));
+
+    b.set_insert_point(fn, entry);
+    auto method = V(b.emit_req_method());
+    auto get_const = V(b.emit_const_method(static_cast<u8>(0)));  // GET = 0 in HttpMethod enum
+    auto is_get = V(b.emit_cmp(Opcode::CmpEq, method, get_const));
+    VOK(b.emit_br(is_get, ok, reject));
+
+    b.set_insert_point(fn, reject);
+    VOK(b.emit_ret_status(405));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto* addr = engine.lookup("handler_method_check");
+    REQUIRE(addr != nullptr);
+    auto handler = reinterpret_cast<HandlerFn>(addr);
+
+    // GET request → 200
+    {
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetApiRequest),
+                                               sizeof(kGetApiRequest) - 1,
+                                               nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        // Method enum value: GET=0 matches const_method(0)
+        CHECK(r.status_code == 200);
+    }
+
+    // POST request → 405
+    {
+        static const char post_req[] =
+            "POST /api HTTP/1.1\r\n"
+            "Host: localhost\r\n"
+            "Content-Length: 0\r\n"
+            "\r\n";
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(post_req),
+                                               sizeof(post_req) - 1,
+                                               nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 405);
+    }
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Runtime Helper Tests ───────────────────────────────────────────
+
+TEST(helpers, req_method) {
+    // GET
+    u8 m = rut_helper_req_method(reinterpret_cast<const u8*>(kGetApiRequest),
+                                 sizeof(kGetApiRequest) - 1);
+    CHECK(m == 0);  // HttpMethod::GET = 0
+
+    // POST
+    static const char post[] = "POST / HTTP/1.1\r\nHost: h\r\n\r\n";
+    m = rut_helper_req_method(reinterpret_cast<const u8*>(post), sizeof(post) - 1);
+    CHECK(m == 1);  // HttpMethod::POST = 1
+}
+
+TEST(helpers, req_header_case_insensitive) {
+    static const char req[] =
+        "GET / HTTP/1.1\r\n"
+        "Content-Type: text/html\r\n"
+        "\r\n";
+    u8 has = 0;
+    const char* ptr = nullptr;
+    u32 len = 0;
+
+    // Exact case
+    rut_helper_req_header(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "Content-Type", 12, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK(len == 9);  // "text/html"
+
+    // Lowercase lookup
+    has = 0;
+    ptr = nullptr;
+    len = 0;
+    rut_helper_req_header(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "content-type", 12, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK(len == 9);
+
+    // Missing header
+    has = 1;
+    rut_helper_req_header(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "X-Missing", 9, &has, &ptr, &len);
+    CHECK(has == 0);
+}
+
+TEST(helpers, req_remote_addr) {
+    Connection conn;
+    conn.reset();
+    conn.peer_addr = 0x0A000001;  // 10.0.0.1 in network order
+    u32 addr = rut_helper_req_remote_addr(&conn);
+    CHECK(addr == 0x0A000001);
+}
+
+TEST(helpers, str_has_prefix_edge_cases) {
+    // Empty prefix matches everything
+    CHECK(rut_helper_str_has_prefix("hello", 5, "", 0) == 1);
+
+    // Equal strings
+    CHECK(rut_helper_str_has_prefix("/api", 4, "/api", 4) == 1);
+
+    // Prefix longer than string
+    CHECK(rut_helper_str_has_prefix("/a", 2, "/api", 4) == 0);
+
+    // Empty string with non-empty prefix
+    CHECK(rut_helper_str_has_prefix("", 0, "/", 1) == 0);
+
+    // Both empty
+    CHECK(rut_helper_str_has_prefix("", 0, "", 0) == 1);
+}
+
+TEST(helpers, str_trim_prefix) {
+    const char* out = nullptr;
+    u32 len = 0;
+
+    // Prefix present
+    rut_helper_str_trim_prefix("/api/users", 10, "/api", 4, &out, &len);
+    CHECK(len == 6);  // "/users"
+    CHECK(out[0] == '/');
+    CHECK(out[1] == 'u');
+
+    // Prefix not present
+    rut_helper_str_trim_prefix("/other", 6, "/api", 4, &out, &len);
+    CHECK(len == 6);  // unchanged
+    CHECK(out[0] == '/');
+    CHECK(out[1] == 'o');
+
+    // Trim entire string
+    rut_helper_str_trim_prefix("/api", 4, "/api", 4, &out, &len);
+    CHECK(len == 0);
+}
+
+// ── HandlerResult pack/unpack Tests ───────────────────────────────
+
+TEST(result, pack_unpack_status) {
+    auto r = HandlerResult::make_status(404);
+    u64 packed = r.pack();
+    auto r2 = HandlerResult::unpack(packed);
+    CHECK(r2.action == HandlerAction::ReturnStatus);
+    CHECK(r2.status_code == 404);
+    CHECK(r2.upstream_id == 0);
+    CHECK(r2.next_state == 0);
+}
+
+TEST(result, pack_unpack_proxy) {
+    auto r = HandlerResult::make_proxy(7);
+    u64 packed = r.pack();
+    auto r2 = HandlerResult::unpack(packed);
+    CHECK(r2.action == HandlerAction::Proxy);
+    CHECK(r2.upstream_id == 7);
+    CHECK(r2.status_code == 0);
+}
+
+TEST(result, pack_unpack_yield) {
+    auto r = HandlerResult::make_yield(3, YieldKind::Proxy);
+    u64 packed = r.pack();
+    auto r2 = HandlerResult::unpack(packed);
+    CHECK(r2.action == HandlerAction::Yield);
+    CHECK(r2.next_state == 3);
+    CHECK(r2.yield_kind == YieldKind::Proxy);
+}
+
+TEST(result, pack_matches_codegen_layout) {
+    // Verify pack() produces the same bit layout as the codegen's i64.
+    // Codegen for RetStatus(200): action(0) | (200 << 8)
+    u64 codegen_200 = 0 | (static_cast<u64>(200) << 8);
+    auto r = HandlerResult::unpack(codegen_200);
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    // And the other direction
+    auto r2 = HandlerResult::make_status(200);
+    CHECK(r2.pack() == codegen_200);
+}
+
+// ── Codegen: Unconditional Jump ───────────────────────────────────
+
+// handler:
+//   entry: jmp ok
+//   ok: ret.status 200
+TEST(jit, unconditional_jmp) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("jmp_test"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_jmp(ok));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_jmp_test"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Codegen: ConstBool + comparison operators ─────────────────────
+
+// handler:
+//   %t = const.bool true
+//   %f = const.bool false
+//   %eq = cmp.eq %t, %f  → false
+//   br %eq, bad, good
+//   bad: ret.status 500
+//   good: ret.status 200
+TEST(jit, const_bool_and_cmp_ne) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("bool_test"), lit("/"), 0));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto good = V(b.create_block(fn, lit("good")));
+    auto bad = V(b.create_block(fn, lit("bad")));
+
+    b.set_insert_point(fn, entry);
+    auto t = V(b.emit_const_bool(true));
+    auto f = V(b.emit_const_bool(false));
+    auto eq = V(b.emit_cmp(Opcode::CmpEq, t, f));
+    VOK(b.emit_br(eq, bad, good));
+
+    b.set_insert_point(fn, bad);
+    VOK(b.emit_ret_status(500));
+
+    b.set_insert_point(fn, good);
+    VOK(b.emit_ret_status(200));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_bool_test"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);  // true != false → good path
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Codegen: ConstI32 + CmpLt ─────────────────────────────────────
+
+// Simulates: if (42 < 100) return 200 else return 500
+TEST(jit, const_i32_cmp_lt) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("i32_lt"), lit("/"), 0));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto yes = V(b.create_block(fn, lit("yes")));
+    auto no = V(b.create_block(fn, lit("no")));
+
+    b.set_insert_point(fn, entry);
+    auto a = V(b.emit_const_i32(42));
+    auto bb_val = V(b.emit_const_i32(100));
+    auto lt = V(b.emit_cmp(Opcode::CmpLt, a, bb_val));
+    VOK(b.emit_br(lt, yes, no));
+
+    b.set_insert_point(fn, yes);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, no);
+    VOK(b.emit_ret_status(500));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_i32_lt"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);  // 42 < 100 → yes
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Codegen: Unsigned comparison (ByteSize) ───────────────────────
+
+// Verifies that CmpLt on unsigned types uses unsigned predicates.
+// ByteSize is i64 with unsigned semantics. A large ByteSize value
+// has the high bit set; signed comparison would treat it as negative.
+//
+//   %a = const.bytesize 0x8000000000000000  (2^63, large positive unsigned)
+//   %b = const.bytesize 1
+//   %lt = cmp.lt %a, %b   → unsigned: false (2^63 > 1)
+//                          → WRONG if signed: true (-2^63 < 1)
+//   br %lt, wrong, correct
+//   wrong: ret.status 500
+//   correct: ret.status 200
+TEST(jit, unsigned_cmp_lt) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("ucmp_lt"), lit("/"), 0));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto wrong = V(b.create_block(fn, lit("wrong")));
+    auto correct = V(b.create_block(fn, lit("correct")));
+
+    b.set_insert_point(fn, entry);
+    // 0x8000000000000000 = 2^63 — high bit set, positive as unsigned
+    auto a = V(b.emit_const_bytesize(static_cast<i64>(0x8000000000000000ULL)));
+    auto bb_val = V(b.emit_const_bytesize(1));
+    auto lt = V(b.emit_cmp(Opcode::CmpLt, a, bb_val));
+    VOK(b.emit_br(lt, wrong, correct));
+
+    b.set_insert_point(fn, wrong);
+    VOK(b.emit_ret_status(500));
+
+    b.set_insert_point(fn, correct);
+    VOK(b.emit_ret_status(200));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_ucmp_lt"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);  // 2^63 is NOT < 1 (unsigned)
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Codegen: OptUnwrap ────────────────────────────────────────────
+
+// handler:
+//   %hdr = req.header "Host"
+//   %nil = opt.is_nil %hdr
+//   br %nil, missing, found
+//   missing: ret.status 400
+//   found:
+//     %val = opt.unwrap %hdr
+//     %prefix = const.str "localhost"
+//     %match = str.has_prefix %val, %prefix
+//     br %match, ok, mismatch
+//   ok: ret.status 200
+//   mismatch: ret.status 421
+TEST(jit, opt_unwrap_and_use) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("unwrap_test"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto missing = V(b.create_block(fn, lit("missing")));
+    auto found = V(b.create_block(fn, lit("found")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto mismatch = V(b.create_block(fn, lit("mismatch")));
+
+    b.set_insert_point(fn, entry);
+    auto hdr = V(b.emit_req_header(lit("Host")));
+    auto nil = V(b.emit_opt_is_nil(hdr));
+    VOK(b.emit_br(nil, missing, found));
+
+    b.set_insert_point(fn, missing);
+    VOK(b.emit_ret_status(400));
+
+    // Get the inner Str type for unwrap
+    auto str_ty = V(b.make_type(TypeKind::Str));
+
+    b.set_insert_point(fn, found);
+    auto val = V(b.emit_opt_unwrap(hdr, str_ty));
+    auto prefix = V(b.emit_const_str(lit("localhost")));
+    auto match = V(b.emit_str_has_prefix(val, prefix));
+    VOK(b.emit_br(match, ok, mismatch));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, mismatch);
+    VOK(b.emit_ret_status(421));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_unwrap_test"));
+    REQUIRE(handler != nullptr);
+
+    // Request with Host: localhost → 200
+    {
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetApiRequest),
+                                               sizeof(kGetApiRequest) - 1,
+                                               nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 200);
+    }
+
+    // Request with Host: example.com → 421
+    {
+        static const char req[] =
+            "GET / HTTP/1.1\r\n"
+            "Host: example.com\r\n"
+            "\r\n";
+        auto r = HandlerResult::unpack(
+            handler(nullptr, nullptr, reinterpret_cast<const u8*>(req), sizeof(req) - 1, nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 421);
+    }
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Codegen: StrTrimPrefix ────────────────────────────────────────
+
+// handler:
+//   %path = req.path
+//   %prefix = const.str "/api"
+//   %trimmed = str.trim_prefix %path, %prefix
+//   %slash = const.str "/users"
+//   %match = str.has_prefix %trimmed, %slash
+//   br %match, ok, reject
+//   ok: ret.status 200
+//   reject: ret.status 404
+TEST(jit, str_trim_prefix) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("trim_test"), lit("/api"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto reject = V(b.create_block(fn, lit("reject")));
+
+    b.set_insert_point(fn, entry);
+    auto path = V(b.emit_req_path());
+    auto prefix = V(b.emit_const_str(lit("/api")));
+    auto trimmed = V(b.emit_str_trim_prefix(path, prefix));
+    auto suffix = V(b.emit_const_str(lit("/users")));
+    auto match = V(b.emit_str_has_prefix(trimmed, suffix));
+    VOK(b.emit_br(match, ok, reject));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, reject);
+    VOK(b.emit_ret_status(404));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_trim_test"));
+    REQUIRE(handler != nullptr);
+
+    // /api/users → trim "/api" → "/users" → has_prefix "/users" → 200
+    {
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetApiRequest),
+                                               sizeof(kGetApiRequest) - 1,
+                                               nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 200);
+    }
+
+    // / → trim "/api" fails → "/" → has_prefix "/users" → 404
+    {
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetRootRequest),
+                                               sizeof(kGetRootRequest) - 1,
+                                               nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 404);
+    }
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Runtime helper: req_remote_addr via Connection ────────────────
+// ReqRemoteAddr returns TypeKind::IP which can't be compared with
+// ConstI32 (TypeKind::I32) at the RIR level — IP comparisons use
+// IpInCidr (Phase 2). Here we test the helper directly from C++
+// and verify the codegen emits a valid call.
+
+TEST(jit, req_remote_addr) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    // Minimal handler that calls req.remote_addr then returns 200.
+    // This verifies the codegen emits the helper call correctly;
+    // we check the addr value via the C++ helper test above.
+    auto* fn = V(b.create_function(lit("addr_test"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+
+    b.set_insert_point(fn, entry);
+    V(b.emit_req_remote_addr());  // exercise codegen, discard result
+    VOK(b.emit_ret_status(200));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_addr_test"));
+    REQUIRE(handler != nullptr);
+
+    Connection conn;
+    conn.reset();
+    conn.peer_addr = 0x0100007F;
+    auto r = HandlerResult::unpack(handler(&conn,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Codegen: Multiple functions in one module ─────────────────────
+
+TEST(jit, multiple_functions) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    // Function 1: always 200
+    {
+        auto* fn = V(b.create_function(lit("fn_a"), lit("/a"), 'G'));
+        auto entry = V(b.create_block(fn, lit("entry")));
+        b.set_insert_point(fn, entry);
+        VOK(b.emit_ret_status(200));
+    }
+
+    // Function 2: always 404
+    {
+        auto* fn = V(b.create_function(lit("fn_b"), lit("/b"), 'G'));
+        auto entry = V(b.create_block(fn, lit("entry")));
+        b.set_insert_point(fn, entry);
+        VOK(b.emit_ret_status(404));
+    }
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto fn_a = reinterpret_cast<HandlerFn>(engine.lookup("handler_fn_a"));
+    auto fn_b = reinterpret_cast<HandlerFn>(engine.lookup("handler_fn_b"));
+    REQUIRE(fn_a != nullptr);
+    REQUIRE(fn_b != nullptr);
+
+    auto ra = HandlerResult::unpack(fn_a(nullptr,
+                                         nullptr,
+                                         reinterpret_cast<const u8*>(kGetApiRequest),
+                                         sizeof(kGetApiRequest) - 1,
+                                         nullptr));
+    CHECK(ra.status_code == 200);
+
+    auto rb = HandlerResult::unpack(fn_b(nullptr,
+                                         nullptr,
+                                         reinterpret_cast<const u8*>(kGetApiRequest),
+                                         sizeof(kGetApiRequest) - 1,
+                                         nullptr));
+    CHECK(rb.status_code == 404);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Codegen: Diamond CFG (if/else join) ───────────────────────────
+
+// handler:
+//   entry:
+//     %path = req.path
+//     %prefix = const.str "/admin"
+//     %is_admin = str.has_prefix %path, %prefix
+//     br %is_admin, admin, user
+//   admin:
+//     jmp merge
+//   user:
+//     jmp merge
+//   merge:
+//     ret.status 200
+//
+// Tests: forward Jmp + multiple predecessors on merge block
+TEST(jit, diamond_cfg) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("diamond"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto admin = V(b.create_block(fn, lit("admin")));
+    auto user = V(b.create_block(fn, lit("user")));
+    auto merge = V(b.create_block(fn, lit("merge")));
+
+    b.set_insert_point(fn, entry);
+    auto path = V(b.emit_req_path());
+    auto prefix = V(b.emit_const_str(lit("/admin")));
+    auto is_admin = V(b.emit_str_has_prefix(path, prefix));
+    VOK(b.emit_br(is_admin, admin, user));
+
+    b.set_insert_point(fn, admin);
+    VOK(b.emit_jmp(merge));
+
+    b.set_insert_point(fn, user);
+    VOK(b.emit_jmp(merge));
+
+    b.set_insert_point(fn, merge);
+    VOK(b.emit_ret_status(200));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_diamond"));
+    REQUIRE(handler != nullptr);
+
+    // Both paths merge to 200
+    auto r1 = HandlerResult::unpack(handler(nullptr,
+                                            nullptr,
+                                            reinterpret_cast<const u8*>(kGetApiRequest),
+                                            sizeof(kGetApiRequest) - 1,
+                                            nullptr));
+    CHECK(r1.status_code == 200);
+
+    static const char admin_req[] = "GET /admin/dashboard HTTP/1.1\r\nHost: h\r\n\r\n";
+    auto r2 = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(admin_req), sizeof(admin_req) - 1, nullptr));
+    CHECK(r2.status_code == 200);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Codegen: Deep chain (entry → b1 → b2 → b3 → ret) ────────────
+
+TEST(jit, chained_blocks) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("chain"), lit("/"), 0));
+    auto b0 = V(b.create_block(fn, lit("b0")));
+    auto b1 = V(b.create_block(fn, lit("b1")));
+    auto b2 = V(b.create_block(fn, lit("b2")));
+    auto b3 = V(b.create_block(fn, lit("b3")));
+
+    b.set_insert_point(fn, b0);
+    VOK(b.emit_jmp(b1));
+
+    b.set_insert_point(fn, b1);
+    VOK(b.emit_jmp(b2));
+
+    b.set_insert_point(fn, b2);
+    VOK(b.emit_jmp(b3));
+
+    b.set_insert_point(fn, b3);
+    VOK(b.emit_ret_status(201));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_chain"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 201);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── JIT Engine: lookup failure ────────────────────────────────────
+
+TEST(jit, lookup_nonexistent) {
+    JitEngine engine;
+    REQUIRE(engine.init());
+
+    // No modules compiled — any lookup should return nullptr
+    void* addr = engine.lookup("nonexistent_function");
+    CHECK(addr == nullptr);
+
+    engine.shutdown();
+}
+
+// ── Codegen: RetProxy ─────────────────────────────────────────────
+
+// handler:
+//   %upstream = const.i32 3
+//   ret.proxy %upstream
+TEST(jit, ret_proxy) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("proxy_test"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+
+    b.set_insert_point(fn, entry);
+    auto upstream = V(b.emit_const_i32(3));
+    VOK(b.emit_ret_proxy(upstream));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_proxy_test"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::Proxy);
+    CHECK(r.upstream_id == 3);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// ── Complex: multi-guard handler ──────────────────────────────────
+
+// Simulates a realistic middleware chain:
+//   guard req.method == GET else { return 405 }
+//   guard req.path.has_prefix("/api") else { return 404 }
+//   guard req.header("Authorization") != nil else { return 401 }
+//   return 200
+TEST(jit, multi_guard) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("multi_guard"), lit("/api"), 'G'));
+    auto check_method = V(b.create_block(fn, lit("check_method")));
+    auto check_path = V(b.create_block(fn, lit("check_path")));
+    auto check_auth = V(b.create_block(fn, lit("check_auth")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto err_405 = V(b.create_block(fn, lit("err_405")));
+    auto err_404 = V(b.create_block(fn, lit("err_404")));
+    auto err_401 = V(b.create_block(fn, lit("err_401")));
+
+    // Guard 1: method == GET
+    b.set_insert_point(fn, check_method);
+    auto method = V(b.emit_req_method());
+    auto get = V(b.emit_const_method(0));
+    auto is_get = V(b.emit_cmp(Opcode::CmpEq, method, get));
+    VOK(b.emit_br(is_get, check_path, err_405));
+
+    // Guard 2: path.has_prefix("/api")
+    b.set_insert_point(fn, check_path);
+    auto path = V(b.emit_req_path());
+    auto prefix = V(b.emit_const_str(lit("/api")));
+    auto has_prefix = V(b.emit_str_has_prefix(path, prefix));
+    VOK(b.emit_br(has_prefix, check_auth, err_404));
+
+    // Guard 3: header("Authorization") != nil
+    b.set_insert_point(fn, check_auth);
+    auto auth = V(b.emit_req_header(lit("Authorization")));
+    auto no_auth = V(b.emit_opt_is_nil(auth));
+    VOK(b.emit_br(no_auth, err_401, ok));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, err_405);
+    VOK(b.emit_ret_status(405));
+
+    b.set_insert_point(fn, err_404);
+    VOK(b.emit_ret_status(404));
+
+    b.set_insert_point(fn, err_401);
+    VOK(b.emit_ret_status(401));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_multi_guard"));
+    REQUIRE(handler != nullptr);
+
+    // All guards pass: GET /api with Authorization → 200
+    {
+        static const char req[] =
+            "GET /api/v1 HTTP/1.1\r\n"
+            "Host: localhost\r\n"
+            "Authorization: Bearer tok\r\n"
+            "\r\n";
+        auto r = HandlerResult::unpack(
+            handler(nullptr, nullptr, reinterpret_cast<const u8*>(req), sizeof(req) - 1, nullptr));
+        CHECK(r.status_code == 200);
+    }
+
+    // Wrong method: POST → 405
+    {
+        static const char req[] =
+            "POST /api/v1 HTTP/1.1\r\n"
+            "Host: localhost\r\n"
+            "Authorization: Bearer tok\r\n"
+            "Content-Length: 0\r\n"
+            "\r\n";
+        auto r = HandlerResult::unpack(
+            handler(nullptr, nullptr, reinterpret_cast<const u8*>(req), sizeof(req) - 1, nullptr));
+        CHECK(r.status_code == 405);
+    }
+
+    // Wrong path: GET / → 404
+    {
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetRootRequest),
+                                               sizeof(kGetRootRequest) - 1,
+                                               nullptr));
+        CHECK(r.status_code == 404);
+    }
+
+    // Missing auth: GET /api without Authorization → 401
+    {
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetApiRequest),
+                                               sizeof(kGetApiRequest) - 1,
+                                               nullptr));
+        CHECK(r.status_code == 401);
+    }
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -1123,27 +1123,27 @@ TEST(copilot4, init_returns_success) {
     CHECK(loop.backend.init(0, -1).has_value());
 }
 
-// Arena init returns Expected on failure.
+// MmapArena init returns Expected on failure.
 // Verify success returns has_value().
 TEST(copilot4, arena_init_returns_success) {
-    Arena a;
+    MmapArena a;
     CHECK(a.init(4096).has_value());
     a.destroy();
 }
 
-// Arena init with absurdly large size should fail gracefully.
+// MmapArena init with absurdly large size should fail gracefully.
 // mmap of near-max u64 will fail → should return error.
 TEST(copilot4, arena_init_huge_fails) {
-    Arena a;
+    MmapArena a;
     auto rc = a.init(static_cast<u64>(-1));  // ~18 exabytes
     CHECK(!rc);
     // Should carry a real errno code
     CHECK(rc.error().code > 0);
 }
 
-// Arena alloc overflow protection
+// MmapArena alloc overflow protection
 TEST(copilot4, arena_alloc_overflow_returns_null) {
-    Arena a;
+    MmapArena a;
     REQUIRE(a.init(4096).has_value());
     // size close to u64 max → overflow in (size+7) alignment
     void* p = a.alloc(static_cast<u64>(-1));

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -26,9 +26,9 @@ static Str lit(const char* s) {
 // For void Expected results.
 #define VOK(expr) REQUIRE(static_cast<bool>(expr))
 
-// Arena-backed module initialization.
+// MmapArena-backed module initialization.
 struct TestContext {
-    Arena arena;
+    MmapArena arena;
     Module mod;
 
     bool init() {


### PR DESCRIPTION
## Summary

- **JIT pipeline (Phase 1)**: Complete RIR → LLVM IR → ORC JIT → native function pointer path using LLVM C API. Supports 20 RIR opcodes (constants, request access, string ops, comparisons, optional ops, control flow, RetStatus/RetProxy).
- **Handler ABI**: `HandlerFn` returns `u64` (not packed struct) to avoid clang sret ABI mismatch. `HandlerResult::pack()`/`unpack()` for field access.
- **Runtime helpers**: `extern "C"` functions (`rut_helper_req_path`, `rut_helper_req_header`, etc.) pre-registered as absolute symbols via `LLVMOrcLLJITMangleAndIntern`.
- **Arena<Backend> refactor**: Arena parameterized on block backend — `MmapBackend` (compiler, variable-size mmap blocks) and `SlicePoolBackend` (runtime, fixed 16KB slices from SlicePool). Aliases: `MmapArena`, `SliceArena`.
- **Codegen correctness**: Unsigned comparison predicates for U32/U64/ByteSize/Duration types. `make_global_str()` with explicit length instead of `LLVMBuildGlobalStringPtr` (Str is not null-terminated). Proper LLVM ownership on all error paths.
- **27 JIT tests**: E2E pipeline tests (return_200, guard_path_prefix, header_check, method_check, multi_guard), runtime helper edge cases, HandlerResult pack/unpack, unsigned comparisons, diamond CFG, RetProxy, symbol lookup failure.
- **11 SliceArena tests**: Basic alloc, chain growth, reset/destroy pool accounting, pool exhaustion, multi-arena sharing.

## Test plan

- [x] `./dev.sh test` — 790 tests all passing
- [x] JIT tests exercise full pipeline: hand-built RIR → codegen → JIT compile → call native handler → verify result
- [x] SliceArena tests verify pool slice accounting (alloc/free counts match)
- [x] Existing MmapArena tests (47) unchanged and passing


🤖 Generated with [Claude Code](https://claude.com/claude-code)