### PR TITLE
[codex] add offline rut-simulate binary

### DIFF
--- a/include/rut/jit/codegen.h
+++ b/include/rut/jit/codegen.h
@@ -27,6 +27,10 @@ struct CodegenResult {
     bool ok;
 };
 
+// Format the JIT handler symbol for an RIR function name.
+// Returns the output length excluding the trailing '\0'.
+u32 format_handler_symbol(Str name, char* out, u32 out_size);
+
 // Translate all functions in the RIR module to LLVM IR.
 // Returns {module, context, true} on success, {null, null, false} on error.
 CodegenResult codegen(const rir::Module& rir_mod);

--- a/include/rut/jit/handler_abi.h
+++ b/include/rut/jit/handler_abi.h
@@ -103,7 +103,7 @@ struct HandlerCtx {
     T load_slot(u32 idx) const {
         static_assert(sizeof(T) <= 8, "Slot values must be <= 8 bytes");
         T val{};
-        const u8* src = slots() + idx * 8;
+        const u8* src = slots() + static_cast<size_t>(idx) * 8;
         __builtin_memcpy(&val, src, sizeof(T));
         return val;
     }
@@ -111,7 +111,7 @@ struct HandlerCtx {
     template <typename T>
     void store_slot(u32 idx, T val) {
         static_assert(sizeof(T) <= 8, "Slot values must be <= 8 bytes");
-        u8* dst = slots() + idx * 8;
+        u8* dst = slots() + static_cast<size_t>(idx) * 8;
         u64 zero = 0;
         __builtin_memcpy(dst, &zero, 8);
         __builtin_memcpy(dst, &val, sizeof(T));

--- a/include/rut/runtime/arena.h
+++ b/include/rut/runtime/arena.h
@@ -142,7 +142,7 @@ struct Arena {
         void* p = alloc(static_cast<u64>(sizeof(T)) * count);
         if (!p) return nullptr;
         auto* a = static_cast<T*>(p);
-        for (u32 i = 0; i < count; i++) ::new (&a[i]) T{};
+        for (u32 i = 0; i < count; i++) ::new (static_cast<void*>(&a[i])) T{};
         return a;
     }
 

--- a/include/rut/runtime/arena.h
+++ b/include/rut/runtime/arena.h
@@ -138,12 +138,15 @@ struct Arena {
     // Array bump alloc, value-initialized via placement new.
     template <typename T>
     T* alloc_array(u32 count) {
-        T* const kType = nullptr;
-        if (count > 0 && sizeof(*kType) > static_cast<u64>(-1) / count) return nullptr;
-        void* p = alloc(static_cast<u64>(sizeof(*kType)) * count);
+        T* a = nullptr;
+        if (count > 0 && sizeof(a[0]) > static_cast<u64>(-1) / count) return nullptr;
+        void* p = alloc(static_cast<u64>(sizeof(a[0])) * count);
         if (!p) return nullptr;
-        auto* a = static_cast<T*>(p);
-        for (u32 i = 0; i < count; i++) ::new (static_cast<void*>(&a[i])) T{};
+        a = static_cast<T*>(p);
+        for (u32 i = 0; i < count; i++) {
+            void* slot = static_cast<void*>(a + i);
+            ::new (slot) T{};
+        }
         return a;
     }
 

--- a/include/rut/runtime/arena.h
+++ b/include/rut/runtime/arena.h
@@ -139,11 +139,14 @@ struct Arena {
     template <typename T>
     T* alloc_array(u32 count) {
         T* a = nullptr;
+        // NOLINTNEXTLINE(bugprone-sizeof-expression)
         if (count > 0 && sizeof(a[0]) > static_cast<u64>(-1) / count) return nullptr;
+        // NOLINTNEXTLINE(bugprone-sizeof-expression)
         void* p = alloc(static_cast<u64>(sizeof(a[0])) * count);
         if (!p) return nullptr;
         a = static_cast<T*>(p);
         for (u32 i = 0; i < count; i++) {
+            // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion)
             void* slot = static_cast<void*>(a + i);
             ::new (slot) T{};
         }

--- a/include/rut/runtime/arena.h
+++ b/include/rut/runtime/arena.h
@@ -138,8 +138,9 @@ struct Arena {
     // Array bump alloc, value-initialized via placement new.
     template <typename T>
     T* alloc_array(u32 count) {
-        if (count > 0 && sizeof(T) > static_cast<u64>(-1) / count) return nullptr;
-        void* p = alloc(static_cast<u64>(sizeof(T)) * count);
+        T* const kType = nullptr;
+        if (count > 0 && sizeof(*kType) > static_cast<u64>(-1) / count) return nullptr;
+        void* p = alloc(static_cast<u64>(sizeof(*kType)) * count);
         if (!p) return nullptr;
         auto* a = static_cast<T*>(p);
         for (u32 i = 0; i < count; i++) ::new (static_cast<void*>(&a[i])) T{};

--- a/include/rut/sim/simulate_engine.h
+++ b/include/rut/sim/simulate_engine.h
@@ -59,6 +59,10 @@ struct ModuleContext {
 //   route <METHOD|ANY> <pattern> proxy <upstream-id>
 //
 // Tokens are whitespace-separated; blank lines and '#' comments are ignored.
+// Route matching uses the request path only and ignores any query string.
+// METHOD is matched RouteConfig-style by first character; ANY matches any method.
+// <pattern> is prefix-matched and may include ':param' segments.
+// Each ':param' matches exactly one non-empty path segment and never crosses '/'.
 bool load_manifest(const char* path, Manifest& out);
 
 // Build a sync-only RIR module that mirrors the manifest.

--- a/include/rut/sim/simulate_engine.h
+++ b/include/rut/sim/simulate_engine.h
@@ -89,11 +89,11 @@ struct SimulateResult {
 };
 
 struct SimulateSummary {
-    u32 total = 0;
-    u32 matched = 0;
-    u32 mismatched = 0;
-    u32 failed = 0;
-    u32 unsupported = 0;
+    u64 total = 0;
+    u64 matched = 0;
+    u64 mismatched = 0;
+    u64 failed = 0;
+    u64 unsupported = 0;
 };
 
 struct Engine {
@@ -121,6 +121,8 @@ struct Engine {
 
 SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry);
 SimulateSummary simulate_file(Engine& engine, ReplayReader& reader);
+void accumulate_summary(SimulateSummary& summary, Verdict verdict);
+void finalize_summary(SimulateSummary& summary, const ReplayReader& reader);
 
 u32 format_result(const SimulateResult& result, char* buf, u32 buf_size);
 u32 format_summary(const SimulateSummary& summary, char* buf, u32 buf_size);

--- a/include/rut/sim/simulate_engine.h
+++ b/include/rut/sim/simulate_engine.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include "rut/common/types.h"
+#include "rut/compiler/rir.h"
+#include "rut/jit/handler_abi.h"
+#include "rut/jit/jit_engine.h"
+#include "rut/runtime/access_log.h"
+#include "rut/runtime/arena.h"
+#include "rut/runtime/connection.h"
+#include "rut/runtime/http_parser.h"
+#include "rut/runtime/traffic_capture.h"
+#include "rut/runtime/traffic_replay.h"
+
+namespace rut::sim {
+
+struct ManifestUpstream {
+    u16 id = 0;
+    char name[32]{};
+};
+
+enum class ManifestAction : u8 {
+    ReturnStatus = 0,
+    Proxy = 1,
+};
+
+struct ManifestRoute {
+    u8 method = 0;  // 0 = any, otherwise RouteConfig-style first-char match.
+    char pattern[128]{};
+    ManifestAction action = ManifestAction::ReturnStatus;
+    u16 status_code = 200;
+    u16 upstream_id = 0;
+};
+
+struct Manifest {
+    static constexpr u32 kMaxRoutes = 128;
+    static constexpr u32 kMaxUpstreams = 64;
+
+    ManifestRoute routes[kMaxRoutes];
+    u32 route_count = 0;
+
+    ManifestUpstream upstreams[kMaxUpstreams];
+    u32 upstream_count = 0;
+};
+
+// Compiler-owned storage for building an RIR module from a manifest.
+struct ModuleContext {
+    MmapArena arena;
+    rir::Module module{};
+
+    bool init(u32 func_cap, u32 struct_cap = 1);
+    void destroy();
+};
+
+// Read a simple simulate manifest from disk.
+//
+// Grammar:
+//   upstream <id> <name>
+//   route <METHOD|ANY> <pattern> status <code>
+//   route <METHOD|ANY> <pattern> proxy <upstream-id>
+//
+// Tokens are whitespace-separated; blank lines and '#' comments are ignored.
+bool load_manifest(const char* path, Manifest& out);
+
+// Build a sync-only RIR module that mirrors the manifest.
+bool build_module_from_manifest(const Manifest& manifest, ModuleContext& ctx);
+
+enum class Verdict : u8 {
+    Match,
+    Mismatch,
+    Failed,
+    Unsupported,
+};
+
+struct SimulateResult {
+    u8 method = static_cast<u8>(LogHttpMethod::Other);
+    char path[64]{};
+
+    jit::HandlerAction action = jit::HandlerAction::ReturnStatus;
+    u16 expected_status = 0;
+    u16 actual_status = 0;
+    char expected_upstream[32]{};
+    char actual_upstream[32]{};
+
+    Verdict verdict = Verdict::Failed;
+};
+
+struct SimulateSummary {
+    u32 total = 0;
+    u32 matched = 0;
+    u32 mismatched = 0;
+    u32 failed = 0;
+    u32 unsupported = 0;
+};
+
+struct Engine {
+    static constexpr u32 kMaxRoutes = Manifest::kMaxRoutes;
+    static constexpr u32 kMaxUpstreams = Manifest::kMaxUpstreams;
+
+    struct CompiledRoute {
+        u8 method = 0;
+        char pattern[128]{};
+        u32 pattern_len = 0;
+        jit::HandlerFn fn = nullptr;
+    };
+
+    CompiledRoute routes[kMaxRoutes];
+    u32 route_count = 0;
+
+    ManifestUpstream upstreams[kMaxUpstreams];
+    u32 upstream_count = 0;
+
+    jit::JitEngine jit;
+
+    bool init(const rir::Module& module, const ManifestUpstream* upstream_list, u32 upstreams_len);
+    void shutdown();
+};
+
+SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry);
+SimulateSummary simulate_file(Engine& engine, ReplayReader& reader);
+
+u32 format_result(const SimulateResult& result, char* buf, u32 buf_size);
+u32 format_summary(const SimulateSummary& summary, char* buf, u32 buf_size);
+
+}  // namespace rut::sim

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,10 +185,30 @@ target_compile_definitions(rue_jit PRIVATE ${LLVM_DEFINITIONS})
 # rue_jit also links rue_runtime for runtime_helpers (uses HttpParser, Connection)
 target_link_libraries(rue_jit rue_runtime)
 
+# Offline simulate library — JIT-backed capture validation with no event loop.
+add_library(rue_simulate STATIC
+    sim/simulate_engine.cc
+)
+target_include_directories(rue_simulate PUBLIC
+    ${PROJECT_SOURCE_DIR}/include
+    ${LLVM_INCLUDE_DIRS}
+)
+target_compile_definitions(rue_simulate PRIVATE ${LLVM_DEFINITIONS})
+target_link_libraries(rue_simulate
+    rue_runtime
+    rue_compiler
+    rue_jit
+)
+
 # Main executable
 add_executable(rue main.cc)
 target_link_libraries(rue
     rue_runtime
     rue_compiler
     rue_jit
+)
+
+add_executable(rut-simulate sim/main.cc)
+target_link_libraries(rut-simulate
+    rue_simulate
 )

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -6,6 +6,26 @@
 
 namespace rut::jit {
 
+u32 format_handler_symbol(Str name, char* out, u32 out_size) {
+    if (!out || out_size == 0) return 0;
+
+    static constexpr char kPrefix[] = "handler_";
+    u32 pos = 0;
+    while (kPrefix[pos] && pos + 1 < out_size) {
+        out[pos] = kPrefix[pos];
+        pos++;
+    }
+
+    u32 max_pos = 0;
+    if (out_size > 1) max_pos = out_size - 2;
+    if (max_pos > 254) max_pos = 254;
+    for (u32 i = 0; i < name.len && pos < max_pos; i++) {
+        out[pos++] = name.ptr[i];
+    }
+    out[pos] = '\0';
+    return pos;
+}
+
 // ── Codegen Context ────────────────────────────────────────────────
 // Per-compilation state. Holds LLVM context, module, builder, and
 // mapping tables from RIR IDs to LLVM values/blocks.
@@ -558,12 +578,8 @@ static bool emit_function(Ctx& c, const rir::Function& fn) {
     c.cur_fn = &fn;
 
     // Build function name: "handler_<name>"
-    char fname[256] = "handler_";
-    u32 pos = 8;
-    for (u32 i = 0; i < fn.name.len && pos < 254; i++) {
-        fname[pos++] = fn.name.ptr[i];
-    }
-    fname[pos] = '\0';
+    char fname[256];
+    format_handler_symbol(fn.name, fname, sizeof(fname));
 
     LLVMValueRef func = LLVMAddFunction(c.llvm_mod, fname, c.handler_fn_ty);
 

--- a/src/sim/main.cc
+++ b/src/sim/main.cc
@@ -1,0 +1,90 @@
+#include "rut/sim/simulate_engine.h"
+
+#include <unistd.h>
+
+using namespace rut;
+
+namespace {
+
+static void write_str(i32 fd, const char* s) {
+    u32 len = 0;
+    while (s[len]) len++;
+    (void)::write(fd, s, len);
+}
+
+static void usage() {
+    write_str(2, "Usage: rut-simulate <manifest.txt> <capture.bin>\n");
+    write_str(2, "Manifest format:\n");
+    write_str(2, "  upstream <id> <name>\n");
+    write_str(2, "  route <METHOD|ANY> <pattern> status <code>\n");
+    write_str(2, "  route <METHOD|ANY> <pattern> proxy <upstream-id>\n");
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 3) {
+        usage();
+        return 2;
+    }
+
+    sim::Manifest manifest;
+    if (!sim::load_manifest(argv[1], manifest)) {
+        write_str(2, "Failed to load manifest\n");
+        return 1;
+    }
+
+    sim::ModuleContext module_ctx;
+    if (!sim::build_module_from_manifest(manifest, module_ctx)) {
+        write_str(2, "Failed to build RIR module from manifest\n");
+        return 1;
+    }
+
+    sim::Engine engine;
+    if (!engine.init(module_ctx.module, manifest.upstreams, manifest.upstream_count)) {
+        module_ctx.destroy();
+        write_str(2, "Failed to initialize simulate engine\n");
+        return 1;
+    }
+
+    ReplayReader reader;
+    if (reader.open(argv[2]) != 0) {
+        engine.shutdown();
+        module_ctx.destroy();
+        write_str(2, "Failed to open capture file\n");
+        return 1;
+    }
+
+    CaptureEntry entry{};
+    char line[512];
+    sim::SimulateSummary summary{};
+    while (reader.next(entry) == 0) {
+        const sim::SimulateResult result = sim::simulate_one(engine, entry);
+        summary.total++;
+        switch (result.verdict) {
+            case sim::Verdict::Match:
+                summary.matched++;
+                break;
+            case sim::Verdict::Mismatch:
+                summary.mismatched++;
+                break;
+            case sim::Verdict::Failed:
+                summary.failed++;
+                break;
+            case sim::Verdict::Unsupported:
+                summary.unsupported++;
+                break;
+        }
+        const u32 len = sim::format_result(result, line, sizeof(line));
+        (void)::write(1, line, len);
+    }
+
+    char summary_buf[256];
+    const u32 slen = sim::format_summary(summary, summary_buf, sizeof(summary_buf));
+    (void)::write(1, summary_buf, slen);
+
+    reader.close();
+    engine.shutdown();
+    module_ctx.destroy();
+    return (summary.failed == 0 && summary.mismatched == 0 && summary.unsupported == 0) ? 0 : 1;
+}

--- a/src/sim/main.cc
+++ b/src/sim/main.cc
@@ -37,8 +37,9 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    sim::ModuleContext module_ctx;
+    sim::ModuleContext module_ctx{};
     if (!sim::build_module_from_manifest(manifest, module_ctx)) {
+        module_ctx.destroy();
         write_str(2, "Failed to build RIR module from manifest\n");
         return 1;
     }

--- a/src/sim/main.cc
+++ b/src/sim/main.cc
@@ -3,16 +3,31 @@
 #include "rut/runtime/traffic_replay.h"
 #include "rut/sim/simulate_engine.h"
 
+#include <errno.h>
 #include <unistd.h>
 
 using namespace rut;
 
 namespace {
 
+static bool write_all(i32 fd, const char* s, u32 len) {
+    u32 pos = 0;
+    while (pos < len) {
+        const ssize_t n = ::write(fd, s + pos, len - pos);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (n == 0) return false;
+        pos += static_cast<u32>(n);
+    }
+    return true;
+}
+
 static void write_str(i32 fd, const char* s) {
     u32 len = 0;
     while (s[len]) len++;
-    (void)::write(fd, s, len);
+    (void)write_all(fd, s, len);
 }
 
 static void usage() {
@@ -21,6 +36,7 @@ static void usage() {
     write_str(2, "  upstream <id> <name>\n");
     write_str(2, "  route <METHOD|ANY> <pattern> status <code>\n");
     write_str(2, "  route <METHOD|ANY> <pattern> proxy <upstream-id>\n");
+    write_str(2, "  pattern is prefix-matched and may include ':param' segments\n");
 }
 
 }  // namespace
@@ -80,12 +96,12 @@ int main(int argc, char** argv) {
                 break;
         }
         const u32 kLen = sim::format_result(kResult, line, sizeof(line));
-        (void)::write(1, line, kLen);
+        (void)write_all(1, line, kLen);
     }
 
     char summary_buf[256];
     const u32 kSlen = sim::format_summary(summary, summary_buf, sizeof(summary_buf));
-    (void)::write(1, summary_buf, kSlen);
+    (void)write_all(1, summary_buf, kSlen);
 
     reader.close();
     engine.shutdown();

--- a/src/sim/main.cc
+++ b/src/sim/main.cc
@@ -1,3 +1,6 @@
+#include "rut/common/types.h"
+#include "rut/runtime/traffic_capture.h"
+#include "rut/runtime/traffic_replay.h"
 #include "rut/sim/simulate_engine.h"
 
 #include <unistd.h>
@@ -59,9 +62,9 @@ int main(int argc, char** argv) {
     char line[512];
     sim::SimulateSummary summary{};
     while (reader.next(entry) == 0) {
-        const sim::SimulateResult result = sim::simulate_one(engine, entry);
+        const sim::SimulateResult kResult = sim::simulate_one(engine, entry);
         summary.total++;
-        switch (result.verdict) {
+        switch (kResult.verdict) {
             case sim::Verdict::Match:
                 summary.matched++;
                 break;
@@ -75,13 +78,13 @@ int main(int argc, char** argv) {
                 summary.unsupported++;
                 break;
         }
-        const u32 len = sim::format_result(result, line, sizeof(line));
-        (void)::write(1, line, len);
+        const u32 kLen = sim::format_result(kResult, line, sizeof(line));
+        (void)::write(1, line, kLen);
     }
 
     char summary_buf[256];
-    const u32 slen = sim::format_summary(summary, summary_buf, sizeof(summary_buf));
-    (void)::write(1, summary_buf, slen);
+    const u32 kSlen = sim::format_summary(summary, summary_buf, sizeof(summary_buf));
+    (void)::write(1, summary_buf, kSlen);
 
     reader.close();
     engine.shutdown();

--- a/src/sim/main.cc
+++ b/src/sim/main.cc
@@ -81,30 +81,13 @@ int main(int argc, char** argv) {
     while (reader.next(entry) == 0) {
         const sim::SimulateResult kResult = sim::simulate_one(engine, entry);
         summary.total++;
-        switch (kResult.verdict) {
-            case sim::Verdict::Match:
-                summary.matched++;
-                break;
-            case sim::Verdict::Mismatch:
-                summary.mismatched++;
-                break;
-            case sim::Verdict::Failed:
-                summary.failed++;
-                break;
-            case sim::Verdict::Unsupported:
-                summary.unsupported++;
-                break;
-        }
+        sim::accumulate_summary(summary, kResult.verdict);
         const u32 kLen = sim::format_result(kResult, line, sizeof(line));
         (void)write_all(1, line, kLen);
     }
-    if (reader.entries_read != reader.entry_count()) {
-        const u64 kExpected = reader.entry_count();
-        const u64 kMissing = kExpected > summary.total ? (kExpected - summary.total) : 0;
-        if (kMissing > 0) {
-            summary.failed += static_cast<u32>(kMissing);
-            summary.total += static_cast<u32>(kMissing);
-        }
+    const bool kTruncated = reader.entries_read != reader.entry_count();
+    sim::finalize_summary(summary, reader);
+    if (kTruncated) {
         write_str(2, "Capture file is truncated or unreadable\n");
     }
 

--- a/src/sim/main.cc
+++ b/src/sim/main.cc
@@ -98,6 +98,15 @@ int main(int argc, char** argv) {
         const u32 kLen = sim::format_result(kResult, line, sizeof(line));
         (void)write_all(1, line, kLen);
     }
+    if (reader.entries_read != reader.entry_count()) {
+        const u64 kExpected = reader.entry_count();
+        const u64 kMissing = kExpected > summary.total ? (kExpected - summary.total) : 0;
+        if (kMissing > 0) {
+            summary.failed += static_cast<u32>(kMissing);
+            summary.total += static_cast<u32>(kMissing);
+        }
+        write_str(2, "Capture file is truncated or unreadable\n");
+    }
 
     char summary_buf[256];
     const u32 kSlen = sim::format_summary(summary, summary_buf, sizeof(summary_buf));

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -531,11 +531,8 @@ bool Engine::init(const rir::Module& module,
             jit.shutdown();
             return false;
         }
-        char symbol[256] = "handler_";
-        u32 pos = 8;
-        for (u32 j = 0; j < fn.name.len && pos + 1 < sizeof(symbol); j++)
-            symbol[pos++] = fn.name.ptr[j];
-        symbol[pos] = '\0';
+        char symbol[256];
+        jit::format_handler_symbol(fn.name, symbol, sizeof(symbol));
 
         void* addr = jit.lookup(symbol);
         if (!addr) {
@@ -543,11 +540,16 @@ bool Engine::init(const rir::Module& module,
             return false;
         }
 
+        if (fn.route_pattern.len >= sizeof(routes[0].pattern)) {
+            jit.shutdown();
+            route_count = 0;
+            upstream_count = 0;
+            return false;
+        }
+
         auto& route = routes[route_count++];
         route.method = fn.http_method;
         route.pattern_len = fn.route_pattern.len;
-        if (route.pattern_len >= sizeof(route.pattern))
-            route.pattern_len = sizeof(route.pattern) - 1;
         for (u32 j = 0; j < route.pattern_len; j++) route.pattern[j] = fn.route_pattern.ptr[j];
         route.pattern[route.pattern_len] = '\0';
         route.fn = reinterpret_cast<jit::HandlerFn>(addr);

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -177,7 +177,9 @@ static bool route_matches(const Engine::CompiledRoute& route, const char* path, 
     u32 pi = 0;
     u32 ri = 0;
     while (ri < route.pattern_len) {
-        if (route.pattern[ri] == ':') {
+        const bool kParamSegment =
+            route.pattern[ri] == ':' && (ri == 0 || route.pattern[ri - 1] == '/');
+        if (kParamSegment) {
             ri++;
             while (ri < route.pattern_len && route.pattern[ri] != '/') ri++;
             const u32 param_start = pi;
@@ -510,44 +512,35 @@ bool Engine::init(const rir::Module& module,
                   const ManifestUpstream* upstream_list,
                   u32 upstreams_len) {
     if (upstreams_len > kMaxUpstreams || module.func_count > kMaxRoutes) return false;
-    route_count = 0;
-    upstream_count = upstreams_len;
-    for (u32 i = 0; i < upstreams_len; i++) upstreams[i] = upstream_list[i];
+    shutdown();
+
+    const auto fail = [this]() {
+        shutdown();
+        return false;
+    };
 
     if (!jit.init()) return false;
     auto cg = jit::codegen(module);
-    if (!cg.ok) {
-        jit.shutdown();
-        return false;
-    }
-    if (!jit.compile(cg.mod, cg.ctx)) {
-        jit.shutdown();
-        return false;
-    }
+    if (!cg.ok) return fail();
+    if (!jit.compile(cg.mod, cg.ctx)) return fail();
+
+    CompiledRoute next_routes[kMaxRoutes]{};
+    ManifestUpstream next_upstreams[kMaxUpstreams]{};
+    u32 next_route_count = 0;
+    for (u32 i = 0; i < upstreams_len; i++) next_upstreams[i] = upstream_list[i];
 
     for (u32 i = 0; i < module.func_count; i++) {
         const auto& fn = module.functions[i];
-        if (route_count >= kMaxRoutes) {
-            jit.shutdown();
-            return false;
-        }
+        if (next_route_count >= kMaxRoutes) return fail();
         char symbol[256];
         jit::format_handler_symbol(fn.name, symbol, sizeof(symbol));
 
         void* addr = jit.lookup(symbol);
-        if (!addr) {
-            jit.shutdown();
-            return false;
-        }
+        if (!addr) return fail();
 
-        if (fn.route_pattern.len >= sizeof(routes[0].pattern)) {
-            jit.shutdown();
-            route_count = 0;
-            upstream_count = 0;
-            return false;
-        }
+        if (fn.route_pattern.len >= sizeof(next_routes[0].pattern)) return fail();
 
-        auto& route = routes[route_count++];
+        auto& route = next_routes[next_route_count++];
         route.method = fn.http_method;
         route.pattern_len = fn.route_pattern.len;
         for (u32 j = 0; j < route.pattern_len; j++) route.pattern[j] = fn.route_pattern.ptr[j];
@@ -555,6 +548,10 @@ bool Engine::init(const rir::Module& module,
         route.fn = reinterpret_cast<jit::HandlerFn>(addr);
     }
 
+    for (u32 i = 0; i < next_route_count; i++) routes[i] = next_routes[i];
+    for (u32 i = 0; i < upstreams_len; i++) upstreams[i] = next_upstreams[i];
+    route_count = next_route_count;
+    upstream_count = upstreams_len;
     return true;
 }
 

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -217,7 +217,7 @@ static const char* verdict_str(Verdict verdict) {
         case Verdict::Match:
             return "MATCH";
         case Verdict::Mismatch:
-            return "MISS";
+            return "MISMATCH";
         case Verdict::Failed:
             return "FAIL";
         case Verdict::Unsupported:

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -1,0 +1,632 @@
+#include "rut/sim/simulate_engine.h"
+
+#include "rut/compiler/rir_builder.h"
+#include "rut/jit/codegen.h"
+#include "rut/jit/jit_engine.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace rut::sim {
+
+namespace {
+
+static u32 cstr_len(const char* s) {
+    u32 n = 0;
+    while (s[n]) n++;
+    return n;
+}
+
+static void copy_cstr(char* dst, u32 dst_size, const char* src) {
+    if (dst_size == 0) return;
+    u32 i = 0;
+    while (i + 1 < dst_size && src[i]) {
+        dst[i] = src[i];
+        i++;
+    }
+    dst[i] = '\0';
+}
+
+static bool streq(const char* a, const char* b) {
+    u32 i = 0;
+    while (a[i] && b[i]) {
+        if (a[i] != b[i]) return false;
+        i++;
+    }
+    return a[i] == b[i];
+}
+
+static bool parse_u32_token(const char* s, u32 len, u32* out) {
+    if (len == 0) return false;
+    u32 v = 0;
+    for (u32 i = 0; i < len; i++) {
+        if (s[i] < '0' || s[i] > '9') return false;
+        v = v * 10 + static_cast<u32>(s[i] - '0');
+    }
+    *out = v;
+    return true;
+}
+
+static u8 parse_method_token(const char* s, u32 len, bool* ok) {
+    *ok = true;
+    if (len == 3 && s[0] == 'A' && s[1] == 'N' && s[2] == 'Y') return 0;
+    if (len == 3 && s[0] == 'G' && s[1] == 'E' && s[2] == 'T') return 'G';
+    if (len == 4 && s[0] == 'P' && s[1] == 'O' && s[2] == 'S' && s[3] == 'T') return 'P';
+    if (len == 3 && s[0] == 'P' && s[1] == 'U' && s[2] == 'T') return 'P';
+    if (len == 6 && s[0] == 'D' && s[1] == 'E' && s[2] == 'L' && s[3] == 'E' && s[4] == 'T' &&
+        s[5] == 'E')
+        return 'D';
+    if (len == 5 && s[0] == 'P' && s[1] == 'A' && s[2] == 'T' && s[3] == 'C' && s[4] == 'H')
+        return 'P';
+    if (len == 4 && s[0] == 'H' && s[1] == 'E' && s[2] == 'A' && s[3] == 'D') return 'H';
+    if (len == 7 && s[0] == 'O' && s[1] == 'P' && s[2] == 'T' && s[3] == 'I' && s[4] == 'O' &&
+        s[5] == 'N' && s[6] == 'S')
+        return 'O';
+    if (len == 7 && s[0] == 'C' && s[1] == 'O' && s[2] == 'N' && s[3] == 'N' && s[4] == 'E' &&
+        s[5] == 'C' && s[6] == 'T')
+        return 'C';
+    if (len == 5 && s[0] == 'T' && s[1] == 'R' && s[2] == 'A' && s[3] == 'C' && s[4] == 'E')
+        return 'T';
+    *ok = false;
+    return 0;
+}
+
+static u8 http_method_char(HttpMethod method) {
+    switch (method) {
+        case HttpMethod::GET:
+            return 'G';
+        case HttpMethod::POST:
+            return 'P';
+        case HttpMethod::PUT:
+            return 'P';
+        case HttpMethod::DELETE:
+            return 'D';
+        case HttpMethod::PATCH:
+            return 'P';
+        case HttpMethod::HEAD:
+            return 'H';
+        case HttpMethod::OPTIONS:
+            return 'O';
+        case HttpMethod::CONNECT:
+            return 'C';
+        case HttpMethod::TRACE:
+            return 'T';
+        case HttpMethod::Unknown:
+            return 0;
+    }
+    return 0;
+}
+
+static u8 log_method(HttpMethod method) {
+    switch (method) {
+        case HttpMethod::GET:
+            return static_cast<u8>(LogHttpMethod::Get);
+        case HttpMethod::POST:
+            return static_cast<u8>(LogHttpMethod::Post);
+        case HttpMethod::PUT:
+            return static_cast<u8>(LogHttpMethod::Put);
+        case HttpMethod::DELETE:
+            return static_cast<u8>(LogHttpMethod::Delete);
+        case HttpMethod::PATCH:
+            return static_cast<u8>(LogHttpMethod::Patch);
+        case HttpMethod::HEAD:
+            return static_cast<u8>(LogHttpMethod::Head);
+        case HttpMethod::OPTIONS:
+            return static_cast<u8>(LogHttpMethod::Options);
+        case HttpMethod::CONNECT:
+            return static_cast<u8>(LogHttpMethod::Connect);
+        case HttpMethod::TRACE:
+            return static_cast<u8>(LogHttpMethod::Trace);
+        case HttpMethod::Unknown:
+            return static_cast<u8>(LogHttpMethod::Other);
+    }
+    return static_cast<u8>(LogHttpMethod::Other);
+}
+
+static const ManifestUpstream* find_upstream(const Engine& engine, u16 id) {
+    for (u32 i = 0; i < engine.upstream_count; i++) {
+        if (engine.upstreams[i].id == id) return &engine.upstreams[i];
+    }
+    return nullptr;
+}
+
+static bool copy_str_into_arena(MmapArena& arena, const char* src, u32 len, Str* out) {
+    char* mem = arena.alloc_array<char>(len + 1);
+    if (!mem) return false;
+    for (u32 i = 0; i < len; i++) mem[i] = src[i];
+    mem[len] = '\0';
+    out->ptr = mem;
+    out->len = len;
+    return true;
+}
+
+static bool route_matches(const Engine::CompiledRoute& route, const char* path, u32 path_len) {
+    u32 pi = 0;
+    u32 ri = 0;
+    while (ri < route.pattern_len) {
+        if (route.pattern[ri] == ':') {
+            ri++;
+            while (ri < route.pattern_len && route.pattern[ri] != '/') ri++;
+            while (pi < path_len && path[pi] != '/' && path[pi] != '?') pi++;
+            continue;
+        }
+        if (pi >= path_len) return false;
+        if (path[pi] == '?') return false;
+        if (route.pattern[ri] != path[pi]) return false;
+        ri++;
+        pi++;
+    }
+    return true;
+}
+
+static const Engine::CompiledRoute* select_route(const Engine& engine,
+                                                 u8 method_char,
+                                                 const char* path,
+                                                 u32 path_len) {
+    for (u32 i = 0; i < engine.route_count; i++) {
+        const auto& route = engine.routes[i];
+        if (route.method != 0 && route.method != method_char) continue;
+        if (route_matches(route, path, path_len)) return &route;
+    }
+    return nullptr;
+}
+
+static u32 visible_path_len(Str path) {
+    u32 n = 0;
+    while (n < path.len && path.ptr[n] != '?') n++;
+    return n;
+}
+
+static const char* verdict_str(Verdict verdict) {
+    switch (verdict) {
+        case Verdict::Match:
+            return "MATCH";
+        case Verdict::Mismatch:
+            return "MISS";
+        case Verdict::Failed:
+            return "FAIL";
+        case Verdict::Unsupported:
+            return "UNSUPPORTED";
+    }
+    return "FAIL";
+}
+
+static const char* action_str(jit::HandlerAction action) {
+    switch (action) {
+        case jit::HandlerAction::ReturnStatus:
+            return "status";
+        case jit::HandlerAction::Proxy:
+            return "proxy";
+        case jit::HandlerAction::Yield:
+            return "yield";
+    }
+    return "status";
+}
+
+static void put_str(char* buf, u32 buf_size, u32* pos, const char* s) {
+    while (*s && *pos + 1 < buf_size) buf[(*pos)++] = *s++;
+}
+
+static void put_u32(char* buf, u32 buf_size, u32* pos, u32 value) {
+    char tmp[11];
+    u32 n = 0;
+    if (value == 0) {
+        tmp[n++] = '0';
+    } else {
+        while (value > 0) {
+            tmp[n++] = static_cast<char>('0' + value % 10);
+            value /= 10;
+        }
+    }
+    while (n > 0 && *pos + 1 < buf_size) buf[(*pos)++] = tmp[--n];
+}
+
+static void put_name(char* buf, u32 buf_size, u32* pos, const char* s) {
+    for (u32 i = 0; s[i] && *pos + 1 < buf_size; i++) buf[(*pos)++] = s[i];
+}
+
+}  // namespace
+
+bool ModuleContext::init(u32 func_cap, u32 struct_cap) {
+    if (!arena.init(4096)) return false;
+    module.name = {"simulate_manifest", 17};
+    module.arena = &arena;
+    module.functions = arena.alloc_array<rir::Function>(func_cap == 0 ? 1 : func_cap);
+    if (!module.functions) {
+        arena.destroy();
+        return false;
+    }
+    module.func_count = 0;
+    module.func_cap = func_cap == 0 ? 1 : func_cap;
+    module.struct_defs = arena.alloc_array<rir::StructDef*>(struct_cap == 0 ? 1 : struct_cap);
+    if (!module.struct_defs) {
+        arena.destroy();
+        return false;
+    }
+    module.struct_count = 0;
+    module.struct_cap = struct_cap == 0 ? 1 : struct_cap;
+    return true;
+}
+
+void ModuleContext::destroy() { arena.destroy(); }
+
+bool load_manifest(const char* path, Manifest& out) {
+    out = Manifest{};
+
+    i32 fd = ::open(path, O_RDONLY);
+    if (fd < 0) return false;
+
+    struct stat st;
+    if (fstat(fd, &st) < 0) {
+        ::close(fd);
+        return false;
+    }
+    if (st.st_size <= 0) {
+        ::close(fd);
+        return true;
+    }
+
+    void* map = mmap(nullptr, static_cast<u64>(st.st_size), PROT_READ, MAP_PRIVATE, fd, 0);
+    ::close(fd);
+    if (map == MAP_FAILED) return false;
+
+    const char* data = static_cast<const char*>(map);
+    u32 size = static_cast<u32>(st.st_size);
+    u32 pos = 0;
+
+    while (pos < size) {
+        while (pos < size && (data[pos] == ' ' || data[pos] == '\t' || data[pos] == '\r')) pos++;
+        if (pos >= size) break;
+        if (data[pos] == '\n') {
+            pos++;
+            continue;
+        }
+        if (data[pos] == '#') {
+            while (pos < size && data[pos] != '\n') pos++;
+            continue;
+        }
+
+        const char* toks[5]{};
+        u32 lens[5]{};
+        u32 tok_count = 0;
+        while (pos < size && data[pos] != '\n') {
+            while (pos < size && (data[pos] == ' ' || data[pos] == '\t' || data[pos] == '\r')) pos++;
+            if (pos >= size || data[pos] == '\n' || data[pos] == '#') break;
+            if (tok_count >= 5) {
+                munmap(map, static_cast<u64>(st.st_size));
+                return false;
+            }
+            toks[tok_count] = data + pos;
+            while (pos < size && data[pos] != '\n' && data[pos] != ' ' && data[pos] != '\t' &&
+                   data[pos] != '\r')
+                pos++;
+            lens[tok_count] = static_cast<u32>((data + pos) - toks[tok_count]);
+            tok_count++;
+        }
+        while (pos < size && data[pos] != '\n') pos++;
+        if (pos < size && data[pos] == '\n') pos++;
+        if (tok_count == 0) continue;
+
+        if (lens[0] == 8 && __builtin_memcmp(toks[0], "upstream", 8) == 0) {
+            if (tok_count != 3 || out.upstream_count >= Manifest::kMaxUpstreams) {
+                munmap(map, static_cast<u64>(st.st_size));
+                return false;
+            }
+            u32 id = 0;
+            if (!parse_u32_token(toks[1], lens[1], &id) || id > 65535) {
+                munmap(map, static_cast<u64>(st.st_size));
+                return false;
+            }
+            auto& up = out.upstreams[out.upstream_count++];
+            up.id = static_cast<u16>(id);
+            u32 copy_len = lens[2];
+            if (copy_len >= sizeof(up.name)) copy_len = sizeof(up.name) - 1;
+            for (u32 i = 0; i < copy_len; i++) up.name[i] = toks[2][i];
+            up.name[copy_len] = '\0';
+            continue;
+        }
+
+        if (lens[0] == 5 && __builtin_memcmp(toks[0], "route", 5) == 0) {
+            if (tok_count != 5 || out.route_count >= Manifest::kMaxRoutes) {
+                munmap(map, static_cast<u64>(st.st_size));
+                return false;
+            }
+            bool method_ok = false;
+            u8 method = parse_method_token(toks[1], lens[1], &method_ok);
+            if (!method_ok) {
+                munmap(map, static_cast<u64>(st.st_size));
+                return false;
+            }
+            auto& route = out.routes[out.route_count++];
+            route.method = method;
+            u32 pattern_len = lens[2];
+            if (pattern_len >= sizeof(route.pattern)) pattern_len = sizeof(route.pattern) - 1;
+            for (u32 i = 0; i < pattern_len; i++) route.pattern[i] = toks[2][i];
+            route.pattern[pattern_len] = '\0';
+
+            if (lens[3] == 6 && __builtin_memcmp(toks[3], "status", 6) == 0) {
+                u32 code = 0;
+                if (!parse_u32_token(toks[4], lens[4], &code) || code > 65535) {
+                    munmap(map, static_cast<u64>(st.st_size));
+                    return false;
+                }
+                route.action = ManifestAction::ReturnStatus;
+                route.status_code = static_cast<u16>(code);
+            } else if (lens[3] == 5 && __builtin_memcmp(toks[3], "proxy", 5) == 0) {
+                u32 id = 0;
+                if (!parse_u32_token(toks[4], lens[4], &id) || id > 65535) {
+                    munmap(map, static_cast<u64>(st.st_size));
+                    return false;
+                }
+                route.action = ManifestAction::Proxy;
+                route.upstream_id = static_cast<u16>(id);
+            } else {
+                munmap(map, static_cast<u64>(st.st_size));
+                return false;
+            }
+            continue;
+        }
+
+        munmap(map, static_cast<u64>(st.st_size));
+        return false;
+    }
+
+    munmap(map, static_cast<u64>(st.st_size));
+    return true;
+}
+
+bool build_module_from_manifest(const Manifest& manifest, ModuleContext& ctx) {
+    if (!ctx.init(manifest.route_count == 0 ? 1 : manifest.route_count)) return false;
+
+    rir::Builder b;
+    b.init(&ctx.module);
+
+    for (u32 i = 0; i < manifest.route_count; i++) {
+        char name_buf[32];
+        name_buf[0] = 'r';
+        name_buf[1] = 'o';
+        name_buf[2] = 'u';
+        name_buf[3] = 't';
+        name_buf[4] = 'e';
+        name_buf[5] = '_';
+        u32 pos = 6;
+        u32 v = i;
+        char tmp[10];
+        u32 tn = 0;
+        if (v == 0) {
+            tmp[tn++] = '0';
+        } else {
+            while (v > 0) {
+                tmp[tn++] = static_cast<char>('0' + v % 10);
+                v /= 10;
+            }
+        }
+        while (tn > 0 && pos + 1 < sizeof(name_buf)) name_buf[pos++] = tmp[--tn];
+        name_buf[pos] = '\0';
+
+        Str name;
+        if (!copy_str_into_arena(ctx.arena, name_buf, cstr_len(name_buf), &name)) return false;
+        Str pattern;
+        if (!copy_str_into_arena(ctx.arena,
+                                 manifest.routes[i].pattern,
+                                 cstr_len(manifest.routes[i].pattern),
+                                 &pattern))
+            return false;
+
+        auto fn = b.create_function(name, pattern, manifest.routes[i].method);
+        if (!fn) return false;
+        auto entry = b.create_block(fn.value(), {"entry", 5});
+        if (!entry) return false;
+        b.set_insert_point(fn.value(), entry.value());
+
+        if (manifest.routes[i].action == ManifestAction::ReturnStatus) {
+            if (!b.emit_ret_status(manifest.routes[i].status_code)) return false;
+        } else {
+            auto upstream = b.emit_const_i32(manifest.routes[i].upstream_id);
+            if (!upstream) return false;
+            if (!b.emit_ret_proxy(upstream.value())) return false;
+        }
+    }
+
+    return true;
+}
+
+bool Engine::init(const rir::Module& module,
+                  const ManifestUpstream* upstream_list,
+                  u32 upstreams_len) {
+    if (upstreams_len > kMaxUpstreams || module.func_count > kMaxRoutes) return false;
+    route_count = 0;
+    upstream_count = upstreams_len;
+    for (u32 i = 0; i < upstreams_len; i++) upstreams[i] = upstream_list[i];
+
+    if (!jit.init()) return false;
+    auto cg = jit::codegen(module);
+    if (!cg.ok) {
+        jit.shutdown();
+        return false;
+    }
+    if (!jit.compile(cg.mod, cg.ctx)) {
+        jit.shutdown();
+        return false;
+    }
+
+    for (u32 i = 0; i < module.func_count; i++) {
+        const auto& fn = module.functions[i];
+        if (route_count >= kMaxRoutes) {
+            jit.shutdown();
+            return false;
+        }
+        char symbol[256] = "handler_";
+        u32 pos = 8;
+        for (u32 j = 0; j < fn.name.len && pos + 1 < sizeof(symbol); j++) symbol[pos++] = fn.name.ptr[j];
+        symbol[pos] = '\0';
+
+        void* addr = jit.lookup(symbol);
+        if (!addr) {
+            jit.shutdown();
+            return false;
+        }
+
+        auto& route = routes[route_count++];
+        route.method = fn.http_method;
+        route.pattern_len = fn.route_pattern.len;
+        if (route.pattern_len >= sizeof(route.pattern)) route.pattern_len = sizeof(route.pattern) - 1;
+        for (u32 j = 0; j < route.pattern_len; j++) route.pattern[j] = fn.route_pattern.ptr[j];
+        route.pattern[route.pattern_len] = '\0';
+        route.fn = reinterpret_cast<jit::HandlerFn>(addr);
+    }
+
+    return true;
+}
+
+void Engine::shutdown() {
+    jit.shutdown();
+    route_count = 0;
+    upstream_count = 0;
+}
+
+SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
+    SimulateResult result{};
+    result.expected_status = entry.resp_status;
+    copy_cstr(result.expected_upstream, sizeof(result.expected_upstream), entry.upstream_name);
+
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    req.reset();
+    if (parser.parse(entry.raw_headers, entry.raw_header_len, &req) != ParseStatus::Complete) {
+        result.verdict = Verdict::Failed;
+        return result;
+    }
+
+    result.method = log_method(req.method);
+    const u32 path_len = visible_path_len(req.path);
+    u32 copy_len = path_len;
+    if (copy_len >= sizeof(result.path)) copy_len = sizeof(result.path) - 1;
+    for (u32 i = 0; i < copy_len; i++) result.path[i] = req.path.ptr[i];
+    result.path[copy_len] = '\0';
+
+    const auto* route = select_route(engine, http_method_char(req.method), req.path.ptr, path_len);
+    if (!route) {
+        result.action = jit::HandlerAction::ReturnStatus;
+        result.actual_status = 200;
+        result.verdict = (entry.resp_status == 200 && entry.upstream_name[0] == '\0')
+                             ? Verdict::Match
+                             : Verdict::Mismatch;
+        return result;
+    }
+
+    Connection conn;
+    conn.reset();
+    jit::HandlerCtx ctx{};
+    ctx.state = 0;
+    ctx.handler_idx = 0;
+    ctx.slot_count = 0;
+
+    const u64 packed = route->fn(&conn,
+                                 &ctx,
+                                 entry.raw_headers,
+                                 entry.raw_header_len,
+                                 nullptr);
+    const auto handler = jit::HandlerResult::unpack(packed);
+    result.action = handler.action;
+
+    if (handler.action == jit::HandlerAction::ReturnStatus) {
+        result.actual_status = handler.status_code;
+        result.verdict = (handler.status_code == entry.resp_status && entry.upstream_name[0] == '\0')
+                             ? Verdict::Match
+                             : Verdict::Mismatch;
+        return result;
+    }
+
+    if (handler.action == jit::HandlerAction::Proxy) {
+        const auto* upstream = find_upstream(engine, handler.upstream_id);
+        if (!upstream) {
+            result.verdict = Verdict::Failed;
+            return result;
+        }
+        copy_cstr(result.actual_upstream, sizeof(result.actual_upstream), upstream->name);
+        result.verdict = streq(result.actual_upstream, result.expected_upstream) ? Verdict::Match
+                                                                                 : Verdict::Mismatch;
+        return result;
+    }
+
+    result.verdict = Verdict::Unsupported;
+    return result;
+}
+
+SimulateSummary simulate_file(Engine& engine, ReplayReader& reader) {
+    SimulateSummary summary{};
+    CaptureEntry entry{};
+    while (reader.next(entry) == 0) {
+        summary.total++;
+        const SimulateResult result = simulate_one(engine, entry);
+        switch (result.verdict) {
+            case Verdict::Match:
+                summary.matched++;
+                break;
+            case Verdict::Mismatch:
+                summary.mismatched++;
+                break;
+            case Verdict::Failed:
+                summary.failed++;
+                break;
+            case Verdict::Unsupported:
+                summary.unsupported++;
+                break;
+        }
+    }
+    return summary;
+}
+
+u32 format_result(const SimulateResult& result, char* buf, u32 buf_size) {
+    u32 pos = 0;
+    put_str(buf, buf_size, &pos, verdict_str(result.verdict));
+    put_str(buf, buf_size, &pos, " ");
+
+    static const char* kMethods[] = {"GET", "POST", "PUT", "DELETE", "PATCH",
+                                     "HEAD", "OPTIONS", "CONNECT", "TRACE", "OTHER"};
+    u8 method_idx = result.method < 10 ? result.method : 9;
+    put_str(buf, buf_size, &pos, kMethods[method_idx]);
+    put_str(buf, buf_size, &pos, " ");
+    put_str(buf, buf_size, &pos, result.path[0] ? result.path : "/");
+    put_str(buf, buf_size, &pos, " ");
+    put_str(buf, buf_size, &pos, action_str(result.action));
+    put_str(buf, buf_size, &pos, " ");
+
+    if (result.action == jit::HandlerAction::Proxy) {
+        put_name(buf, buf_size, &pos, result.expected_upstream[0] ? result.expected_upstream : "-");
+        put_str(buf, buf_size, &pos, " -> ");
+        put_name(buf, buf_size, &pos, result.actual_upstream[0] ? result.actual_upstream : "-");
+    } else {
+        put_u32(buf, buf_size, &pos, result.expected_status);
+        put_str(buf, buf_size, &pos, " -> ");
+        put_u32(buf, buf_size, &pos, result.actual_status);
+    }
+
+    if (pos + 1 < buf_size) buf[pos++] = '\n';
+    if (pos < buf_size) buf[pos] = '\0';
+    return pos;
+}
+
+u32 format_summary(const SimulateSummary& summary, char* buf, u32 buf_size) {
+    u32 pos = 0;
+    put_str(buf, buf_size, &pos, "--- Simulate Summary ---\n");
+    put_str(buf, buf_size, &pos, "Total: ");
+    put_u32(buf, buf_size, &pos, summary.total);
+    put_str(buf, buf_size, &pos, "\nMatched: ");
+    put_u32(buf, buf_size, &pos, summary.matched);
+    put_str(buf, buf_size, &pos, "\nMismatched: ");
+    put_u32(buf, buf_size, &pos, summary.mismatched);
+    put_str(buf, buf_size, &pos, "\nFailed: ");
+    put_u32(buf, buf_size, &pos, summary.failed);
+    put_str(buf, buf_size, &pos, "\nUnsupported: ");
+    put_u32(buf, buf_size, &pos, summary.unsupported);
+    if (pos + 1 < buf_size) buf[pos++] = '\n';
+    if (pos < buf_size) buf[pos] = '\0';
+    return pos;
+}
+
+}  // namespace rut::sim

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -1,8 +1,17 @@
 #include "rut/sim/simulate_engine.h"
 
+#include "rut/common/types.h"
+#include "rut/compiler/rir.h"
 #include "rut/compiler/rir_builder.h"
 #include "rut/jit/codegen.h"
+#include "rut/jit/handler_abi.h"
 #include "rut/jit/jit_engine.h"
+#include "rut/runtime/access_log.h"
+#include "rut/runtime/arena.h"
+#include "rut/runtime/connection.h"
+#include "rut/runtime/http_parser.h"
+#include "rut/runtime/traffic_capture.h"
+#include "rut/runtime/traffic_replay.h"
 
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -78,13 +87,11 @@ static u8 http_method_char(HttpMethod method) {
         case HttpMethod::GET:
             return 'G';
         case HttpMethod::POST:
-            return 'P';
         case HttpMethod::PUT:
+        case HttpMethod::PATCH:
             return 'P';
         case HttpMethod::DELETE:
             return 'D';
-        case HttpMethod::PATCH:
-            return 'P';
         case HttpMethod::HEAD:
             return 'H';
         case HttpMethod::OPTIONS:
@@ -250,113 +257,119 @@ bool ModuleContext::init(u32 func_cap, u32 struct_cap) {
     return true;
 }
 
-void ModuleContext::destroy() { arena.destroy(); }
+void ModuleContext::destroy() {
+    arena.destroy();
+}
 
 bool load_manifest(const char* path, Manifest& out) {
     out = Manifest{};
 
-    i32 fd = ::open(path, O_RDONLY);
-    if (fd < 0) return false;
+    const i32 kFd = ::open(path, O_RDONLY);
+    if (kFd < 0) return false;
 
     struct stat st;
-    if (fstat(fd, &st) < 0) {
-        ::close(fd);
+    if (fstat(kFd, &st) < 0) {
+        ::close(kFd);
         return false;
     }
     if (st.st_size <= 0) {
-        ::close(fd);
+        ::close(kFd);
         return true;
     }
 
-    void* map = mmap(nullptr, static_cast<u64>(st.st_size), PROT_READ, MAP_PRIVATE, fd, 0);
-    ::close(fd);
+    void* map = mmap(nullptr, static_cast<u64>(st.st_size), PROT_READ, MAP_PRIVATE, kFd, 0);
+    ::close(kFd);
     if (map == MAP_FAILED) return false;
 
     const char* data = static_cast<const char*>(map);
-    u32 size = static_cast<u32>(st.st_size);
+    const u32 kSize = static_cast<u32>(st.st_size);
     u32 pos = 0;
 
-    while (pos < size) {
-        while (pos < size && (data[pos] == ' ' || data[pos] == '\t' || data[pos] == '\r')) pos++;
-        if (pos >= size) break;
+    while (pos < kSize) {
+        while (pos < kSize && (data[pos] == ' ' || data[pos] == '\t' || data[pos] == '\r')) pos++;
+        if (pos >= kSize) break;
         if (data[pos] == '\n') {
             pos++;
             continue;
         }
         if (data[pos] == '#') {
-            while (pos < size && data[pos] != '\n') pos++;
+            while (pos < kSize && data[pos] != '\n') pos++;
             continue;
         }
 
-        const char* toks[5]{};
-        u32 lens[5]{};
+        struct Token {
+            const char* ptr = nullptr;
+            u32 len = 0;
+        };
+        Token tokens[5]{};
         u32 tok_count = 0;
-        while (pos < size && data[pos] != '\n') {
-            while (pos < size && (data[pos] == ' ' || data[pos] == '\t' || data[pos] == '\r')) pos++;
-            if (pos >= size || data[pos] == '\n' || data[pos] == '#') break;
+        while (pos < kSize && data[pos] != '\n') {
+            while (pos < kSize && (data[pos] == ' ' || data[pos] == '\t' || data[pos] == '\r'))
+                pos++;
+            if (pos >= kSize || data[pos] == '\n' || data[pos] == '#') break;
             if (tok_count >= 5) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
-            toks[tok_count] = data + pos;
-            while (pos < size && data[pos] != '\n' && data[pos] != ' ' && data[pos] != '\t' &&
+            tokens[tok_count].ptr = data + pos;
+            while (pos < kSize && data[pos] != '\n' && data[pos] != ' ' && data[pos] != '\t' &&
                    data[pos] != '\r')
                 pos++;
-            lens[tok_count] = static_cast<u32>((data + pos) - toks[tok_count]);
+            tokens[tok_count].len = static_cast<u32>((data + pos) - tokens[tok_count].ptr);
             tok_count++;
         }
-        while (pos < size && data[pos] != '\n') pos++;
-        if (pos < size && data[pos] == '\n') pos++;
+        while (pos < kSize && data[pos] != '\n') pos++;
+        if (pos < kSize && data[pos] == '\n') pos++;
         if (tok_count == 0) continue;
 
-        if (lens[0] == 8 && __builtin_memcmp(toks[0], "upstream", 8) == 0) {
+        if (tokens[0].len == 8 && __builtin_memcmp(tokens[0].ptr, "upstream", 8) == 0) {
             if (tok_count != 3 || out.upstream_count >= Manifest::kMaxUpstreams) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
             u32 id = 0;
-            if (!parse_u32_token(toks[1], lens[1], &id) || id > 65535) {
+            if (!parse_u32_token(tokens[1].ptr, tokens[1].len, &id) || id > 65535) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
             auto& up = out.upstreams[out.upstream_count++];
             up.id = static_cast<u16>(id);
-            u32 copy_len = lens[2];
+            u32 copy_len = tokens[2].len;
             if (copy_len >= sizeof(up.name)) copy_len = sizeof(up.name) - 1;
-            for (u32 i = 0; i < copy_len; i++) up.name[i] = toks[2][i];
+            for (u32 i = 0; i < copy_len; i++) up.name[i] = tokens[2].ptr[i];
             up.name[copy_len] = '\0';
             continue;
         }
 
-        if (lens[0] == 5 && __builtin_memcmp(toks[0], "route", 5) == 0) {
+        if (tokens[0].len == 5 && __builtin_memcmp(tokens[0].ptr, "route", 5) == 0) {
             if (tok_count != 5 || out.route_count >= Manifest::kMaxRoutes) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
             bool method_ok = false;
-            u8 method = parse_method_token(toks[1], lens[1], &method_ok);
+            const u8 kMethod = parse_method_token(tokens[1].ptr, tokens[1].len, &method_ok);
             if (!method_ok) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
             auto& route = out.routes[out.route_count++];
-            route.method = method;
-            u32 pattern_len = lens[2];
+            route.method = kMethod;
+            u32 pattern_len = tokens[2].len;
             if (pattern_len >= sizeof(route.pattern)) pattern_len = sizeof(route.pattern) - 1;
-            for (u32 i = 0; i < pattern_len; i++) route.pattern[i] = toks[2][i];
+            for (u32 i = 0; i < pattern_len; i++) route.pattern[i] = tokens[2].ptr[i];
             route.pattern[pattern_len] = '\0';
 
-            if (lens[3] == 6 && __builtin_memcmp(toks[3], "status", 6) == 0) {
+            if (tokens[3].len == 6 && __builtin_memcmp(tokens[3].ptr, "status", 6) == 0) {
                 u32 code = 0;
-                if (!parse_u32_token(toks[4], lens[4], &code) || code > 65535) {
+                if (!parse_u32_token(tokens[4].ptr, tokens[4].len, &code) || code > 65535) {
                     munmap(map, static_cast<u64>(st.st_size));
                     return false;
                 }
                 route.action = ManifestAction::ReturnStatus;
                 route.status_code = static_cast<u16>(code);
-            } else if (lens[3] == 5 && __builtin_memcmp(toks[3], "proxy", 5) == 0) {
+            } else if (tokens[3].len == 5 && __builtin_memcmp(tokens[3].ptr, "proxy", 5) == 0) {
                 u32 id = 0;
-                if (!parse_u32_token(toks[4], lens[4], &id) || id > 65535) {
+                if (!parse_u32_token(tokens[4].ptr, tokens[4].len, &id) || id > 65535) {
                     munmap(map, static_cast<u64>(st.st_size));
                     return false;
                 }
@@ -460,7 +473,8 @@ bool Engine::init(const rir::Module& module,
         }
         char symbol[256] = "handler_";
         u32 pos = 8;
-        for (u32 j = 0; j < fn.name.len && pos + 1 < sizeof(symbol); j++) symbol[pos++] = fn.name.ptr[j];
+        for (u32 j = 0; j < fn.name.len && pos + 1 < sizeof(symbol); j++)
+            symbol[pos++] = fn.name.ptr[j];
         symbol[pos] = '\0';
 
         void* addr = jit.lookup(symbol);
@@ -472,7 +486,8 @@ bool Engine::init(const rir::Module& module,
         auto& route = routes[route_count++];
         route.method = fn.http_method;
         route.pattern_len = fn.route_pattern.len;
-        if (route.pattern_len >= sizeof(route.pattern)) route.pattern_len = sizeof(route.pattern) - 1;
+        if (route.pattern_len >= sizeof(route.pattern))
+            route.pattern_len = sizeof(route.pattern) - 1;
         for (u32 j = 0; j < route.pattern_len; j++) route.pattern[j] = fn.route_pattern.ptr[j];
         route.pattern[route.pattern_len] = '\0';
         route.fn = reinterpret_cast<jit::HandlerFn>(addr);
@@ -502,13 +517,13 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
     }
 
     result.method = log_method(req.method);
-    const u32 path_len = visible_path_len(req.path);
-    u32 copy_len = path_len;
+    const u32 kPathLen = visible_path_len(req.path);
+    u32 copy_len = kPathLen;
     if (copy_len >= sizeof(result.path)) copy_len = sizeof(result.path) - 1;
     for (u32 i = 0; i < copy_len; i++) result.path[i] = req.path.ptr[i];
     result.path[copy_len] = '\0';
 
-    const auto* route = select_route(engine, http_method_char(req.method), req.path.ptr, path_len);
+    const auto* route = select_route(engine, http_method_char(req.method), req.path.ptr, kPathLen);
     if (!route) {
         result.action = jit::HandlerAction::ReturnStatus;
         result.actual_status = 200;
@@ -525,31 +540,29 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
     ctx.handler_idx = 0;
     ctx.slot_count = 0;
 
-    const u64 packed = route->fn(&conn,
-                                 &ctx,
-                                 entry.raw_headers,
-                                 entry.raw_header_len,
-                                 nullptr);
-    const auto handler = jit::HandlerResult::unpack(packed);
-    result.action = handler.action;
+    const u64 kPacked = route->fn(&conn, &ctx, entry.raw_headers, entry.raw_header_len, nullptr);
+    const auto kUnpacked = jit::HandlerResult::unpack(kPacked);
+    result.action = kUnpacked.action;
 
-    if (handler.action == jit::HandlerAction::ReturnStatus) {
-        result.actual_status = handler.status_code;
-        result.verdict = (handler.status_code == entry.resp_status && entry.upstream_name[0] == '\0')
-                             ? Verdict::Match
-                             : Verdict::Mismatch;
+    if (kUnpacked.action == jit::HandlerAction::ReturnStatus) {
+        result.actual_status = kUnpacked.status_code;
+        result.verdict =
+            (kUnpacked.status_code == entry.resp_status && entry.upstream_name[0] == '\0')
+                ? Verdict::Match
+                : Verdict::Mismatch;
         return result;
     }
 
-    if (handler.action == jit::HandlerAction::Proxy) {
-        const auto* upstream = find_upstream(engine, handler.upstream_id);
+    if (kUnpacked.action == jit::HandlerAction::Proxy) {
+        const auto* upstream = find_upstream(engine, kUnpacked.upstream_id);
         if (!upstream) {
             result.verdict = Verdict::Failed;
             return result;
         }
         copy_cstr(result.actual_upstream, sizeof(result.actual_upstream), upstream->name);
-        result.verdict = streq(result.actual_upstream, result.expected_upstream) ? Verdict::Match
-                                                                                 : Verdict::Mismatch;
+        result.verdict = streq(result.actual_upstream, result.expected_upstream)
+                             ? Verdict::Match
+                             : Verdict::Mismatch;
         return result;
     }
 
@@ -562,8 +575,8 @@ SimulateSummary simulate_file(Engine& engine, ReplayReader& reader) {
     CaptureEntry entry{};
     while (reader.next(entry) == 0) {
         summary.total++;
-        const SimulateResult result = simulate_one(engine, entry);
-        switch (result.verdict) {
+        const SimulateResult kSimResult = simulate_one(engine, entry);
+        switch (kSimResult.verdict) {
             case Verdict::Match:
                 summary.matched++;
                 break;
@@ -586,10 +599,10 @@ u32 format_result(const SimulateResult& result, char* buf, u32 buf_size) {
     put_str(buf, buf_size, &pos, verdict_str(result.verdict));
     put_str(buf, buf_size, &pos, " ");
 
-    static const char* kMethods[] = {"GET", "POST", "PUT", "DELETE", "PATCH",
-                                     "HEAD", "OPTIONS", "CONNECT", "TRACE", "OTHER"};
-    u8 method_idx = result.method < 10 ? result.method : 9;
-    put_str(buf, buf_size, &pos, kMethods[method_idx]);
+    static const char* const kMethodNames[] = {
+        "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE", "OTHER"};
+    const u8 kMethodIdx = result.method < 10 ? result.method : 9;
+    put_str(buf, buf_size, &pos, kMethodNames[kMethodIdx]);
     put_str(buf, buf_size, &pos, " ");
     put_str(buf, buf_size, &pos, result.path[0] ? result.path : "/");
     put_str(buf, buf_size, &pos, " ");

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -285,10 +285,12 @@ bool ModuleContext::init(u32 func_cap, u32 struct_cap) {
 
 void ModuleContext::destroy() {
     arena.destroy();
+    module = {};
 }
 
 bool load_manifest(const char* path, Manifest& out) {
     out = Manifest{};
+    Manifest parsed{};
 
     const i32 kFd = ::open(path, O_RDONLY);
     if (kFd < 0) return false;
@@ -353,7 +355,7 @@ bool load_manifest(const char* path, Manifest& out) {
         if (tok_count == 0) continue;
 
         if (tokens[0].len == 8 && __builtin_memcmp(tokens[0].ptr, "upstream", 8) == 0) {
-            if (tok_count != 3 || out.upstream_count >= Manifest::kMaxUpstreams) {
+            if (tok_count != 3 || parsed.upstream_count >= Manifest::kMaxUpstreams) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
@@ -362,12 +364,12 @@ bool load_manifest(const char* path, Manifest& out) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
-            auto& up = out.upstreams[out.upstream_count];
+            auto& up = parsed.upstreams[parsed.upstream_count];
             if (tokens[2].len >= sizeof(up.name)) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
-            out.upstream_count++;
+            parsed.upstream_count++;
             up.id = static_cast<u16>(id);
             u32 copy_len = tokens[2].len;
             for (u32 i = 0; i < copy_len; i++) up.name[i] = tokens[2].ptr[i];
@@ -376,7 +378,7 @@ bool load_manifest(const char* path, Manifest& out) {
         }
 
         if (tokens[0].len == 5 && __builtin_memcmp(tokens[0].ptr, "route", 5) == 0) {
-            if (tok_count != 5 || out.route_count >= Manifest::kMaxRoutes) {
+            if (tok_count != 5 || parsed.route_count >= Manifest::kMaxRoutes) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
@@ -386,7 +388,7 @@ bool load_manifest(const char* path, Manifest& out) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
-            auto& route = out.routes[out.route_count++];
+            auto& route = parsed.routes[parsed.route_count++];
             route.method = kMethod;
             if (tokens[2].len >= sizeof(route.pattern)) {
                 munmap(map, static_cast<u64>(st.st_size));
@@ -423,12 +425,14 @@ bool load_manifest(const char* path, Manifest& out) {
         return false;
     }
 
-    const bool ok = validate_manifest(out);
+    const bool ok = validate_manifest(parsed);
     munmap(map, static_cast<u64>(st.st_size));
+    if (ok) out = parsed;
     return ok;
 }
 
 bool build_module_from_manifest(const Manifest& manifest, ModuleContext& ctx) {
+    if (manifest.route_count > Manifest::kMaxRoutes) return false;
     if (!ctx.init(manifest.route_count == 0 ? 1 : manifest.route_count)) return false;
     const auto fail = [&ctx]() {
         ctx.destroy();

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -256,6 +256,20 @@ static void put_u32(char* buf, u32 buf_size, u32* pos, u32 value) {
     while (n > 0 && *pos + 1 < buf_size) buf[(*pos)++] = tmp[--n];
 }
 
+static void put_u64(char* buf, u32 buf_size, u32* pos, u64 value) {
+    char tmp[21];
+    u32 n = 0;
+    if (value == 0) {
+        tmp[n++] = '0';
+    } else {
+        while (value > 0) {
+            tmp[n++] = static_cast<char>('0' + value % 10);
+            value /= 10;
+        }
+    }
+    while (n > 0 && *pos + 1 < buf_size) buf[(*pos)++] = tmp[--n];
+}
+
 static void put_name(char* buf, u32 buf_size, u32* pos, const char* s) {
     for (u32 i = 0; s[i] && *pos + 1 < buf_size; i++) buf[(*pos)++] = s[i];
 }
@@ -622,28 +636,36 @@ SimulateSummary simulate_file(Engine& engine, ReplayReader& reader) {
     while (reader.next(entry) == 0) {
         summary.total++;
         const SimulateResult kSimResult = simulate_one(engine, entry);
-        switch (kSimResult.verdict) {
-            case Verdict::Match:
-                summary.matched++;
-                break;
-            case Verdict::Mismatch:
-                summary.mismatched++;
-                break;
-            case Verdict::Failed:
-                summary.failed++;
-                break;
-            case Verdict::Unsupported:
-                summary.unsupported++;
-                break;
-        }
+        accumulate_summary(summary, kSimResult.verdict);
     }
+    finalize_summary(summary, reader);
+    return summary;
+}
+
+void accumulate_summary(SimulateSummary& summary, Verdict verdict) {
+    switch (verdict) {
+        case Verdict::Match:
+            summary.matched++;
+            break;
+        case Verdict::Mismatch:
+            summary.mismatched++;
+            break;
+        case Verdict::Failed:
+            summary.failed++;
+            break;
+        case Verdict::Unsupported:
+            summary.unsupported++;
+            break;
+    }
+}
+
+void finalize_summary(SimulateSummary& summary, const ReplayReader& reader) {
     const u64 kExpectedTotal = reader.entry_count();
     if (summary.total < kExpectedTotal) {
         const u64 kMissing = kExpectedTotal - summary.total;
-        summary.failed += static_cast<u32>(kMissing);
-        summary.total += static_cast<u32>(kMissing);
+        summary.failed += kMissing;
+        summary.total += kMissing;
     }
-    return summary;
 }
 
 u32 format_result(const SimulateResult& result, char* buf, u32 buf_size) {
@@ -665,6 +687,11 @@ u32 format_result(const SimulateResult& result, char* buf, u32 buf_size) {
         put_name(buf, buf_size, &pos, result.expected_upstream[0] ? result.expected_upstream : "-");
         put_str(buf, buf_size, &pos, " -> ");
         put_name(buf, buf_size, &pos, result.actual_upstream[0] ? result.actual_upstream : "-");
+    } else if (result.action == jit::HandlerAction::Yield) {
+        put_str(buf, buf_size, &pos, "- -> -");
+    } else if (result.verdict == Verdict::Failed || result.verdict == Verdict::Unsupported) {
+        put_u32(buf, buf_size, &pos, result.expected_status);
+        put_str(buf, buf_size, &pos, " -> -");
     } else {
         put_u32(buf, buf_size, &pos, result.expected_status);
         put_str(buf, buf_size, &pos, " -> ");
@@ -680,15 +707,15 @@ u32 format_summary(const SimulateSummary& summary, char* buf, u32 buf_size) {
     u32 pos = 0;
     put_str(buf, buf_size, &pos, "--- Simulate Summary ---\n");
     put_str(buf, buf_size, &pos, "Total: ");
-    put_u32(buf, buf_size, &pos, summary.total);
+    put_u64(buf, buf_size, &pos, summary.total);
     put_str(buf, buf_size, &pos, "\nMatched: ");
-    put_u32(buf, buf_size, &pos, summary.matched);
+    put_u64(buf, buf_size, &pos, summary.matched);
     put_str(buf, buf_size, &pos, "\nMismatched: ");
-    put_u32(buf, buf_size, &pos, summary.mismatched);
+    put_u64(buf, buf_size, &pos, summary.mismatched);
     put_str(buf, buf_size, &pos, "\nFailed: ");
-    put_u32(buf, buf_size, &pos, summary.failed);
+    put_u64(buf, buf_size, &pos, summary.failed);
     put_str(buf, buf_size, &pos, "\nUnsupported: ");
-    put_u32(buf, buf_size, &pos, summary.unsupported);
+    put_u64(buf, buf_size, &pos, summary.unsupported);
     if (pos + 1 < buf_size) buf[pos++] = '\n';
     if (pos < buf_size) buf[pos] = '\0';
     return pos;

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -141,6 +141,28 @@ static const ManifestUpstream* find_upstream(const Engine& engine, u16 id) {
     return nullptr;
 }
 
+static bool manifest_has_upstream_id(const Manifest& manifest, u16 id) {
+    for (u32 i = 0; i < manifest.upstream_count; i++) {
+        if (manifest.upstreams[i].id == id) return true;
+    }
+    return false;
+}
+
+static bool validate_manifest(const Manifest& manifest) {
+    for (u32 i = 0; i < manifest.upstream_count; i++) {
+        for (u32 j = i + 1; j < manifest.upstream_count; j++) {
+            if (manifest.upstreams[i].id == manifest.upstreams[j].id) return false;
+        }
+    }
+    for (u32 i = 0; i < manifest.route_count; i++) {
+        const auto& route = manifest.routes[i];
+        if (route.action == ManifestAction::Proxy &&
+            !manifest_has_upstream_id(manifest, route.upstream_id))
+            return false;
+    }
+    return true;
+}
+
 static bool copy_str_into_arena(MmapArena& arena, const char* src, u32 len, Str* out) {
     char* mem = arena.alloc_array<char>(len + 1);
     if (!mem) return false;
@@ -393,8 +415,9 @@ bool load_manifest(const char* path, Manifest& out) {
         return false;
     }
 
+    const bool ok = validate_manifest(out);
     munmap(map, static_cast<u64>(st.st_size));
-    return true;
+    return ok;
 }
 
 bool build_module_from_manifest(const Manifest& manifest, ModuleContext& ctx) {

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -637,6 +637,12 @@ SimulateSummary simulate_file(Engine& engine, ReplayReader& reader) {
                 break;
         }
     }
+    const u64 kExpectedTotal = reader.entry_count();
+    if (summary.total < kExpectedTotal) {
+        const u64 kMissing = kExpectedTotal - summary.total;
+        summary.failed += static_cast<u32>(kMissing);
+        summary.total += static_cast<u32>(kMissing);
+    }
     return summary;
 }
 

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -302,6 +302,10 @@ bool load_manifest(const char* path, Manifest& out) {
         ::close(kFd);
         return true;
     }
+    if (static_cast<u64>(st.st_size) > static_cast<u64>(static_cast<u32>(-1))) {
+        ::close(kFd);
+        return false;
+    }
 
     void* map = mmap(nullptr, static_cast<u64>(st.st_size), PROT_READ, MAP_PRIVATE, kFd, 0);
     ::close(kFd);
@@ -358,10 +362,14 @@ bool load_manifest(const char* path, Manifest& out) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
-            auto& up = out.upstreams[out.upstream_count++];
+            auto& up = out.upstreams[out.upstream_count];
+            if (tokens[2].len >= sizeof(up.name)) {
+                munmap(map, static_cast<u64>(st.st_size));
+                return false;
+            }
+            out.upstream_count++;
             up.id = static_cast<u16>(id);
             u32 copy_len = tokens[2].len;
-            if (copy_len >= sizeof(up.name)) copy_len = sizeof(up.name) - 1;
             for (u32 i = 0; i < copy_len; i++) up.name[i] = tokens[2].ptr[i];
             up.name[copy_len] = '\0';
             continue;
@@ -422,6 +430,10 @@ bool load_manifest(const char* path, Manifest& out) {
 
 bool build_module_from_manifest(const Manifest& manifest, ModuleContext& ctx) {
     if (!ctx.init(manifest.route_count == 0 ? 1 : manifest.route_count)) return false;
+    const auto fail = [&ctx]() {
+        ctx.destroy();
+        return false;
+    };
 
     rir::Builder b;
     b.init(&ctx.module);
@@ -450,26 +462,26 @@ bool build_module_from_manifest(const Manifest& manifest, ModuleContext& ctx) {
         name_buf[pos] = '\0';
 
         Str name;
-        if (!copy_str_into_arena(ctx.arena, name_buf, cstr_len(name_buf), &name)) return false;
+        if (!copy_str_into_arena(ctx.arena, name_buf, cstr_len(name_buf), &name)) return fail();
         Str pattern;
         if (!copy_str_into_arena(ctx.arena,
                                  manifest.routes[i].pattern,
                                  cstr_len(manifest.routes[i].pattern),
                                  &pattern))
-            return false;
+            return fail();
 
         auto fn = b.create_function(name, pattern, manifest.routes[i].method);
-        if (!fn) return false;
+        if (!fn) return fail();
         auto entry = b.create_block(fn.value(), {"entry", 5});
-        if (!entry) return false;
+        if (!entry) return fail();
         b.set_insert_point(fn.value(), entry.value());
 
         if (manifest.routes[i].action == ManifestAction::ReturnStatus) {
-            if (!b.emit_ret_status(manifest.routes[i].status_code)) return false;
+            if (!b.emit_ret_status(manifest.routes[i].status_code)) return fail();
         } else {
             auto upstream = b.emit_const_i32(manifest.routes[i].upstream_id);
-            if (!upstream) return false;
-            if (!b.emit_ret_proxy(upstream.value())) return false;
+            if (!upstream) return fail();
+            if (!b.emit_ret_proxy(upstream.value())) return fail();
         }
     }
 

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -52,7 +52,9 @@ static bool parse_u32_token(const char* s, u32 len, u32* out) {
     u32 v = 0;
     for (u32 i = 0; i < len; i++) {
         if (s[i] < '0' || s[i] > '9') return false;
-        v = v * 10 + static_cast<u32>(s[i] - '0');
+        const u32 digit = static_cast<u32>(s[i] - '0');
+        if (v > (static_cast<u32>(-1) - digit) / 10) return false;
+        v = v * 10 + digit;
     }
     *out = v;
     return true;
@@ -156,7 +158,9 @@ static bool route_matches(const Engine::CompiledRoute& route, const char* path, 
         if (route.pattern[ri] == ':') {
             ri++;
             while (ri < route.pattern_len && route.pattern[ri] != '/') ri++;
+            const u32 param_start = pi;
             while (pi < path_len && path[pi] != '/' && path[pi] != '?') pi++;
+            if (pi == param_start) return false;
             continue;
         }
         if (pi >= path_len) return false;
@@ -354,8 +358,11 @@ bool load_manifest(const char* path, Manifest& out) {
             }
             auto& route = out.routes[out.route_count++];
             route.method = kMethod;
-            u32 pattern_len = tokens[2].len;
-            if (pattern_len >= sizeof(route.pattern)) pattern_len = sizeof(route.pattern) - 1;
+            if (tokens[2].len >= sizeof(route.pattern)) {
+                munmap(map, static_cast<u64>(st.st_size));
+                return false;
+            }
+            const u32 pattern_len = tokens[2].len;
             for (u32 i = 0; i < pattern_len; i++) route.pattern[i] = tokens[2].ptr[i];
             route.pattern[pattern_len] = '\0';
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -200,6 +200,7 @@ add_test(NAME test_sim COMMAND test_sim)
 set_tests_properties(test_sim PROPERTIES LABELS "integration;sim")
 
 add_executable(test_simulate_engine test_simulate_engine.cc)
+add_dependencies(test_simulate_engine rut-simulate)
 target_link_libraries(test_simulate_engine rue_simulate)
 target_include_directories(test_simulate_engine PRIVATE
     ${PROJECT_SOURCE_DIR}/include
@@ -232,6 +233,6 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_traffic_replay>
     COMMAND $<TARGET_FILE:test_sim>
     COMMAND $<TARGET_FILE:test_simulate_engine>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim test_simulate_engine
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine
     COMMENT "Running all tests..."
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -207,6 +207,9 @@ target_include_directories(test_simulate_engine PRIVATE
     ${LLVM_INCLUDE_DIRS}
 )
 target_compile_definitions(test_simulate_engine PRIVATE ${LLVM_DEFINITIONS})
+target_compile_definitions(test_simulate_engine PRIVATE
+    RUT_SIMULATE_BIN_PATH="$<TARGET_FILE:rut-simulate>"
+)
 add_test(NAME test_simulate_engine COMMAND test_simulate_engine)
 set_tests_properties(test_simulate_engine PROPERTIES LABELS "unit;sim;jit")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -199,6 +199,17 @@ target_include_directories(test_sim PRIVATE
 add_test(NAME test_sim COMMAND test_sim)
 set_tests_properties(test_sim PROPERTIES LABELS "integration;sim")
 
+add_executable(test_simulate_engine test_simulate_engine.cc)
+target_link_libraries(test_simulate_engine rue_simulate)
+target_include_directories(test_simulate_engine PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+    ${LLVM_INCLUDE_DIRS}
+)
+target_compile_definitions(test_simulate_engine PRIVATE ${LLVM_DEFINITIONS})
+add_test(NAME test_simulate_engine COMMAND test_simulate_engine)
+set_tests_properties(test_simulate_engine PROPERTIES LABELS "unit;sim;jit")
+
 add_custom_target(check
     COMMAND $<TARGET_FILE:test_network>
     COMMAND $<TARGET_FILE:test_integration>
@@ -217,6 +228,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_traffic_capture>
     COMMAND $<TARGET_FILE:test_traffic_replay>
     COMMAND $<TARGET_FILE:test_sim>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim
+    COMMAND $<TARGET_FILE:test_simulate_engine>
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim test_simulate_engine
     COMMENT "Running all tests..."
 )

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2060,7 +2060,7 @@ TEST(route, capture_real_socket) {
     REQUIRE(loop->init(0, lfd).has_value());
     loop->config_ptr = &active;
     loop->set_capture(&ring);
-    LoopThread lt = {loop, {}, 20};
+    LoopThread lt = {loop, {}, 200};
     lt.start();
 
     i32 c = connect_to(port);
@@ -2071,11 +2071,10 @@ TEST(route, capture_real_socket) {
     CHECK_GT(n, 0);
     close(c);
 
-    lt.stop();
-    // Small delay for request completion
-    usleep(5000);
+    for (i32 i = 0; i < 200 && ring.available() == 0; i++) usleep(1000);
     CHECK_EQ(ring.available(), 1u);
 
+    lt.stop();
     loop->shutdown();
     close(lfd);
     destroy_real_loop(loop);

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -45,7 +45,8 @@ TEST(simulate_engine, load_manifest_file) {
         "upstream 7 api-v1\n"
         "route GET /health status 204\n"
         "route ANY /api proxy 7\n";
-    REQUIRE(write(fd, kManifest, sizeof(kManifest) - 1) == static_cast<ssize_t>(sizeof(kManifest) - 1));
+    REQUIRE(write(fd, kManifest, sizeof(kManifest) - 1) ==
+            static_cast<ssize_t>(sizeof(kManifest) - 1));
     close(fd);
 
     Manifest manifest;
@@ -71,7 +72,8 @@ TEST(simulate_engine, static_status_match) {
     Engine engine;
     REQUIRE(init_engine(manifest, ctx, engine));
 
-    const auto result = simulate_one(engine, make_entry("GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    const auto result =
+        simulate_one(engine, make_entry("GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 204));
     CHECK_EQ(result.verdict, Verdict::Match);
     CHECK_EQ(result.actual_status, 204u);
 
@@ -94,8 +96,8 @@ TEST(simulate_engine, proxy_upstream_match) {
     Engine engine;
     REQUIRE(init_engine(manifest, ctx, engine));
 
-    const auto result =
-        simulate_one(engine, make_entry("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 502, "api-v1"));
+    const auto result = simulate_one(
+        engine, make_entry("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 502, "api-v1"));
     CHECK_EQ(result.verdict, Verdict::Match);
     CHECK_EQ(result.action, jit::HandlerAction::Proxy);
 
@@ -111,7 +113,8 @@ TEST(simulate_engine, default_200_when_no_route_matches) {
     Engine engine;
     REQUIRE(engine.init(ctx.module, manifest.upstreams, manifest.upstream_count));
 
-    const auto result = simulate_one(engine, make_entry("GET /miss HTTP/1.1\r\nHost: x\r\n\r\n", 200));
+    const auto result =
+        simulate_one(engine, make_entry("GET /miss HTTP/1.1\r\nHost: x\r\n\r\n", 200));
     CHECK_EQ(result.verdict, Verdict::Match);
     CHECK_EQ(result.actual_status, 200u);
 
@@ -166,10 +169,10 @@ TEST(simulate_engine, summary_counts_mismatch) {
     hdr.entry_count = 3;
     REQUIRE(write(fd, &hdr, sizeof(hdr)) == static_cast<ssize_t>(sizeof(hdr)));
     REQUIRE(capture_write_entry(fd, make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200)) == 0);
-    REQUIRE(capture_write_entry(fd,
-                                make_entry("GET /api/x HTTP/1.1\r\nHost: x\r\n\r\n", 503, "edge")) == 0);
-    REQUIRE(capture_write_entry(fd,
-                                make_entry("GET /api/y HTTP/1.1\r\nHost: x\r\n\r\n", 503, "wrong")) == 0);
+    REQUIRE(capture_write_entry(
+                fd, make_entry("GET /api/x HTTP/1.1\r\nHost: x\r\n\r\n", 503, "edge")) == 0);
+    REQUIRE(capture_write_entry(
+                fd, make_entry("GET /api/y HTTP/1.1\r\nHost: x\r\n\r\n", 503, "wrong")) == 0);
     close(fd);
 
     ReplayReader reader;

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -75,6 +75,23 @@ TEST(simulate_engine, load_manifest_file) {
     unlink(path);
 }
 
+TEST(simulate_engine, load_manifest_accepts_whitespace_comments_and_forward_refs) {
+    static const char kManifest[] =
+        "\n"
+        "   # comment before content\n"
+        "\troute GET /health status 204   \n"
+        "route ANY /api proxy 7   # trailing comment\n"
+        "   \n"
+        "upstream 7 api-v1\n";
+
+    Manifest manifest;
+    REQUIRE(load_manifest_text(kManifest, &manifest));
+    CHECK_EQ(manifest.upstream_count, 1u);
+    CHECK_EQ(manifest.route_count, 2u);
+    CHECK_EQ(manifest.routes[0].status_code, 204u);
+    CHECK_EQ(manifest.routes[1].upstream_id, 7u);
+}
+
 TEST(simulate_engine, static_status_match) {
     Manifest manifest{};
     manifest.route_count = 1;
@@ -232,6 +249,7 @@ TEST(simulate_engine, load_manifest_rejects_invalid_inputs) {
     static const Case kCases[] = {
         {"upstream x api-v1\n"},
         {"upstream 65536 api-v1\n"},
+        {"upstream 7 api-v1 extra\n"},
         {"route FETCH /x status 204\n"},
         {"route GET /x bounce 7\n"},
         {"route GET /x status 70000\n"},
@@ -239,6 +257,10 @@ TEST(simulate_engine, load_manifest_rejects_invalid_inputs) {
         {"route GET /x status 42949672960\n"},
         {"route GET /x proxy 42949672960\n"},
         {"route GET /x status\n"},
+        {"route GET /x status 204 extra\n"},
+        {"unknown thing here\n"},
+        {"upstream 7 api-v1\nupstream 7 api-v2\n"},
+        {"route GET /x proxy 7\n"},
     };
 
     for (const auto& tc : kCases) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -241,6 +241,26 @@ TEST(simulate_engine, load_manifest_rejects_too_long_pattern) {
     unlink(path);
 }
 
+TEST(simulate_engine, load_manifest_rejects_too_long_upstream_name) {
+    char name[64];
+    for (u32 i = 0; i + 1 < sizeof(name); i++) name[i] = 'a';
+    name[sizeof(name) - 1] = '\0';
+
+    char manifest_buf[128];
+    const i32 manifest_len = snprintf(manifest_buf, sizeof(manifest_buf), "upstream 7 %s\n", name);
+    REQUIRE(manifest_len > 0);
+
+    char path[] = "/tmp/rut_sim_manifest_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+    REQUIRE(write(fd, manifest_buf, static_cast<size_t>(manifest_len)) == manifest_len);
+    close(fd);
+
+    Manifest manifest;
+    CHECK(!load_manifest(path, manifest));
+    unlink(path);
+}
+
 TEST(simulate_engine, load_manifest_rejects_invalid_inputs) {
     struct Case {
         const char* text;
@@ -267,6 +287,18 @@ TEST(simulate_engine, load_manifest_rejects_invalid_inputs) {
         Manifest manifest;
         CHECK(!load_manifest_text(tc.text, &manifest));
     }
+}
+
+TEST(simulate_engine, load_manifest_rejects_too_large_file) {
+    char path[] = "/tmp/rut_sim_manifest_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+    REQUIRE(ftruncate(fd, static_cast<off_t>(1ULL << 32)) == 0);
+    close(fd);
+
+    Manifest manifest;
+    CHECK(!load_manifest(path, manifest));
+    unlink(path);
 }
 
 TEST(simulate_engine, param_route_matching_matrix) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -1,6 +1,7 @@
 #include "rut/sim/simulate_engine.h"
 #include "test.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -14,8 +15,10 @@ static CaptureEntry make_entry(const char* req, u16 status, const char* upstream
     CaptureEntry entry{};
     u32 len = 0;
     while (req[len]) len++;
-    __builtin_memcpy(entry.raw_headers, req, len);
-    entry.raw_header_len = static_cast<u16>(len);
+    const u32 bounded_len =
+        len > CaptureEntry::kMaxHeaderLen ? static_cast<u32>(CaptureEntry::kMaxHeaderLen) : len;
+    __builtin_memcpy(entry.raw_headers, req, bounded_len);
+    entry.raw_header_len = static_cast<u16>(bounded_len);
     entry.resp_status = status;
     if (upstream) {
         u32 i = 0;
@@ -140,6 +143,73 @@ TEST(simulate_engine, param_prefix_route_matches) {
 
     engine.shutdown();
     ctx.destroy();
+}
+
+TEST(simulate_engine, param_route_rejects_empty_segment) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/users/:id");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 201;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    const auto result =
+        simulate_one(engine, make_entry("GET /users/ HTTP/1.1\r\nHost: x\r\n\r\n", 200));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 200u);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, make_entry_clamps_long_headers) {
+    char req[CaptureEntry::kMaxHeaderLen + 32];
+    for (u32 i = 0; i + 1 < sizeof(req); i++) req[i] = 'a';
+    req[sizeof(req) - 1] = '\0';
+
+    const auto entry = make_entry(req, 204);
+    CHECK_EQ(entry.raw_header_len, static_cast<u16>(CaptureEntry::kMaxHeaderLen));
+}
+
+TEST(simulate_engine, load_manifest_rejects_overflowing_u32) {
+    char path[] = "/tmp/rut_sim_manifest_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+
+    static const char kManifest[] = "upstream 42949672960 api-v1\n";
+    REQUIRE(write(fd, kManifest, sizeof(kManifest) - 1) ==
+            static_cast<ssize_t>(sizeof(kManifest) - 1));
+    close(fd);
+
+    Manifest manifest;
+    CHECK(!load_manifest(path, manifest));
+    unlink(path);
+}
+
+TEST(simulate_engine, load_manifest_rejects_too_long_pattern) {
+    char pattern[160];
+    pattern[0] = '/';
+    for (u32 i = 1; i + 1 < sizeof(pattern); i++) pattern[i] = 'a';
+    pattern[sizeof(pattern) - 1] = '\0';
+
+    char manifest_buf[256];
+    const i32 manifest_len =
+        snprintf(manifest_buf, sizeof(manifest_buf), "route GET %s status 204\n", pattern);
+    REQUIRE(manifest_len > 0);
+
+    char path[] = "/tmp/rut_sim_manifest_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+    REQUIRE(write(fd, manifest_buf, static_cast<size_t>(manifest_len)) == manifest_len);
+    close(fd);
+
+    Manifest manifest;
+    CHECK(!load_manifest(path, manifest));
+    unlink(path);
 }
 
 TEST(simulate_engine, summary_counts_mismatch) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -38,6 +38,14 @@ static bool init_engine(const Manifest& manifest, ModuleContext& ctx, Engine& en
     return engine.init(ctx.module, manifest.upstreams, manifest.upstream_count);
 }
 
+static Str arena_copy(MmapArena& arena, const char* src, u32 len) {
+    char* mem = arena.alloc_array<char>(len + 1);
+    if (!mem) __builtin_trap();
+    for (u32 i = 0; i < len; i++) mem[i] = src[i];
+    mem[len] = '\0';
+    return {mem, len};
+}
+
 static bool load_manifest_text(const char* text, Manifest* manifest) {
     char path[] = "/tmp/rut_sim_manifest_XXXXXX";
     const i32 fd = mkstemp(path);
@@ -465,6 +473,58 @@ TEST(simulate_engine, build_module_rejects_invalid_route_count_without_init) {
     CHECK_EQ(ctx.arena.current, nullptr);
     CHECK_EQ(ctx.module.arena, nullptr);
     CHECK_EQ(ctx.module.functions, nullptr);
+}
+
+TEST(simulate_engine, engine_init_accepts_codegen_truncated_handler_symbol_names) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/long-name");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 204;
+
+    ModuleContext ctx{};
+    REQUIRE(build_module_from_manifest(manifest, ctx));
+
+    char long_name[248];
+    for (u32 i = 0; i < 247; i++) long_name[i] = 'a';
+    long_name[247] = '\0';
+    ctx.module.functions[0].name = arena_copy(ctx.arena, long_name, 247);
+
+    Engine engine;
+    REQUIRE(engine.init(ctx.module, manifest.upstreams, manifest.upstream_count));
+
+    const auto result =
+        simulate_one(engine, make_entry("GET /long-name HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Match);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, engine_init_rejects_overlong_compiled_route_patterns) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/ok");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 200;
+
+    ModuleContext ctx{};
+    REQUIRE(build_module_from_manifest(manifest, ctx));
+
+    char pattern[129];
+    pattern[0] = '/';
+    for (u32 i = 1; i < 128; i++) pattern[i] = 'p';
+    pattern[128] = '\0';
+    ctx.module.functions[0].route_pattern = arena_copy(ctx.arena, pattern, 128);
+
+    Engine engine;
+    CHECK(!engine.init(ctx.module, manifest.upstreams, manifest.upstream_count));
+    CHECK_EQ(engine.route_count, 0u);
+    CHECK_EQ(engine.upstream_count, 0u);
+
+    ctx.destroy();
 }
 
 TEST(simulate_engine, param_route_matching_matrix) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -1,9 +1,11 @@
 #include "rut/sim/simulate_engine.h"
 #include "test.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 using namespace rut;
@@ -46,6 +48,84 @@ static bool load_manifest_text(const char* text, Manifest* manifest) {
     close(fd);
     unlink(path);
     return ok;
+}
+
+static bool read_all_fd(i32 fd, char* buf, u32 cap, u32* out_len) {
+    u32 pos = 0;
+    while (pos + 1 < cap) {
+        const ssize_t n = read(fd, buf + pos, cap - 1 - pos);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        if (n == 0) break;
+        pos += static_cast<u32>(n);
+    }
+    buf[pos] = '\0';
+    *out_len = pos;
+    return true;
+}
+
+static bool run_simulate_cli(const char* arg1,
+                             const char* arg2,
+                             i32* exit_code,
+                             char* stdout_buf,
+                             u32 stdout_cap,
+                             char* stderr_buf,
+                             u32 stderr_cap) {
+    i32 out_pipe[2];
+    i32 err_pipe[2];
+    if (pipe(out_pipe) != 0) return false;
+    if (pipe(err_pipe) != 0) {
+        close(out_pipe[0]);
+        close(out_pipe[1]);
+        return false;
+    }
+
+    const pid_t pid = fork();
+    if (pid < 0) {
+        close(out_pipe[0]);
+        close(out_pipe[1]);
+        close(err_pipe[0]);
+        close(err_pipe[1]);
+        return false;
+    }
+
+    if (pid == 0) {
+        dup2(out_pipe[1], 1);
+        dup2(err_pipe[1], 2);
+        close(out_pipe[0]);
+        close(out_pipe[1]);
+        close(err_pipe[0]);
+        close(err_pipe[1]);
+        if (arg1 && arg2) {
+            execl(RUT_SIMULATE_BIN_PATH,
+                  RUT_SIMULATE_BIN_PATH,
+                  arg1,
+                  arg2,
+                  static_cast<char*>(nullptr));
+        } else {
+            execl(RUT_SIMULATE_BIN_PATH, RUT_SIMULATE_BIN_PATH, static_cast<char*>(nullptr));
+        }
+        _exit(127);
+    }
+
+    close(out_pipe[1]);
+    close(err_pipe[1]);
+
+    u32 stdout_len = 0;
+    u32 stderr_len = 0;
+    const bool stdout_ok = read_all_fd(out_pipe[0], stdout_buf, stdout_cap, &stdout_len);
+    const bool stderr_ok = read_all_fd(err_pipe[0], stderr_buf, stderr_cap, &stderr_len);
+    close(out_pipe[0]);
+    close(err_pipe[0]);
+
+    i32 status = 0;
+    if (waitpid(pid, &status, 0) < 0) return false;
+    if (!stdout_ok || !stderr_ok) return false;
+    if (!WIFEXITED(status)) return false;
+    *exit_code = WEXITSTATUS(status);
+    return true;
 }
 
 }  // namespace
@@ -451,6 +531,25 @@ TEST(simulate_engine, format_result_uses_mismatch_label) {
     REQUIRE(len > 0);
     CHECK(strstr(buf, "MISMATCH") != nullptr);
     CHECK(strstr(buf, "MISS ") == nullptr);
+}
+
+TEST(simulate_engine, cli_usage_mentions_param_prefix_matching) {
+    char stdout_buf[64];
+    char stderr_buf[512];
+    i32 exit_code = -1;
+
+    REQUIRE(run_simulate_cli(nullptr,
+                             nullptr,
+                             &exit_code,
+                             stdout_buf,
+                             sizeof(stdout_buf),
+                             stderr_buf,
+                             sizeof(stderr_buf)));
+    CHECK_EQ(exit_code, 2);
+    CHECK_EQ(stdout_buf[0], '\0');
+    CHECK(strstr(stderr_buf, "Usage: rut-simulate") != nullptr);
+    CHECK(strstr(stderr_buf, "prefix-matched") != nullptr);
+    CHECK(strstr(stderr_buf, "':param'") != nullptr);
 }
 
 int main(int argc, char** argv) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -437,6 +437,22 @@ TEST(simulate_engine, summary_counts_mismatch) {
     ctx.destroy();
 }
 
+TEST(simulate_engine, format_result_uses_mismatch_label) {
+    SimulateResult result{};
+    result.verdict = Verdict::Mismatch;
+    result.method = 'G';
+    strcpy(result.path, "/api");
+    result.action = jit::HandlerAction::ReturnStatus;
+    result.expected_status = 200;
+    result.actual_status = 503;
+
+    char buf[256];
+    const u32 len = format_result(result, buf, sizeof(buf));
+    REQUIRE(len > 0);
+    CHECK(strstr(buf, "MISMATCH") != nullptr);
+    CHECK(strstr(buf, "MISS ") == nullptr);
+}
+
 int main(int argc, char** argv) {
     return rut::test::run_all(argc, argv);
 }

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -128,6 +128,27 @@ static bool run_simulate_cli(const char* arg1,
     return true;
 }
 
+static bool write_capture_file(i32 fd,
+                               u64 declared_count,
+                               const CaptureEntry* entries,
+                               u32 entry_count,
+                               const CaptureEntry* partial_entry = nullptr,
+                               u32 partial_len = 0) {
+    CaptureFileHeader hdr;
+    capture_file_header_init(&hdr);
+    hdr.entry_count = declared_count;
+    if (write(fd, &hdr, sizeof(hdr)) != static_cast<ssize_t>(sizeof(hdr))) return false;
+    for (u32 i = 0; i < entry_count; i++) {
+        if (capture_write_entry(fd, entries[i]) != 0) return false;
+    }
+    if (partial_entry && partial_len > 0) {
+        if (partial_len > sizeof(CaptureEntry)) return false;
+        if (write(fd, partial_entry, partial_len) != static_cast<ssize_t>(partial_len))
+            return false;
+    }
+    return true;
+}
+
 }  // namespace
 
 TEST(simulate_engine, load_manifest_file) {
@@ -534,6 +555,16 @@ TEST(simulate_engine, summary_counts_mismatch) {
 }
 
 TEST(simulate_engine, simulate_file_counts_truncated_capture_as_failed) {
+    struct Case {
+        const char* name;
+        u64 declared_count;
+        u32 full_count;
+        u32 partial_len;
+        u32 expected_total;
+        u32 expected_matched;
+        u32 expected_failed;
+    };
+
     Manifest manifest{};
     manifest.route_count = 1;
     manifest.routes[0].method = 'G';
@@ -545,25 +576,39 @@ TEST(simulate_engine, simulate_file_counts_truncated_capture_as_failed) {
     Engine engine;
     REQUIRE(init_engine(manifest, ctx, engine));
 
-    char path[] = "/tmp/rut_sim_capture_XXXXXX";
-    i32 fd = mkstemp(path);
-    REQUIRE(fd >= 0);
-    CaptureFileHeader hdr;
-    capture_file_header_init(&hdr);
-    hdr.entry_count = 2;
-    REQUIRE(write(fd, &hdr, sizeof(hdr)) == static_cast<ssize_t>(sizeof(hdr)));
-    REQUIRE(capture_write_entry(fd, make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200)) == 0);
-    close(fd);
+    const CaptureEntry entries[] = {
+        make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+        make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+    };
+    static const Case kCases[] = {
+        {"header_only", 1, 0, 0, 1, 0, 1},
+        {"missing_second_entry", 2, 1, 0, 2, 1, 1},
+        {"partial_second_entry", 2, 1, sizeof(CaptureEntry) / 2, 2, 1, 1},
+    };
 
-    ReplayReader reader;
-    REQUIRE(reader.open(path) == 0);
-    const auto summary = simulate_file(engine, reader);
-    CHECK_EQ(summary.total, 2u);
-    CHECK_EQ(summary.matched, 1u);
-    CHECK_EQ(summary.failed, 1u);
-    CHECK_EQ(summary.mismatched, 0u);
-    reader.close();
-    unlink(path);
+    for (const auto& tc : kCases) {
+        char path[] = "/tmp/rut_sim_capture_XXXXXX";
+        i32 fd = mkstemp(path);
+        REQUIRE(fd >= 0);
+        REQUIRE(write_capture_file(fd,
+                                   tc.declared_count,
+                                   entries,
+                                   tc.full_count,
+                                   tc.partial_len ? &entries[1] : nullptr,
+                                   tc.partial_len));
+        close(fd);
+
+        ReplayReader reader;
+        REQUIRE(reader.open(path) == 0);
+        const auto summary = simulate_file(engine, reader);
+        CHECK_EQ(summary.total, tc.expected_total);
+        CHECK_EQ(summary.matched, tc.expected_matched);
+        CHECK_EQ(summary.failed, tc.expected_failed);
+        CHECK_EQ(summary.mismatched, 0u);
+        reader.close();
+        unlink(path);
+    }
+
     engine.shutdown();
     ctx.destroy();
 }
@@ -604,6 +649,15 @@ TEST(simulate_engine, cli_usage_mentions_param_prefix_matching) {
 }
 
 TEST(simulate_engine, cli_fails_on_truncated_capture) {
+    struct Case {
+        const char* name;
+        u64 declared_count;
+        u32 full_count;
+        u32 partial_len;
+        const char* total_line;
+        const char* failed_line;
+    };
+
     char manifest_path[] = "/tmp/rut_sim_manifest_XXXXXX";
     i32 manifest_fd = mkstemp(manifest_path);
     REQUIRE(manifest_fd >= 0);
@@ -612,34 +666,46 @@ TEST(simulate_engine, cli_fails_on_truncated_capture) {
             static_cast<ssize_t>(sizeof(kManifest) - 1));
     close(manifest_fd);
 
-    char capture_path[] = "/tmp/rut_sim_capture_XXXXXX";
-    i32 capture_fd = mkstemp(capture_path);
-    REQUIRE(capture_fd >= 0);
-    CaptureFileHeader hdr;
-    capture_file_header_init(&hdr);
-    hdr.entry_count = 2;
-    REQUIRE(write(capture_fd, &hdr, sizeof(hdr)) == static_cast<ssize_t>(sizeof(hdr)));
-    REQUIRE(capture_write_entry(capture_fd,
-                                make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200)) == 0);
-    close(capture_fd);
+    const CaptureEntry entries[] = {
+        make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+        make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+    };
+    static const Case kCases[] = {
+        {"header_only", 1, 0, 0, "Total: 1", "Failed: 1"},
+        {"partial_second_entry", 2, 1, sizeof(CaptureEntry) / 2, "Total: 2", "Failed: 1"},
+    };
 
-    char stdout_buf[512];
-    char stderr_buf[512];
-    i32 exit_code = -1;
-    REQUIRE(run_simulate_cli(manifest_path,
-                             capture_path,
-                             &exit_code,
-                             stdout_buf,
-                             sizeof(stdout_buf),
-                             stderr_buf,
-                             sizeof(stderr_buf)));
-    CHECK_EQ(exit_code, 1);
-    CHECK(strstr(stderr_buf, "Capture file is truncated or unreadable") != nullptr);
-    CHECK(strstr(stdout_buf, "Total: 2") != nullptr);
-    CHECK(strstr(stdout_buf, "Failed: 1") != nullptr);
+    for (const auto& tc : kCases) {
+        char capture_path[] = "/tmp/rut_sim_capture_XXXXXX";
+        i32 capture_fd = mkstemp(capture_path);
+        REQUIRE(capture_fd >= 0);
+        REQUIRE(write_capture_file(capture_fd,
+                                   tc.declared_count,
+                                   entries,
+                                   tc.full_count,
+                                   tc.partial_len ? &entries[1] : nullptr,
+                                   tc.partial_len));
+        close(capture_fd);
+
+        char stdout_buf[512];
+        char stderr_buf[512];
+        i32 exit_code = -1;
+        REQUIRE(run_simulate_cli(manifest_path,
+                                 capture_path,
+                                 &exit_code,
+                                 stdout_buf,
+                                 sizeof(stdout_buf),
+                                 stderr_buf,
+                                 sizeof(stderr_buf)));
+        CHECK_EQ(exit_code, 1);
+        CHECK(strstr(stderr_buf, "Capture file is truncated or unreadable") != nullptr);
+        CHECK(strstr(stdout_buf, tc.total_line) != nullptr);
+        CHECK(strstr(stdout_buf, tc.failed_line) != nullptr);
+
+        unlink(capture_path);
+    }
 
     unlink(manifest_path);
-    unlink(capture_path);
 }
 
 int main(int argc, char** argv) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -1,0 +1,191 @@
+#include "rut/sim/simulate_engine.h"
+#include "test.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+using namespace rut;
+using namespace rut::sim;
+
+namespace {
+
+static CaptureEntry make_entry(const char* req, u16 status, const char* upstream = nullptr) {
+    CaptureEntry entry{};
+    u32 len = 0;
+    while (req[len]) len++;
+    __builtin_memcpy(entry.raw_headers, req, len);
+    entry.raw_header_len = static_cast<u16>(len);
+    entry.resp_status = status;
+    if (upstream) {
+        u32 i = 0;
+        while (upstream[i] && i + 1 < sizeof(entry.upstream_name)) {
+            entry.upstream_name[i] = upstream[i];
+            i++;
+        }
+        entry.upstream_name[i] = '\0';
+    }
+    return entry;
+}
+
+static bool init_engine(const Manifest& manifest, ModuleContext& ctx, Engine& engine) {
+    if (!build_module_from_manifest(manifest, ctx)) return false;
+    return engine.init(ctx.module, manifest.upstreams, manifest.upstream_count);
+}
+
+}  // namespace
+
+TEST(simulate_engine, load_manifest_file) {
+    char path[] = "/tmp/rut_sim_manifest_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+
+    static const char kManifest[] =
+        "# comment\n"
+        "upstream 7 api-v1\n"
+        "route GET /health status 204\n"
+        "route ANY /api proxy 7\n";
+    REQUIRE(write(fd, kManifest, sizeof(kManifest) - 1) == static_cast<ssize_t>(sizeof(kManifest) - 1));
+    close(fd);
+
+    Manifest manifest;
+    REQUIRE(load_manifest(path, manifest));
+    CHECK_EQ(manifest.upstream_count, 1u);
+    CHECK_EQ(manifest.route_count, 2u);
+    CHECK_EQ(manifest.upstreams[0].id, 7u);
+    CHECK_EQ(manifest.routes[0].status_code, 204u);
+    CHECK_EQ(manifest.routes[1].upstream_id, 7u);
+
+    unlink(path);
+}
+
+TEST(simulate_engine, static_status_match) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/health");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 204;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    const auto result = simulate_one(engine, make_entry("GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 204u);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, proxy_upstream_match) {
+    Manifest manifest{};
+    manifest.upstream_count = 1;
+    manifest.upstreams[0].id = 7;
+    strcpy(manifest.upstreams[0].name, "api-v1");
+    manifest.route_count = 1;
+    manifest.routes[0].method = 0;
+    strcpy(manifest.routes[0].pattern, "/api");
+    manifest.routes[0].action = ManifestAction::Proxy;
+    manifest.routes[0].upstream_id = 7;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    const auto result =
+        simulate_one(engine, make_entry("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 502, "api-v1"));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.action, jit::HandlerAction::Proxy);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, default_200_when_no_route_matches) {
+    Manifest manifest{};
+
+    ModuleContext ctx;
+    REQUIRE(ctx.init(1));
+    Engine engine;
+    REQUIRE(engine.init(ctx.module, manifest.upstreams, manifest.upstream_count));
+
+    const auto result = simulate_one(engine, make_entry("GET /miss HTTP/1.1\r\nHost: x\r\n\r\n", 200));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 200u);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, param_prefix_route_matches) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/users/:id");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 201;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    const auto result =
+        simulate_one(engine, make_entry("GET /users/123/profile HTTP/1.1\r\nHost: x\r\n\r\n", 201));
+    CHECK_EQ(result.verdict, Verdict::Match);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, summary_counts_mismatch) {
+    Manifest manifest{};
+    manifest.upstream_count = 1;
+    manifest.upstreams[0].id = 9;
+    strcpy(manifest.upstreams[0].name, "edge");
+    manifest.route_count = 2;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/ok");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 200;
+    manifest.routes[1].method = 'G';
+    strcpy(manifest.routes[1].pattern, "/api");
+    manifest.routes[1].action = ManifestAction::Proxy;
+    manifest.routes[1].upstream_id = 9;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    char path[] = "/tmp/rut_sim_capture_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+    CaptureFileHeader hdr;
+    capture_file_header_init(&hdr);
+    hdr.entry_count = 3;
+    REQUIRE(write(fd, &hdr, sizeof(hdr)) == static_cast<ssize_t>(sizeof(hdr)));
+    REQUIRE(capture_write_entry(fd, make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200)) == 0);
+    REQUIRE(capture_write_entry(fd,
+                                make_entry("GET /api/x HTTP/1.1\r\nHost: x\r\n\r\n", 503, "edge")) == 0);
+    REQUIRE(capture_write_entry(fd,
+                                make_entry("GET /api/y HTTP/1.1\r\nHost: x\r\n\r\n", 503, "wrong")) == 0);
+    close(fd);
+
+    ReplayReader reader;
+    REQUIRE(reader.open(path) == 0);
+    const auto summary = simulate_file(engine, reader);
+    CHECK_EQ(summary.total, 3u);
+    CHECK_EQ(summary.matched, 2u);
+    CHECK_EQ(summary.mismatched, 1u);
+    CHECK_EQ(summary.failed, 0u);
+
+    reader.close();
+    unlink(path);
+    engine.shutdown();
+    ctx.destroy();
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -388,7 +388,23 @@ TEST(simulate_engine, load_manifest_rejects_too_large_file) {
     char path[] = "/tmp/rut_sim_manifest_XXXXXX";
     i32 fd = mkstemp(path);
     REQUIRE(fd >= 0);
-    REQUIRE(ftruncate(fd, static_cast<off_t>(1ULL << 32)) == 0);
+    const i32 rc = ftruncate(fd, static_cast<off_t>(1ULL << 32));
+    if (rc != 0) {
+        const i32 truncate_errno = errno;
+        close(fd);
+        unlink(path);
+        if (truncate_errno == ENOSPC
+#ifdef EDQUOT
+            || truncate_errno == EDQUOT
+#endif
+#ifdef EFBIG
+            || truncate_errno == EFBIG
+#endif
+        ) {
+            return;
+        }
+        REQUIRE(rc == 0);
+    }
     close(fd);
 
     Manifest manifest;
@@ -517,6 +533,41 @@ TEST(simulate_engine, summary_counts_mismatch) {
     ctx.destroy();
 }
 
+TEST(simulate_engine, simulate_file_counts_truncated_capture_as_failed) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/ok");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 200;
+
+    ModuleContext ctx{};
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    char path[] = "/tmp/rut_sim_capture_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+    CaptureFileHeader hdr;
+    capture_file_header_init(&hdr);
+    hdr.entry_count = 2;
+    REQUIRE(write(fd, &hdr, sizeof(hdr)) == static_cast<ssize_t>(sizeof(hdr)));
+    REQUIRE(capture_write_entry(fd, make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200)) == 0);
+    close(fd);
+
+    ReplayReader reader;
+    REQUIRE(reader.open(path) == 0);
+    const auto summary = simulate_file(engine, reader);
+    CHECK_EQ(summary.total, 2u);
+    CHECK_EQ(summary.matched, 1u);
+    CHECK_EQ(summary.failed, 1u);
+    CHECK_EQ(summary.mismatched, 0u);
+    reader.close();
+    unlink(path);
+    engine.shutdown();
+    ctx.destroy();
+}
+
 TEST(simulate_engine, format_result_uses_mismatch_label) {
     SimulateResult result{};
     result.verdict = Verdict::Mismatch;
@@ -550,6 +601,45 @@ TEST(simulate_engine, cli_usage_mentions_param_prefix_matching) {
     CHECK(strstr(stderr_buf, "Usage: rut-simulate") != nullptr);
     CHECK(strstr(stderr_buf, "prefix-matched") != nullptr);
     CHECK(strstr(stderr_buf, "':param'") != nullptr);
+}
+
+TEST(simulate_engine, cli_fails_on_truncated_capture) {
+    char manifest_path[] = "/tmp/rut_sim_manifest_XXXXXX";
+    i32 manifest_fd = mkstemp(manifest_path);
+    REQUIRE(manifest_fd >= 0);
+    static const char kManifest[] = "route GET /ok status 200\n";
+    REQUIRE(write(manifest_fd, kManifest, sizeof(kManifest) - 1) ==
+            static_cast<ssize_t>(sizeof(kManifest) - 1));
+    close(manifest_fd);
+
+    char capture_path[] = "/tmp/rut_sim_capture_XXXXXX";
+    i32 capture_fd = mkstemp(capture_path);
+    REQUIRE(capture_fd >= 0);
+    CaptureFileHeader hdr;
+    capture_file_header_init(&hdr);
+    hdr.entry_count = 2;
+    REQUIRE(write(capture_fd, &hdr, sizeof(hdr)) == static_cast<ssize_t>(sizeof(hdr)));
+    REQUIRE(capture_write_entry(capture_fd,
+                                make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200)) == 0);
+    close(capture_fd);
+
+    char stdout_buf[512];
+    char stderr_buf[512];
+    i32 exit_code = -1;
+    REQUIRE(run_simulate_cli(manifest_path,
+                             capture_path,
+                             &exit_code,
+                             stdout_buf,
+                             sizeof(stdout_buf),
+                             stderr_buf,
+                             sizeof(stderr_buf)));
+    CHECK_EQ(exit_code, 1);
+    CHECK(strstr(stderr_buf, "Capture file is truncated or unreadable") != nullptr);
+    CHECK(strstr(stdout_buf, "Total: 2") != nullptr);
+    CHECK(strstr(stdout_buf, "Failed: 1") != nullptr);
+
+    unlink(manifest_path);
+    unlink(capture_path);
 }
 
 int main(int argc, char** argv) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -36,6 +36,18 @@ static bool init_engine(const Manifest& manifest, ModuleContext& ctx, Engine& en
     return engine.init(ctx.module, manifest.upstreams, manifest.upstream_count);
 }
 
+static bool load_manifest_text(const char* text, Manifest* manifest) {
+    char path[] = "/tmp/rut_sim_manifest_XXXXXX";
+    const i32 fd = mkstemp(path);
+    if (fd < 0) return false;
+    const size_t len = strlen(text);
+    const bool ok =
+        write(fd, text, len) == static_cast<ssize_t>(len) && load_manifest(path, *manifest);
+    close(fd);
+    unlink(path);
+    return ok;
+}
+
 }  // namespace
 
 TEST(simulate_engine, load_manifest_file) {
@@ -210,6 +222,69 @@ TEST(simulate_engine, load_manifest_rejects_too_long_pattern) {
     Manifest manifest;
     CHECK(!load_manifest(path, manifest));
     unlink(path);
+}
+
+TEST(simulate_engine, load_manifest_rejects_invalid_inputs) {
+    struct Case {
+        const char* text;
+    };
+
+    static const Case kCases[] = {
+        {"upstream x api-v1\n"},
+        {"upstream 65536 api-v1\n"},
+        {"route FETCH /x status 204\n"},
+        {"route GET /x bounce 7\n"},
+        {"route GET /x status 70000\n"},
+        {"route GET /x proxy 65536\n"},
+        {"route GET /x status 42949672960\n"},
+        {"route GET /x proxy 42949672960\n"},
+        {"route GET /x status\n"},
+    };
+
+    for (const auto& tc : kCases) {
+        Manifest manifest;
+        CHECK(!load_manifest_text(tc.text, &manifest));
+    }
+}
+
+TEST(simulate_engine, param_route_matching_matrix) {
+    struct Case {
+        const char* req;
+        u16 expected_status;
+    };
+
+    Manifest manifest{};
+    manifest.route_count = 2;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/users/:id");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 201;
+    manifest.routes[1].method = 'G';
+    strcpy(manifest.routes[1].pattern, "/teams/:team/members/:member");
+    manifest.routes[1].action = ManifestAction::ReturnStatus;
+    manifest.routes[1].status_code = 202;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    static const Case kCases[] = {
+        {"GET /users/123 HTTP/1.1\r\nHost: x\r\n\r\n", 201},
+        {"GET /users/123?active=1 HTTP/1.1\r\nHost: x\r\n\r\n", 201},
+        {"GET /users/ HTTP/1.1\r\nHost: x\r\n\r\n", 200},
+        {"GET /users HTTP/1.1\r\nHost: x\r\n\r\n", 200},
+        {"GET /teams/alpha/members/bravo HTTP/1.1\r\nHost: x\r\n\r\n", 202},
+        {"GET /teams/alpha/members/ HTTP/1.1\r\nHost: x\r\n\r\n", 200},
+    };
+
+    for (const auto& tc : kCases) {
+        const auto result = simulate_one(engine, make_entry(tc.req, tc.expected_status));
+        CHECK_EQ(result.verdict, Verdict::Match);
+        CHECK_EQ(result.actual_status, tc.expected_status);
+    }
+
+    engine.shutdown();
+    ctx.destroy();
 }
 
 TEST(simulate_engine, summary_counts_mismatch) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -60,16 +60,31 @@ static bool load_manifest_text(const char* text, Manifest* manifest) {
 
 static bool read_all_fd(i32 fd, char* buf, u32 cap, u32* out_len) {
     u32 pos = 0;
-    while (pos + 1 < cap) {
-        const ssize_t n = read(fd, buf + pos, cap - 1 - pos);
+    char discard[256];
+    for (;;) {
+        char* dst = discard;
+        u32 to_read = sizeof(discard);
+        if (pos + 1 < cap) {
+            dst = buf + pos;
+            to_read = cap - 1 - pos;
+        }
+
+        const ssize_t n = read(fd, dst, to_read);
         if (n < 0) {
             if (errno == EINTR) continue;
             return false;
         }
         if (n == 0) break;
-        pos += static_cast<u32>(n);
+
+        if (pos + 1 < cap) {
+            const u32 kRemaining = cap - 1 - pos;
+            const u32 kStored = static_cast<u32>(n) > kRemaining ? kRemaining : static_cast<u32>(n);
+            pos += kStored;
+        }
     }
-    buf[pos] = '\0';
+    if (cap > 0) {
+        buf[pos < cap ? pos : cap - 1] = '\0';
+    }
     *out_len = pos;
     return true;
 }
@@ -304,6 +319,31 @@ TEST(simulate_engine, param_route_rejects_empty_segment) {
     ctx.destroy();
 }
 
+TEST(simulate_engine, colon_inside_segment_matches_literal_colon) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/v1:beta");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 201;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    const auto literal_match =
+        simulate_one(engine, make_entry("GET /v1:beta HTTP/1.1\r\nHost: x\r\n\r\n", 201));
+    CHECK_EQ(literal_match.verdict, Verdict::Match);
+    CHECK_EQ(literal_match.actual_status, 201u);
+
+    const auto literal_miss =
+        simulate_one(engine, make_entry("GET /v1x HTTP/1.1\r\nHost: x\r\n\r\n", 200));
+    CHECK_EQ(literal_miss.verdict, Verdict::Match);
+    CHECK_EQ(literal_miss.actual_status, 200u);
+
+    engine.shutdown();
+    ctx.destroy();
+}
 TEST(simulate_engine, make_entry_clamps_long_headers) {
     char req[CaptureEntry::kMaxHeaderLen + 32];
     for (u32 i = 0; i + 1 < sizeof(req); i++) req[i] = 'a';
@@ -504,6 +544,9 @@ TEST(simulate_engine, engine_init_accepts_codegen_truncated_handler_symbol_names
 
 TEST(simulate_engine, engine_init_rejects_overlong_compiled_route_patterns) {
     Manifest manifest{};
+    manifest.upstream_count = 1;
+    manifest.upstreams[0].id = 7;
+    strcpy(manifest.upstreams[0].name, "api-v1");
     manifest.route_count = 1;
     manifest.routes[0].method = 'G';
     strcpy(manifest.routes[0].pattern, "/ok");
@@ -520,6 +563,10 @@ TEST(simulate_engine, engine_init_rejects_overlong_compiled_route_patterns) {
     ctx.module.functions[0].route_pattern = arena_copy(ctx.arena, pattern, 128);
 
     Engine engine;
+    engine.route_count = 3;
+    engine.upstream_count = 2;
+    engine.upstreams[0].id = 99;
+    strcpy(engine.upstreams[0].name, "stale");
     CHECK(!engine.init(ctx.module, manifest.upstreams, manifest.upstream_count));
     CHECK_EQ(engine.route_count, 0u);
     CHECK_EQ(engine.upstream_count, 0u);
@@ -717,6 +764,26 @@ TEST(simulate_engine, format_result_yield_uses_placeholders) {
     REQUIRE(len > 0);
     CHECK(strstr(buf, "yield - -> -") != nullptr);
     CHECK(strstr(buf, "204 ->") == nullptr);
+}
+
+TEST(simulate_engine, read_all_fd_drains_bytes_beyond_output_buffer) {
+    i32 pipefd[2];
+    REQUIRE(pipe(pipefd) == 0);
+
+    char payload[512];
+    for (u32 i = 0; i < sizeof(payload); i++) payload[i] = 'a';
+    REQUIRE(write(pipefd[1], payload, sizeof(payload)) == static_cast<ssize_t>(sizeof(payload)));
+    close(pipefd[1]);
+
+    char buf[32];
+    u32 out_len = 0;
+    REQUIRE(read_all_fd(pipefd[0], buf, sizeof(buf), &out_len));
+    CHECK_EQ(out_len, static_cast<u32>(sizeof(buf) - 1));
+
+    char tail[8];
+    const ssize_t tail_n = read(pipefd[0], tail, sizeof(tail));
+    CHECK_EQ(tail_n, 0);
+    close(pipefd[0]);
 }
 
 TEST(simulate_engine, cli_usage_mentions_param_prefix_matching) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -289,6 +289,21 @@ TEST(simulate_engine, load_manifest_rejects_invalid_inputs) {
     }
 }
 
+TEST(simulate_engine, load_manifest_failure_clears_partial_state) {
+    Manifest manifest{};
+    manifest.route_count = 3;
+    manifest.upstream_count = 2;
+    manifest.routes[0].status_code = 503;
+    strcpy(manifest.upstreams[0].name, "stale");
+
+    CHECK(!load_manifest_text("upstream 7 api-v1\nroute GET /x proxy 9\n", &manifest));
+    CHECK_EQ(manifest.route_count, 0u);
+    CHECK_EQ(manifest.upstream_count, 0u);
+    CHECK_EQ(manifest.routes[0].status_code, 200u);
+    CHECK_EQ(manifest.routes[0].upstream_id, 0u);
+    CHECK_EQ(manifest.upstreams[0].name[0], '\0');
+}
+
 TEST(simulate_engine, load_manifest_rejects_too_large_file) {
     char path[] = "/tmp/rut_sim_manifest_XXXXXX";
     i32 fd = mkstemp(path);
@@ -299,6 +314,40 @@ TEST(simulate_engine, load_manifest_rejects_too_large_file) {
     Manifest manifest;
     CHECK(!load_manifest(path, manifest));
     unlink(path);
+}
+
+TEST(simulate_engine, module_context_destroy_resets_state) {
+    ModuleContext ctx{};
+    REQUIRE(ctx.init(2));
+    CHECK(ctx.arena.current != nullptr);
+    CHECK(ctx.module.arena == &ctx.arena);
+    CHECK(ctx.module.functions != nullptr);
+    CHECK(ctx.module.struct_defs != nullptr);
+
+    ctx.destroy();
+    CHECK_EQ(ctx.arena.current, nullptr);
+    CHECK_EQ(ctx.module.arena, nullptr);
+    CHECK_EQ(ctx.module.functions, nullptr);
+    CHECK_EQ(ctx.module.struct_defs, nullptr);
+    CHECK_EQ(ctx.module.func_count, 0u);
+    CHECK_EQ(ctx.module.func_cap, 0u);
+    CHECK_EQ(ctx.module.struct_count, 0u);
+    CHECK_EQ(ctx.module.struct_cap, 0u);
+
+    ctx.destroy();
+    CHECK_EQ(ctx.arena.current, nullptr);
+    CHECK_EQ(ctx.module.arena, nullptr);
+}
+
+TEST(simulate_engine, build_module_rejects_invalid_route_count_without_init) {
+    Manifest manifest{};
+    manifest.route_count = Manifest::kMaxRoutes + 1;
+
+    ModuleContext ctx{};
+    CHECK(!build_module_from_manifest(manifest, ctx));
+    CHECK_EQ(ctx.arena.current, nullptr);
+    CHECK_EQ(ctx.module.arena, nullptr);
+    CHECK_EQ(ctx.module.functions, nullptr);
 }
 
 TEST(simulate_engine, param_route_matching_matrix) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -629,6 +629,36 @@ TEST(simulate_engine, format_result_uses_mismatch_label) {
     CHECK(strstr(buf, "MISS ") == nullptr);
 }
 
+TEST(simulate_engine, format_result_failed_status_uses_placeholder) {
+    SimulateResult result{};
+    result.verdict = Verdict::Failed;
+    result.method = 'G';
+    strcpy(result.path, "/bad");
+    result.action = jit::HandlerAction::ReturnStatus;
+    result.expected_status = 502;
+
+    char buf[256];
+    const u32 len = format_result(result, buf, sizeof(buf));
+    REQUIRE(len > 0);
+    CHECK(strstr(buf, "502 -> -") != nullptr);
+}
+
+TEST(simulate_engine, format_result_yield_uses_placeholders) {
+    SimulateResult result{};
+    result.verdict = Verdict::Unsupported;
+    result.method = 'G';
+    strcpy(result.path, "/yield");
+    result.action = jit::HandlerAction::Yield;
+    strcpy(result.expected_upstream, "edge");
+    result.expected_status = 204;
+
+    char buf[256];
+    const u32 len = format_result(result, buf, sizeof(buf));
+    REQUIRE(len > 0);
+    CHECK(strstr(buf, "yield - -> -") != nullptr);
+    CHECK(strstr(buf, "204 ->") == nullptr);
+}
+
 TEST(simulate_engine, cli_usage_mentions_param_prefix_matching) {
     char stdout_buf[64];
     char stderr_buf[512];
@@ -706,6 +736,21 @@ TEST(simulate_engine, cli_fails_on_truncated_capture) {
     }
 
     unlink(manifest_path);
+}
+
+TEST(simulate_engine, format_summary_supports_u64_counters) {
+    SimulateSummary summary{};
+    summary.total = (1ULL << 32) + 7;
+    summary.matched = 3;
+    summary.mismatched = 2;
+    summary.failed = (1ULL << 32) + 1;
+    summary.unsupported = 4;
+
+    char buf[256];
+    const u32 len = format_summary(summary, buf, sizeof(buf));
+    REQUIRE(len > 0);
+    CHECK(strstr(buf, "Total: 4294967303") != nullptr);
+    CHECK(strstr(buf, "Failed: 4294967297") != nullptr);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## What changed
- add a standalone `rut-simulate` binary for offline traffic simulation without `eventloop`
- add a `rue_simulate` library that reuses Rut's parser, RIR, JIT, and capture reader
- add a simple manifest format for static/proxy route simulation and matching against capture files
- add focused tests for manifest loading, route dispatch, summary accounting, and end-to-end CLI wiring

## Why
`replay` exercises a much heavier execution path. This adds a lighter-weight validation tool that can compare captured traffic against routing/JIT decisions without starting shards or driving socket/event callbacks.

## Impact
- gives us a separate offline validation path for captured traffic
- keeps the implementation independent from `eventloop`
- scopes this PR to sync route decisions only (`status` and `proxy`), without expanding parser/yield behavior

## Root cause
We did not have a dedicated binary for offline simulation. The existing mechanisms were tied either to callback/event injection or to full runtime execution.

## Validation
- `./build-cov2/tests/test_simulate_engine`
- `./build-cov2/src/rut-simulate <manifest> <capture>` smoke test with matching static and proxy routes
