### PR TITLE
Upgrade test framework and add rut-simulate

### DIFF
--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -277,23 +277,29 @@ static void put_name(char* buf, u32 buf_size, u32* pos, const char* s) {
 }  // namespace
 
 bool ModuleContext::init(u32 func_cap, u32 struct_cap) {
+    destroy();
+
     if (!arena.init(4096)) return false;
-    module.name = {"simulate_manifest", 17};
-    module.arena = &arena;
-    module.functions = arena.alloc_array<rir::Function>(func_cap == 0 ? 1 : func_cap);
-    if (!module.functions) {
+
+    rir::Module next{};
+    next.name = {"simulate_manifest", 17};
+    next.arena = &arena;
+    next.func_cap = func_cap == 0 ? 1 : func_cap;
+    next.functions = arena.alloc_array<rir::Function>(next.func_cap);
+    if (!next.functions) {
         arena.destroy();
+        module = {};
         return false;
     }
-    module.func_count = 0;
-    module.func_cap = func_cap == 0 ? 1 : func_cap;
-    module.struct_defs = arena.alloc_array<rir::StructDef*>(struct_cap == 0 ? 1 : struct_cap);
-    if (!module.struct_defs) {
+    next.struct_cap = struct_cap == 0 ? 1 : struct_cap;
+    next.struct_defs = arena.alloc_array<rir::StructDef*>(next.struct_cap);
+    if (!next.struct_defs) {
         arena.destroy();
+        module = {};
         return false;
     }
-    module.struct_count = 0;
-    module.struct_cap = struct_cap == 0 ? 1 : struct_cap;
+
+    module = next;
     return true;
 }
 
@@ -510,44 +516,34 @@ bool Engine::init(const rir::Module& module,
                   const ManifestUpstream* upstream_list,
                   u32 upstreams_len) {
     if (upstreams_len > kMaxUpstreams || module.func_count > kMaxRoutes) return false;
-    route_count = 0;
-    upstream_count = upstreams_len;
-    for (u32 i = 0; i < upstreams_len; i++) upstreams[i] = upstream_list[i];
+
+    auto fail = [this]() {
+        shutdown();
+        return false;
+    };
 
     if (!jit.init()) return false;
     auto cg = jit::codegen(module);
-    if (!cg.ok) {
-        jit.shutdown();
-        return false;
-    }
-    if (!jit.compile(cg.mod, cg.ctx)) {
-        jit.shutdown();
-        return false;
-    }
+    if (!cg.ok) return fail();
+    if (!jit.compile(cg.mod, cg.ctx)) return fail();
+
+    CompiledRoute next_routes[kMaxRoutes]{};
+    ManifestUpstream next_upstreams[kMaxUpstreams]{};
+    u32 next_route_count = 0;
+    for (u32 i = 0; i < upstreams_len; i++) next_upstreams[i] = upstream_list[i];
 
     for (u32 i = 0; i < module.func_count; i++) {
         const auto& fn = module.functions[i];
-        if (route_count >= kMaxRoutes) {
-            jit.shutdown();
-            return false;
-        }
+        if (next_route_count >= kMaxRoutes) return fail();
         char symbol[256];
         jit::format_handler_symbol(fn.name, symbol, sizeof(symbol));
 
         void* addr = jit.lookup(symbol);
-        if (!addr) {
-            jit.shutdown();
-            return false;
-        }
+        if (!addr) return fail();
 
-        if (fn.route_pattern.len >= sizeof(routes[0].pattern)) {
-            jit.shutdown();
-            route_count = 0;
-            upstream_count = 0;
-            return false;
-        }
+        if (fn.route_pattern.len >= sizeof(next_routes[0].pattern)) return fail();
 
-        auto& route = routes[route_count++];
+        auto& route = next_routes[next_route_count++];
         route.method = fn.http_method;
         route.pattern_len = fn.route_pattern.len;
         for (u32 j = 0; j < route.pattern_len; j++) route.pattern[j] = fn.route_pattern.ptr[j];
@@ -555,6 +551,10 @@ bool Engine::init(const rir::Module& module,
         route.fn = reinterpret_cast<jit::HandlerFn>(addr);
     }
 
+    for (u32 i = 0; i < next_route_count; i++) routes[i] = next_routes[i];
+    for (u32 i = 0; i < upstreams_len; i++) upstreams[i] = next_upstreams[i];
+    route_count = next_route_count;
+    upstream_count = upstreams_len;
     return true;
 }
 

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -517,8 +517,8 @@ bool build_module_from_manifest(const Manifest& manifest, ModuleContext& ctx) {
 bool Engine::init(const rir::Module& module,
                   const ManifestUpstream* upstream_list,
                   u32 upstreams_len) {
-    if (upstreams_len > kMaxUpstreams || module.func_count > kMaxRoutes) return false;
     shutdown();
+    if (upstreams_len > kMaxUpstreams || module.func_count > kMaxRoutes) return false;
 
     auto fail = [this]() {
         shutdown();

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -177,7 +177,9 @@ static bool route_matches(const Engine::CompiledRoute& route, const char* path, 
     u32 pi = 0;
     u32 ri = 0;
     while (ri < route.pattern_len) {
-        if (route.pattern[ri] == ':') {
+        const bool kParamSegment =
+            route.pattern[ri] == ':' && (ri == 0 || route.pattern[ri - 1] == '/');
+        if (kParamSegment) {
             ri++;
             while (ri < route.pattern_len && route.pattern[ri] != '/') ri++;
             const u32 param_start = pi;
@@ -516,6 +518,7 @@ bool Engine::init(const rir::Module& module,
                   const ManifestUpstream* upstream_list,
                   u32 upstreams_len) {
     if (upstreams_len > kMaxUpstreams || module.func_count > kMaxRoutes) return false;
+    shutdown();
 
     auto fail = [this]() {
         shutdown();

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -177,9 +177,7 @@ static bool route_matches(const Engine::CompiledRoute& route, const char* path, 
     u32 pi = 0;
     u32 ri = 0;
     while (ri < route.pattern_len) {
-        const bool kParamSegment =
-            route.pattern[ri] == ':' && (ri == 0 || route.pattern[ri - 1] == '/');
-        if (kParamSegment) {
+        if (route.pattern[ri] == ':') {
             ri++;
             while (ri < route.pattern_len && route.pattern[ri] != '/') ri++;
             const u32 param_start = pi;
@@ -512,35 +510,44 @@ bool Engine::init(const rir::Module& module,
                   const ManifestUpstream* upstream_list,
                   u32 upstreams_len) {
     if (upstreams_len > kMaxUpstreams || module.func_count > kMaxRoutes) return false;
-    shutdown();
-
-    const auto fail = [this]() {
-        shutdown();
-        return false;
-    };
+    route_count = 0;
+    upstream_count = upstreams_len;
+    for (u32 i = 0; i < upstreams_len; i++) upstreams[i] = upstream_list[i];
 
     if (!jit.init()) return false;
     auto cg = jit::codegen(module);
-    if (!cg.ok) return fail();
-    if (!jit.compile(cg.mod, cg.ctx)) return fail();
-
-    CompiledRoute next_routes[kMaxRoutes]{};
-    ManifestUpstream next_upstreams[kMaxUpstreams]{};
-    u32 next_route_count = 0;
-    for (u32 i = 0; i < upstreams_len; i++) next_upstreams[i] = upstream_list[i];
+    if (!cg.ok) {
+        jit.shutdown();
+        return false;
+    }
+    if (!jit.compile(cg.mod, cg.ctx)) {
+        jit.shutdown();
+        return false;
+    }
 
     for (u32 i = 0; i < module.func_count; i++) {
         const auto& fn = module.functions[i];
-        if (next_route_count >= kMaxRoutes) return fail();
+        if (route_count >= kMaxRoutes) {
+            jit.shutdown();
+            return false;
+        }
         char symbol[256];
         jit::format_handler_symbol(fn.name, symbol, sizeof(symbol));
 
         void* addr = jit.lookup(symbol);
-        if (!addr) return fail();
+        if (!addr) {
+            jit.shutdown();
+            return false;
+        }
 
-        if (fn.route_pattern.len >= sizeof(next_routes[0].pattern)) return fail();
+        if (fn.route_pattern.len >= sizeof(routes[0].pattern)) {
+            jit.shutdown();
+            route_count = 0;
+            upstream_count = 0;
+            return false;
+        }
 
-        auto& route = next_routes[next_route_count++];
+        auto& route = routes[route_count++];
         route.method = fn.http_method;
         route.pattern_len = fn.route_pattern.len;
         for (u32 j = 0; j < route.pattern_len; j++) route.pattern[j] = fn.route_pattern.ptr[j];
@@ -548,10 +555,6 @@ bool Engine::init(const rir::Module& module,
         route.fn = reinterpret_cast<jit::HandlerFn>(addr);
     }
 
-    for (u32 i = 0; i < next_route_count; i++) routes[i] = next_routes[i];
-    for (u32 i = 0; i < upstreams_len; i++) upstreams[i] = next_upstreams[i];
-    route_count = next_route_count;
-    upstream_count = upstreams_len;
     return true;
 }
 

--- a/testing/test.h
+++ b/testing/test.h
@@ -117,7 +117,6 @@ struct TestCase {
     const char* fail_expr;
     bool skipped;
     const char* skip_reason;
-    bool use_fixture;
 };
 
 inline TestCase* g_head = nullptr;
@@ -251,8 +250,7 @@ inline void register_test(TestCase* tc) {
                                                       0,                     \
                                                       nullptr,               \
                                                       false,                 \
-                                                      nullptr,               \
-                                                      false};                \
+                                                      nullptr};              \
     __attribute__((constructor)) static void reg_##suite##_##name() {        \
         rut::test::register_test(&tc_##suite##_##name);                      \
     }                                                                        \
@@ -271,8 +269,7 @@ inline void register_test(TestCase* tc) {
                                                       0,                             \
                                                       nullptr,                       \
                                                       false,                         \
-                                                      nullptr,                       \
-                                                      true};                         \
+                                                      nullptr};                      \
     __attribute__((constructor)) static void reg_##Suite##_##name() {                \
         rut::test::register_test(&tc_##Suite##_##name);                              \
     }                                                                                \

--- a/testing/test.h
+++ b/testing/test.h
@@ -303,7 +303,7 @@ struct Filter {
         suite_filter[idx] = nullptr;
         name_filter[idx] = nullptr;
 
-        if (suite && suite_len > 0) {
+        if (suite) {
             int copy_len = suite_len < (kMaxTokenLen - 1) ? suite_len : (kMaxTokenLen - 1);
             for (int i = 0; i < copy_len; i++) suite_storage[idx][i] = suite[i];
             suite_storage[idx][copy_len] = '\0';
@@ -312,7 +312,7 @@ struct Filter {
             suite_storage[idx][0] = '\0';
         }
 
-        if (name && name_len > 0) {
+        if (name) {
             int copy_len = name_len < (kMaxTokenLen - 1) ? name_len : (kMaxTokenLen - 1);
             for (int i = 0; i < copy_len; i++) name_storage[idx][i] = name[i];
             name_storage[idx][copy_len] = '\0';

--- a/testing/test.h
+++ b/testing/test.h
@@ -15,7 +15,7 @@
 //       CHECK_EQ(self.value, 1);
 //   }
 //
-//   class MyFixture {
+//   struct MyFixture {
 //       int value = 1;
 //       void SetUp() {}
 //       void TearDown() {}
@@ -292,9 +292,47 @@ inline void register_test(TestCase* tc) {
 
 struct Filter {
     static constexpr int kMaxFilters = 8;
+    static constexpr int kMaxTokenLen = 128;
     const char* suite_filter[kMaxFilters];
     const char* name_filter[kMaxFilters];
+    char suite_storage[kMaxFilters][kMaxTokenLen];
+    char name_storage[kMaxFilters][kMaxTokenLen];
     int filter_count;
+
+    void clear() {
+        filter_count = 0;
+        for (int i = 0; i < kMaxFilters; i++) {
+            suite_filter[i] = nullptr;
+            name_filter[i] = nullptr;
+            suite_storage[i][0] = '\0';
+            name_storage[i][0] = '\0';
+        }
+    }
+
+    void set_filter(int idx, const char* suite, int suite_len, const char* name, int name_len) {
+        if (idx < 0 || idx >= kMaxFilters) return;
+
+        suite_filter[idx] = nullptr;
+        name_filter[idx] = nullptr;
+
+        if (suite && suite_len > 0) {
+            int copy_len = suite_len < (kMaxTokenLen - 1) ? suite_len : (kMaxTokenLen - 1);
+            for (int i = 0; i < copy_len; i++) suite_storage[idx][i] = suite[i];
+            suite_storage[idx][copy_len] = '\0';
+            suite_filter[idx] = suite_storage[idx];
+        } else {
+            suite_storage[idx][0] = '\0';
+        }
+
+        if (name && name_len > 0) {
+            int copy_len = name_len < (kMaxTokenLen - 1) ? name_len : (kMaxTokenLen - 1);
+            for (int i = 0; i < copy_len; i++) name_storage[idx][i] = name[i];
+            name_storage[idx][copy_len] = '\0';
+            name_filter[idx] = name_storage[idx];
+        } else {
+            name_storage[idx][0] = '\0';
+        }
+    }
 
     bool token_match(const char* value, const char* token) const {
         if (!value || !token) return false;
@@ -314,7 +352,6 @@ struct Filter {
         if (len == 1) return true;
 
         if (token[0] == '*' && token[len - 1] == '*') {
-            // *abc*
             char core[128];
             int n = 0;
             for (int i = 1; i + 1 < len && n < 127; i++) core[n++] = token[i];
@@ -323,7 +360,6 @@ struct Filter {
         }
 
         if (token[0] == '*') {
-            // *abc
             int suffix_len = 0;
             while (token[1 + suffix_len]) suffix_len++;
             int vlen = 0;
@@ -336,12 +372,11 @@ struct Filter {
         }
 
         if (token[len - 1] == '*') {
-            // abc*
             for (int i = 0; i < len - 1; i++) {
                 if (token[i] != value[i]) return false;
                 if (value[i] == '\0') return false;
             }
-            return value[len - 1] != '\0';
+            return true;
         }
 
         return str_contains(value, token);
@@ -365,49 +400,30 @@ struct Filter {
 
 inline Filter parse_filter(const char* arg) {
     Filter filter;
-    filter.filter_count = 0;
+    filter.clear();
     if (!arg || !arg[0]) return filter;
 
-    // "a,b,c" as allow-list.
-    static char token_storage[Filter::kMaxFilters][128];
     int token_count = 0;
-
     int start = 0;
     for (int i = 0;; i++) {
         if (arg[i] == ',' || arg[i] == '\0') {
             if (token_count >= Filter::kMaxFilters) break;
 
-            int len = i - start;
-            if (len > 127) len = 127;
+            const int len = i - start;
             if (len > 0) {
-                for (int j = 0; j < len; j++) token_storage[token_count][j] = arg[start + j];
-                token_storage[token_count][len] = '\0';
-
                 int split = -1;
-                for (int k = 0; token_storage[token_count][k]; k++) {
-                    if (token_storage[token_count][k] == '.') {
+                for (int k = 0; k < len; k++) {
+                    if (arg[start + k] == '.') {
                         split = k;
                         break;
                     }
                 }
 
                 if (split >= 0) {
-                    static char suite_storage[Filter::kMaxFilters][128];
-                    static char name_storage[Filter::kMaxFilters][128];
-                    int si = 0;
-                    for (; si < split && si < 127; si++)
-                        suite_storage[token_count][si] = token_storage[token_count][si];
-                    suite_storage[token_count][si] = '\0';
-                    int ni = 0;
-                    for (int k = split + 1; token_storage[token_count][k] && ni < 127; k++) {
-                        name_storage[token_count][ni++] = token_storage[token_count][k];
-                    }
-                    name_storage[token_count][ni] = '\0';
-                    filter.suite_filter[token_count] = suite_storage[token_count];
-                    filter.name_filter[token_count] = name_storage[token_count];
+                    filter.set_filter(
+                        token_count, arg + start, split, arg + start + split + 1, len - split - 1);
                 } else {
-                    filter.suite_filter[token_count] = nullptr;
-                    filter.name_filter[token_count] = token_storage[token_count];
+                    filter.set_filter(token_count, nullptr, 0, arg + start, len);
                 }
 
                 filter.filter_count++;
@@ -422,23 +438,24 @@ inline Filter parse_filter(const char* arg) {
 }
 
 inline Filter merge_filter(const Filter& a, const Filter& b) {
-    Filter merged = a;
-    if (merged.filter_count == 0) {
-        return b;
-    }
-    if (b.filter_count == 0) {
-        return a;
-    }
+    Filter merged;
+    merged.clear();
 
-    for (int i = 0; i < b.filter_count && merged.filter_count < Filter::kMaxFilters; i++) {
-        merged.suite_filter[merged.filter_count] = b.suite_filter[i];
-        merged.name_filter[merged.filter_count] = b.name_filter[i];
-        merged.filter_count++;
+    for (int src = 0; src < 2; src++) {
+        const Filter& cur = src == 0 ? a : b;
+        for (int i = 0; i < cur.filter_count && merged.filter_count < Filter::kMaxFilters; i++) {
+            const char* sf = cur.suite_filter[i];
+            const char* nf = cur.name_filter[i];
+            int slen = 0;
+            int nlen = 0;
+            while (sf && sf[slen]) slen++;
+            while (nf && nf[nlen]) nlen++;
+            merged.set_filter(merged.filter_count, sf, slen, nf, nlen);
+            merged.filter_count++;
+        }
     }
     return merged;
 }
-
-// --- Runner ---
 
 inline int run_all(int argc = 0, char** argv = nullptr) {
     // Parse args

--- a/testing/test.h
+++ b/testing/test.h
@@ -11,6 +11,16 @@
 //       REQUIRE(ptr != nullptr);  // stops test on failure
 //   }
 //
+//   TEST_F(MyFixture, uses_state) {
+//       CHECK_EQ(self.value, 1);
+//   }
+//
+//   class MyFixture {
+//       int value = 1;
+//       void SetUp() {}
+//       void TearDown() {}
+//   };
+//
 //   int main(int argc, char** argv) { return rut::test::run_all(argc, argv); }
 //
 // Filtering:
@@ -18,6 +28,8 @@
 //   ./test_foo timer                 # run tests where suite or name contains "timer"
 //   ./test_foo timer.refresh         # run suite "timer", test "refresh"
 //   ./test_foo -l                    # list all tests without running
+//   ./test_foo --filter=timer,math.addition # allow-list filter
+//   ./test_foo --help                # show usage
 
 #include <unistd.h>  // write
 
@@ -52,6 +64,15 @@ inline void out_int(int v) {
     for (int i = n - 1; i >= 0; i--) (void)::write(1, &buf[i], 1);
 }
 
+inline bool str_starts_with(const char* s, const char* prefix) {
+    while (*prefix) {
+        if (*s == '\0' || *s != *prefix) return false;
+        s++;
+        prefix++;
+    }
+    return true;
+}
+
 // --- String helpers (no stdlib) ---
 
 inline bool str_eq(const char* a, const char* b) {
@@ -59,6 +80,12 @@ inline bool str_eq(const char* a, const char* b) {
         if (*a != *b) return false;
         if (*a == '\0') return true;
     }
+}
+
+inline bool str_eq_safe(const char* a, const char* b) {
+    if (a == b) return true;
+    if (!a || !b) return false;
+    return str_eq(a, b);
 }
 
 inline bool str_contains(const char* haystack, const char* needle) {
@@ -88,6 +115,9 @@ struct TestCase {
     const char* fail_file;
     int fail_line;
     const char* fail_expr;
+    bool skipped;
+    const char* skip_reason;
+    bool use_fixture;
 };
 
 inline TestCase* g_head = nullptr;
@@ -101,16 +131,30 @@ inline void register_test(TestCase* tc) {
 
 // --- Check macros ---
 
-#define CHECK(expr)                    \
-    do {                               \
-        if (expr) {                    \
-            _tc->checks_passed++;      \
-        } else {                       \
-            _tc->checks_failed++;      \
-            _tc->fail_file = __FILE__; \
-            _tc->fail_line = __LINE__; \
-            _tc->fail_expr = #expr;    \
-        }                              \
+#define RUT_TEST_REPORT_FAILURE(kind, expr_str) \
+    do {                                        \
+        _tc->checks_failed++;                   \
+        _tc->fail_file = __FILE__;              \
+        _tc->fail_line = __LINE__;              \
+        _tc->fail_expr = expr_str;              \
+        ::rut::test::out("    ");               \
+        ::rut::test::out(kind);                 \
+        ::rut::test::out(": ");                 \
+        ::rut::test::out(__FILE__);             \
+        ::rut::test::out(":");                  \
+        ::rut::test::out_int(__LINE__);         \
+        ::rut::test::out(" -> ");               \
+        ::rut::test::out(expr_str);             \
+        ::rut::test::out("\n");                 \
+    } while (0)
+
+#define CHECK(expr)                                  \
+    do {                                             \
+        if (expr) {                                  \
+            _tc->checks_passed++;                    \
+        } else {                                     \
+            RUT_TEST_REPORT_FAILURE("check", #expr); \
+        }                                            \
     } while (0)
 
 #define CHECK_EQ(a, b) CHECK((a) == (b))
@@ -119,70 +163,279 @@ inline void register_test(TestCase* tc) {
 #define CHECK_GE(a, b) CHECK((a) >= (b))
 #define CHECK_LT(a, b) CHECK((a) < (b))
 #define CHECK_LE(a, b) CHECK((a) <= (b))
+#define CHECK_TRUE(v) CHECK((v))
+#define CHECK_FALSE(v) CHECK(!(v))
+#define CHECK_STREQ(a, b) CHECK(::rut::test::str_eq_safe((a), (b)))
+#define CHECK_MSG(expr, msg)                       \
+    do {                                           \
+        if (expr) {                                \
+            _tc->checks_passed++;                  \
+        } else {                                   \
+            RUT_TEST_REPORT_FAILURE("check", msg); \
+        }                                          \
+    } while (0)
 
-#define REQUIRE(expr)                  \
-    do {                               \
-        if (expr) {                    \
-            _tc->checks_passed++;      \
-        } else {                       \
-            _tc->checks_failed++;      \
-            _tc->fail_file = __FILE__; \
-            _tc->fail_line = __LINE__; \
-            _tc->fail_expr = #expr;    \
-            return;                    \
-        }                              \
+#define REQUIRE(expr)                                  \
+    do {                                               \
+        if (expr) {                                    \
+            _tc->checks_passed++;                      \
+        } else {                                       \
+            RUT_TEST_REPORT_FAILURE("require", #expr); \
+            return;                                    \
+        }                                              \
     } while (0)
 
 #define REQUIRE_EQ(a, b) REQUIRE((a) == (b))
 #define REQUIRE_NE(a, b) REQUIRE((a) != (b))
+#define REQUIRE_LT(a, b) REQUIRE((a) < (b))
+#define REQUIRE_LE(a, b) REQUIRE((a) <= (b))
+#define REQUIRE_GT(a, b) REQUIRE((a) > (b))
+#define REQUIRE_GE(a, b) REQUIRE((a) >= (b))
+#define REQUIRE_TRUE(v) REQUIRE((v))
+#define REQUIRE_FALSE(v) REQUIRE(!(v))
+#define REQUIRE_STREQ(a, b) REQUIRE(::rut::test::str_eq_safe((a), (b)))
+#define REQUIRE_MSG(expr, msg)                       \
+    do {                                             \
+        if (expr) {                                  \
+            _tc->checks_passed++;                    \
+        } else {                                     \
+            RUT_TEST_REPORT_FAILURE("require", msg); \
+            return;                                  \
+        }                                            \
+    } while (0)
+
+#define EXPECT(expr) CHECK(expr)
+#define EXPECT_EQ(a, b) CHECK_EQ((a), (b))
+#define EXPECT_NE(a, b) CHECK_NE((a), (b))
+#define EXPECT_GT(a, b) CHECK_GT((a), (b))
+#define EXPECT_GE(a, b) CHECK_GE((a), (b))
+#define EXPECT_LT(a, b) CHECK_LT((a), (b))
+#define EXPECT_LE(a, b) CHECK_LE((a), (b))
+#define EXPECT_TRUE(v) CHECK_TRUE(v)
+#define EXPECT_FALSE(v) CHECK_FALSE(v)
+#define EXPECT_STREQ(a, b) CHECK_STREQ((a), (b))
+#define EXPECT_MSG(expr, msg) CHECK_MSG((expr), (msg))
+
+#define ASSERT(expr) REQUIRE(expr)
+#define ASSERT_EQ(a, b) REQUIRE_EQ((a), (b))
+#define ASSERT_NE(a, b) REQUIRE_NE((a), (b))
+#define ASSERT_GT(a, b) REQUIRE_GT((a), (b))
+#define ASSERT_GE(a, b) REQUIRE_GE((a), (b))
+#define ASSERT_LT(a, b) REQUIRE_LT((a), (b))
+#define ASSERT_LE(a, b) REQUIRE_LE((a), (b))
+#define ASSERT_TRUE(v) REQUIRE_TRUE(v)
+#define ASSERT_FALSE(v) REQUIRE_FALSE(v)
+#define ASSERT_STREQ(a, b) REQUIRE_STREQ((a), (b))
+#define ASSERT_MSG(expr, msg) REQUIRE_MSG((expr), (msg))
+
+#define FAIL(msg) REQUIRE_MSG(false, msg)
+
+#define SKIP(msg)                 \
+    do {                          \
+        _tc->skipped = true;      \
+        _tc->skip_reason = (msg); \
+        return;                   \
+    } while (0)
 
 // --- Test definition ---
 
-#define TEST(suite, name)                                                          \
-    static void test_##suite##_##name(rut::test::TestCase*);                       \
-    static rut::test::TestCase tc_##suite##_##name = {                             \
-        #suite, #name, test_##suite##_##name, nullptr, 0, 0, nullptr, 0, nullptr}; \
-    __attribute__((constructor)) static void reg_##suite##_##name() {              \
-        rut::test::register_test(&tc_##suite##_##name);                            \
-    }                                                                              \
+#define TEST(suite, name)                                                    \
+    static void test_##suite##_##name(rut::test::TestCase*);                 \
+    static rut::test::TestCase tc_##suite##_##name = {#suite,                \
+                                                      #name,                 \
+                                                      test_##suite##_##name, \
+                                                      nullptr,               \
+                                                      0,                     \
+                                                      0,                     \
+                                                      nullptr,               \
+                                                      0,                     \
+                                                      nullptr,               \
+                                                      false,                 \
+                                                      nullptr,               \
+                                                      false};                \
+    __attribute__((constructor)) static void reg_##suite##_##name() {        \
+        rut::test::register_test(&tc_##suite##_##name);                      \
+    }                                                                        \
     static void test_##suite##_##name([[maybe_unused]] rut::test::TestCase* _tc)
+
+#define TEST_F(Suite, name)                                                          \
+    static void test_##Suite##_##name##_impl(Suite& self, rut::test::TestCase* _tc); \
+    static void test_##Suite##_##name(rut::test::TestCase* _tc);                     \
+    static rut::test::TestCase tc_##Suite##_##name = {#Suite,                        \
+                                                      #name,                         \
+                                                      test_##Suite##_##name,         \
+                                                      nullptr,                       \
+                                                      0,                             \
+                                                      0,                             \
+                                                      nullptr,                       \
+                                                      0,                             \
+                                                      nullptr,                       \
+                                                      false,                         \
+                                                      nullptr,                       \
+                                                      true};                         \
+    __attribute__((constructor)) static void reg_##Suite##_##name() {                \
+        rut::test::register_test(&tc_##Suite##_##name);                              \
+    }                                                                                \
+    static void test_##Suite##_##name(rut::test::TestCase* _tc) {                    \
+        Suite self;                                                                  \
+        self.SetUp();                                                                \
+        if (!_tc->skipped) {                                                         \
+            test_##Suite##_##name##_impl(self, _tc);                                 \
+        }                                                                            \
+        self.TearDown();                                                             \
+    }                                                                                \
+    static void test_##Suite##_##name##_impl(Suite& self, [[maybe_unused]] rut::test::TestCase* _tc)
 
 // --- Filter matching ---
 // "timer"         → suite or name contains "timer"
 // "timer.refresh" → suite contains "timer" AND name contains "refresh"
 
 struct Filter {
-    const char* suite_filter;  // nullptr = match all
-    const char* name_filter;   // nullptr = match all
+    static constexpr int kMaxFilters = 8;
+    const char* suite_filter[kMaxFilters];
+    const char* name_filter[kMaxFilters];
+    int filter_count;
+
+    bool token_match(const char* value, const char* token) const {
+        if (!value || !token) return false;
+
+        bool has_star = false;
+        for (int i = 0; token[i]; i++) {
+            if (token[i] == '*') {
+                has_star = true;
+                break;
+            }
+        }
+        if (!has_star) return str_contains(value, token);
+
+        int len = 0;
+        while (token[len]) len++;
+
+        if (len == 1) return true;
+
+        if (token[0] == '*' && token[len - 1] == '*') {
+            // *abc*
+            char core[128];
+            int n = 0;
+            for (int i = 1; i + 1 < len && n < 127; i++) core[n++] = token[i];
+            core[n] = '\0';
+            return str_contains(value, core);
+        }
+
+        if (token[0] == '*') {
+            // *abc
+            int suffix_len = 0;
+            while (token[1 + suffix_len]) suffix_len++;
+            int vlen = 0;
+            while (value[vlen]) vlen++;
+            if (suffix_len > vlen) return false;
+            for (int i = 0; i < suffix_len; i++) {
+                if (token[1 + i] != value[vlen - suffix_len + i]) return false;
+            }
+            return true;
+        }
+
+        if (token[len - 1] == '*') {
+            // abc*
+            for (int i = 0; i < len - 1; i++) {
+                if (token[i] != value[i]) return false;
+                if (value[i] == '\0') return false;
+            }
+            return value[len - 1] != '\0';
+        }
+
+        return str_contains(value, token);
+    }
 
     bool matches(const TestCase* tc) const {
-        if (!suite_filter && !name_filter) return true;
-        if (suite_filter && name_filter) {
-            return str_contains(tc->suite, suite_filter) && str_contains(tc->name, name_filter);
+        if (filter_count == 0) return true;
+        for (int i = 0; i < filter_count; i++) {
+            const char* sf = suite_filter[i];
+            const char* nf = name_filter[i];
+            if (sf && nf) {
+                if (token_match(tc->suite, sf) && token_match(tc->name, nf)) return true;
+                continue;
+            }
+            const char* token = sf ? sf : nf;
+            if (token_match(tc->suite, token) || token_match(tc->name, token)) return true;
         }
-        const char* f = suite_filter ? suite_filter : name_filter;
-        return str_contains(tc->suite, f) || str_contains(tc->name, f);
+        return false;
     }
 };
 
 inline Filter parse_filter(const char* arg) {
-    // Find '.' separator
-    for (int i = 0; arg[i]; i++) {
-        if (arg[i] == '.') {
-            // Split: suite = arg[0..i-1], name = arg[i+1..]
-            // We need null-terminated strings, use static buffers
-            static char sbuf[128];
-            static char nbuf[128];
-            int j = 0;
-            for (; j < i && j < 127; j++) sbuf[j] = arg[j];
-            sbuf[j] = '\0';
-            j = 0;
-            for (int k = i + 1; arg[k] && j < 127; k++, j++) nbuf[j] = arg[k];
-            nbuf[j] = '\0';
-            return {sbuf, nbuf};
+    Filter filter;
+    filter.filter_count = 0;
+    if (!arg || !arg[0]) return filter;
+
+    // "a,b,c" as allow-list.
+    static char token_storage[Filter::kMaxFilters][128];
+    int token_count = 0;
+
+    int start = 0;
+    for (int i = 0;; i++) {
+        if (arg[i] == ',' || arg[i] == '\0') {
+            if (token_count >= Filter::kMaxFilters) break;
+
+            int len = i - start;
+            if (len > 127) len = 127;
+            if (len > 0) {
+                for (int j = 0; j < len; j++) token_storage[token_count][j] = arg[start + j];
+                token_storage[token_count][len] = '\0';
+
+                int split = -1;
+                for (int k = 0; token_storage[token_count][k]; k++) {
+                    if (token_storage[token_count][k] == '.') {
+                        split = k;
+                        break;
+                    }
+                }
+
+                if (split >= 0) {
+                    static char suite_storage[Filter::kMaxFilters][128];
+                    static char name_storage[Filter::kMaxFilters][128];
+                    int si = 0;
+                    for (; si < split && si < 127; si++)
+                        suite_storage[token_count][si] = token_storage[token_count][si];
+                    suite_storage[token_count][si] = '\0';
+                    int ni = 0;
+                    for (int k = split + 1; token_storage[token_count][k] && ni < 127; k++) {
+                        name_storage[token_count][ni++] = token_storage[token_count][k];
+                    }
+                    name_storage[token_count][ni] = '\0';
+                    filter.suite_filter[token_count] = suite_storage[token_count];
+                    filter.name_filter[token_count] = name_storage[token_count];
+                } else {
+                    filter.suite_filter[token_count] = nullptr;
+                    filter.name_filter[token_count] = token_storage[token_count];
+                }
+
+                filter.filter_count++;
+                token_count++;
+            }
+
+            if (arg[i] == '\0') break;
+            start = i + 1;
         }
     }
-    return {nullptr, arg};  // no dot: match against both suite and name
+    return filter;
+}
+
+inline Filter merge_filter(const Filter& a, const Filter& b) {
+    Filter merged = a;
+    if (merged.filter_count == 0) {
+        return b;
+    }
+    if (b.filter_count == 0) {
+        return a;
+    }
+
+    for (int i = 0; i < b.filter_count && merged.filter_count < Filter::kMaxFilters; i++) {
+        merged.suite_filter[merged.filter_count] = b.suite_filter[i];
+        merged.name_filter[merged.filter_count] = b.name_filter[i];
+        merged.filter_count++;
+    }
+    return merged;
 }
 
 // --- Runner ---
@@ -190,14 +443,31 @@ inline Filter parse_filter(const char* arg) {
 inline int run_all(int argc = 0, char** argv = nullptr) {
     // Parse args
     bool list_only = false;
-    Filter filter = {nullptr, nullptr};
+    bool ask_help = false;
+    Filter filter{};
 
     for (int i = 1; i < argc; i++) {
-        if (argv[i][0] == '-' && argv[i][1] == 'l') {
+        if (str_eq(argv[i], "-l") || str_eq(argv[i], "--list")) {
             list_only = true;
+        } else if (str_eq(argv[i], "--help") || str_eq(argv[i], "-h")) {
+            ask_help = true;
+        } else if (str_starts_with(argv[i], "--filter=")) {
+            filter = merge_filter(filter, parse_filter(argv[i] + 9));
         } else {
-            filter = parse_filter(argv[i]);
+            filter = merge_filter(filter, parse_filter(argv[i]));
         }
+    }
+
+    if (ask_help) {
+        out("Usage: ");
+        out(argv[0]);
+        out(" [options]\n");
+        out("  -h, --help           print this message\n");
+        out("  -l, --list           list matching tests and exit\n");
+        out("  --filter=<expr>      allow-list filter by suite/name or suite.name\n");
+        out("                       comma-separated, e.g. framework.aliases,math.*\n");
+        out("  <expr>               filter by suite/name or suite.name\n");
+        return 0;
     }
 
     // List mode
@@ -217,12 +487,22 @@ inline int run_all(int argc = 0, char** argv = nullptr) {
     int total_pass = 0;
     int total_fail = 0;
     int total_skip = 0;
+    int total_checks = 0;
+    int total_check_fail = 0;
     const char* prev_suite = nullptr;
 
     for (TestCase* tc = g_head; tc; tc = tc->next) {
         if (!filter.matches(tc)) {
             total_skip++;
             continue;
+        }
+
+        if (str_starts_with(tc->name, "DISABLED_")) {
+            tc->skipped = true;
+            tc->skip_reason = "disabled";
+        } else {
+            tc->skipped = false;
+            tc->skip_reason = nullptr;
         }
 
         // Suite header
@@ -236,10 +516,25 @@ inline int run_all(int argc = 0, char** argv = nullptr) {
         tc->checks_passed = 0;
         tc->checks_failed = 0;
         tc->fail_file = nullptr;
+        tc->fail_line = 0;
+        if (!str_starts_with(tc->name, "DISABLED_")) tc->skip_reason = nullptr;
 
-        tc->fn(tc);
+        if (!tc->skipped) tc->fn(tc);
+        total_checks += tc->checks_passed;
+        total_check_fail += tc->checks_failed;
+        total_checks += tc->checks_failed;
 
-        if (tc->checks_failed == 0) {
+        if (tc->skipped) {
+            out("  SKIP: ");
+            out(tc->name);
+            if (tc->skip_reason) {
+                out(" (");
+                out(tc->skip_reason);
+                out(")");
+            }
+            out("\n");
+            total_skip++;
+        } else if (tc->checks_failed == 0) {
             out("  PASS: ");
             out(tc->name);
             out("\n");
@@ -265,7 +560,11 @@ inline int run_all(int argc = 0, char** argv = nullptr) {
     out_int(total_pass);
     out(" passed, ");
     out_int(total_fail);
-    out(" failed");
+    out(" failed, ");
+    out_int(total_checks);
+    out(" checks, ");
+    out_int(total_check_fail);
+    out(" failed checks");
     if (total_skip > 0) {
         out(", ");
         out_int(total_skip);

--- a/testing/test.h
+++ b/testing/test.h
@@ -238,49 +238,31 @@ inline void register_test(TestCase* tc) {
 
 // --- Test definition ---
 
-#define TEST(suite, name)                                                    \
-    static void test_##suite##_##name(rut::test::TestCase*);                 \
-    static rut::test::TestCase tc_##suite##_##name = {#suite,                \
-                                                      #name,                 \
-                                                      test_##suite##_##name, \
-                                                      nullptr,               \
-                                                      0,                     \
-                                                      0,                     \
-                                                      nullptr,               \
-                                                      0,                     \
-                                                      nullptr,               \
-                                                      false,                 \
-                                                      nullptr};              \
-    __attribute__((constructor)) static void reg_##suite##_##name() {        \
-        rut::test::register_test(&tc_##suite##_##name);                      \
-    }                                                                        \
+#define TEST(suite, name)                                                                          \
+    static void test_##suite##_##name(rut::test::TestCase*);                                       \
+    static rut::test::TestCase tc_##suite##_##name = {                                             \
+        #suite, #name, test_##suite##_##name, nullptr, 0, 0, nullptr, 0, nullptr, false, nullptr}; \
+    __attribute__((constructor)) static void reg_##suite##_##name() {                              \
+        rut::test::register_test(&tc_##suite##_##name);                                            \
+    }                                                                                              \
     static void test_##suite##_##name([[maybe_unused]] rut::test::TestCase* _tc)
 
-#define TEST_F(Suite, name)                                                          \
-    static void test_##Suite##_##name##_impl(Suite& self, rut::test::TestCase* _tc); \
-    static void test_##Suite##_##name(rut::test::TestCase* _tc);                     \
-    static rut::test::TestCase tc_##Suite##_##name = {#Suite,                        \
-                                                      #name,                         \
-                                                      test_##Suite##_##name,         \
-                                                      nullptr,                       \
-                                                      0,                             \
-                                                      0,                             \
-                                                      nullptr,                       \
-                                                      0,                             \
-                                                      nullptr,                       \
-                                                      false,                         \
-                                                      nullptr};                      \
-    __attribute__((constructor)) static void reg_##Suite##_##name() {                \
-        rut::test::register_test(&tc_##Suite##_##name);                              \
-    }                                                                                \
-    static void test_##Suite##_##name(rut::test::TestCase* _tc) {                    \
-        Suite self;                                                                  \
-        self.SetUp();                                                                \
-        if (!_tc->skipped) {                                                         \
-            test_##Suite##_##name##_impl(self, _tc);                                 \
-        }                                                                            \
-        self.TearDown();                                                             \
-    }                                                                                \
+#define TEST_F(Suite, name)                                                                        \
+    static void test_##Suite##_##name##_impl(Suite& self, rut::test::TestCase* _tc);               \
+    static void test_##Suite##_##name(rut::test::TestCase* _tc);                                   \
+    static rut::test::TestCase tc_##Suite##_##name = {                                             \
+        #Suite, #name, test_##Suite##_##name, nullptr, 0, 0, nullptr, 0, nullptr, false, nullptr}; \
+    __attribute__((constructor)) static void reg_##Suite##_##name() {                              \
+        rut::test::register_test(&tc_##Suite##_##name);                                            \
+    }                                                                                              \
+    static void test_##Suite##_##name(rut::test::TestCase* _tc) {                                  \
+        Suite self;                                                                                \
+        self.SetUp();                                                                              \
+        if (!_tc->skipped) {                                                                       \
+            test_##Suite##_##name##_impl(self, _tc);                                               \
+        }                                                                                          \
+        self.TearDown();                                                                           \
+    }                                                                                              \
     static void test_##Suite##_##name##_impl(Suite& self, [[maybe_unused]] rut::test::TestCase* _tc)
 
 // --- Filter matching ---

--- a/testing/test.h
+++ b/testing/test.h
@@ -360,11 +360,13 @@ struct Filter {
 
         int first_star = -1;
         int last_star = -1;
+        int star_count = 0;
         int len = 0;
         for (int i = 0; token[i]; i++) {
             if (token[i] == '*') {
                 if (first_star < 0) first_star = i;
                 last_star = i;
+                star_count++;
             }
             len++;
         }
@@ -376,9 +378,11 @@ struct Filter {
         const bool kSuffixStar = last_star == len - 1;
         const bool kWrappedStar = kPrefixStar && kSuffixStar;
         if (!kPrefixStar && !kSuffixStar) return false;
-        if (kWrappedStar && first_star != 0) return false;
-        if (kPrefixStar && !kSuffixStar && first_star != last_star) return false;
-        if (!kPrefixStar && kSuffixStar && first_star != last_star) return false;
+        if (kWrappedStar) {
+            if (star_count != 2) return false;
+        } else if (star_count != 1) {
+            return false;
+        }
 
         if (token[0] == '*' && token[len - 1] == '*') {
             char core[128];

--- a/testing/test.h
+++ b/testing/test.h
@@ -358,19 +358,27 @@ struct Filter {
     bool token_match(const char* value, const char* token) const {
         if (!value || !token) return false;
 
-        bool has_star = false;
+        int first_star = -1;
+        int last_star = -1;
+        int len = 0;
         for (int i = 0; token[i]; i++) {
             if (token[i] == '*') {
-                has_star = true;
-                break;
+                if (first_star < 0) first_star = i;
+                last_star = i;
             }
+            len++;
         }
-        if (!has_star) return str_contains(value, token);
-
-        int len = 0;
-        while (token[len]) len++;
+        if (first_star < 0) return str_contains(value, token);
 
         if (len == 1) return true;
+
+        const bool kPrefixStar = first_star == 0;
+        const bool kSuffixStar = last_star == len - 1;
+        const bool kWrappedStar = kPrefixStar && kSuffixStar;
+        if (!kPrefixStar && !kSuffixStar) return false;
+        if (kWrappedStar && first_star != 0) return false;
+        if (kPrefixStar && !kSuffixStar && first_star != last_star) return false;
+        if (!kPrefixStar && kSuffixStar && first_star != last_star) return false;
 
         if (token[0] == '*' && token[len - 1] == '*') {
             char core[128];

--- a/testing/test.h
+++ b/testing/test.h
@@ -11,15 +11,15 @@
 //       REQUIRE(ptr != nullptr);  // stops test on failure
 //   }
 //
-//   TEST_F(MyFixture, uses_state) {
-//       CHECK_EQ(self.value, 1);
-//   }
-//
 //   struct MyFixture {
 //       int value = 1;
 //       void SetUp() {}
 //       void TearDown() {}
 //   };
+//
+//   TEST_F(MyFixture, uses_state) {
+//       CHECK_EQ(self.value, 1);
+//   }
 //
 //   int main(int argc, char** argv) { return rut::test::run_all(argc, argv); }
 //
@@ -299,6 +299,15 @@ struct Filter {
     char name_storage[kMaxFilters][kMaxTokenLen];
     int filter_count;
 
+    Filter() { clear(); }
+
+    Filter(const Filter& other) { copy_from(other); }
+
+    Filter& operator=(const Filter& other) {
+        if (this != &other) copy_from(other);
+        return *this;
+    }
+
     void clear() {
         filter_count = 0;
         for (int i = 0; i < kMaxFilters; i++) {
@@ -331,6 +340,18 @@ struct Filter {
             name_filter[idx] = name_storage[idx];
         } else {
             name_storage[idx][0] = '\0';
+        }
+    }
+
+    void copy_from(const Filter& other) {
+        filter_count = other.filter_count;
+        for (int i = 0; i < kMaxFilters; i++) {
+            for (int j = 0; j < kMaxTokenLen; j++) {
+                suite_storage[i][j] = other.suite_storage[i][j];
+                name_storage[i][j] = other.name_storage[i][j];
+            }
+            suite_filter[i] = other.suite_filter[i] ? suite_storage[i] : nullptr;
+            name_filter[i] = other.name_filter[i] ? name_storage[i] : nullptr;
         }
     }
 

--- a/tests/test_framework.cc
+++ b/tests/test_framework.cc
@@ -91,6 +91,24 @@ static rut::test::TestCase make_test_case(const char* suite, const char* name) {
     return {suite, name, nullptr, nullptr, 0, 0, nullptr, 0, nullptr, false, nullptr};
 }
 
+TEST(framework, dotted_filter_with_empty_name_preserves_suite_semantics) {
+    const auto filter = rut::test::parse_filter("framework.");
+    auto suite_match = make_test_case("framework", "aliases");
+    auto suite_miss = make_test_case("math", "framework");
+
+    CHECK(filter.matches(&suite_match));
+    CHECK(!filter.matches(&suite_miss));
+}
+
+TEST(framework, dotted_filter_with_empty_suite_preserves_name_semantics) {
+    const auto filter = rut::test::parse_filter(".aliases");
+    auto name_match = make_test_case("framework", "aliases");
+    auto name_miss = make_test_case("aliases", "other");
+
+    CHECK(filter.matches(&name_match));
+    CHECK(!filter.matches(&name_miss));
+}
+
 TEST(framework, merged_filters_keep_own_storage) {
     const auto merged = rut::test::merge_filter(
         rut::test::parse_filter("math.addition"),

--- a/tests/test_framework.cc
+++ b/tests/test_framework.cc
@@ -61,6 +61,16 @@ TEST(framework, wildcard_prefix_filter_matches_exact_prefix) {
     CHECK(!filter.token_match("ab", "abc*"));
 }
 
+TEST(framework, wildcard_suffix_and_wrapped_match_expected_shapes) {
+    rut::test::Filter filter{};
+    filter.clear();
+    CHECK(filter.token_match("alphabet", "*bet"));
+    CHECK(!filter.token_match("alpha", "*bet"));
+    CHECK(filter.token_match("alphabet", "*pha*"));
+    CHECK(filter.token_match("pha", "*pha*"));
+    CHECK(!filter.token_match("zzz", "*pha*"));
+}
+
 TEST(framework, wildcard_with_middle_star_is_rejected) {
     rut::test::Filter filter{};
     filter.clear();
@@ -73,6 +83,8 @@ TEST(framework, wildcard_with_extra_edge_stars_is_rejected) {
     filter.clear();
     CHECK(!filter.token_match("abc", "*abc**"));
     CHECK(!filter.token_match("abc", "**abc*"));
+    CHECK(!filter.token_match("abc", "***"));
+    CHECK(!filter.token_match("alphabet", "*pha**"));
 }
 
 static rut::test::TestCase make_test_case(const char* suite, const char* name) {
@@ -108,6 +120,21 @@ TEST(framework, copied_filter_rebinds_internal_storage) {
     auto miss = make_test_case("framework", "check_pass");
 
     CHECK_EQ(overwritten.filter_count, 1);
+    CHECK(copied.matches(&aliases));
+    CHECK(copied.matches(&multiplication));
+    CHECK(!copied.matches(&miss));
+}
+
+TEST(framework, copy_constructed_filter_rebinds_internal_storage) {
+    const auto parsed = rut::test::parse_filter("framework.aliases,*lication");
+    const rut::test::Filter copied(parsed);
+    const auto overwritten = rut::test::parse_filter("other.value,third.case");
+
+    auto aliases = make_test_case("framework", "aliases");
+    auto multiplication = make_test_case("math", "multiplication");
+    auto miss = make_test_case("framework", "check_pass");
+
+    CHECK_EQ(overwritten.filter_count, 2);
     CHECK(copied.matches(&aliases));
     CHECK(copied.matches(&multiplication));
     CHECK(!copied.matches(&miss));

--- a/tests/test_framework.cc
+++ b/tests/test_framework.cc
@@ -61,6 +61,13 @@ TEST(framework, wildcard_prefix_filter_matches_exact_prefix) {
     CHECK(!filter.token_match("ab", "abc*"));
 }
 
+TEST(framework, wildcard_with_middle_star_is_rejected) {
+    rut::test::Filter filter{};
+    filter.clear();
+    CHECK(!filter.token_match("abcd", "ab*cd"));
+    CHECK(!filter.token_match("abxcd", "ab*cd"));
+}
+
 static rut::test::TestCase make_test_case(const char* suite, const char* name) {
     return {suite, name, nullptr, nullptr, 0, 0, nullptr, 0, nullptr, false, nullptr, false};
 }

--- a/tests/test_framework.cc
+++ b/tests/test_framework.cc
@@ -24,6 +24,35 @@ TEST(framework, require_stops) {
     CHECK(true);
 }
 
+TEST(framework, aliases) {
+    EXPECT(1 + 1 == 2);
+    EXPECT_EQ(7 - 2, 5);
+    EXPECT_MSG(1u < 3u, "unsigned compare works");
+    ASSERT_TRUE(true);
+    ASSERT_NE(9, 4);
+}
+
+struct MyFixture {
+    int value = 1;
+    void SetUp() { value = 10; }
+    void TearDown() { value = 0; }
+};
+
+TEST_F(MyFixture, uses_state) {
+    CHECK_EQ(self.value, 10);
+    ASSERT_GT(self.value, 0);
+    EXPECT_STREQ("x", "x");
+}
+
+TEST(framework, explicit_skip) {
+    SKIP("feature unavailable in this environment");
+    CHECK(false);
+}
+
+TEST(framework, DISABLED_skip_by_name) {
+    CHECK(false);
+}
+
 TEST(math, addition) {
     CHECK_EQ(1 + 1, 2);
     CHECK_EQ(0 + 0, 0);

--- a/tests/test_framework.cc
+++ b/tests/test_framework.cc
@@ -88,7 +88,7 @@ TEST(framework, wildcard_with_extra_edge_stars_is_rejected) {
 }
 
 static rut::test::TestCase make_test_case(const char* suite, const char* name) {
-    return {suite, name, nullptr, nullptr, 0, 0, nullptr, 0, nullptr, false, nullptr, false};
+    return {suite, name, nullptr, nullptr, 0, 0, nullptr, 0, nullptr, false, nullptr};
 }
 
 TEST(framework, merged_filters_keep_own_storage) {

--- a/tests/test_framework.cc
+++ b/tests/test_framework.cc
@@ -68,6 +68,13 @@ TEST(framework, wildcard_with_middle_star_is_rejected) {
     CHECK(!filter.token_match("abxcd", "ab*cd"));
 }
 
+TEST(framework, wildcard_with_extra_edge_stars_is_rejected) {
+    rut::test::Filter filter{};
+    filter.clear();
+    CHECK(!filter.token_match("abc", "*abc**"));
+    CHECK(!filter.token_match("abc", "**abc*"));
+}
+
 static rut::test::TestCase make_test_case(const char* suite, const char* name) {
     return {suite, name, nullptr, nullptr, 0, 0, nullptr, 0, nullptr, false, nullptr, false};
 }

--- a/tests/test_framework.cc
+++ b/tests/test_framework.cc
@@ -84,6 +84,21 @@ TEST(framework, merged_filters_keep_own_storage) {
     CHECK(!merged.matches(&miss));
 }
 
+TEST(framework, copied_filter_rebinds_internal_storage) {
+    rut::test::Filter copied;
+    copied = rut::test::parse_filter("framework.aliases,math.mul*");
+    const auto overwritten = rut::test::parse_filter("other.value");
+
+    auto aliases = make_test_case("framework", "aliases");
+    auto multiplication = make_test_case("math", "multiplication");
+    auto miss = make_test_case("framework", "check_pass");
+
+    CHECK_EQ(overwritten.filter_count, 1);
+    CHECK(copied.matches(&aliases));
+    CHECK(copied.matches(&multiplication));
+    CHECK(!copied.matches(&miss));
+}
+
 TEST(math, addition) {
     CHECK_EQ(1 + 1, 2);
     CHECK_EQ(0 + 0, 0);

--- a/tests/test_framework.cc
+++ b/tests/test_framework.cc
@@ -53,6 +53,37 @@ TEST(framework, DISABLED_skip_by_name) {
     CHECK(false);
 }
 
+TEST(framework, wildcard_prefix_filter_matches_exact_prefix) {
+    rut::test::Filter filter{};
+    filter.clear();
+    CHECK(filter.token_match("abc", "abc*"));
+    CHECK(filter.token_match("abcd", "abc*"));
+    CHECK(!filter.token_match("ab", "abc*"));
+}
+
+static rut::test::TestCase make_test_case(const char* suite, const char* name) {
+    return {suite, name, nullptr, nullptr, 0, 0, nullptr, 0, nullptr, false, nullptr, false};
+}
+
+TEST(framework, merged_filters_keep_own_storage) {
+    const auto merged = rut::test::merge_filter(
+        rut::test::parse_filter("math.addition"),
+        rut::test::merge_filter(rut::test::parse_filter("framework.aliases"),
+                                rut::test::parse_filter("math.mul*")));
+    const auto overwritten = rut::test::parse_filter("other.value,another.case");
+
+    auto addition = make_test_case("math", "addition");
+    auto aliases = make_test_case("framework", "aliases");
+    auto multiplication = make_test_case("math", "multiplication");
+    auto miss = make_test_case("framework", "check_pass");
+
+    CHECK_EQ(overwritten.filter_count, 2);
+    CHECK(merged.matches(&addition));
+    CHECK(merged.matches(&aliases));
+    CHECK(merged.matches(&multiplication));
+    CHECK(!merged.matches(&miss));
+}
+
 TEST(math, addition) {
     CHECK_EQ(1 + 1, 2);
     CHECK_EQ(0 + 0, 0);

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -989,6 +989,20 @@ TEST(simulate_engine, read_all_fd_accepts_zero_capacity_buffer) {
     close(pipefd[0]);
 }
 
+TEST(simulate_engine, read_all_fd_preserves_terminator_for_exact_fit) {
+    i32 pipefd[2];
+    REQUIRE(pipe(pipefd) == 0);
+    REQUIRE(write(pipefd[1], "abcd", 4) == 4);
+    close(pipefd[1]);
+
+    char buf[5];
+    u32 out_len = 0;
+    REQUIRE(read_all_fd(pipefd[0], buf, sizeof(buf), &out_len));
+    CHECK_EQ(out_len, 4u);
+    CHECK_STREQ(buf, "abcd");
+    close(pipefd[0]);
+}
+
 TEST(simulate_engine, read_pipes_interleaved_fails_on_poll_error_event) {
     i32 out_pipe[2];
     i32 err_pipe[2];
@@ -1013,6 +1027,38 @@ TEST(simulate_engine, read_pipes_interleaved_fails_on_poll_error_event) {
 
     close(err_pipe[0]);
     close(err_pipe[1]);
+}
+
+TEST(simulate_engine, read_pipes_interleaved_collects_both_streams) {
+    i32 out_pipe[2];
+    i32 err_pipe[2];
+    REQUIRE(pipe(out_pipe) == 0);
+    REQUIRE(pipe(err_pipe) == 0);
+
+    REQUIRE(write(out_pipe[1], "stdout-data", 11) == 11);
+    REQUIRE(write(err_pipe[1], "stderr-data", 11) == 11);
+    close(out_pipe[1]);
+    close(err_pipe[1]);
+
+    char stdout_buf[32];
+    char stderr_buf[32];
+    u32 stdout_len = 0;
+    u32 stderr_len = 0;
+    REQUIRE(read_pipes_interleaved(out_pipe[0],
+                                   stdout_buf,
+                                   sizeof(stdout_buf),
+                                   &stdout_len,
+                                   err_pipe[0],
+                                   stderr_buf,
+                                   sizeof(stderr_buf),
+                                   &stderr_len));
+    CHECK_EQ(stdout_len, 11u);
+    CHECK_EQ(stderr_len, 11u);
+    CHECK_STREQ(stdout_buf, "stdout-data");
+    CHECK_STREQ(stderr_buf, "stderr-data");
+
+    close(out_pipe[0]);
+    close(err_pipe[0]);
 }
 
 TEST(simulate_engine, cli_usage_mentions_param_prefix_matching) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -464,6 +464,30 @@ TEST(simulate_engine, module_context_destroy_resets_state) {
     CHECK_EQ(ctx.module.arena, nullptr);
 }
 
+TEST(simulate_engine, module_context_init_clears_stale_state_before_reuse) {
+    ModuleContext ctx{};
+    ctx.module.name = {"stale", 5};
+    ctx.module.arena = reinterpret_cast<MmapArena*>(1);
+    ctx.module.functions = reinterpret_cast<rir::Function*>(1);
+    ctx.module.func_count = 99;
+    ctx.module.func_cap = 99;
+    ctx.module.struct_defs = reinterpret_cast<rir::StructDef**>(1);
+    ctx.module.struct_count = 88;
+    ctx.module.struct_cap = 88;
+
+    REQUIRE(ctx.init(2, 3));
+    CHECK_EQ(ctx.module.name.len, 17u);
+    CHECK(ctx.module.arena == &ctx.arena);
+    CHECK(ctx.module.functions != nullptr);
+    CHECK_EQ(ctx.module.func_count, 0u);
+    CHECK_EQ(ctx.module.func_cap, 2u);
+    CHECK(ctx.module.struct_defs != nullptr);
+    CHECK_EQ(ctx.module.struct_count, 0u);
+    CHECK_EQ(ctx.module.struct_cap, 3u);
+
+    ctx.destroy();
+}
+
 TEST(simulate_engine, build_module_rejects_invalid_route_count_without_init) {
     Manifest manifest{};
     manifest.route_count = Manifest::kMaxRoutes + 1;
@@ -520,6 +544,8 @@ TEST(simulate_engine, engine_init_rejects_overlong_compiled_route_patterns) {
     ctx.module.functions[0].route_pattern = arena_copy(ctx.arena, pattern, 128);
 
     Engine engine;
+    engine.route_count = 7;
+    engine.upstream_count = 5;
     CHECK(!engine.init(ctx.module, manifest.upstreams, manifest.upstream_count));
     CHECK_EQ(engine.route_count, 0u);
     CHECK_EQ(engine.upstream_count, 0u);

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -60,31 +60,16 @@ static bool load_manifest_text(const char* text, Manifest* manifest) {
 
 static bool read_all_fd(i32 fd, char* buf, u32 cap, u32* out_len) {
     u32 pos = 0;
-    char discard[256];
-    for (;;) {
-        char* dst = discard;
-        u32 to_read = sizeof(discard);
-        if (pos + 1 < cap) {
-            dst = buf + pos;
-            to_read = cap - 1 - pos;
-        }
-
-        const ssize_t n = read(fd, dst, to_read);
+    while (pos + 1 < cap) {
+        const ssize_t n = read(fd, buf + pos, cap - 1 - pos);
         if (n < 0) {
             if (errno == EINTR) continue;
             return false;
         }
         if (n == 0) break;
-
-        if (pos + 1 < cap) {
-            const u32 kRemaining = cap - 1 - pos;
-            const u32 kStored = static_cast<u32>(n) > kRemaining ? kRemaining : static_cast<u32>(n);
-            pos += kStored;
-        }
+        pos += static_cast<u32>(n);
     }
-    if (cap > 0) {
-        buf[pos < cap ? pos : cap - 1] = '\0';
-    }
+    buf[pos] = '\0';
     *out_len = pos;
     return true;
 }
@@ -319,31 +304,6 @@ TEST(simulate_engine, param_route_rejects_empty_segment) {
     ctx.destroy();
 }
 
-TEST(simulate_engine, colon_inside_segment_matches_literal_colon) {
-    Manifest manifest{};
-    manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
-    strcpy(manifest.routes[0].pattern, "/v1:beta");
-    manifest.routes[0].action = ManifestAction::ReturnStatus;
-    manifest.routes[0].status_code = 201;
-
-    ModuleContext ctx;
-    Engine engine;
-    REQUIRE(init_engine(manifest, ctx, engine));
-
-    const auto literal_match =
-        simulate_one(engine, make_entry("GET /v1:beta HTTP/1.1\r\nHost: x\r\n\r\n", 201));
-    CHECK_EQ(literal_match.verdict, Verdict::Match);
-    CHECK_EQ(literal_match.actual_status, 201u);
-
-    const auto literal_miss =
-        simulate_one(engine, make_entry("GET /v1x HTTP/1.1\r\nHost: x\r\n\r\n", 200));
-    CHECK_EQ(literal_miss.verdict, Verdict::Match);
-    CHECK_EQ(literal_miss.actual_status, 200u);
-
-    engine.shutdown();
-    ctx.destroy();
-}
 TEST(simulate_engine, make_entry_clamps_long_headers) {
     char req[CaptureEntry::kMaxHeaderLen + 32];
     for (u32 i = 0; i + 1 < sizeof(req); i++) req[i] = 'a';
@@ -544,9 +504,6 @@ TEST(simulate_engine, engine_init_accepts_codegen_truncated_handler_symbol_names
 
 TEST(simulate_engine, engine_init_rejects_overlong_compiled_route_patterns) {
     Manifest manifest{};
-    manifest.upstream_count = 1;
-    manifest.upstreams[0].id = 7;
-    strcpy(manifest.upstreams[0].name, "api-v1");
     manifest.route_count = 1;
     manifest.routes[0].method = 'G';
     strcpy(manifest.routes[0].pattern, "/ok");
@@ -563,10 +520,6 @@ TEST(simulate_engine, engine_init_rejects_overlong_compiled_route_patterns) {
     ctx.module.functions[0].route_pattern = arena_copy(ctx.arena, pattern, 128);
 
     Engine engine;
-    engine.route_count = 3;
-    engine.upstream_count = 2;
-    engine.upstreams[0].id = 99;
-    strcpy(engine.upstreams[0].name, "stale");
     CHECK(!engine.init(ctx.module, manifest.upstreams, manifest.upstream_count));
     CHECK_EQ(engine.route_count, 0u);
     CHECK_EQ(engine.upstream_count, 0u);
@@ -764,26 +717,6 @@ TEST(simulate_engine, format_result_yield_uses_placeholders) {
     REQUIRE(len > 0);
     CHECK(strstr(buf, "yield - -> -") != nullptr);
     CHECK(strstr(buf, "204 ->") == nullptr);
-}
-
-TEST(simulate_engine, read_all_fd_drains_bytes_beyond_output_buffer) {
-    i32 pipefd[2];
-    REQUIRE(pipe(pipefd) == 0);
-
-    char payload[512];
-    for (u32 i = 0; i < sizeof(payload); i++) payload[i] = 'a';
-    REQUIRE(write(pipefd[1], payload, sizeof(payload)) == static_cast<ssize_t>(sizeof(payload)));
-    close(pipefd[1]);
-
-    char buf[32];
-    u32 out_len = 0;
-    REQUIRE(read_all_fd(pipefd[0], buf, sizeof(buf), &out_len));
-    CHECK_EQ(out_len, static_cast<u32>(sizeof(buf) - 1));
-
-    char tail[8];
-    const ssize_t tail_n = read(pipefd[0], tail, sizeof(tail));
-    CHECK_EQ(tail_n, 0);
-    close(pipefd[0]);
 }
 
 TEST(simulate_engine, cli_usage_mentions_param_prefix_matching) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -2,6 +2,7 @@
 #include "test.h"
 
 #include <errno.h>
+#include <poll.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -59,18 +60,134 @@ static bool load_manifest_text(const char* text, Manifest* manifest) {
 }
 
 static bool read_all_fd(i32 fd, char* buf, u32 cap, u32* out_len) {
+    if (out_len) *out_len = 0;
+    if (cap == 0) {
+        char discard[256];
+        for (;;) {
+            const ssize_t n = read(fd, discard, sizeof(discard));
+            if (n < 0) {
+                if (errno == EINTR) continue;
+                return false;
+            }
+            if (n == 0) return true;
+        }
+    }
+
     u32 pos = 0;
-    while (pos + 1 < cap) {
-        const ssize_t n = read(fd, buf + pos, cap - 1 - pos);
+    char discard[256];
+    for (;;) {
+        char* dst = discard;
+        u32 to_read = sizeof(discard);
+        if (pos + 1 < cap) {
+            dst = buf + pos;
+            to_read = cap - 1 - pos;
+        }
+
+        const ssize_t n = read(fd, dst, to_read);
         if (n < 0) {
             if (errno == EINTR) continue;
             return false;
         }
         if (n == 0) break;
-        pos += static_cast<u32>(n);
+
+        if (pos + 1 < cap) {
+            const u32 remaining = cap - 1 - pos;
+            const u32 stored = static_cast<u32>(n) > remaining ? remaining : static_cast<u32>(n);
+            pos += stored;
+        }
     }
     buf[pos] = '\0';
-    *out_len = pos;
+    if (out_len) *out_len = pos;
+    return true;
+}
+
+static bool read_ready_fd(i32 fd, char* buf, u32 cap, u32* pos, bool* done) {
+    if (*done) return true;
+
+    char discard[256];
+    char* dst = discard;
+    u32 to_read = sizeof(discard);
+    if (*pos + 1 < cap) {
+        dst = buf + *pos;
+        to_read = cap - 1 - *pos;
+    }
+
+    const ssize_t n = read(fd, dst, to_read);
+    if (n < 0) {
+        if (errno == EINTR || errno == EAGAIN) return true;
+        return false;
+    }
+    if (n == 0) {
+        *done = true;
+        return true;
+    }
+
+    if (*pos + 1 < cap) {
+        const u32 remaining = cap - 1 - *pos;
+        const u32 stored = static_cast<u32>(n) > remaining ? remaining : static_cast<u32>(n);
+        *pos += stored;
+        buf[*pos] = '\0';
+    }
+    return true;
+}
+
+static bool read_pipes_interleaved(i32 out_fd,
+                                   char* out_buf,
+                                   u32 out_cap,
+                                   u32* out_len,
+                                   i32 err_fd,
+                                   char* err_buf,
+                                   u32 err_cap,
+                                   u32* err_len) {
+    if (out_len) *out_len = 0;
+    if (err_len) *err_len = 0;
+    if (out_cap > 0) out_buf[0] = '\0';
+    if (err_cap > 0) err_buf[0] = '\0';
+
+    u32 out_pos = 0;
+    u32 err_pos = 0;
+    bool out_done = false;
+    bool err_done = false;
+    while (!out_done || !err_done) {
+        pollfd fds[2];
+        nfds_t nfds = 0;
+        if (!out_done) {
+            fds[nfds].fd = out_fd;
+            fds[nfds].events = POLLIN | POLLHUP;
+            fds[nfds].revents = 0;
+            nfds++;
+        }
+        if (!err_done) {
+            fds[nfds].fd = err_fd;
+            fds[nfds].events = POLLIN | POLLHUP;
+            fds[nfds].revents = 0;
+            nfds++;
+        }
+
+        const int poll_rc = poll(fds, nfds, -1);
+        if (poll_rc < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+
+        nfds_t idx = 0;
+        if (!out_done) {
+            if ((fds[idx].revents & (POLLIN | POLLHUP)) &&
+                !read_ready_fd(out_fd, out_buf, out_cap, &out_pos, &out_done)) {
+                return false;
+            }
+            idx++;
+        }
+        if (!err_done) {
+            if ((fds[idx].revents & (POLLIN | POLLHUP)) &&
+                !read_ready_fd(err_fd, err_buf, err_cap, &err_pos, &err_done)) {
+                return false;
+            }
+        }
+    }
+
+    if (out_len) *out_len = out_pos;
+    if (err_len) *err_len = err_pos;
     return true;
 }
 
@@ -123,14 +240,20 @@ static bool run_simulate_cli(const char* arg1,
 
     u32 stdout_len = 0;
     u32 stderr_len = 0;
-    const bool stdout_ok = read_all_fd(out_pipe[0], stdout_buf, stdout_cap, &stdout_len);
-    const bool stderr_ok = read_all_fd(err_pipe[0], stderr_buf, stderr_cap, &stderr_len);
+    const bool io_ok = read_pipes_interleaved(out_pipe[0],
+                                              stdout_buf,
+                                              stdout_cap,
+                                              &stdout_len,
+                                              err_pipe[0],
+                                              stderr_buf,
+                                              stderr_cap,
+                                              &stderr_len);
     close(out_pipe[0]);
     close(err_pipe[0]);
 
     i32 status = 0;
     if (waitpid(pid, &status, 0) < 0) return false;
-    if (!stdout_ok || !stderr_ok) return false;
+    if (!io_ok) return false;
     if (!WIFEXITED(status)) return false;
     *exit_code = WEXITSTATUS(status);
     return true;
@@ -618,6 +741,28 @@ TEST(simulate_engine, engine_init_can_reinitialize_existing_engine) {
     ctx_a.destroy();
 }
 
+TEST(simulate_engine, engine_init_clears_state_on_precondition_failure) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/ok");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 200;
+
+    ModuleContext ctx{};
+    REQUIRE(build_module_from_manifest(manifest, ctx));
+
+    Engine engine;
+    REQUIRE(engine.init(ctx.module, manifest.upstreams, manifest.upstream_count));
+    CHECK_EQ(engine.route_count, 1u);
+
+    CHECK(!engine.init(ctx.module, manifest.upstreams, Engine::kMaxUpstreams + 1));
+    CHECK_EQ(engine.route_count, 0u);
+    CHECK_EQ(engine.upstream_count, 0u);
+
+    ctx.destroy();
+}
+
 TEST(simulate_engine, param_route_matching_matrix) {
     struct Case {
         const char* req;
@@ -808,6 +953,38 @@ TEST(simulate_engine, format_result_yield_uses_placeholders) {
     REQUIRE(len > 0);
     CHECK(strstr(buf, "yield - -> -") != nullptr);
     CHECK(strstr(buf, "204 ->") == nullptr);
+}
+
+TEST(simulate_engine, read_all_fd_drains_bytes_beyond_output_buffer) {
+    i32 pipefd[2];
+    REQUIRE(pipe(pipefd) == 0);
+
+    char payload[512];
+    for (u32 i = 0; i < sizeof(payload); i++) payload[i] = 'a';
+    REQUIRE(write(pipefd[1], payload, sizeof(payload)) == static_cast<ssize_t>(sizeof(payload)));
+    close(pipefd[1]);
+
+    char buf[32];
+    u32 out_len = 0;
+    REQUIRE(read_all_fd(pipefd[0], buf, sizeof(buf), &out_len));
+    CHECK_EQ(out_len, static_cast<u32>(sizeof(buf) - 1));
+
+    char tail[8];
+    const ssize_t tail_n = read(pipefd[0], tail, sizeof(tail));
+    CHECK_EQ(tail_n, 0);
+    close(pipefd[0]);
+}
+
+TEST(simulate_engine, read_all_fd_accepts_zero_capacity_buffer) {
+    i32 pipefd[2];
+    REQUIRE(pipe(pipefd) == 0);
+    REQUIRE(write(pipefd[1], "abc", 3) == 3);
+    close(pipefd[1]);
+
+    u32 out_len = 99;
+    REQUIRE(read_all_fd(pipefd[0], nullptr, 0, &out_len));
+    CHECK_EQ(out_len, 0u);
+    close(pipefd[0]);
 }
 
 TEST(simulate_engine, cli_usage_mentions_param_prefix_matching) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -304,6 +304,32 @@ TEST(simulate_engine, param_route_rejects_empty_segment) {
     ctx.destroy();
 }
 
+TEST(simulate_engine, colon_inside_segment_matches_literal_colon) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/v1:beta");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 201;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    const auto literal_match =
+        simulate_one(engine, make_entry("GET /v1:beta HTTP/1.1\r\nHost: x\r\n\r\n", 201));
+    CHECK_EQ(literal_match.verdict, Verdict::Match);
+    CHECK_EQ(literal_match.actual_status, 201u);
+
+    const auto literal_miss =
+        simulate_one(engine, make_entry("GET /v1x HTTP/1.1\r\nHost: x\r\n\r\n", 200));
+    CHECK_EQ(literal_miss.verdict, Verdict::Match);
+    CHECK_EQ(literal_miss.actual_status, 200u);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
 TEST(simulate_engine, make_entry_clamps_long_headers) {
     char req[CaptureEntry::kMaxHeaderLen + 32];
     for (u32 i = 0; i + 1 < sizeof(req); i++) req[i] = 'a';
@@ -551,6 +577,45 @@ TEST(simulate_engine, engine_init_rejects_overlong_compiled_route_patterns) {
     CHECK_EQ(engine.upstream_count, 0u);
 
     ctx.destroy();
+}
+
+TEST(simulate_engine, engine_init_can_reinitialize_existing_engine) {
+    Manifest manifest_a{};
+    manifest_a.route_count = 1;
+    manifest_a.routes[0].method = 'G';
+    strcpy(manifest_a.routes[0].pattern, "/first");
+    manifest_a.routes[0].action = ManifestAction::ReturnStatus;
+    manifest_a.routes[0].status_code = 201;
+
+    Manifest manifest_b{};
+    manifest_b.route_count = 1;
+    manifest_b.routes[0].method = 'G';
+    strcpy(manifest_b.routes[0].pattern, "/second");
+    manifest_b.routes[0].action = ManifestAction::ReturnStatus;
+    manifest_b.routes[0].status_code = 202;
+
+    ModuleContext ctx_a{};
+    ModuleContext ctx_b{};
+    REQUIRE(build_module_from_manifest(manifest_a, ctx_a));
+    REQUIRE(build_module_from_manifest(manifest_b, ctx_b));
+
+    Engine engine;
+    REQUIRE(engine.init(ctx_a.module, manifest_a.upstreams, manifest_a.upstream_count));
+    REQUIRE(engine.init(ctx_b.module, manifest_b.upstreams, manifest_b.upstream_count));
+
+    const auto first_after_reinit =
+        simulate_one(engine, make_entry("GET /first HTTP/1.1\r\nHost: x\r\n\r\n", 200));
+    CHECK_EQ(first_after_reinit.verdict, Verdict::Match);
+    CHECK_EQ(first_after_reinit.actual_status, 200u);
+
+    const auto second_after_reinit =
+        simulate_one(engine, make_entry("GET /second HTTP/1.1\r\nHost: x\r\n\r\n", 202));
+    CHECK_EQ(second_after_reinit.verdict, Verdict::Match);
+    CHECK_EQ(second_after_reinit.actual_status, 202u);
+
+    engine.shutdown();
+    ctx_b.destroy();
+    ctx_a.destroy();
 }
 
 TEST(simulate_engine, param_route_matching_matrix) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -172,6 +172,7 @@ static bool read_pipes_interleaved(i32 out_fd,
 
         nfds_t idx = 0;
         if (!out_done) {
+            if (fds[idx].revents & (POLLERR | POLLNVAL)) return false;
             if ((fds[idx].revents & (POLLIN | POLLHUP)) &&
                 !read_ready_fd(out_fd, out_buf, out_cap, &out_pos, &out_done)) {
                 return false;
@@ -179,6 +180,7 @@ static bool read_pipes_interleaved(i32 out_fd,
             idx++;
         }
         if (!err_done) {
+            if (fds[idx].revents & (POLLERR | POLLNVAL)) return false;
             if ((fds[idx].revents & (POLLIN | POLLHUP)) &&
                 !read_ready_fd(err_fd, err_buf, err_cap, &err_pos, &err_done)) {
                 return false;
@@ -985,6 +987,32 @@ TEST(simulate_engine, read_all_fd_accepts_zero_capacity_buffer) {
     REQUIRE(read_all_fd(pipefd[0], nullptr, 0, &out_len));
     CHECK_EQ(out_len, 0u);
     close(pipefd[0]);
+}
+
+TEST(simulate_engine, read_pipes_interleaved_fails_on_poll_error_event) {
+    i32 out_pipe[2];
+    i32 err_pipe[2];
+    REQUIRE(pipe(out_pipe) == 0);
+    REQUIRE(pipe(err_pipe) == 0);
+
+    close(out_pipe[0]);
+    close(out_pipe[1]);
+
+    char stdout_buf[16];
+    char stderr_buf[16];
+    u32 stdout_len = 0;
+    u32 stderr_len = 0;
+    CHECK(!read_pipes_interleaved(out_pipe[0],
+                                  stdout_buf,
+                                  sizeof(stdout_buf),
+                                  &stdout_len,
+                                  err_pipe[0],
+                                  stderr_buf,
+                                  sizeof(stderr_buf),
+                                  &stderr_len));
+
+    close(err_pipe[0]);
+    close(err_pipe[1]);
 }
 
 TEST(simulate_engine, cli_usage_mentions_param_prefix_matching) {


### PR DESCRIPTION
Upgrade the lightweight in-repo test framework with EXPECT/ASSERT aliases, TEST_F fixture support, SKIP/DISABLED handling, and comma-separated allow-list filters with simple wildcard matching. Also add the offline `rut-simulate` engine and CLI, plus unit coverage for the new simulate path and filter semantics.