### PR TITLE
Frontend completion + decorator language feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: ninja -C build
 
       - name: Test
-        run: ninja -C build check
+        run: ctest --test-dir build --output-on-failure --no-tests=error -j 1 --timeout 120
 
   coverage:
     name: Code Coverage

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ build/
 build-cov/
 .cache/
 build-release/
+build-review/
 node_modules/
+.codex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,18 @@ endif()
 # Core compiler flags per DESIGN.md: no exceptions, no RTTI, no C++ stdlib
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti -fno-unwind-tables -fno-asynchronous-unwind-tables")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffunction-sections -fdata-sections -Wall -Wextra -Wpedantic")
-# Use CMake's native LTO support — handles llvm-ar/gcc-ar automatically.
-# Applied to both C and C++ so mixed-language targets (bench/llhttp) link correctly.
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
-check_ipo_supported(RESULT RUE_IPO_SUPPORTED OUTPUT RUE_IPO_OUTPUT LANGUAGES C CXX)
-if(RUE_IPO_SUPPORTED)
-    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+option(RUT_ENABLE_IPO "Enable interprocedural optimization/LTO for Release builds" OFF)
+if(RUT_ENABLE_IPO)
+    # Use CMake's native IPO support only when explicitly requested.
+    # In the default developer/test build, keep archives and test linking simple and stable.
+    check_ipo_supported(RESULT RUE_IPO_SUPPORTED OUTPUT RUE_IPO_OUTPUT LANGUAGES C CXX)
+    if(RUE_IPO_SUPPORTED)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+    else()
+        message(WARNING "IPO requested but not supported: ${RUE_IPO_OUTPUT}")
+    endif()
 endif()
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG")
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -193,9 +193,41 @@ and   or   not                  // boolean (keywords)
 ??                              // null coalescing (x ?? default)
 !                               // logical not (alias for not)
 @                               // decorator prefix
-=>                              // single expression, implicit return
+=>                              // single-expression body / branch result
 ->                              // function return type
 ```
+
+### 3.2.2 Core Control-Flow Surface
+
+Rut keeps a small set of branching constructs with clear roles:
+
+- `if` — the lightweight boolean branch
+- `guard` — fail-fast branch for error handling
+- `match` — the general multi-branch construct
+
+`switch` is not a language keyword. Where a traditional switch would normally be
+used, Rut uses `match`.
+
+`=>` has one uniform meaning across the language: it introduces a single-expression
+body or branch result. It is not function-specific syntax.
+
+Examples:
+
+- `func id(x: i32) -> i32 => x`
+- `get /health => 200`
+- `case .ok(v) => v`
+
+Where a construct uses `=>`, the right-hand side is interpreted as a single
+expression body with implicit result/return semantics appropriate to that
+construct.
+
+`match` is the general form:
+
+- `if` is the boolean special case users will usually prefer for simple two-way conditions
+- `match` handles general value dispatch, structured variants, and richer multi-way branching
+- `match const` is the compile-time form for branching on compile-time-known values
+
+Likewise, `if const` is the lightweight compile-time boolean branch.
 
 ### 3.3 Type System
 
@@ -215,7 +247,7 @@ ip.isLoopback                        // bool — 127.0.0.0/8 or ::1
 ip.in(10.0.0.0/8)                    // bool — CIDR containment
 ip.octets                            // [u8] — 4 or 16 bytes
 ip as string                         // "10.0.0.1"
-"10.0.0.1" as IP                     // Result<IP>
+IP.parse("10.0.0.1")                // IP? / error-capable parse, depending on context
 ```
 
 **CIDR** — network range
@@ -378,8 +410,8 @@ req.query("page")       // string? — single query parameter
 req.query("tags")       // [string]? — multi-value parameter (?tags=a&tags=b)
 
 // Body
-req.body(User)          // parse body as User struct → Result<User>
-req.bodyRaw             // raw body as string → Result<string>
+req.body(User)          // parse body as User struct, error-capable
+req.bodyRaw             // raw body as string, error-capable
 req.bodyRaw = newBody   // replace body before forward (recomputes Content-Length)
 
 // Cookies
@@ -576,7 +608,7 @@ let blacklist = Set<IP>(capacity: 100000)
 
 post /admin/ban {
     let ip = req.body(IP)
-    guard let ip else { return 400 }
+    guard ip else { return 400 }
     blacklist.add(ip)              // local shard — immediate
     notify all blacklist.add(ip)   // all other shards — next event loop tick
     return 200
@@ -691,76 +723,104 @@ These rules are deliberately conservative. They keep the language contract tight
 than the current implementation so runtime shortcuts do not accidentally become
 part of the public semantics.
 
-#### 3.3.7 Error Handling: Result and guard
+#### 3.3.7 Error Handling: values, nil, error, and guard
 
-No exceptions. No try/catch. Every fallible operation returns `Result<T>`, which
-carries either a value or an error message. The caller **must** use `guard let` to
-unwrap a Result — the compiler rejects code that ignores a Result value.
+No exceptions. No try/catch. Rut is primarily a value-flow language: most ergonomic
+syntax works in terms of values and `nil`, not explicit `Result<T, E>` plumbing in
+ordinary user code.
 
-**Result vs Optional:**
-- `string?` (Optional) — value may be absent, not an error. E.g., optional header.
-- `Result<User>` — operation may fail with an error message. E.g., body parse.
+The language still has a standard built-in `Error` type. A function that can produce
+an `error(...)` value is error-capable, and the compiler may normalize such code in
+HIR to `Result<V, Error>` internally. That normalized form is mainly for compiler
+semantics, analysis, and lowering, not the default surface syntax that ordinary
+users are expected to write every day.
 
-**Nil handling — four operators:**
+**Nil vs Error**
 
-| Syntax | Name | Returns | Meaning |
-|--------|------|---------|---------|
-| `x?` | nil check | `bool` | `x != nil` |
-| `x?.method` | optional chaining | `T?` | if x is nil → nil, else → x.method |
-| `x ?? default` | null coalescing | `T` | if x is nil → default, else → x |
-| `guard let x else { return N }` | unwrap or reject | `T` | if x is nil → exit handler |
+- `nil` means "there is no usable value here"
+- `error(...)` carries failure information
+
+In surface value-flow syntax, errors are treated as producing no usable value. The
+short forms therefore work on the value channel and naturally see failure as `nil`.
+Users who care about the precise error reason enter an explicit error-handling path
+with `guard` (and later possibly `match`).
+
+**Value-flow operators**
+
+| Syntax | Meaning |
+|--------|---------|
+| `x?` | nil check on the usable value channel |
+| `x?.field` / `x?.method()` | continue only if a usable value exists |
+| `x ?? default` | provide a default when no usable value exists |
+| `a | f(_, ...)` | pipeline over the usable value channel |
+
+These operators intentionally optimize for the common case: keep the normal logic
+flowing without forcing local `if/else`, `match`, or `guard` at every step.
+
+That means a pipeline or optional-style expression may ignore detailed error causes
+and simply continue in terms of "value present" vs "value absent":
 
 ```swift
-// x? — check existence (bool)
-guard req.authorization? else { return 401 }
-if req.origin? {
-    resp.Vary = "Origin"
-}
-
-// x?.method — optional chaining (nil propagation)
-let len = req.authorization?.len               // i32? — nil if no header
-let ok = req.authorization?.hasPrefix("Bearer") // bool? — nil if no header
-
-// x ?? default — null coalescing (provide default)
 let name = req.query("name") ?? "anonymous"
-let page = parseInt(req.query("page") ?? "1")
+let parts = req.path | trimPrefix("/api", _) | split(_, "/")
+let userName = findUser(id)?.profile?.name ?? "guest"
+```
 
-// guard let — unwrap or reject (early return)
-guard let token = req.authorization else { return 401 }
-// token is now a string, usable below
+When a caller needs to care about the failure reason rather than just the absence
+of a usable value, they should switch to explicit handling:
 
-// Result — operation can fail with an error
-let user = req.body(User)                  // Result<User>
-guard let user else { return 400 }         // discard error message
-guard let user else { return 400, user.error }  // include error in response
-guard let user else {
-    log.warn("bad body", { error: user.error })
-    return 400, "invalid request body"
+```swift
+guard let user = req.body(User) else {
+    log.warn("bad body")
+    return .badRequest
 }
 ```
 
-**Result types by operation:**
+`guard let` is therefore the main bridge from the ergonomic value-flow world into
+the explicit failure-handling world.
 
-| Operation | Return type | Typical guard |
-|-----------|-------------|---------------|
-| `req.body(T)` | `Result<T>` | `guard let x else { return 400 }` |
-| `get/post http://...` | `Result<Response>` | `guard let res else { return 502 }` |
-| `jwtDecode(token, secret:)` | `Result<Claims>` | `guard let claims else { return 401 }` |
-| `forward(upstream)` | built-in, returns 502 on failure | no guard needed |
-| `req.authorization` | `string?` (Optional) | `guard let x else { return 401 }` |
-| `req.query("key")` | `string?` (Optional) | `guard let x else { return 400 }` |
+Tuple values remain ordinary values. Numbered placeholders such as `_1` and `_2`
+only project tuple slots; they do not introduce a separate error model.
 
-**Compile-time enforcement:** if a Result is assigned to `let` without a subsequent
-`guard let ... else`, the compiler emits an error:
+**`guard` scope and role**
+
+Rut `guard` is intentionally narrower than Swift-style optional unwrapping:
+
+- `guard` handles **error**, not `nil`
+- `nil` remains part of the normal value channel and is handled by `?`, `?.`, `??`, and `or(...)`
+- `guard ... else { ... }` must terminate control flow in the `else` block
+- `guard let x = expr else { ... }` binds the success value of `expr`, but does not implicitly unwrap optional payloads inside that success value
+
+This means:
+
+- use `guard` when the caller needs to stop and explicitly handle failure
+- use value-flow operators when the caller only cares whether a usable value exists
+
+When a caller needs to distinguish *which* error occurred, they should use `match`
+rather than trying to overload `guard` with pattern semantics.
+
+**`or(...)`**
+
+`or(...)` is the standard value fallback operation:
+
+- if a usable value exists, return it
+- if the expression yields `nil`, return the fallback
+- if the expression fails with `error(...)`, also return the fallback
+
+Examples:
 
 ```swift
-let user = req.body(User)
-forward(users)
-// ERROR: Result<User> must be unwrapped with 'guard let user else { return ... }'
+let page = req.query("page").or("1")
+let n = parseInt(raw).or(0)
+let name = findUser(id)?.profile?.name.or("guest")
 ```
 
-**Runtime errors** (division by zero, array out of bounds) are programming bugs —
-they return 500 immediately. No recovery mechanism.
+`or(...)` is deliberately value-oriented. It does not expose or classify the error.
+
+**Runtime bugs**
+
+Division by zero, out-of-bounds access, and similar programming bugs are not modeled
+as ordinary `error(...)` values. They remain runtime faults.
 
 #### 3.3.8 Compile-Time Constants
 
@@ -1151,11 +1211,11 @@ Two types of middleware, distinguished by whether the signature contains `Respon
 
 ```swift
 func auth(_ req: Request, role: string) -> User {
-    guard let token = req.authorization else { return 401 }
+    let token = req.authorization.or("")
     guard token.hasPrefix("Bearer ") else { return 401 }
 
     let claims = jwtDecode(token.trimPrefix("Bearer "), secret: env("JWT_SECRET"))
-    guard let claims else { return 401 }
+    guard claims else { return 401 }
     guard claims.exp >= now() else { return 401, "token expired" }
     guard claims.role == role else { return 403 }
 
@@ -1196,7 +1256,8 @@ func cors(_ req: Request, origins: [string]) {
 }
 
 func verifySig(_ req: Request, secret: string) {
-    guard let ts = req.X-Timestamp else { return 401 }
+    let ts = req.X-Timestamp.or("")
+    guard ts.isEmpty == false else { return 401 }
     guard now() - time(ts) <= 5m else { return 401, "expired" }
 
     let payload = "\(req.method)\n\(req.path)\n\(ts)"
@@ -1458,7 +1519,7 @@ route {
 
         post /orders {
             let order = req.body(Order)
-            guard let order else { return 400 }
+            guard order else { return 400 }
             for item in order.items {
                 guard item.qty > 0 else { return 400, "invalid quantity" }
             }
@@ -1882,7 +1943,7 @@ zero-cost upgrade when the infrastructure supports it.
 determined by usage, same as `forward`:
 
 - `return read(...)` or `=> read(...)` → **zero-copy** (sendfile/splice)
-- `let content = read(...)` → **buffered**, returns `Result<string>`
+- `let content = read(...)` → **buffered**, error-capable value
 
 ```swift
 // Zero-copy — static file serving, data goes directly to client socket
@@ -1905,8 +1966,8 @@ get /stream => read(path: "/tmp/data_pipe")
 // Buffered — read into memory for modification
 get /index.html {
     let content = read(path: "/var/www/index.html")
-    guard let content else { return 404 }
-    let html = content.replace("{{VERSION}}", env("APP_VERSION"))
+    guard content else { return 404 }
+    let html = content.or("").replace("{{VERSION}}", env("APP_VERSION"))
     let resp = response(200)
     resp.Content-Type = "text/html"
     resp.body = html
@@ -1937,23 +1998,23 @@ Same async safety model — compiler generates yield points, io_uring/epoll back
 **TCP — connection-oriented, stream:**
 
 ```swift
-let conn = tcp("redis:6379")           // Result<TcpConn>, compiler yields
-guard let conn else { return 502 }
+let conn = tcp("redis:6379")           // error-capable TcpConn, compiler yields
+guard conn else { return 502 }
 defer conn.close()
 
 conn.send("PING\r\n")                  // send data
-let data = conn.recv(maxSize: 4kb)     // Result<string>, compiler yields
-guard let data else { return 502 }
+let data = conn.recv(maxSize: 4kb)     // error-capable string, compiler yields
+guard data else { return 502 }
 
 // With timeout
 let h = submit conn.recv(maxSize: 4kb)
 let data = any(wait(h, 1s))
-guard let data else { return 504 }
+guard data else { return 504 }
 ```
 
 `TcpConn` members:
-- `.send(data)` — send data, returns `Result<i32>` (bytes sent)
-- `.recv(maxSize:)` — receive data, returns `Result<string>`
+- `.send(data)` — send data, error-capable bytes-sent result
+- `.recv(maxSize:)` — receive data, error-capable string result
 - `.close()` — close connection
 - `.remoteAddr` — `IP`
 - `.localAddr` — `IP`
@@ -1962,15 +2023,15 @@ guard let data else { return 504 }
 
 ```swift
 let sock = udp()
-guard let sock else { return 500 }
+guard sock else { return 500 }
 defer sock.close()
 
 // Send (fire-and-forget, typical for metrics/logging)
 sock.sendTo("10.0.0.1:8125", "myapp.requests:1|c")
 
 // Receive
-let data = sock.recvFrom(maxSize: 4kb)   // Result<(string, IP)>
-guard let data else { return 502 }
+let data = sock.recvFrom(maxSize: 4kb)   // error-capable `(string, IP)`
+guard data else { return 502 }
 let (payload, sender) = data
 ```
 
@@ -1984,11 +2045,11 @@ via `defer`. No `while` loops prevent unbounded read loops.
 // stdlib/redis.rut
 func redisGet(_ req: Request, addr: string, key: string) -> string? {
     let conn = tcp(addr)
-    guard let conn else { return nil }
+    guard conn else { return nil }
     defer conn.close()
     conn.send("GET \(key)\r\n")
     let resp = conn.recv(maxSize: 16kb)
-    guard let resp else { return nil }
+    guard resp else { return nil }
     return parseRedisReply(resp)
 }
 ```
@@ -2095,9 +2156,9 @@ database for one-pass scanning.
 // Matching
 guard req.path.matches(re"^/api/v\d+/") else { return 404 }
 
-// Capture groups — returns Result<Match>
+// Capture groups — error-capable match extraction
 let m = req.path.match(re"^/api/v(\d+)/(.*)")
-guard let m else { return 404 }
+guard m else { return 404 }
 let version = m[1]    // "2"
 let rest = m[2]       // "users/123"
 
@@ -2142,6 +2203,8 @@ import "middleware/security.rut"        // security.cors, security.waf
 
 // Selective import — symbols brought into current scope, no prefix
 import { cors, securityHeaders } from "stdlib/security.rut"
+import { jwtAuth as authV1 } from "middleware/auth.rut"
+import { Hashable as Digestible, Box as AuthBox } from "proto.rut"
 
 // using — create alias for namespaced symbol
 import "middleware/v1.rut"
@@ -2152,37 +2215,218 @@ using authV2 = v2.jwtAuth
 
 Rules:
 - File name is the namespace: `"path/foo.rut"` → `foo.symbol`
-- Selective import (`import { x } from`) puts symbols in current scope without prefix
+- Selective import (`import { x } from`) puts only the selected top-level symbols in current scope without prefix
+- Selective import supports aliasing via `import { x as y } from "file"`; imported functions and top-level type declarations (`struct` / `variant` / `protocol`) can be renamed, and the original imported name is not brought into scope
+- Referencing a non-selected name is a compile error
+- Selecting a symbol that the imported file does not export is a compile error
+- Repeated selective imports of the same file merge selected-name sets; any plain `import "file"` upgrades visibility to the full file
 - `using name = module.symbol` creates an alias
+- `using` is only for alias/import syntax; it must not be reused for protocol conformance
 - Circular imports are a compile error
 - Importing a symbol that doesn't exist is a compile error
 - Duplicate imports of the same file are silently deduplicated
+- Relative `import` is resolved from the importing file path
+- The current first-stage multi-file implementation merges imported top-level functions and makes imported `struct` / `variant` / `protocol` declarations visible during analysis
+- Imported explicit `impl` blocks participate in the same visible conformance set as local `impl` blocks
+- Any visible overlap in explicit `impl` for the same `Type + Protocol` pair is a compile error, regardless of whether the overlap is local vs imported, imported vs imported, concrete vs generic, or import order
+- `namespace` is the language-level naming model; imports, qualified names, and aliases resolve through namespaces, not through package-specific lookup rules
 
-#### 3.4.18 Type Conversion
+#### 3.4.18 Package Metadata
 
-`as` converts between types. Returns `Result<T>` when conversion can fail
-(string → number), returns `T` directly when it cannot fail (number → string).
+Rut may eventually expose a lightweight `package` concept, but only as a
+distribution boundary, not as a second namespace system and not as a full
+dependency solver.
+
+Intended boundary:
+
+- `namespace` remains the language-level name-resolution concept
+- `package` is only a unit of publication / reuse
+- imports still resolve to namespaces and module paths
+- package metadata must stay lightweight enough for a DSL workflow
+
+The intended first-stage package model is:
+
+- by default, one file is one implicit package unit
+- a file may declare `package foo` at the top to join a named package
+- multiple files that declare the same `package foo` belong to the same package
+- package grouping is explicit in source, not inferred from a directory-only rule
+- `package foo` is a file-header declaration and must appear before other top-level declarations
+- a package declaration groups files for distribution/reuse, but each file still keeps its own file/module namespace
+- no registry protocol
+- no semantic-version solving
+- no lockfile-driven dependency graph resolution
+- no separate package-level namespace rules beyond normal module/namespace lookup
+
+If Rut later adds package-manager metadata for dependencies, the design must
+distinguish between:
+
+- a dependency requirement recorded in manifest metadata
+- a resolved dependency version recorded by package-management tooling
+- downloaded artifact integrity recorded for verification
+
+So a manifest version string by itself is not enough to verify dependency
+correctness. Correctness eventually depends on resolver output, lock data, and
+integrity checks.
+
+The current design direction is:
+
+- every declared dependency must carry an explicit version requirement
+- version requirements may later be exact versions or constrained ranges, but
+  manifest requirements are not themselves the final verified install result
+- missing dependency versions are invalid
+- a future lock step is responsible for recording resolved exact versions
+- a future integrity step is responsible for recording source/checksum data
+
+What package metadata is allowed to affect:
+
+- how a file or file-group is identified for publication / reuse
+- whether multiple files are grouped into one named package
+- future packaging / release tooling
+- package-level validation that a set of files intentionally belong together
+
+What package metadata must not affect in the first stage:
+
+- local lexical scope rules
+- namespace formation rules
+- qualified-name syntax
+- import semantics inside a package once the target file/module is resolved
+- heavy dependency resolution or transitive version selection
+
+First-stage package validity rules:
+
+- `package foo` must be the first non-comment, non-whitespace declaration in a file
+- a file has at most one package declaration
+- files that omit `package` remain standalone implicit package units
+- files that declare the same package still do not merge into one flat namespace; top-level lookup continues to go through file/module namespaces
+- if two files in the same package expose colliding top-level names through the same namespace path, that is still a normal namespace/import conflict, not a special package rule
+
+Current implementation status:
+
+- file-header `package foo` is parsed and recorded in `AstFile` and `HirModule`
+- imported files also carry package metadata into `HirImport`
+- `HirImport.same_package` is available as a compiler-internal signal when the
+  importing file and imported file both declare the same package name
+- this `same_package` signal is recorded consistently for plain import,
+  selective import, and namespace-alias import
+- this signal is currently observational only; it does not yet change import
+  resolution, namespace formation, or visibility
+- package-aware import resolution, package namespaces, and package-manager
+  behavior are intentionally still out of scope
+
+Example:
 
 ```swift
-// String → number (fallible → Result)
-let page = "42" as i32                        // Result<i32>
-guard let page else { return 400 }
+// implicit file package unit
+func jwtAuth() -> i32 => 200
+```
 
-let weight = "3.14" as f64                    // Result<f64>
-guard let weight else { return 400 }
+```swift
+package auth
 
-// With ?? for defaults
-let limit = (req.query("limit") ?? "20") as i32
-guard let limit else { return 400 }
+func jwtAuth() -> i32 => 200
+```
+
+```swift
+package auth
+
+func basicAuth() -> i32 => 200
+```
+
+In the example above, the first file stands alone as its own package unit. The
+last two files belong to the same explicit package `auth`, while still being
+separate file/module namespaces.
+
+Possible future package-manager metadata shape:
+
+```swift
+package auth
+
+manifest {
+    version: "1.2.3"
+    root: "src"
+    deps: [
+        dep("security", "0.4.1"),
+        dep("jwt", "1.2.0"),
+    ]
+}
+```
+
+The intent is that package metadata remains self-described in Rut rather than
+switching to TOML or YAML. At the same time, this manifest form should stay a
+restricted declaration surface, not an arbitrary executable Rut program.
+
+This example only illustrates manifest-level dependency requirements. A future
+package manager would still need resolver output and lock/integrity data before
+dependency versions are actually reproducible and verifiable.
+
+Package grouping does not replace file/module namespaces. Once a module is
+loaded, the compiler still reasons in terms of file/module namespaces such as
+`auth.jwtAuth` or `proto.Box`.
+
+So the design target is:
+
+- keep namespace semantics in the compiler
+- optionally add package metadata for distribution and reuse
+- do not turn Rut into a general-purpose package-managed ecosystem
+
+#### 3.4.19 Current Scope And Name Resolution
+
+Current implementation behavior should be read as:
+
+- a file provides a **top-level declaration namespace**, not a general-purpose local variable scope
+- top-level names include declarations such as `func`, `struct`, `variant`, `protocol`, `impl`, `import`, and `using` alias declarations
+- imported top-level declarations participate in the same visible lookup set as local top-level declarations, subject to the import rules above
+
+Local variable scope is block-oriented:
+
+- route-body `let` bindings are visible to later statements in the same route body
+- function parameters are visible throughout the function body
+- function-body `let` bindings are visible to later statements in the same block
+- bindings introduced inside `if` / `match` / branch blocks stay inside that branch block
+- `match` payload bindings are visible only inside their corresponding arm
+
+Current `guard` scoping rules:
+
+- `guard let x = expr else { ... }` extends `x` into the success path after the guard
+- `guard match ... else { ... }` is a control-flow check; it does not itself introduce a new post-guard binding name
+
+Name-resolution consequences:
+
+- a plain file import such as `import "auth.rut"` makes the file stem available as a namespace for value/type references such as `auth.jwtAuth()` and `auth.Box`
+- `import * as auth from "auth.rut"` creates an explicit namespace alias
+- selective import brings only the selected symbols into the current top-level namespace and does not create a namespace object
+- `using` only creates aliases for already-visible names; it is not a second conformance system and is not a local-value binding construct
+- package metadata does not replace namespace lookup; imported names still resolve through file/module namespaces and explicit aliases
+
+This is the current implementation contract. A future language-level scope chapter may formalize this more completely, but current tests and compiler behavior already rely on these rules.
+
+#### 3.4.20 Type Conversion
+
+`as` is for value-to-value conversion, not text parsing.
+
+- infallible conversions stay as `as`
+- checked conversions use `as?`
+- string/domain decoding belongs to parse APIs such as `parseInt(...)`, `IP.parse(...)`, and `Duration.parse(...)`
+
+```swift
+// Checked numeric conversion
+let page = parseInt("42")
+guard page else { return 400 }
+
+let weight = parseFloat("3.14")
+guard weight else { return 400 }
+
+// With value fallback
+let limit = parseInt(req.query("limit").or("20")).or(20)
 
 // Number → string (infallible)
 let s = 200 as string                         // "200"
 let s = 3.14 as string                        // "3.14"
 
-// Domain type parsing (fallible → Result)
-let ip = "10.0.0.1" as IP                     // Result<IP>
-let cidr = "10.0.0.0/8" as CIDR               // Result<CIDR>
-let dur = "30s" as Duration                    // Result<Duration>
+// Domain type parsing
+let ip = IP.parse("10.0.0.1")
+let cidr = CIDR.parse("10.0.0.0/8")
+let dur = Duration.parse("30s")
 ```
 
 **Standard library:**
@@ -2225,17 +2469,18 @@ let h1 = submit get http://user-service/users/1
 let h2 = submit get http://order-service/orders?user=1
 
 // Wait all — single yield point, one io_uring_enter syscall
-let (r1, r2) = wait(h1, h2)           // (Result<Response>, Result<Response>)
-guard let r1 else { return 502 }
-guard let r2 else { return 502 }
+let (r1, r2) = wait(h1, h2)           // pair of error-capable responses
+guard r1 else { return 502 }
+guard r2 else { return 502 }
 return 200, json({ user: r1.body, orders: r2.body })
 
 // Wait any — first response wins, cancel rest
-let first = any(wait(h1, h2))         // Result<Response>
+let first = any(wait(h1, h2))         // first-completing error-capable response
 
 // All — wait all, fail-fast on first error (cancel rest)
 let (r1, r2) = all(h1, h2)            // both succeed or first error
-guard let r1, r2 else { return 502 }
+guard r1 else { return 502 }
+guard r2 else { return 502 }
 ```
 
 `wait` also accepts a Duration — compiler generates `IORING_OP_TIMEOUT`:
@@ -2247,12 +2492,12 @@ wait(2s)
 // Timeout — race I/O against deadline, cancel loser
 let h = submit get http://slow-service/data
 let result = any(wait(h, 5s))     // first to complete wins
-guard let result else { return 504, "timeout" }
+guard result else { return 504, "timeout" }
 
 // Custom timeout on any I/O (alternative to per-call timeout: parameter)
 let h1 = submit forward(userService, buffered: true)
 let resp = any(wait(h1, 30s))
-guard let resp else { return 504 }
+guard resp else { return 504 }
 return resp
 ```
 
@@ -2314,7 +2559,7 @@ Both can use I/O.
 ```swift
 init {
     let resp = get http://config-service/warmup
-    guard let resp else {
+    guard resp else {
         log.error("warmup failed")
         return
     }
@@ -2441,23 +2686,22 @@ s.replace(old, new)               // string
 s.split(sep)                      // [string]
 s.slice(start, end)               // string
 s.matches(re"pattern")            // bool (Vectorscan)
-s.match(re"pattern")              // Result<Match> (capture groups)
+s.match(re"pattern")              // error-capable match object (capture groups)
 
-// --- Type Conversion (runtime C++ built-in, via `as` keyword) ---
-"42" as i32                       // Result<i32>
-"3.14" as f64                     // Result<f64>
-42 as string                      // string (infallible)
-"10.0.0.1" as IP                  // Result<IP>
+// --- Type Conversion / Parse ---
+42 as string                      // string (infallible conversion)
+IP.parse("10.0.0.1")              // typed parse
+parseInt("42")                    // typed parse
 
 // --- JSON ---
-req.body(Type)                    // parse body → Result<T>
+req.body(Type)                    // typed body parse, error-capable
 json(value)                       // serialize to JSON string
 resp.body                         // response body string
 
 // --- Regex (Vectorscan) ---
 re"pattern"                       // compile-time validated regex literal
 s.matches(re"pat")                // bool
-s.match(re"(group)")              // Result<Match>, m[1] for captures
+s.match(re"(group)")              // match object on success
 s.replace(re"pat", replacement)   // string
 
 // --- Hash ---
@@ -2474,14 +2718,14 @@ hmacSha384(key, data)         // string (hex)
 hmacSha512(key, data)         // string (hex)
 
 // --- JWT (multi-algorithm, backed by BoringSSL) ---
-jwtDecode(token, secret: key)               // Result<Claims> — HS256/384/512
-jwtDecode(token, publicKey: pem)            // Result<Claims> — RS256/384/512, ES256/384/512
+jwtDecode(token, secret: key)               // error-capable Claims decode — HS256/384/512
+jwtDecode(token, publicKey: pem)            // error-capable Claims decode — RS256/384/512, ES256/384/512
 jwtEncode(claims, secret: key, alg: .HS256) // string — sign with HMAC
 jwtEncode(claims, privateKey: pem, alg: .RS256)  // string — sign with RSA/ECDSA
 
 // --- Encryption ---
 aesGcmEncrypt(key, plaintext, nonce)        // [u8] — AES-256-GCM authenticated encryption
-aesGcmDecrypt(key, ciphertext)              // Result<[u8]> — decrypt + verify tag
+aesGcmDecrypt(key, ciphertext)              // error-capable decrypt + verify tag
 
 // --- Random ---
 randomBytes(n)                // [u8] — cryptographically secure random
@@ -2492,23 +2736,23 @@ base64(data)                  // string
 base64url(data)               // string
 hex(data)                     // string
 urlEncode(data)               // string
-urlDecode(data)               // Result<string>
+urlDecode(data)               // error-capable decode
 htmlDecode(data)              // string — &#x3C; → <, &amp; → &, etc.
 unicodeNormalize(data)        // string — \u003C → <, NFC normalization
 
 // --- Request Body ---
-req.body(Type)                // typed parse → Result<T>
-req.bodyRaw                   // raw body → Result<string> (auto-decompresses)
-req.bodyJson()                // dynamic JSON → Result<Json>
-req.multipart()               // multipart/form-data → Result<[Part]>
+req.body(Type)                // typed parse, error-capable
+req.bodyRaw                   // raw body, error-capable (auto-decompresses)
+req.bodyJson()                // dynamic JSON, error-capable
+req.multipart()               // multipart/form-data, error-capable
 
 // Json — dynamic JSON access (no struct required)
 let j = req.bodyJson()
-guard let j else { return 400 }
+guard j else { return 400 }
 j.field("name")              // Json? — nested access
-j.string()                   // Result<string> — extract as string
-j.int()                      // Result<i32> — extract as number
-j.array()                    // Result<[Json]> — extract as array
+j.string()                   // error-capable extract as string
+j.int()                      // error-capable extract as number
+j.array()                    // error-capable extract as array
 j.allValues()                // [string] — all leaf values (for WAF scanning)
 j.allKeys()                  // [string] — all keys
 
@@ -2559,15 +2803,15 @@ Bit operations: & | ^ << >> ~
 | CIDR format | `req.remoteAddr.in(999.0.0.0/8)` | "invalid IP in CIDR" |
 | Header spell | `req.athorization` | "warning: did you mean authorization?" |
 | Indirect call | `let f = auth; f(req)` | "functions cannot be assigned to variables" |
-| guard exhaustive | `guard let x = opt` (no else) | "guard must have else clause" |
-| Optional access | `req.authorization.hasPrefix("B")` | "value is optional, use guard let or ??" |
+| guard exhaustive | `guard expr else { ... }` with non-terminating or missing `else` | "guard must have else clause" |
+| Optional access | `req.authorization.hasPrefix("B")` | "value may be nil, use ?, ?., ??, or or(...)" |
 | Response middleware | `func f(_ resp: Response)` applied where only pre-middleware expected | "signature contains Response — this is a post-middleware, will run after handler" (info) |
 | TLS without host | `tls "x.com"` but no `x.com { }` in route | warning: "TLS cert declared but no routes for x.com" |
 | Host without TLS | `x.com { }` in route but no `tls "x.com"` and listen uses TLS | "no TLS certificate for host x.com" |
 | Duplicate TLS | two `tls "x.com"` declarations | "duplicate TLS declaration for x.com" |
 | Host pattern | `x.y.z { }` in route with invalid domain chars | "invalid host pattern" |
-| Result unused | `let x = req.body(User)` without `guard let` | "Result\<User\> must be unwrapped with guard let" |
-| Result as Optional | `if x != nil` on a Result value | "use guard let to unwrap Result, not nil check" |
+| Error-capable value ignored | `let x = req.body(User)` and later code assumes a usable value without fallback/guard | "expression may fail; use guard, match, or a value fallback such as or(...)" |
+| Error/nil confusion | treating an error-capable value as plain Optional without an explicit value-flow operation | "failure and nil are distinct; use guard/match for error handling or value-flow operators to treat failure as no value" |
 | Regex syntax | `re"[unclosed"` | "invalid regex: unclosed bracket" |
 | Regex capture | `m[3]` but pattern has 2 groups | "regex has 2 capture groups, index 3 out of range" |
 | Recursion | `func foo() { foo() }` | "recursive call detected: foo → foo" |
@@ -2589,14 +2833,15 @@ The language has no `async`, `await`, `future`, or `promise` keywords. User writ
 ```swift
 // User writes:
 func auth(_ req: Request, role: string) -> User {
-    guard let token = req.authorization else { return 401 }
+    let token = req.authorization.or("")
+    guard token.isEmpty == false else { return 401 }
     let res = get http://auth/verify {     // compiler knows: I/O point
         Authorization: token
     }
-    guard let res else { return 502 }      // Result<Response> — must guard
+    guard res else { return 502 }          // error-capable response
     guard res.status == 200 else { return 401 }
     let user = res.body(User)
-    guard let user else { return 401 }     // Result<User> — must guard
+    guard user else { return 401 }         // error-capable body parse
     guard user.role == role else { return 403 }
     req.X-User-ID = user.id
     return user
@@ -2622,7 +2867,7 @@ func auth(_ req: Request, role: string) -> User {
 
 | Feature | Example | Why |
 |---------|---------|-----|
-| `guard ... else` | `guard let token = req.authorization else { return 401 }` | Perfect for middleware "reject or continue" pattern |
+| `guard ... else` | `guard jwtDecode(token, secret: key) else { return 401 }` | Perfect for middleware "reject or continue" pattern |
 | Named parameters | `auth(req, role: "user")` | Self-documenting calls, LLMs generate correct argument order |
 | `_` unlabeled param | `func auth(_ req: Request, role: string)` | First param (always req) doesn't need label |
 | Optional chaining | `req.authorization?.hasPrefix("Bearer ")` | Safe navigation on nullable headers |
@@ -2706,11 +2951,12 @@ let userCache = LRU<string, string>(capacity: 10000, ttl: 5m, coalesce: true)
 // ---------- Middleware ----------
 
 func auth(_ req: Request, role: string) {
-    guard let token = req.authorization else { return 401 }
+    let token = req.authorization.or("")
+    guard token.isEmpty == false else { return 401 }
     guard token.hasPrefix("Bearer ") else { return 401 }
 
     let claims = jwtDecode(token.trimPrefix("Bearer "), secret: env("JWT_SECRET"))
-    guard let claims else { return 401 }
+    guard claims else { return 401 }
     guard claims.exp >= now() else { return 401, "token expired" }
     guard claims.role == role else { return 403 }
 
@@ -2774,7 +3020,7 @@ route {
 
         post /orders {
             let order = req.body(Order)
-            guard let order else { return 400 }
+            guard order else { return 400 }
             for item in order.items {
                 guard item.qty > 0 else { return 400, "invalid quantity" }
             }
@@ -2803,7 +3049,7 @@ route {
         }
         post /ban {
             let ip = req.body(IP)
-            guard let ip else { return 400 }
+            guard ip else { return 400 }
             blacklist.add(ip)
             notify all blacklist.add(ip)
             return 200
@@ -2958,7 +3204,7 @@ null dereference) **must never take down the shard**.
 The compiler eliminates most crash sources:
 - Division by zero → compiler inserts check before every `/`, returns 500 if divisor is 0
 - Array out of bounds → compiler inserts bounds check on every `[]` access
-- Null/nil access → `Result` and `Optional` force `guard let` before access
+- Null/nil access → use `?`, `?.`, `??`, or `or(...)`; use `guard` only for explicit error handling
 - Infinite loops → no `while`, no recursion, `for` only on finite collections
 - Stack overflow → all functions inline, no call stack depth
 
@@ -4562,25 +4808,31 @@ During shutdown:
   Lexer / Parser (hand-written recursive descent)
     │
     ▼
-  Untyped AST
+  AST
     │
     ▼
-  Type Checker / Semantic Analysis
-    │  - type inference
+  HIR (resolved + typed language semantics)
+    │  - name resolution
+    │  - type inference / checking
     │  - route conflict detection
     │  - domain value range checks
-    │  - unreachable code detection
     │  - header spell check
     │  - optional access safety
     ▼
-  Typed AST
+  MIR (normalized execution model / CFG)
+    │
+    │  - explicit control flow
+    │  - evaluation order
+    │  - early return / guard lowering
+    │  - yield boundary placement
+    │  - unreachable code detection
+    ▼
+  Inline Expansion + Lowering
     │
     ▼
-  Inline Expansion (all func calls expanded)
+  RIR (backend-facing typed IR)
     │
     ▼
-  Rutlang IR (RIR)  ◄── custom IR, backend-agnostic
-    │
     ├── Optimization passes (on RIR)
     │   - dead code elimination
     │   - constant folding / propagation
@@ -4604,9 +4856,687 @@ During shutdown:
   CompiledConfig { version, routes, handlers }
 ```
 
+#### 11.1.1 Layer Responsibilities
+
+The compiler is intentionally split into four semantic layers:
+
+- **AST** — source-structure model. Preserves the user's surface syntax and source spans.
+- **HIR** — language-semantics model. Names are resolved, types are known, and Rut-specific objects such as `route`, `upstream`, and `forward` are explicit.
+- **MIR** — execution-semantics model. Control flow, evaluation order, short-circuiting, early returns, and yield boundaries become explicit.
+- **RIR** — backend contract. A compact, typed, SSA-friendly IR consumed by optimization passes and code generation.
+
+The intended boundary between these layers is:
+
+- **AST answers:** "What did the user write?"
+- **HIR answers:** "What does that code mean in Rut?"
+- **MIR answers:** "How does that meaning execute?"
+- **RIR answers:** "What primitive operations must the backend emit?"
+
+Concrete ownership rules:
+
+- **AST** carries source structure and `span` information, but not resolved symbols, inferred types, or backend opcodes.
+- **HIR** carries resolved references, type information, and normalized language semantics, but not SSA numbering or backend instruction selection.
+- **MIR** carries blocks, branches, terminators, evaluation order, and temporary values, but not target-specific code generation details.
+- **RIR** carries explicit backend-facing operations and source locations, but does not try to model high-level parser recovery state or unresolved language constructs.
+
+`HIR -> MIR` is the key semantic boundary in the compiler:
+
+- `HIR` is where the compiler understands the language.
+- `MIR` is where the compiler understands execution.
+
+That split exists so Rut-specific language features can evolve without forcing the backend IR to absorb high-level control-flow lowering, optional semantics, or route-level sugar directly.
+
+#### 11.1.2 Optimization Ownership by Layer
+
+Optimization responsibility is intentionally layered as well:
+
+- **HIR** may perform language-semantic simplifications that depend on type knowledge or constant domain values, but it is not responsible for storage reuse or backend-style value scheduling.
+- **MIR** is the first good place for temporary-value cleanup, such as trivial copy propagation, dead temporary elimination, expression flattening, and simplifications that depend on explicit control flow or evaluation order.
+- **RIR** is the main optimization IR for backend-independent passes such as dead code elimination, constant folding, guard coalescing, and state-machine construction.
+- **Backend / LLVM** owns physical storage reuse: register allocation, stack-slot reuse, frame layout, and related lifetime-based memory optimizations.
+
+In practice this means:
+
+- "Can this temporary value be optimized away?" is usually a **MIR or RIR** question.
+- "Can two dead/non-overlapping variables reuse the same storage?" is a **backend allocation** question, typically handled after RIR lowering by LLVM or an equivalent code generator.
+
+#### 11.1.3 Type System Boundaries
+
+Rut's type system is intentionally designed to avoid runtime type uncertainty.
+
+The target model is:
+
+- No inheritance
+- No subtype polymorphism
+- No runtime RTTI-style type discovery
+- No trait objects / erased interface dispatch
+- No implicit fallback to dynamic `Any`
+
+This means every expression must have a single, fully known static type by the end of HIR construction.
+
+Failure may still occur in the language, but not because the runtime is discovering the type of a value. The remaining failure categories are:
+
+- value-range checks (for example, narrowing numeric conversions)
+- optional absence / `nil`
+- parsing failures
+- explicitly modeled sum/variant matching, if such types are introduced later
+
+As a result:
+
+- `is` is not a runtime type-test operator in Rut's design
+- `as` is not a dynamic cast
+- MIR and RIR are not expected to carry runtime type tests as ordinary program operations
+
+Instead, Rut should treat these features as follows:
+
+- **`is`** — a compile-time type/shape predicate only. It answers questions about statically known type relationships and should fold during semantic analysis whenever possible.
+- **`as`** — an explicit conversion that is guaranteed to succeed if accepted by the type checker.
+- **`as?`** — an explicit checked conversion for cases where the conversion is semantically valid but may fail.
+- **`parse`** — text-to-value interpretation. String-to-domain conversions belong here rather than in `as` / `as?`.
+
+That distinction is important:
+
+- `i32 as i64` is a conversion
+- `i64 as? i32` is a checked conversion
+- `string -> IP` is parsing, not casting
+
+The language should avoid treating text as a universal source type. In particular, most `string -> T` operations for domain types (`IP`, `CIDR`, `Duration`, `StatusCode`, etc.) should be modeled as parse operations rather than casts.
+
+Optionality must also remain explicit in the semantic layers, even if the surface
+language sometimes hides it ergonomically. In particular, the compiler must
+distinguish:
+
+- `T`
+- `T?`
+- `Result<T, Error>`
+- `Result<T?, Error>`
+
+These are not interchangeable. They imply different control-flow shapes, different
+dataflow facts, and different optimization opportunities.
+
+Semantically, the two key questions are independent:
+
+- **optionality** — can this expression yield no usable value (`nil`)?
+- **error capability** — can this expression carry failure information?
+
+That means the compiler should treat "may be nil" and "may have error" as separate
+dimensions of the internal model rather than collapsing them into one flag.
+
+The same rule applies to function return-type inference.
+
+At the surface level, users may omit the return type or spell it explicitly. But by
+the end of HIR construction, the compiler must normalize each function's return
+shape using two independent dimensions:
+
+- `may_nil`
+- `may_error`
+
+That yields exactly four normalized semantic forms:
+
+- `T` — not optional, not error-capable
+- `T?` — optional, not error-capable
+- `Result<T, Error>` — error-capable, success value required
+- `Result<T?, Error>` — error-capable, success value may still be absent
+
+This means surface syntax may look lightweight, but the normalized semantic return
+shape must remain precise for control-flow lowering, diagnostics, and optimization.
+
+However, the *representation* of `T?` is a backend choice, not a language promise.
+When the compiler can prove it is safe, it may represent optional values using:
+
+- spare / niche bit patterns
+- out-of-range sentinel values
+- tagged pointers or equivalent compact layouts
+
+For example, a reference-like type may use `null` as `nil`, while certain bounded
+domain values may be able to reserve an impossible value as the `nil` sentinel.
+
+This is purely an implementation optimization. It must not change source-level
+semantics. If the compiler cannot prove a niche/sentinel encoding is safe, it must
+fall back to an explicit tag or equivalent representation.
+
+#### 11.1.4 Generics and Constraints
+
+Rut still needs abstraction power, even though it avoids runtime type uncertainty.
+
+The intended answer is **compile-time generics with monomorphization**, not subtype polymorphism:
+
+- Generic functions are instantiated at compile time
+- Generic structs / enums / sum types are instantiated at compile time
+- Generated MIR/RIR always see concrete types after instantiation
+- No runtime generic erasure is required
+
+This is important for ergonomics. Without generics, routine language building blocks such as `Option<T>`, `Result<T, E>`, typed collections, and reusable helper functions would force large amounts of duplicated code.
+
+Traits / constraints are still needed, but mainly for people defining abstractions rather than ordinary users writing application logic.
+
+The intended usage split is:
+
+- **Ordinary users** mostly consume generic APIs and usually do not write explicit constraints
+- **Library authors / framework authors / large-system authors** define generic abstractions and therefore write constraints
+
+For that reason, constraints should optimize for semantic clarity, extensibility, and diagnostics more than for being the shortest syntax in everyday code.
+
+Rut should therefore distinguish clearly between three different surface concerns:
+
+- `protocol` declares a behavioral contract
+- `impl` declares that a type conforms to one or more protocols and optionally provides method bodies
+- `using` is reserved for import / alias syntax only; it must not be used to declare protocol conformance
+
+Conformance should therefore use `impl`, not `using`.
+If a type only wants to adopt protocol default implementations, it should do so with an empty `impl` block:
+
+```rut
+Box impl Hashable {}
+```
+
+Rut should therefore use a single semantic core for constraints:
+
+- predicate-based constraint solving inside the compiler
+- trait-like surface syntax only as sugar, if desired
+
+In other words, the compiler should not maintain two separate type-system mechanisms for "traits" and "constraints". There should be one internal constraint model, with optional lighter surface syntax layered on top.
+
+Examples of the intended layering:
+
+- User-facing sugar: `func contains<T: Eq>(xs: [T], needle: T) -> bool`
+- Canonical semantic form: `func contains<T>(xs: [T], needle: T) -> bool where Eq(T)`
+
+The second form is the semantic core. The first is optional sugar.
+
+**Protocol Conformance and Default Implementations**
+
+Rut should support explicit protocol conformance blocks in type-first form:
+
+```rut
+Box impl Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+```
+
+A single block may list multiple protocols:
+
+```rut
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+    func add(self: Box, x: i32) -> i32 => x
+}
+```
+
+First-stage conformance rules:
+
+- `impl` itself declares conformance; no separate conformance declaration syntax is needed
+- an empty `impl` block is valid when all required protocol methods have default implementations
+- if a required protocol method has no default implementation, the `impl` block must provide it
+- one type may conform to multiple protocols, but if two protocols in the same `impl` block define the same method name, the block must be rejected as ambiguous
+- `using Type as Protocol` is not protocol syntax and must remain invalid for conformance
+
+Dispatch rules for the first stage:
+
+- dispatch is static
+- concrete receiver calls may resolve to either an explicit `impl` method or a protocol default method
+- explicit `impl` methods take precedence over protocol default methods
+- generic receiver calls may dispatch through protocol constraints when the generic type is known to conform
+- imported explicit `impl` blocks are visible to the importing file for both concrete receiver dispatch and generic constraint satisfaction
+- empty imported `impl` blocks may adopt protocol default methods just like local empty `impl` blocks
+- explicit `impl` uniqueness is global within the current visible import graph: if two visible explicit `impl` blocks overlap on the same `Type + Protocol`, the program must be rejected rather than selecting one by priority
+- dynamic dispatch, witness tables, and trait objects are out of scope for the first stage
+
+#### 11.1.5 Type-Level Computation for Constraints
+
+If Rut supports generic constraints seriously, the compiler needs internal type predicates and type computation utilities.
+
+At minimum, the type checker needs internal operations such as:
+
+- type equality
+- "is this type comparable / hashable / optional / numeric?"
+- "what is the inner type of `Optional<T>`?"
+- "can `T` be compared to `U`?"
+- "is this cast total, checked, or forbidden?"
+
+These capabilities are primarily compiler infrastructure. They do not imply that the language must immediately expose a full user-programmable type-level function language.
+
+The intended order of exposure is:
+
+- internal type predicates and type computations first
+- user-visible generic constraints second
+- only later, if truly needed, richer user-facing type-level expressions
+
+This keeps the implementation coherent while avoiding premature complexity in the surface language.
+
+#### 11.1.6 Pipeline Placeholder Rules
+
+Rut may support a pipeline operator for staged dataflow, but if it does, the placeholder rules should be explicit and compile-time checked.
+
+The intended placeholder model is:
+
+- `_` is syntax sugar for `_1`
+- `_N` refers to pipeline input slot `N`
+- placeholders are positional, not named
+
+The key rule is:
+
+- a pipeline stage may only reference input slots that are statically provided by the value on the left-hand side
+
+For the first-stage design this means:
+
+- a non-tuple value provides only slot `_1`
+- a tuple value with arity `K` provides slots `_1 ... _K`
+- the maximum placeholder index referenced by the right-hand stage must be `<=` the left-hand input arity
+
+Examples:
+
+- `x | f(_)` is valid because `_` means `_1`
+- `x | f(_1)` is valid
+- `x | f(_2)` is invalid because a single value only provides one slot
+- `(a, b) | f(_1, _2)` is valid
+- `(a, b) | f(_3)` is invalid
+
+The compiler should reject placeholder misuse during semantic analysis, before MIR/RIR lowering.
+
+This placeholder system is intentionally future-friendly:
+
+- single-input pipelines stay simple
+- multi-input pipelines can later reuse the same numbered-slot model
+- the syntax does not need to be redesigned when tuple-fed stages are introduced
+
+The pipeline operator should only trigger its special pipeline semantics when the right-hand side is a stage application using placeholders. That keeps bitwise operators and pipeline syntax distinguishable at compile time while preserving a clear path for stream-style lowering and fusion optimizations.
+
+#### 11.1.6A Recursive Tuple Type Shapes
+
+Rut's current tuple handling may begin with a flat internal representation such as:
+
+- `tuple_len`
+- `tuple_types[]`
+- `tuple_variant_indices[]`
+- `tuple_struct_indices[]`
+
+That flat form is acceptable as an implementation starting point, but it is not
+the right long-term semantic model.
+
+The target model is a recursive type-shape graph:
+
+- `Bool`
+- `I32`
+- `Str`
+- `Generic`
+- `Variant`
+- `Struct`
+- `Tuple([TypeShape, ...])`
+
+In particular, tuple element shapes must be allowed to contain:
+
+- nested tuples
+- concrete generic instances
+- qualified imported types
+- structs and variants with their own concrete payload/field shapes
+
+Examples that should be representable directly in the type model:
+
+- `(i32, i32)`
+- `(Box, i32)`
+- `((Box, i32), i32)`
+- `Result<Box<i32>>`
+- `Result<(Box<i32>, i32)>`
+
+This matters because a flat tuple metadata scheme creates avoidable special cases:
+
+- nested tuple elements become artificially forbidden or awkward
+- tuple equality / ordering lowering needs ad hoc parallel arrays
+- imported qualified generic type arguments become harder to preserve
+- tuple fields, tuple payloads, tuple params, and tuple returns drift apart semantically
+
+So the intended invariant is:
+
+- **HIR semantic type identity must be expressible using recursive type shapes**
+- backend-facing flattened tuple metadata may still exist temporarily as lowering cache or compatibility data
+- but flattened metadata must not be treated as the semantic source of truth forever
+
+The recommended migration order is:
+
+1. Introduce a recursive `TypeShape` pool in HIR.
+2. Record function parameter and return shapes there first.
+3. Extend the same shape model to struct fields, variant payloads, locals, and expressions.
+4. Keep flat tuple arrays only as compatibility fields until MIR/RIR lowering fully consumes recursive shapes.
+5. Remove duplicated flat semantic metadata once lowering no longer depends on it.
+
+During the migration period, both representations may coexist, but the rule should be:
+
+- new type-system features must attach to the recursive shape model first
+- flat tuple arrays exist only to preserve existing lowering paths until they are retired
+
+Current implementation status for this migration is intentionally split into two
+separate signals:
+
+- `is_concrete`
+  - means the recursive shape is fully concrete as a type
+  - examples: `i32`, `Box<i32>`, `Result<Box<i32>>`
+  - this does **not** imply lowering can already materialize every required runtime carrier
+
+- `carrier_ready`
+  - means lowering may safely consume that shape without violating the current
+    build order for struct/variant runtime carriers
+  - this is stricter than `is_concrete`
+  - it is currently computed in MIR, not inferred ad hoc in lowering
+
+That distinction exists because a shape may be fully concrete while still depending
+on a struct definition or variant carrier that has not yet been materialized in the
+current lowering pass.
+
+The current intended lowering rule is:
+
+- prefer recursive shape metadata when `carrier_ready` is true
+- otherwise fall back to the legacy flat metadata / existing build-order checks
+
+At the moment, that `carrier_ready` gate is already used in conservative lowering
+entry points such as:
+
+- shape-sensitive comparison / field-access helpers
+- struct field type selection during user-struct build
+- variant payload carrier selection for tuple / struct / variant payload paths
+
+More concretely, the current `lower_rir` implementation already prefers
+shape-derived views at these call sites:
+
+- top-level binary `Eq` / `Lt` / `Gt` dispatch after MIR values are materialized
+- tuple-valued `materialize_value(...)` paths before tuple lowering lookup
+- struct field `Eq` / `Ord` recursion
+- variant payload `Eq` / `Ord` recursion
+- struct-build field type selection
+- variant payload carrier selection
+
+And it still intentionally keeps legacy flat tuple metadata as the primary source
+in a few narrower places:
+
+- tuple comparison / ordering recursion at individual tuple-slot level
+- tuple lowering cache keys and tuple-shape equality checks
+- variant pre-scan logic that merges multiple tuple payload cases into one
+  lowering record
+
+Those remaining flat-metadata paths are not accidental. They still operate on
+slot-level tuple metadata without an existing standalone `FlatMirShape` value, so
+they have been left in place until that representation is promoted cleanly rather
+than patched ad hoc.
+
+Current analyzer-side shape refresh rules are also important here:
+
+- generic struct instantiation and generic struct refresh recompute `field.shape_index`
+  from the instantiated field type, rather than inheriting a template-era shape index
+- generic variant instantiation and generic variant refresh recompute
+  `payload_shape_index` from the instantiated payload type for the same reason
+- generic function instantiation recomputes expression `shape_index` after named
+  struct/variant instances are concretized, so inlined generic call results do not
+  retain template-era shape indices
+- concrete generic struct / variant instances now also record per-type-argument
+  `instance_shape_indices[]`, instead of only base kind + flat tuple metadata
+- helper paths that reconstruct generic bindings from existing concrete instances
+  are expected to preserve those `instance_shape_indices[]`, not silently drop
+  back to shape-less bindings
+- declaration-side `TypeArgRef.shape_index` is no longer just transitional storage:
+  deferred named-type instantiation and generic-binding reconstruction helpers are
+  expected to reuse an existing `shape_index` first, and only recompute shape when
+  a legacy path still leaves it absent
+- analyzer-side generic binding reconstruction is now partially centralized through
+  `fill_bound_binding_from_type_metadata(...)`; current high-traffic users include:
+  explicit generic `StructInit`, explicit generic `VariantCase`, function
+  parameter/return named-generic paths, and declaration-side struct-field / variant
+  payload named-generic paths
+- that helper coverage now also extends into lower-frequency reconstruction paths:
+  explicit call-site `generic_bindings`, imported target instance bindings,
+  concrete instance refresh, concrete generic type-ref instantiation,
+  impl generic binding reconstruction, named-instance concretization, and the
+  `Self` fallback binding used during method-body instantiation
+- transitional tuple metadata remains semantically relevant during this migration:
+  `tuple_types[]`, `tuple_variant_indices[]`, and `tuple_struct_indices[]` must
+  stay in sync across generic binding, named type concretization, and instance reuse
+
+This matters because `carrier_ready` is only meaningful if the shape attached to
+an instantiated field / payload / expression is itself the instantiated shape.
+If template-era shape indices leak through, MIR may stay artificially conservative
+even when the concrete type graph is already safe to consume.
+
+The same is true for the flat tuple compatibility layer:
+
+- tuple elements with `Variant` kind must use `tuple_variant_indices[i]`
+- tuple elements with `Struct` kind must use `tuple_struct_indices[i]`
+- generic struct / variant instance equality and reuse must compare both arrays,
+  not only the variant-side indices
+
+Until recursive `TypeShape` fully replaces the old tuple metadata, these flat
+arrays remain part of the implementation contract and cannot be treated as
+optional compatibility trivia.
+
+The current observed consequence is:
+
+- simple concrete type-decl paths such as `(Box, i32)` can now become `carrier_ready`
+- imported nested generic payload paths such as `Result<Box<Result<i32>>>` can also
+  become `carrier_ready` once their instantiated payload shapes are recomputed
+- the generic-instance readiness path now has an explicit shape-based chain:
+  HIR `instance_shape_indices[]` -> MIR `instance_shape_indices[]` ->
+  MIR fixed-point `carrier_ready` -> lowering-side generic-instance gates
+- analyzer helper code is in a mixed state:
+  high-frequency generic-binding paths now prefer existing `shape_index` values,
+  and several formerly low-frequency paths now share the same reconstruction helper;
+  remaining outliers are expected to be genuinely specialized sites rather than the
+  old repeated "copy flat metadata then recompute shape" pattern
+- readiness is still allowed to remain conservative where the recursive shape is not
+  yet fully propagated or where lowering still depends on legacy compatibility data
+
+But the migration is not complete yet:
+
+- recursive shape metadata is the semantic source of truth
+- legacy flat tuple metadata still remains a compatibility layer for older lowering paths
+- lowering must continue to prefer explicit safety gates over guessing readiness from
+  `Unknown`, missing indices, or similar indirect signals
+
+#### 11.1.7 Error Model and Pipeline Short-Circuiting
+
+Rut's surface language should not force ordinary users to spell `Result<T, E>`
+everywhere, but the compiler still needs one clear semantic failure model.
+
+The intended split is:
+
+- **Surface language** may use ordinary values, `nil`, and explicit `error(...)`
+- **HIR** may normalize error-capable expressions and functions to `Result<V, Error>`
+
+This means `Result<V, Error>` remains the compiler's internal semantic model even
+when the user-facing syntax is lighter and more DSL-like.
+
+The built-in `Error` type is standard language infrastructure:
+
+- it is not the same as `nil`
+- it may carry structured information
+- it is the common failure payload used by the compiler's normalized `Result<V, Error>` form
+
+The semantic distinction still matters:
+
+- `nil` is the absence of a usable value on the value channel
+- `error(...)` is structured failure information
+- HIR is allowed to preserve and analyze that failure information explicitly
+
+But the ergonomic operators of the language intentionally work in terms of the
+value channel:
+
+- `|`, `?`, `?.`, and `??` are value-oriented syntax
+- they optimize for "keep going if a usable value exists"
+- in those forms, failure behaves like "no usable value", so the expression flows as `nil`
+
+This is a deliberate usability tradeoff for gateway-style code, where many failures
+are tolerated locally and only need logging, counting, or fallback behavior.
+
+Explicit failure handling remains available:
+
+- `guard let` is the primary entry into explicit error handling
+- future `match` may expose error details more directly where needed
+
+So Rut keeps one semantic failure model for the compiler, while allowing the common
+surface syntax to treat failure as absence when that is the more ergonomic thing to do.
+
+#### 11.1.8 Standard Error Model
+
+Ordinary users should not need to define a custom error type just to return a
+failure. Rut therefore needs a standard concrete `Error` struct in the language.
+
+The standard `Error` should contain at least:
+
+- `code`
+- `msg`
+- `file`
+- `func`
+- `line`
+
+`code` and `msg` are the semantic identity of the error. `file`, `func`, and
+`line` are source-origin diagnostics and should normally be injected automatically
+by the compiler at the error-construction site.
+
+The preferred ordinary-user construction path is a lightweight built-in
+constructor:
+
+- `error(.badRegex)`
+- `error(.badRegex, "invalid regex")`
+
+That constructor builds the standard `Error` value and fills source-location fields
+automatically.
+
+Rut should also have an `Error` protocol so advanced users can define custom error
+types. Those custom types are not the default path; they are for library authors
+and specialized modules that need more payload or domain-specific structure.
+
+The standard `Error` struct should satisfy the `Error` protocol, and custom error
+types may satisfy it as well, typically by composition rather than inheritance.
+
+Finally, error-side type aggregation is allowed:
+
+- if a function may produce multiple distinct error kinds, the compiler may
+  aggregate the error side into a generated variant
+- this auto-aggregation applies to **errors**, not to ordinary success return values
+- ordinary success return values still require an explicit `variant` declaration if
+  multiple normal shapes are intended
+
+This gives Rut a simple default error path for most users while still allowing
+precise typed error handling where it is actually useful.
+
+#### 11.1.9 Variants and Match
+
+Rut needs a first-class way to represent "one of several named cases", but it does
+not need the full complexity of a Rust-sized enum system on day one.
+
+The language should therefore have a `variant` keyword as part of the core syntax.
+
+The intended use is:
+
+- model mutually exclusive named cases
+- optionally attach payload values to each case
+- use `match` as the general branching construct over those cases
+
+Important constraints:
+
+- ordinary success return values do **not** automatically become a variant
+- if a function needs multiple normal return shapes, the user must declare an explicit `variant`
+- error returns may still be aggregated by the compiler as part of the error model
+
+`match` is not variant-only magic. It is the language's general multi-way branching
+construct:
+
+- `if` is the lightweight boolean special case
+- value dispatch that might look like a traditional `switch` is handled by `match`
+- variant dispatch is also handled by `match`
+
+So Rut does not need a separate `switch` keyword.
+
+The first-stage `variant` / `match` surface should stay deliberately small.
+
+**Variant case spelling**
+
+- short form: `.timeout`
+- fully qualified form: `NetError.timeout`
+- bare names like `timeout` are not accepted as variant cases
+
+This keeps variant-case references explicit without forcing full qualification in
+every local context.
+
+**First-stage `match` forms**
+
+Rut should support:
+
+- `match expr { ... }`
+- `case <literal>:`
+- `case .variant:`
+- `case .variant(x):`
+- `case Type.variant:`
+- `case _:` as fallback
+
+Payload binding is intentionally shallow in the first stage:
+
+- single-layer payload binding is supported
+- deep nested destructuring is not
+- OR-patterns, range patterns, and `case ... if cond` are not part of the first stage
+
+`match` is initially a statement form. It does not need to be an expression in the
+first implementation.
+
+**Exhaustiveness**
+
+For `variant`-based matches, the compiler should require either:
+
+- all cases are covered, or
+- a `case _:` fallback is present
+
+That exhaustiveness check is one of the main reasons to have `match` at all, and it
+should be part of the first-stage design.
+
+#### 11.1.10 Compile-Time Branching
+
+Rut should support compile-time branching in a small, explicit form.
+
+The preferred surface direction is:
+
+- `if const` for compile-time boolean branching
+- `match const` for compile-time multi-way branching
+
+In both forms, the condition / matched value must be known at compile time. If it
+is not, compilation fails.
+
+These are true compile-time branches, not ordinary runtime branches that are merely
+optimized later.
+
+That means:
+
+- they are valid for type-based specialization
+- they are valid for compile-time configuration values
+- they are valid for results produced by compile-time-evaluable pure functions
+- they are not valid for request data or other runtime-only values
+
+To preserve their usefulness for specialization, only the selected branch is
+required to pass full semantic and type checking for the current instantiation. An
+unselected branch does not need to type-check under that same compile-time choice.
+
+This provides enough power for specialization and compile-time configuration
+without turning the language into a large meta-programming system.
+
+#### 11.1.11 Response Shorthand
+
+HTTP responses are common enough in Rut that they should have a high-level surface
+form instead of always being assembled from raw status/header/body pieces.
+
+Rut should support response shorthand such as:
+
+- `return .ok`
+- `return .unauthorized`
+- `return .notFound`
+- `return .ok(json: user)`
+- `return .tooManyRequests(retryAfter: 1m)`
+
+These forms are not just printer sugar. The compiler should preserve them as
+high-level response intent in HIR, then lower them later to concrete status codes,
+headers, and body construction.
+
+That keeps routine gateway code compact while still giving the compiler explicit
+HTTP semantics instead of losing intent too early.
+
 ### 11.2 Rutlang IR (RIR)
 
-A lightweight, flat, typed IR between the AST and LLVM IR. Each route handler compiles to one RIR function — a linear sequence of blocks with explicit control flow.
+A lightweight, flat, typed IR between MIR and LLVM IR. Each route handler compiles to one RIR function — a linear sequence of blocks with explicit control flow.
 
 #### 11.2.1 Why RIR
 
@@ -4931,7 +5861,7 @@ Total external dependencies: **7-9**
 ❌ protobuf / grpc
 ❌ OpenSSL (Phase 1)
 ❌ tcmalloc / jemalloc (own allocators)
-❌ any package manager
+❌ heavy package manager / dependency solver
 ```
 
 ---
@@ -5081,7 +6011,7 @@ let users = upstream {
 // Request-level timeout via any(wait()):
 let h = submit forward(userService, buffered: true)
 let resp = any(wait(h, 5s))   // 5s deadline, cancel if exceeded
-guard let resp else { return 504 }
+guard resp else { return 504 }
 ```
 
 ```
@@ -5109,7 +6039,8 @@ let authService = service("http://auth-service") {
 
 // Use like a typed HTTP client — same syntax, but with retry + breaker:
 func auth(_ req: Request, role: string) -> User {
-    guard let token = req.authorization else { return 401 }
+    let token = req.authorization.or("")
+    guard token.isEmpty == false else { return 401 }
 
     let res = authService.get("/verify") {
         Authorization: token
@@ -5156,7 +6087,7 @@ let users = upstream {
 // Periodic refresh using timer:
 timer refreshUsers, every: 10s, shard: 0 {
     let res = get http://consul:8500/v1/health/service/user-service
-    guard let res else { return }
+    guard res else { return }
     // update upstream targets from Consul response
 }
 ```
@@ -5200,7 +6131,8 @@ fire (async calls)      ✅              -               -
 ```swift
 // Structured logging — built into the language
 func auth(_ req: Request, role: string) -> User {
-    guard let token = req.authorization else {
+    let token = req.authorization.or("")
+    guard token.isEmpty == false else {
         log.warn("missing auth token", {
             path: req.path
             addr: req.remoteAddr
@@ -5240,6 +6172,7 @@ func auth(_ req: Request, role: string) -> User {
 func processOrder(_ req: Request) {
     trace.span("validate_order") {
         let order = req.body(Order)
+        guard order else { return 400 }
         guard !order.items.isEmpty else { return 400 }
     }
 
@@ -5827,7 +6760,7 @@ are updated:
 ```swift
 post /admin/ban {
     let ip = req.body(IP)
-    guard let ip else { return 400 }
+    guard ip else { return 400 }
     blacklist.add(ip)               // userspace Set (immediate)
     notify all blacklist.add(ip)    // all shard userspace Sets
     // compiler auto-generates: update eBPF map via Node Agent

--- a/design_cn.md
+++ b/design_cn.md
@@ -1,0 +1,1310 @@
+# Rutlang：设计文档
+
+> 一个强类型 DSL 和高性能 L7 入口运行时。API 网关、WAF、反向代理、服务网格 sidecar、CDN 边缘节点：一门语言，多种编译目标。
+
+## 状态与范围
+
+这份文档目前同时承担三种角色：
+
+- **规范性的语言 / 运行时说明**：描述 Rutlang 期望提供的契约
+- **实现设计文档**：描述编译器、JIT / eBPF 代码生成、运行时和热重载路径应如何工作
+- **路线图**：描述尚未完整实现、但计划支持的能力
+
+这种混合写法有利于设计探索，但也很容易让人把“目标中的能力”误读成“今天已经 shipping 的行为”。除非某一节显式说明了当前实现状态，否则下面的语言与运行时章节都应理解为 **目标契约**，而不是“当前仓库已经完整实现”的声明。
+
+### 阅读指南
+
+- **偏规范 / 契约的章节**：语言语法、类型系统、路由语义、状态语义、编译期检查
+- **偏实现设计的章节**：运行时架构、内存布局、I/O 后端设计、热重载内部机制
+- **偏路线图的章节**：更高级的 TLS 能力、sidecar 集成、部分跨节点 / 分布式能力、可观测性扩展
+
+当实现与设计出现偏差时，仓库内的真实优先级应为：
+
+1. 覆盖当前行为的测试
+2. 当前实际可达的运行时 / 编译器代码路径
+3. 本文档中定义的目标行为
+
+### 实现状态矩阵
+
+这张表刻意保持粗粒度，它的目的是区分“已经设计好”与“今天已经能被稳定依赖”的能力。
+
+| 领域 | 状态 | 说明 |
+|------|------|------|
+| 运行时事件循环、分片、socket 处理 | **已实现** | 仓库中已经有 epoll / io_uring 运行时核心 |
+| HTTP 解析与代理运行时 | **已实现** | 已有面向生产路径的实现与测试 |
+| RIR 数据模型 + builder + printer | **已实现** | RIR 真实存在，并且有测试覆盖 |
+| LLVM ORC JIT 集成 | **已实现** | JIT 引擎和 codegen 路径已经存在 |
+| 离线 manifest → RIR → JIT simulate 流程 | **已实现** | 当前“类似编译”的路径是刻意收窄过的 |
+| `firewall` → eBPF / XDP 编译目标 | **已设计** | 语言设计明确要求该路径生成 eBPF bytecode，而不是用户态 handler |
+| 完整 Rutlang lexer / parser / type checker | **部分完成 / 进行中** | token 面已经声明，但前端尚未闭环 |
+| 路由冲突分析和完整诊断 | **已设计** | 文档里有说明，但当前还没有端到端全部落实 |
+| 下文示例中的完整语言表面 | **已设计** | 很多例子是目标语法，不一定已经被当前代码接受 |
+| 跨 shard 的语言原语（`notify`、`consistent`） | **已设计** | 运行时方向由本文定义，应将其视为目标契约 |
+| 外部状态后端（`backend: .redis`） | **已设计** | 不是当前仓库已经承诺可用的能力 |
+| 完整 `.rut` 程序的零停机热重载 | **部分设计 / 运行时有片段** | 运行时方向明确，但语言级全流程尚未闭环 |
+
+### 文档拆分计划
+
+长期来看，这份文档应拆成：
+
+- `LANG_SPEC.md`：语法、类型、路由、状态语义、诊断
+- `RUNTIME.md`：分片模型、I/O 后端、内存、重载、网络内部机制
+- `ROADMAP.md`：未来阶段、可选能力、部署 / sidecar 扩展
+
+在真正拆分之前，这个文件仍然作为总设计文档存在。
+
+## 1. 项目概览
+
+### 1.1 目标
+
+- 用一门强类型语言替代 nginx 配置文件和 OpenResty Lua
+- 尽可能在编译期捕获错误（类型错误、路由冲突、非法值）
+- 让 LLM 容易生成和理解
+- 高性能：目标支持 C100K+，并把延迟开销压到最低
+- 支持无停机热重载
+- 依赖最小化，控制力最大化
+
+### 1.2 非目标
+
+- 通用编程语言
+- L4 负载均衡（本项目只做 L7 HTTP）
+- DPDK / 内核旁路网络
+- 与 nginx 配置格式兼容
+
+---
+
+## 2. 架构总览
+
+```
+                          ┌─────────────────────────────┐
+    .rut source ───▶   │  Compiler (embedded in proc) │
+                          │  parse → type check → IR     │
+                          └───────┬───────────┬─────────┘
+                                  │           │
+                                  │           └──────────────▶ eBPF bytecode
+                                  ▼                           (for firewall/XDP)
+                         ┌──────────────────────┐
+                         │  JIT (LLVM ORC JIT)   │
+                         └──────────┬───────────┘
+                                    │ native function pointers
+                                    ▼
+   ┌────────────────────────────────────────────────────────┐
+   │                    Rutlang Runtime                    │
+   │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
+   │  │  Shard 0  │ │  Shard 1  │ │  Shard 2  │ │  Shard N  │  │
+   │  │ io_uring  │ │ io_uring  │ │ io_uring  │ │ io_uring  │  │
+   │  │ Router    │ │ Router    │ │ Router    │ │ Router    │  │
+   │  │ Handlers  │ │ Handlers  │ │ Handlers  │ │ Handlers  │  │
+   │  │ ConnPool  │ │ ConnPool  │ │ ConnPool  │ │ ConnPool  │  │
+   │  │ Memory    │ │ Memory    │ │ Memory    │ │ Memory    │  │
+   │  └──────────┘ └──────────┘ └──────────┘ └──────────┘  │
+   │              share-nothing, per-core                   │
+   └────────────────────────────────────────────────────────┘
+```
+
+补充：对普通 `route` / handler 路径，主要编译目标是 LLVM ORC JIT 生成的原生函数指针；
+对 `firewall {}` 这类内核包过滤路径，编译目标是 eBPF bytecode，并加载到 XDP / 内核相关 hook。
+
+### 2.1 关键决策
+
+| 决策项 | 选择 | 理由 |
+|----------|--------|-----------|
+| 运行时 | 自定义 C++ 运行时（不是 Seastar） | 对这个用例来说 Seastar 过于复杂；Seastar 里真正相关的代码大约只有 30%；自定义运行时大约 5000 行，且完全可控 |
+| 网络 | io_uring（优先）+ epoll（回退） | io_uring 在 Linux 6.0+ 上最优；epoll 作为旧内核（3.9+）回退；二者都使用内核 TCP 栈 |
+| 线程模型 | per-core shard、share-nothing | Seastar / Envoy / nginx 已经验证过；能消除锁和竞态 |
+| JIT | LLVM ORC JIT | 与 C++ 工具链一致，零 FFI 开销，支持延迟编译 |
+| HTTP 解析器 | 自定义（约 500 行） | llhttp 是 callback 风格（不适合）；picohttpparser 缺少 strict mode；自定义 parser 可以直接与 Slice buffer + Arena 集成，支持 SIMD，并完全掌控严格性（anti-smuggling） |
+| C++ 标准库 | `-nostdlib++`，仅 musl libc | 完整的内存控制、更快的编译 |
+| 编译器参数 | `-fno-exceptions -fno-rtti` | 不为未使用的 C++ 特性承担额外开销 |
+
+---
+
+## 3. Rutlang 语言
+
+这一章定义 **Rutlang 目标中的表面语言和语义**。其中有些小节描述的是尚未完全在当前前端里接通的功能。如果有疑问，应把这里的示例理解为“目标语言契约”，并结合上面的实现状态矩阵确认今天到底支持到哪里。
+
+### 3.1 设计原则
+
+- **借鉴 Swift 的语法风格**：`guard` 语句、命名参数、可选链、字符串插值，既干净又易读，也有利于 LLM 生成
+- **HTTP 概念是原生对象**：方法、状态码、Header、URL、CIDR、媒体类型都是一等语言构造，而不是字符串
+- **所有函数都在编译期内联**：没有运行时函数调用，每条路由最终编译成一个扁平状态机
+- **异步对用户不可见**：没有 async / await / future / promise；用户写顺序代码，编译器识别 I/O 点并自动生成状态机
+- **强类型 + 领域类型**：Duration、ByteSize、StatusCode、IP、CIDR、MediaType 在编译期校验
+- **中间件就是普通函数**：返回状态码表示拒绝请求，不返回值表示放行
+- **有界执行**：不支持 `while`、不支持递归，`for` 只能迭代有限集合，因此每个 handler 都有编译期可推导的执行上界，不会卡死一个 shard
+- **三层模型**：`listen`（下游 / client）→ `.rut` 文件（网关逻辑）→ `upstream`（后端）。不提供 `gateway` 或 `downstream` 关键字，`.rut` 文件本身就是 gateway，`listen` 就是下游配置
+- **极简关键字集合**：`func`, `let`, `var`, `const`, `guard`, `struct`, `route`, `match`, `if`, `else`, `for`, `in`, `return`, `defer`, `upstream`, `listen`, `tls`, `defaults`, `forward`, `websocket`, `fire`, `submit`, `wait`, `timer`, `init`, `shutdown`, `firewall`, `throttle`, `per`, `notify`, `import`, `using`, `as`, `and`, `or`, `not`, `nil`, `true`, `false`
+
+### 3.2 文件扩展名
+
+`.rut`
+
+### 3.2.1 词法约定
+
+```swift
+// 注释 —— 仅支持行注释，不支持块注释
+// This is a comment
+
+// 字符串 —— 双引号，支持转义
+"hello world"
+"line one\nline two"           // 支持 \n \t \r \\ \"
+"\(req.path)/\(req.method)"    // 使用 \() 做字符串插值
+
+// 正则字面量 —— re 前缀
+re"^/api/v\d+/"
+
+// 数字字面量
+42                              // i32
+3.14                            // f64
+0xFF                            // 十六进制整数
+1_000_000                       // 允许下划线提升可读性
+
+// Duration / ByteSize 字面量（领域类型）
+500ms    1s    5m    1h    1d   // Duration
+64b    1kb    16kb    1mb    1gb // ByteSize
+
+// 语句以换行分隔 —— 不需要分号
+let x = 42
+let y = "hello"
+
+// 长表达式：用括号换行续写
+let result = (
+    someVeryLongFunction(req, arg1: value1, arg2: value2)
+)
+
+// 布尔值
+true   false   nil
+
+// 运算符
+and   or   not                  // 布尔（关键字）
+&   |   ^   ~   <<   >>        // 位运算（符号）
++   -   *   /   %              // 算术
+==  !=  <  >  <=  >=           // 比较
+=                               // 赋值
+?                               // 后缀 nil 检查（x?）
+?.                              // 可选链（x?.method）
+??                              // 空值合并（x ?? default）
+!                               // 逻辑非（`not` 的别名）
+@                               // 装饰器前缀
+=>                              // 单表达式、隐式返回
+->                              // 函数返回类型
+```
+
+### 3.3 类型系统
+
+#### 3.3.1 内建领域类型
+
+HTTP 相关概念是原生类型，并带有成员函数。它们都由运行时 C++ 内建结构体实现：字面量在编译期校验，访问时零额外开销。
+
+**IP** —— IPv4 / IPv6 地址
+
+```swift
+let ip = req.remoteAddr              // IP
+ip.v4?                               // bool —— 是否是 IPv4
+ip.v6?                               // bool —— 是否是 IPv6
+ip.isPrivate                         // bool —— RFC1918（10.x、172.16.x、192.168.x）
+ip.isLoopback                        // bool —— 127.0.0.0/8 或 ::1
+ip.in(10.0.0.0/8)                    // bool —— CIDR 包含关系
+ip.octets                            // [u8] —— 4 或 16 字节
+ip as string                         // "10.0.0.1"
+"10.0.0.1" as IP                     // Result<IP>
+```
+
+**CIDR** —— 网段
+
+```swift
+let cidr = 10.0.0.0/8               // CIDR 字面量
+cidr.network                         // IP —— 网络地址
+cidr.prefix                          // i32 —— 前缀长度（8）
+cidr.contains(req.remoteAddr)        // bool
+cidr as string                       // "10.0.0.0/8"
+```
+
+**Duration** —— 时间间隔
+
+```swift
+let d = 30s                          // Duration 字面量（也支持：ms、m、h、d）
+d.ms                                 // i64 —— 30000
+d.seconds                           // i64 —— 30
+d.minutes                            // f64 —— 0.5
+// 算术：d + 1s, d - 500ms, d * 2, d > 1m, d == 30s
+```
+
+**ByteSize** —— 数据大小
+
+```swift
+let b = 16kb                         // ByteSize 字面量（也支持：b、mb、gb）
+b.bytes                              // i64 —— 16384
+b.kb                                 // f64 —— 16.0
+b.mb                                 // f64 —— 0.015625
+// 算术：b + 1kb, b > 1mb, b == 16kb
+```
+
+**StatusCode** —— HTTP 状态码
+
+```swift
+let s = resp.status                  // StatusCode
+s.code                               // i32 —— 200
+s.isSuccess                          // bool —— 2xx
+s.isRedirect                         // bool —— 3xx
+s.isClientError                      // bool —— 4xx
+s.isServerError                      // bool —— 5xx
+```
+
+**Method** —— HTTP 方法
+
+```swift
+req.method                           // Method
+req.method == .GET                   // bool
+req.method as string                 // "GET"
+```
+
+**MediaType** —— content type
+
+```swift
+let mt = req.contentType             // MediaType
+mt.type                              // string —— "application"
+mt.subtype                           // string —— "json"
+mt as string                         // "application/json"
+```
+
+**Time** —— 时间戳
+
+```swift
+let t = now()                        // Time
+t.unix                               // i64 —— Unix 秒级时间戳
+t.unixMs                             // i64 —— Unix 毫秒级时间戳
+t as string                          // ISO 8601
+now() - t                            // Duration —— 时间差
+t + 1h                               // Time —— 加上 duration
+```
+
+**Regex** —— 编译后的正则模式
+
+```swift
+let r = re"^/api/v\d+"              // 正则字面量，编译期校验
+```
+
+**Port** —— 1..65535
+
+```swift
+let p = :8080                        // Port 字面量
+p.number                             // i32 —— 8080
+```
+
+#### 3.3.2 用户自定义类型
+
+```swift
+struct User {
+    id: string
+    role: string
+    name: string
+}
+
+struct Order {
+    items: [OrderItem]
+    total: f64
+}
+
+struct OrderItem {
+    sku: string
+    qty: i32
+    price: f64
+}
+```
+
+#### 3.3.3 元组
+
+有序、定长、可异构的集合，布局在编译期已知。
+
+```swift
+let pair = (200, "ok")                       // (i32, string)
+let triple = (user, orders, stock)           // (User, [Order], Stock)
+
+// 解构
+let (status, msg) = pair
+
+// 下标访问
+let first = pair.0                           // i32
+let second = pair.1                          // string
+```
+
+它也可作为 `wait()` 返回多个 handle 的返回类型。通过 Arena 分配，不需要额外堆分配。
+
+#### 3.3.4 Request 对象
+
+Request 是内建类型。标准 HTTP header 以原生属性暴露，并带有正确的类型：
+
+```swift
+// 标准 header —— 属性访问，类型正确
+req.method              // Method
+req.path                // string
+req.remoteAddr          // IP
+req.contentLength       // ByteSize（不是 string）
+req.contentType         // MediaType（不是 string）
+req.authorization       // string?（可选 —— 该 header 可能不存在）
+req.host                // string
+req.userAgent           // string
+req.origin              // string?
+req.ifModifiedSince     // Time?
+req.accept              // MediaType?
+
+// 自定义 header —— 通过 header 名访问
+req.X-Request-ID        // string?
+req.X-User-ID           // string?
+req.X-Timestamp         // string?
+
+// 设置 header —— 直接赋值
+req.X-User-ID = "123"
+req.X-Request-ID = uuid()
+
+// 路由参数 —— path capture 自动变成 req 属性
+// 路由：get /users/:id/posts/:postId
+req.id                  // string（来自 :id）
+req.postId              // string（来自 :postId）
+
+// Query string
+req.queryString         // string? —— 原始 query string："page=1&limit=20"
+req.query("page")       // string? —— 单值 query 参数
+req.query("tags")       // [string]? —— 多值参数（?tags=a&tags=b）
+
+// Body
+req.body(User)          // 把 body 解析成 User 结构体 → Result<User>
+req.bodyRaw             // 原始 body 字符串 → Result<string>
+req.bodyRaw = newBody   // 在 forward 之前替换 body（重新计算 Content-Length）
+
+// Cookie
+req.cookie("session_id") // string?
+
+// 多值 header
+req.getAll("Accept")    // [string] —— 某个 header 的全部值
+req.add("X-Tag", "a")   // 追加（不替换已有值）
+
+// request 级上下文 —— 类型化 struct，由中间件和 handler 共享
+req.ctx.userId          // 来自用户声明的 Ctx struct 字段
+req.ctx.startTime       // 由装饰器设置，在 handler 中读取
+```
+
+request context `req.ctx` 需要用户先声明 `Ctx` 结构体：
+
+```swift
+struct Ctx {
+    userId: string
+    userRole: string
+    startTime: Time
+}
+```
+
+编译器会检查：handler 里读取的字段，是否已经在中间件链上的装饰器里被设置。访问未设置字段属于编译错误。
+
+#### 3.3.5 Response 对象
+
+```swift
+// 简单响应
+return 200                           // 空 body
+return 401, "custom message"         // 带字符串 body
+return 200, json(data)               // 带 JSON body
+
+// 带 header —— 构造 response 对象，避免 { } 歧义
+let resp = response(429)
+resp.Retry-After = "60"
+return resp
+
+let resp = response(200)
+resp.Content-Type = "application/json"
+resp.body = json(stats())
+return resp
+
+// 重定向
+let resp = response(301)
+resp.Location = "https://example.com\(req.path)"
+return resp
+
+// Response 上的多值 header
+resp.add("Set-Cookie", "a=1; Path=/")
+resp.add("Set-Cookie", "b=2; Path=/")
+
+// 删除 header
+resp.Server = nil
+```
+
+`response(status)` 是一个内建函数，用来创建 Response 对象。`{ }` 只用于代码块，绝不用于构造 response。
+
+#### 3.3.6 状态类型
+
+所有持久状态都声明为顶层的强类型容器，并带有编译期已知的容量上界。这个设计受 eBPF map 启发：类型化、有界，默认 per-shard。
+
+**Hash<K, V>** —— 通用键值存储。
+
+```swift
+let sessions = Hash<string, Session>(capacity: 50000, ttl: 30m)
+
+sessions.set(sid, user)
+let user = sessions.get(sid)       // V?
+sessions.delete(sid)
+sessions.contains(sid)             // bool
+```
+
+**LRU<K, V>** —— 满时按照 LRU 淘汰的键值存储。
+
+```swift
+let responseCache = LRU<string, CachedResponse>(capacity: 10000, ttl: 5m)
+
+responseCache.set(key, resp)
+let cached = responseCache.get(key)   // V? —— 命中会刷新访问时间
+```
+
+可选参数 `coalesce: true` —— 请求合并（singleflight）。在 cache miss 时避免羊群效应：只有一个请求真正去回源，其余请求等待结果，和 nginx 的 `proxy_cache_lock` 是同一模式。
+
+```swift
+let cache = LRU<string, string>(capacity: 10000, ttl: 5m, coalesce: true)
+
+get /users/:id {
+    let key = "/users/\(req.id)"
+    let cached = cache.get(key)      // miss + 有 in-flight 请求 → 自动等待首个请求
+    if cached? { return 200, cached }
+    let resp = forward(userService, buffered: true)
+    cache.set(key, resp.body)        // 存入结果并唤醒所有等待连接
+    return resp
+}
+```
+
+实现方式：per-shard、单线程。在 `cache.get()` miss 且同 key 已经有挂起请求时，运行时会挂起连接（挂入 intrusive linked list）。在 `cache.set()` 时，用值恢复所有 waiter。由于每个 shard 单线程，不需要 mutex。
+
+**Set<T>** —— 成员测试。
+
+```swift
+let blacklist = Set<IP>(capacity: 100000)
+let trustedNets = Set<CIDR>(capacity: 1000)
+
+blacklist.contains(req.remoteAddr)     // bool
+trustedNets.contains(req.remoteAddr)   // bool —— CIDR set 会对 IP 做最长前缀匹配
+blacklist.add(ip)
+blacklist.remove(ip)
+```
+
+编译器会按元素类型选择实现：`Set<IP>` / `Set<string>` 用 hash set，`Set<CIDR>` 用 LPM trie（最长前缀匹配树）。
+
+**Counter<K>** —— 限流计数器。支持两种算法：
+
+```swift
+// 滑动窗口（默认）—— “窗口内最多 N 个请求”
+let apiLimits = Counter<IP>(capacity: 100000, window: 1m)
+apiLimits.incr(req.remoteAddr)         // +1，返回窗口内当前计数
+apiLimits.get(req.remoteAddr)          // 当前窗口内计数
+guard apiLimits.get(req.remoteAddr) <= 1000 else { return 429 }
+
+// Token bucket —— “速率 N/min，允许突发 B”
+let burstLimits = Counter<IP>(capacity: 100000, rate: 100, burst: 20)
+guard burstLimits.take(req.remoteAddr) else { return 429 }
+// take：消费 1 个 token，空时返回 false
+// 以 100/min 的速率回填，最多积累 20 个 token
+```
+
+编译器通过参数推导算法：有 `window:` 表示滑动窗口；有 `rate:` + `burst:` 表示 token bucket。
+
+**Bloom<T>** —— 概率型集合，适合大基数场景，节省内存。没有假阴性，但会有假阳性。
+
+```swift
+let seenRequests = Bloom<string>(capacity: 1000000, errorRate: 0.01)
+
+seenRequests.add(key)
+seenRequests.mayContain(key)           // bool —— “不在”是确定的，“在”可能是假阳性
+```
+
+适用场景：请求去重、防缓存穿透、大规模黑名单。
+
+**Bitmap** —— 定长位图。
+
+```swift
+let features = Bitmap(size: 256)
+
+features.set(12)                       // 置位
+features.clear(12)                     // 清位
+features.test(12)                      // bool
+features.count()                       // popcount —— 已置位 bit 数量
+```
+
+适用场景：feature flag、upstream 健康位、紧凑布尔数组。
+
+**通用参数：**
+
+| 参数 | 适用对象 | 描述 |
+|-----------|-----------|-------------|
+| `capacity:` | 所有（必填） | 最大条目数，编译期上界 |
+| `ttl:` | Hash、LRU、Counter | 过期时间；对 Counter 来说 ttl 就是滑动窗口 |
+| `window:` | Counter（必填） | ttl 的别名，但更推荐给 Counter 用 |
+| `errorRate:` | Bloom（必填） | 假阳性率，决定内存占用 |
+| `size:` | Bitmap（必填） | 位图 bit 数 |
+| `persist: true` | 所有 | 在热重载中保留数据；若 struct 布局变化则编译报错 |
+| `consistent: true` | Hash、Set、Counter | 按 key hash 把操作路由到 owner shard；提供强一致，但有 SPSC 往返成本；编译器会发 warning，可用 `// rut:allow(consistent)` 抑制 |
+| `coalesce: true` | LRU | 请求合并 —— cache miss 且同 key 已有 in-flight 请求时挂起等待，而不是再发重复回源请求 |
+| `backend: .redis(addr)` | Hash、Counter、Set | 通过外部存储做跨节点状态同步；per-shard 状态退化为本地 cache，Redis 成为真实来源 |
+
+**所有状态默认都是 per-shard。** 每个 shard 持有自己的一份独立副本，单线程访问、零锁。per-shard 计数器是近似的（等效 limit ≈ `limit × shard_count`）。
+
+**跨 shard 通信：`notify`**
+
+`notify` 是 Rutlang 暴露的唯一跨 shard 原语。两种形式：
+
+```swift
+notify all expr                    // 所有 shard —— 最终一致
+notify(key) expr                   // hash(key) → owner shard —— 定向发送
+
+let blacklist = Set<IP>(capacity: 100000)
+
+post /admin/ban {
+    let ip = req.body(IP)
+    guard let ip else { return 400 }
+    blacklist.add(ip)              // 本地 shard —— 立即生效
+    notify all blacklist.add(ip)   // 其他 shard —— 下一个 event loop tick 生效
+    return 200
+}
+```
+
+- `notify all` —— 向其余 N-1 个 shard 广播，最终一致
+- `notify(key)` —— 根据 key 的 hash 选出 owner shard，只发给那个 shard
+
+实现：每个 shard 对之间有一个无锁的 SPSC（single-producer single-consumer）ring buffer。`notify` 用 `release` 语义的 tail 更新和 `relaxed` store 入队；接收 shard 在每个 event loop tick 上用 `acquire` 语义读取 tail 并 drain 队列。不用 `seq_cst`，不需要全栅栏，也避免 cache line 竞争（head 和 tail 分在不同 cache line）。
+
+成本：`notify all` = N-1 次 relaxed 写；`notify(key)` = 1 次 relaxed 写。传播延迟大约是一个 event loop tick（微秒级）。
+
+**强一致：`consistent: true`**
+
+对于全局精确限流等必须强一致的状态，可声明 `consistent: true`。操作会按 key hash 路由到 owner shard，由 owner shard 顺序处理 —— 没有锁，只有一次 SPSC 往返。
+
+```swift
+// rut:allow(consistent)
+let exactLimits = Counter<IP>(capacity: 100000, window: 1m, consistent: true)
+
+get /api/*path {
+    // 编译器生成：hash(remoteAddr) → owner shard → SPSC send → yield → receive
+    exactLimits.incr(req.remoteAddr)
+    guard exactLimits.get(req.remoteAddr) <= 1000 else { return 429 }
+    return forward(userService)
+}
+```
+
+成本：当当前 shard != owner shard 时，需要 1 次 SPSC 往返（若正好是 owner shard，本地操作免费）。编译器会发出 warning，要求用户用 `// rut:allow(consistent)` 明确确认。
+
+**三级成本模型：**
+
+| 模式 | 声明方式 | 成本 | 一致性 |
+|------|-------------|------|-------------|
+| per-shard | 默认 | 零 | 近似 |
+| notify all | `notify all expr` | N-1 次 SPSC 写 | 最终一致 |
+| notify(key) | `notify(key) expr` | 1 次 SPSC 写 | 最终一致，定向 |
+| consistent | `consistent: true` | 1 次 SPSC 往返 | 强一致 |
+
+三者本质上都建立在 SPSC 消息传递之上。没有 atomics 级别的共享状态，没有 STM，没有锁。
+
+**跨节点状态：`backend:` 参数**
+
+per-shard 和跨 shard 状态只在单个 Rut 进程内有效。如果多个 Rut 实例需要共享状态（例如集群级限流），就使用 `backend:` 把状态同步到外部存储：
+
+```swift
+// 仅进程内（默认）—— 快，但近似
+let limits = Counter<IP>(capacity: 100000, window: 1m)
+
+// 通过 Redis 做跨节点共享 —— 精确集群级计数
+let globalLimits = Counter<IP>(capacity: 100000, window: 1m, backend: .redis("redis:6379"))
+
+// 跨节点 session store
+let sessions = Hash<string, Session>(capacity: 100000, ttl: 30m, backend: .redis("redis:6379"))
+```
+
+使用 `backend:` 后，per-shard 状态退化为本地缓存层。写入同时落本地和 Redis（异步 TCP）；读取先查本地，miss 再回 Redis。运行时负责连接池与序列化。
+
+成本：Redis 往返大约 100μs，而本地状态访问大约 10ns。只有真正需要集群级一致性时才值得启用。
+
+##### 3.3.6.1 状态失败与顺序语义
+
+上面的状态 API 还需要显式的失败语义。否则语法是清楚的，但契约依然不完整。
+
+**顺序性**
+
+- 某个 shard 发往某个目标 shard 的操作，按发送顺序处理
+- `notify(key)` 只在该 key 对应的所有操作都 hash 到同一个 owner shard 时，才自然保持 per-key 顺序
+- `notify all` **不**提供跨所有 shard 的全局总序
+
+**队列压力**
+
+- 只有当程序显式选择 lossy 模式时，`notify` 才能是 best-effort
+- 默认语言契约：如果跨 shard 队列已满，该操作应在当前请求路径上表现为运行时失败，而不是静默丢弃
+- 未来也许可以提供 `notify all?, lossy: true` 之类语法，但“默认静默丢消息”不能成为默认行为
+
+**`consistent: true`**
+
+- 一个强一致操作，要么在 owner shard 上完成并返回结果，要么在请求可见层面失败
+- 跨 shard 往返超时必须表现为运行时失败，而不是“超时但成功”
+- 通过 owner shard 路由的读写，应遵守 owner shard 上的程序顺序
+
+**外部后端**
+
+- `backend:` 会把一致性模型从纯进程内语义，切换成由外部后端介导的语义
+- 对 `backend: .redis(...)` 的默认契约应是 write-through 意图；若后端写失败，除非 API 明确允许 degraded-local mode，否则失败必须向请求暴露
+- 只有当本地 cache 条目仍满足声明的 TTL / freshness 规则时，读取才可以直接命中本地缓存
+
+**重载 / 关闭**
+
+- 热重载不能静默丢弃已经确认完成的强一致操作
+- 处于 in-flight 的 best-effort `notify` 操作，在 shutdown 期间可以被丢弃，但前提是该 API 已经明确声明自己不是 durable
+- 持久状态 schema 不兼容时，应作为编译期重载拒绝，而不是尝试 best-effort 迁移
+
+这些规则是刻意保守的。它们把语言契约收得比当前实现更严，避免某些运行时上的临时捷径意外上升为公开语义。
+
+#### 3.3.7 错误处理：Result 与 guard
+
+没有异常。没有 try/catch。所有可能失败的操作都返回 `Result<T>`，其中要么是值，要么是错误消息。调用者 **必须** 用 `guard let` 解包 Result；如果代码忽略一个 Result，编译器应直接拒绝。
+
+**Result 与 Optional 的区别：**
+- `string?`（Optional）—— 值可能不存在，但这不是错误。例如某个可选 header。
+- `Result<User>` —— 操作可能失败，并携带错误消息。例如 body 解析。
+
+**Nil 处理 —— 四种操作符：**
+
+| 语法 | 名称 | 返回值 | 含义 |
+|--------|------|---------|---------|
+| `x?` | nil 检查 | `bool` | `x != nil` |
+| `x?.method` | 可选链 | `T?` | 若 x 为 nil → nil，否则 → x.method |
+| `x ?? default` | 空值合并 | `T` | 若 x 为 nil → default，否则 → x |
+| `guard let x else { return N }` | 解包或拒绝 | `T` | 若 x 为 nil → 退出 handler |
+
+```swift
+// x? —— 检查是否存在（bool）
+guard req.authorization? else { return 401 }
+if req.origin? {
+    resp.Vary = "Origin"
+}
+
+// x?.method —— 可选链（nil 传播）
+let len = req.authorization?.len               // i32? —— 没有 header 时为 nil
+let ok = req.authorization?.hasPrefix("Bearer") // bool? —— 没有 header 时为 nil
+
+// x ?? default —— 空值合并（提供默认值）
+let name = req.query("name") ?? "anonymous"
+let page = parseInt(req.query("page") ?? "1")
+
+// guard let —— 解包或早退
+guard let token = req.authorization else { return 401 }
+// token 现在是 string，可在后续正常使用
+
+// Result —— 操作可能失败
+let user = req.body(User)                  // Result<User>
+guard let user else { return 400 }         // 丢弃错误消息
+guard let user else { return 400, user.error }  // 在响应里带上错误消息
+guard let user else {
+    log.warn("bad body", { error: user.error })
+    return 400, "invalid request body"
+}
+```
+
+**不同操作对应的 Result 类型：**
+
+| 操作 | 返回类型 | 常见 guard 写法 |
+|-----------|-------------|---------------|
+| `req.body(T)` | `Result<T>` | `guard let x else { return 400 }` |
+| `get/post http://...` | `Result<Response>` | `guard let res else { return 502 }` |
+| `jwtDecode(token, secret:)` | `Result<Claims>` | `guard let claims else { return 401 }` |
+| `forward(upstream)` | 内建，失败时返回 502 | 不需要 guard |
+| `req.authorization` | `string?`（Optional） | `guard let x else { return 401 }` |
+| `req.query("key")` | `string?`（Optional） | `guard let x else { return 400 }` |
+
+**编译期强制：** 如果一个 Result 被赋给 `let`，但后续没有 `guard let ... else`，编译器就报错：
+
+```swift
+let user = req.body(User)
+forward(users)
+// ERROR: Result<User> must be unwrapped with 'guard let user else { return ... }'
+```
+
+**运行时错误**（如除零、数组越界）被视为编程错误 —— 应直接返回 500，不提供恢复机制。
+
+#### 3.3.8 编译期常量
+
+`const` 声明一个 **必须在编译期计算** 的值。结果会直接嵌入二进制，没有运行时成本。
+
+```swift
+const secretHash = sha256(env("STATIC_SECRET"))
+const jwtPublicKey = env("JWT_PUBLIC_KEY")
+const maxItems = 100
+const apiPrefix = "/api/v1"
+```
+
+`const` 表达式只能由以下内容组成：字面量、`env()`、纯函数（sha256、base64、字符串操作等）以及其他 `const` 值。I/O 在 `const` 中属于编译错误：
+
+```swift
+const x = sha256(env("KEY"))              // ✅ 纯函数 + env
+const y = get http://config/value         // ❌ 编译错误：const 中不允许 I/O
+```
+
+即使没有 `const`，如果一个 `let` 在编译期可计算，编译器也应自动做常量折叠。`const` 的意义是显式断言：“它必须在编译期得到；做不到就报错。”
+
+#### 3.3.9 控制流约束
+
+Rutlang 保证有界执行 —— 每个 handler 的执行上界都可在编译期推导出来。这可避免一个有 bug 的 handler 卡死整个 shard。
+
+- **`let`** —— 默认不可变绑定
+- **`var`** —— 可变绑定，但 **仅允许 handler 局部使用**。顶层不允许 `var`。这样可以保护 share-nothing：没有全局可变状态，也没有跨 shard 可变状态
+- **只支持 `for ... in`** —— 只能迭代有限集合（数组、struct 字段等），不支持 `while`、不支持无限 `loop`
+- **不支持 `break` / `continue`** —— 每轮迭代都必须完整执行
+- **不支持递归** —— 所有函数在编译期内联；函数调用自身属于编译错误
+- **不支持闭包** —— 没有一等函数、没有回调、没有隐式捕获变量
+
+```swift
+// var —— handler 局部可变变量
+get /api/data {
+    var score = 0                          // ✅ 局部，任意类型
+    var msg = "violations:"
+    if input.matches(re"(?i)UNION\s+SELECT") {
+        score += 5
+        msg = "\(msg) sql_injection"
+    }
+    guard score <= 10 else { return 403, msg }
+    return forward(userService)
+}
+
+// ❌ 顶层 var —— 编译错误
+var globalCounter = 0                      // ERROR: var not allowed at top level
+
+// OK —— 对数组做有界迭代
+for item in order.items {
+    guard item.qty > 0 else { return 400 }
+}
+
+// 编译错误 —— 不支持 while
+while queue.hasNext() { ... }
+
+// 编译错误 —— 不支持递归
+func foo(_ req: Request) {
+    foo(req)    // ERROR: recursive call detected
+}
+```
+
+**`defer` —— 任意退出路径上的清理**
+
+`defer` 注册一个语句，使其在 handler 退出时执行，不论走的是哪条 `return` 路径。多个 `defer` 按逆序（LIFO）执行。这个机制受 Go / Swift / Zig 启发。
+
+```swift
+get /api/data {
+    activeConns.incr(req.remoteAddr)
+    defer activeConns.decr(req.remoteAddr)     // 任意退出路径都执行
+
+    let start = now()
+    defer log.info("done", duration: now() - start)  // 在上一个 defer 之后执行（LIFO）
+
+    guard req.authorization? else { return 401 }      // defer 仍然执行
+    guard req.contentLength <= 1mb else { return 413 } // defer 仍然执行
+    return forward(userService)                        // defer 仍然执行
+}
+```
+
+编译器会把 `defer` 在每个 `return` 处直接展开。没有运行时栈，没有额外分配，纯粹是编译期代码复制。
+
+### 3.4 语法
+
+#### 3.4.1 Listening、TLS 和 Upstream
+
+**Listening**
+
+```swift
+// 最简单形式
+listen :80
+
+// 带连接级安全控制（抗 DDoS / slowloris）
+listen :443 {
+    maxConns: 100000             // 全局最大连接数
+    maxConnsPerIP: 256           // 每个 IP 的连接数上限
+    headerTimeout: 10s           // header 必须在此时间内到达
+    bodyTimeout: 30s             // body 必须在此时间内到达
+    idleTimeout: 60s             // keep-alive 空闲超时
+    maxHeaderSize: 8kb           // header 总大小上限
+    maxHeaderCount: 100          // header 数量上限
+    maxUrlLength: 4kb            // URL 长度上限
+    minRecvRate: 1kb/s           // 收包速率低于这个值则断开
+    strictParsing: true          // 拒绝歧义 HTTP（anti-smuggling）
+}
+
+// 用于 metrics / admin 的内部端口
+listen :9090
+
+// PROXY Protocol —— 解析 HAProxy PROXY v1/v2，从而在 L4 负载均衡后拿到真实客户端 IP
+// 解析后，req.remoteAddr 反映原始客户端 IP，而不是负载均衡器的 IP
+listen :443, proxyProtocol: true
+```
+
+**TLS 证书（SNI）**
+
+TLS 证书声明是顶层语句，和路由分开。编译器会根据这些声明构造 SNI callback table。优先级：精确域名 > 通配域名 > default。
+
+```swift
+// 每域名证书 —— 编译器构造 SNI lookup table
+tls "api.example.com",   cert: env("API_CERT"),      key: env("API_KEY")
+tls "admin.example.com", cert: env("ADMIN_CERT"),     key: env("ADMIN_KEY")
+
+// 通配证书 —— 匹配所有未被精确条目命中的 *.example.com
+tls "*.example.com",     cert: env("WILDCARD_CERT"),  key: env("WILDCARD_KEY")
+
+// 默认证书 —— 当 SNI 不匹配任何域名，或客户端未发送 SNI 时使用
+tls default,             cert: env("DEFAULT_CERT"),   key: env("DEFAULT_KEY")
+
+// 单域名简写（只有一个证书时）
+tls cert: env("CERT"), key: env("KEY")
+
+// OCSP stapling —— 运行时周期性从 CA 拉取 OCSP 响应，
+// 并在 TLS 握手里附带，用于客户端证书吊销检查
+tls "api.example.com", cert: env("CERT"), key: env("KEY"), ocsp: true
+```
+
+**全局默认值**
+
+所有路由共享的配置。若某个 upstream 或 proxy 单独设置了值，则覆盖这些默认值。
+
+```swift
+defaults {
+    forwardBufferSize: 16kb      // 每连接 forward buffer 大小
+    clientMaxBodySize: 10mb      // 默认请求体大小上限
+    compress: .auto(             // 响应压缩
+        types: [text/html, text/css, application/json, application/javascript]
+        minSize: 256b
+        level: 4
+    )
+    errorPages: "/var/www/errors/"   // 自定义错误页：{dir}/{status}.html
+    tracing: .otlp(endpoint: "http://collector:4318")  // 或 .zipkin(...) 或 .off
+    cache: .auto(capacity: 10000, maxSize: 10mb)       // RFC 7234 自动缓存
+}
+```
+
+**错误页：** 当某个 handler 返回 `>= 400` 的状态码时，运行时会去查找 `{errorPages}/{status}.html`。如果找到，就把该文件内容作为 response body；找不到则返回默认纯文本。只要一行配置，不需要写额外 Rutlang 代码。
+
+**请求优先级：** 在高负载下，运行时可以先丢弃低优先级请求。通过在 route 或 group 上使用 `@priority` 装饰器配置：
+
+```swift
+route {
+    @priority(.high)
+    api.example.com/payments { ... }
+
+    @priority(.normal)                    // 默认
+    api.example.com/users { ... }
+
+    @priority(.low)
+    api.example.com/analytics { ... }
+}
+```
+
+当 accept queue 或 per-shard 连接数超过阈值时，运行时会先以 503 拒绝新的 `.low` 优先级连接；如果负载继续上升，再拒绝 `.normal`。`.high` 最后才被 shed。
+
+压缩会依据 `Accept-Encoding` header 和 `types` 列表自动应用。若某个 route 不想压缩（例如已经压缩过的图片，或流式响应），可在 response 里显式设置 `compress: .off`：
+
+```swift
+get /files/:id {
+    forward(storageService, compress: .off)          // 对这个 proxy 禁用压缩
+}
+
+get /images/*path {
+    read(root: "/var/www/images", compress: .off)  // 图片本身已经压缩过
+}
+```
+
+**Upstream**
+
+```swift
+let users = upstream {
+    "10.0.0.1:8080", weight: 3
+    "10.0.0.2:8080"
+    balance: .leastConn
+    health: .active(get: "/ping", every: 5s)              // 主动健康检查 —— timer probe
+    health: .passive(failures: 5, recover: 30s)            // 被动健康检查 —— 连续错误后标记不健康
+    breaker: .consecutive(failures: 5, recover: 30s)
+    retry: .on([502, 503, 504], count: 2, backoff: 100ms)
+    connectTimeout: 3s           // 覆盖默认值
+    readTimeout: 30s             // upstream 读超时
+    sendTimeout: 10s             // upstream 写超时
+    keepalive: 64                // 每 shard 最大空闲连接数
+}
+
+// 带 mTLS 的 upstream —— 连接时出示客户端证书
+let internalService = upstream {
+    "10.0.0.5:8443"
+    tls: .mtls(cert: env("CLIENT_CERT"), key: env("CLIENT_KEY"), ca: env("CA_CERT"))
+}
+
+let orders = upstream { "10.0.1.1:8080" }
+```
+
+**负载均衡算法：**
+
+所有标准算法都属于内建能力。运行时在每个 shard 上维护每个 target 的状态（连接数、延迟、权重等）。
+
+| 算法 | 声明方式 | 描述 |
+|-----------|-------------|-------------|
+| Round Robin | `balance: .roundRobin` | 顺序轮转（默认） |
+| Weighted Round Robin | `balance: .weightedRoundRobin` | 按 `weight:` 比例分配 |
+| Least Connections | `balance: .leastConn` | 选择当前活动连接最少的 target |
+| Random | `balance: .random` | 均匀随机 |
+| Power of Two (P2C) | `balance: .powerOfTwo` | 随机抽两个 target，选连接数更少者 |
+| IP Hash | `balance: .ipHash` | 基于客户端 IP 做一致性 hash（会话亲和） |
+| Consistent Hash | `balance: .hash(expr)` | 对任意字段做一致性 hash（例如 `req.X-User-ID`） |
+| EWMA | `balance: .ewma` | 选择指数滑动平均延迟最低的 target |
+
+**自定义负载均衡：**
+
+用户也可以用 Rutlang 自己实现算法。不是 `forward(upstream)`，而是先遍历 `upstream.servers` 选一个 target，再对具体地址 `forward`：
+
+```swift
+// 自定义：按 header 指定的目标名路由
+func selectByHeader(_ req: Request, up: Upstream) -> Server {
+    for server in up.servers {
+        if server.addr == req.X-Target-Server {
+            return server
+        }
+    }
+    return up.servers[0]    // fallback 到第一个
+}
+
+get /custom {
+    let target = selectByHeader(req, up: users)
+    return forward(target)
+}
+```
+
+`upstream.servers` 暴露 target 列表，类型是 `[Server]`。`Server` 包含字段：`addr`（string）、`weight`（i32）、`healthy`（bool）、`activeConns`（i32）、`latencyEwma`（Duration）。用户可以读取这些字段，自定义任意选择逻辑。
+
+**健康检查模式：**
+
+- `.active(get: path, every: Duration)` —— 定时对每个 target 发 HTTP probe
+- `.passive(failures: N, recover: Duration)` —— 运行时统计每个 target 的 `forward()` 错误；连续 N 次失败后标记不健康，在 Duration 后恢复
+
+**Slow start：**
+
+```swift
+let backend = upstream {
+    "10.0.0.1:8080"
+    slowStart: 30s    // target 恢复健康后，在 30s 内把权重从 0 线性升到配置值
+}
+```
+
+当 target 从 unhealthy 恢复后，有效权重会在 `slowStart:` 时间内从 0 线性增加到配置值，避免把刚启动好的服务瞬间压满。
+
+**Outlier detection：**
+
+比被动健康检查更复杂 —— 它按时间窗口跟踪各 target 的成功率，把明显低于平均水平的 target 剔除。
+
+```swift
+let backend = upstream {
+    "10.0.0.1:8080"
+    "10.0.0.2:8080"
+    outlier: .successRate(
+        threshold: 0.9,         // 成功率低于 90% 则 eject
+        interval: 30s,          // 评估窗口
+        minRequests: 100        // 至少达到这个样本量才评估
+    )
+}
+```
+
+**Retry budget：**
+
+防止重试风暴 —— 将总重试量限制在正常流量的一定比例以内。
+
+```swift
+let backend = upstream {
+    retry: .on([502, 503], count: 2, backoff: 100ms)
+    retryBudget: .percent(20)   // 重试总量不能超过正常请求量的 20%
+}
+```
+
+**Locality-aware routing：**
+
+优先选择和当前 shard 位于同一 zone / region 的 upstream，以减少跨 AZ 延迟和流量成本。
+
+```swift
+let backend = upstream {
+    "10.0.0.1:8080", zone: "us-east-1a"
+    "10.0.0.2:8080", zone: "us-east-1b"
+    "10.0.0.3:8080", zone: "us-west-2a"
+    locality: .preferLocal      // 优先选择和当前 shard 同 zone 的 target
+}
+```
+
+**Happy Eyeballs（RFC 8305）：**
+
+双栈连接竞争 —— IPv4 和 IPv6 同时尝试，先连上谁就用谁。
+
+```swift
+let backend = upstream {
+    "api.example.com:8080"      // DNS 会返回 A + AAAA
+    happyEyeballs: true         // IPv4 / IPv6 并发 connect，使用先成功者
+}
+```
+
+**Cluster warming：**
+
+新 target 在第一次健康检查通过之前，不接收任何流量。
+
+```swift
+let backend = upstream {
+    health: .active(get: "/ping", every: 5s)
+    warming: true               // 健康检查通过前不参与路由
+}
+```
+
+**完整 upstream 示例：**
+
+```swift
+let userService = upstream {
+    "10.0.0.1:8080", weight: 3, zone: "us-east-1a"
+    "10.0.0.2:8080", weight: 1, zone: "us-east-1b"
+    balance: .ewma
+    health: .active(get: "/ping", every: 5s)
+    health: .passive(failures: 5, recover: 30s)
+    outlier: .successRate(threshold: 0.9, interval: 30s, minRequests: 100)
+    breaker: .consecutive(failures: 5, recover: 30s)
+    retry: .on([502, 503], count: 2, backoff: 100ms)
+    retryBudget: .percent(20)
+    connectTimeout: 3s
+    readTimeout: 30s
+    keepalive: 64
+    slowStart: 30s
+    warming: true
+    locality: .preferLocal
+    happyEyeballs: true
+    tls: .mtls(cert: env("CLIENT_CERT"), key: env("CLIENT_KEY"), ca: env("CA_CERT"))
+}
+```
+
+#### 3.4.2 函数（中间件与辅助函数）
+
+所有函数都在编译期内联。不存在运行时函数调用开销。
+
+中间件有两种，由参数签名区分：
+- **Request middleware**：`func f(_ req: Request)` —— 在 handler 之前执行。返回状态码表示拒绝请求，不返回值表示放行
+- **Response middleware**：`func f(_ req: Request, _ resp: Response)` —— 在 handler / proxy 之后、发送给客户端之前执行。可以修改 response header、body、status
+
+`guard` 是表达“检查通过，否则拒绝”的惯用方式。
+
+```swift
+func auth(_ req: Request, role: string) -> User {
+    guard let token = req.authorization else { return 401 }
+    guard token.hasPrefix("Bearer ") else { return 401 }
+
+    let claims = jwtDecode(token.trimPrefix("Bearer "), secret: env("JWT_SECRET"))
+    guard let claims else { return 401 }
+    guard claims.exp >= now() else { return 401, "token expired" }
+    guard claims.role == role else { return 403 }
+
+    req.X-User-ID = claims.sub
+    req.X-User-Role = claims.role
+    return User(id: claims.sub, role: claims.role)
+}
+
+func rateLimit(_ req: Request, limits: Counter<IP>, max: i32) {
+    let count = limits.incr(req.remoteAddr)
+    guard count <= max else { return 429 }
+}
+
+func requestId(_ req: Request) {
+    if req.X-Request-ID.isEmpty {
+        req.X-Request-ID = uuid()
+    }
+}
+
+func cors(_ req: Request, origins: [string]) {
+    let origin = req.origin
+    guard origins.contains(origin) else {
+        if req.method == .OPTIONS { return 403 }
+        return
+    }
+
+    if req.method == .OPTIONS {
+        let resp = response(204)
+        resp.Access-Control-Allow-Origin = origin
+        resp.Access-Control-Allow-Methods = "GET, POST, PUT, DELETE"
+        resp.Access-Control-Allow-Headers = "Content-Type, Authorization"
+        resp.Access-Control-Max-Age = "86400"
+        return resp
+    }
+
+    req.Access-Control-Allow-Origin = origin
+    req.Vary = "Origin"
+}
+
+func verifySig(_ req: Request, secret: string) {
+    guard let ts = req.X-Timestamp else { return 401 }
+    guard now() - time(ts) <= 5m else { return 401, "expired" }
+
+    let payload = "\(req.method)\n\(req.path)\n\(ts)"
+    guard hmacSha256(secret, payload).hex == req.X-Signature else {
+        return 401, "bad signature"
+    }
+}
+
+func ipAllow(_ req: Request, cidrs: [CIDR]) {
+    guard cidrs.contains(req.remoteAddr) else {
+        return 403
+    }
+}
+
+func maxBody(_ req: Request, limit: ByteSize) {
+    guard req.contentLength <= limit else { return 413 }
+}
+
+func concurrencyLimit(_ req: Request, active: Counter<string>, limit: i32) {
+    guard active.get(req.remoteAddr) < limit else { return 503, "overloaded" }
+}
+
+// --- Response 中间件（同时接收 Request 和 Response）---
+
+func securityHeaders(_ req: Request, _ resp: Response) {
+    resp.Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    resp.X-Content-Type-Options = "nosniff"
+    resp.X-Frame-Options = "DENY"
+    resp.X-XSS-Protection = "1; mode=block"
+    resp.Referrer-Policy = "strict-origin-when-cross-origin"
+    resp.Server = nil          // 去掉 server 信息
+}
+
+// --- 安全中间件示例 ---
+
+func antiFlood(_ req: Request, perIP: Counter<IP>, global: Counter<string>) {
+    guard perIP.incr(req.remoteAddr) <= 50 else { return 429 }
+    guard global.incr("total") <= 10000 else { return 503 }
+}
+
+func waf(_ req: Request) {
+    let path = req.path
+    guard !path.contains("/../") else { return 403, "path traversal" }
+    guard !urlDecode(path).contains("/../") else { return 403, "encoded traversal" }
+
+    let input = "\(path) \(req.queryString ?? "")"
+    guard !input.matches(re"(?i)UNION\s+SELECT|DROP\s+TABLE|<script|javascript:") else {
+        log.warn("waf blocked", { addr: req.remoteAddr })
+        return 403
+    }
+}
+
+func blockBots(_ req: Request) {
+    let ua = req.userAgent.lower()
+    guard !ua.isEmpty else { return 403 }
+    let blocked = ["bot", "spider", "crawler", "scraper"]
+    for word in blocked {
+        guard !ua.contains(word) else { return 403 }
+    }
+}
+```
+
+#### 3.4.3 UFCS（统一函数调用语法）
+
+任何第一个参数类型为 `T` 的函数，都可以写成 `t.func(剩余参数)` 的形式调用。编译器会把 `t.func(args)` 重写成 `func(t, args)`。这只是语法糖，没有额外开销。
+
+```swift
+// 下面两种写法等价：
+auth(req, role: "user")
+req.auth(role: "user")
+
+// 链式写法更自然：
+req.requestId()
+req.auth(role: "user")
+req.rateLimit(limits: apiLimits, max: 1000)
+
+// 不只适用于 Request，任何类型都可以：
+let clean = req.path.replace(re"/+", "/")    // replace(req.path, re"/+", "/")
+```
+
+UFCS 并不是给类型动态增加方法，它只是调用约定。目标函数必须真实存在，且其第一个参数类型必须和接收者匹配。
+
+#### 3.4.4 路由定义
+
+`route` 是对请求做模式匹配。这个 block 分为两部分：
+
+1. **中间件绑定**（顶部）—— `@decorator pattern` 声明
+2. **路由条目**（下面）—— `method path { handler }` 或 `method path => expr`
+
+条目之间不写逗号（沿用 Swift 风格）。
+
+**中间件绑定：**
+
+在 `route` block 的顶部（任何 route entry 之前），`@decorator pattern` 会把一个中间件函数绑定到所有匹配该 pattern 的路由。`*` 匹配全部。
+
+```swift
+route {
+    // 中间件绑定 —— 位于 block 顶部
+    @requestId *                           // 所有路由
+    @waf *                                 // 所有路由
+    @apiGuard api.example.com              // 作用域限定在 host
+    @adminGuard admin.example.com          // 作用域限定在 host
+    @maxBody(limit: 1mb) api.example.com/orders  // 作用域限定在 host + path
+
+    // 下方开始是真正的路由条目...
+}
+```
+
+`@decorator` 也可以直接贴在某条 route entry 或某个 group 上，处理 one-off 场景：
+
+```swift
+route {
+    @requestId *
+
+    @maxBody(limit: 100mb)                  // 仅这条路由
+    post /files/upload => forward(storageService, streaming: true)
+
+    get /users/:id => forward(userService)  // 会继承上面的 @requestId 绑定
+}
+```
+
+**前置 / 后置中间件 —— 通过函数签名推导：**
+
+编译器根据中间件第一个参数的类型推断其执行阶段：
+- 第一个参数是 `Request` → **前置中间件**（在 handler 前）
+- 第一个参数是 `Response` → **后置中间件**（在 handler 后）
+
+```swift
+// 前置 —— 第一个参数是 Request
+func requestId(_ req: Request) { ... }
+
+// 后置 —— 第一个参数是 Response
+func addSecurityHeaders(_ resp: Response) {
+    resp.Server = nil
+    resp.X-Content-Type-Options = "nosniff"
+}
+
+// 对两者都使用同样的 @ 语法 —— 编译器自己推断
+route {
+    @requestId *                // Request → pre
+    @addSecurityHeaders *       // Response → post
+
+    get /users/:id => forward(userService)
+}
+
+// 展开后等价于：
+//   requestId(req)              ← pre
+//   handler                     ← forward
+//   addSecurityHeaders(resp)    ← post
+```
+
+**后置中间件会强制 buffered mode。** 当某条用了 zero-copy `forward` 的 route 绑定了后置中间件时，编译器应自动切换为 buffered mode，并发出 warning：
+
+```
+⚠ warning: post-middleware @addSecurityHeaders forces buffered mode for
+            'get /users/:id => forward(userService)'. Zero-copy disabled.
+            To silence: use forward(userService, buffered: true) explicitly.
+```
+
+**条件装饰器：`@if`**
+
+`@if(expr)` 用于按条件应用它后面的装饰器。表达式在编译期计算（`.rut` 编译时就解析 `env()`）。如果结果为 false，则该装饰器绑定会被整体消掉，不产生任何运行时开销。
+
+```swift
+route {
+    @requestId *
+
+    @if(env("ENABLE_WAF") == "true")
+    @waf *
+
+    @if(env("ENV") == "production")
+    @addSecurityHeaders *
+
+    api.example.com {
+        get /users/:id => forward(userService)
+    }
+}
+```

--- a/include/rut/common/types.h
+++ b/include/rut/common/types.h
@@ -46,7 +46,7 @@ struct FixedVec {
     T data[Cap];
     u32 len = 0;
 
-    bool push(T val) {
+    bool push(const T& val) {
         if (len >= Cap) return false;
         data[len++] = val;
         return true;

--- a/include/rut/compiler/analyze.h
+++ b/include/rut/compiler/analyze.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "rut/compiler/ast.h"
+#include "rut/compiler/hir.h"
+
+namespace rut {
+
+FrontendResult<HirModule*> analyze_file(const AstFile& file);
+FrontendResult<HirModule*> analyze_file(const AstFile& file, Str source_path);
+void reset_import_analysis_counter();
+u32 get_import_analysis_counter();
+
+}

--- a/include/rut/compiler/analyze.h
+++ b/include/rut/compiler/analyze.h
@@ -10,4 +10,4 @@ FrontendResult<HirModule*> analyze_file(const AstFile& file, Str source_path);
 void reset_import_analysis_counter();
 u32 get_import_analysis_counter();
 
-}
+}  // namespace rut

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -129,6 +129,7 @@ struct AstFunctionDecl {
     struct ParamDecl {
         Str name{};
         AstTypeRef type{};
+        bool has_underscore_label = false;  // `_ name: Type` (Swift-style omitted-label)
     };
 
     Span span{};
@@ -177,6 +178,7 @@ struct AstProtocolDecl {
         struct ParamDecl {
             Str name{};
             AstTypeRef type{};
+            bool has_underscore_label = false;
         };
         Str name{};
         bool has_return_type = false;
@@ -221,6 +223,12 @@ struct AstImplDecl {
     FixedVec<AstFunctionDecl, kMaxMethods> methods;
 };
 
+struct AstDecorator {
+    Span span{};
+    Str namespace_name{};  // empty unless @ns.name form
+    Str name{};
+};
+
 struct AstRouteDecl {
     Span span{};
     Span body_span{};
@@ -228,6 +236,8 @@ struct AstRouteDecl {
     Str path{};
     static constexpr u32 kMaxStatements = 16;
     FixedVec<AstStatement, kMaxStatements> statements;
+    static constexpr u32 kMaxDecorators = 8;
+    FixedVec<AstDecorator, kMaxDecorators> decorators;
 };
 
 struct AstItem {

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -269,7 +269,10 @@ struct AstFile {
 
     AstFile() = default;
     AstFile(const AstFile& other)
-        : items(other.items), expr_pool(other.expr_pool), stmt_pool(other.stmt_pool), type_pool(other.type_pool) {
+        : items(other.items),
+          expr_pool(other.expr_pool),
+          stmt_pool(other.stmt_pool),
+          type_pool(other.type_pool) {
         rebase_from(other);
     }
     AstFile& operator=(const AstFile& other) {
@@ -282,7 +285,10 @@ struct AstFile {
         return *this;
     }
     AstFile(AstFile&& other) noexcept
-        : items(other.items), expr_pool(other.expr_pool), stmt_pool(other.stmt_pool), type_pool(other.type_pool) {
+        : items(other.items),
+          expr_pool(other.expr_pool),
+          stmt_pool(other.stmt_pool),
+          type_pool(other.type_pool) {
         rebase_from(other);
     }
     AstFile& operator=(AstFile&& other) noexcept {
@@ -404,17 +410,28 @@ private:
         for (u32 i = 0; i < stmt_pool.len; i++) rebase_stmt(other, stmt_pool[i]);
         for (u32 i = 0; i < items.len; i++) {
             switch (items[i].kind) {
-                case AstItemKind::Func: rebase_func(other, items[i].func); break;
-                case AstItemKind::Struct: rebase_struct(other, items[i].struct_decl); break;
-                case AstItemKind::Variant: rebase_variant(other, items[i].variant); break;
-                case AstItemKind::Protocol: rebase_protocol(other, items[i].protocol); break;
-                case AstItemKind::Impl: rebase_impl(other, items[i].impl_decl); break;
+                case AstItemKind::Func:
+                    rebase_func(other, items[i].func);
+                    break;
+                case AstItemKind::Struct:
+                    rebase_struct(other, items[i].struct_decl);
+                    break;
+                case AstItemKind::Variant:
+                    rebase_variant(other, items[i].variant);
+                    break;
+                case AstItemKind::Protocol:
+                    rebase_protocol(other, items[i].protocol);
+                    break;
+                case AstItemKind::Impl:
+                    rebase_impl(other, items[i].impl_decl);
+                    break;
                 case AstItemKind::Route:
                     for (u32 j = 0; j < items[i].route.statements.len; j++) {
                         rebase_stmt(other, items[i].route.statements[j]);
                     }
                     break;
-                default: break;
+                default:
+                    break;
             }
         }
     }

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -1,0 +1,413 @@
+#pragma once
+
+#include "rut/common/types.h"
+#include "rut/compiler/diagnostic.h"
+
+namespace rut {
+
+enum class AstItemKind : u8 {
+    Upstream,
+    Import,
+    Func,
+    Struct,
+    Variant,
+    Protocol,
+    Using,
+    Impl,
+    Route,
+};
+
+enum class AstStmtKind : u8 {
+    Expr,
+    Let,
+    Guard,
+    ReturnStatus,
+    ForwardUpstream,
+    If,
+    Match,
+    Block,
+};
+
+enum class AstExprKind : u8 {
+    BoolLit,
+    IntLit,
+    StrLit,
+    Tuple,
+    StructInit,
+    Placeholder,
+    VariantCase,
+    Call,
+    MethodCall,
+    Field,
+    ReqHeader,
+    Nil,
+    Error,
+    Ident,
+    Eq,
+    Lt,
+    Gt,
+    Or,
+    Pipe,
+};
+
+struct AstTypeRef {
+    static constexpr u32 kMaxTypeArgs = 4;
+    Str namespace_name{};
+    Str name{};
+    bool is_tuple = false;
+    static constexpr u32 kMaxTupleElems = 10;
+    FixedVec<Str, kMaxTupleElems> tuple_elem_names;
+    FixedVec<AstTypeRef*, kMaxTupleElems> tuple_elem_types;
+    FixedVec<Str, kMaxTypeArgs> type_arg_names;
+    FixedVec<Str, kMaxTypeArgs> type_arg_namespaces;
+    FixedVec<AstTypeRef*, kMaxTypeArgs> type_args;
+};
+
+struct AstExpr {
+    static constexpr u32 kMaxTypeArgs = 4;
+    struct FieldInit {
+        Str name{};
+        AstExpr* value = nullptr;
+    };
+
+    AstExprKind kind = AstExprKind::BoolLit;
+    Span span{};
+    bool bool_value = false;
+    i32 int_value = 0;
+    Str str_value{};
+    Str msg{};
+    Str name{};
+    AstExpr* lhs = nullptr;
+    AstExpr* rhs = nullptr;
+    static constexpr u32 kMaxFieldInits = 8;
+    static constexpr u32 kMaxArgs = 8;
+    FixedVec<FieldInit, kMaxFieldInits> field_inits;
+    FixedVec<AstTypeRef, kMaxTypeArgs> type_args;
+    FixedVec<AstExpr*, kMaxArgs> args;
+};
+
+struct AstStatement {
+    AstStmtKind kind = AstStmtKind::ReturnStatus;
+    Span span{};
+    Str name{};
+    bool bind_value = false;
+    bool is_const = false;
+    bool has_type = false;
+    AstTypeRef type{};
+    AstExpr expr{};
+    i32 status_code = 0;
+    AstStatement* then_stmt = nullptr;
+    AstStatement* else_stmt = nullptr;
+    static constexpr u32 kMaxBlockStatements = 8;
+    FixedVec<AstStatement*, kMaxBlockStatements> block_stmts;
+    static constexpr u32 kMaxMatchArms = 8;
+    struct MatchArm {
+        Span span{};
+        bool is_wildcard = false;
+        AstExpr pattern{};
+        AstStatement* stmt = nullptr;
+    };
+    FixedVec<MatchArm, kMaxMatchArms> match_arms;
+};
+
+struct AstUpstreamDecl {
+    Span span{};
+    Str name{};
+};
+
+struct AstFunctionDecl {
+    static constexpr u32 kMaxTypeParams = 4;
+    struct TypeParamDecl {
+        static constexpr u32 kMaxConstraints = 4;
+        Str name{};
+        bool has_constraint = false;
+        Str constraint_namespace{};
+        Str constraint{};
+        FixedVec<Str, kMaxConstraints> constraint_namespaces;
+        FixedVec<Str, kMaxConstraints> constraints;
+    };
+    struct ParamDecl {
+        Str name{};
+        AstTypeRef type{};
+    };
+
+    Span span{};
+    Str name{};
+    bool has_return_type = false;
+    AstTypeRef return_type{};
+    AstStatement* body = nullptr;
+    static constexpr u32 kMaxParams = 8;
+    FixedVec<TypeParamDecl, kMaxTypeParams> type_params;
+    FixedVec<ParamDecl, kMaxParams> params;
+};
+
+struct AstStructDecl {
+    static constexpr u32 kMaxTypeParams = 4;
+    struct FieldDecl {
+        Str name{};
+        AstTypeRef type{};
+    };
+
+    Span span{};
+    Str name{};
+    FixedVec<Str, kMaxTypeParams> type_params;
+    static constexpr u32 kMaxFields = 8;
+    FixedVec<FieldDecl, kMaxFields> fields;
+};
+
+struct AstVariantDecl {
+    static constexpr u32 kMaxTypeParams = 4;
+    struct CaseDecl {
+        Str name{};
+        bool has_payload = false;
+        AstTypeRef payload_type{};
+    };
+
+    Span span{};
+    Str name{};
+    FixedVec<Str, kMaxTypeParams> type_params;
+    static constexpr u32 kMaxCases = 16;
+    FixedVec<CaseDecl, kMaxCases> cases;
+};
+
+struct AstProtocolDecl {
+    static constexpr u32 kMaxMethods = 8;
+    static constexpr u32 kMaxParams = 8;
+    struct MethodDecl {
+        struct ParamDecl {
+            Str name{};
+            AstTypeRef type{};
+        };
+        Str name{};
+        bool has_return_type = false;
+        AstTypeRef return_type{};
+        AstStatement* default_body = nullptr;
+        FixedVec<ParamDecl, kMaxParams> params;
+    };
+    Span span{};
+    Str name{};
+    FixedVec<MethodDecl, kMaxMethods> methods;
+};
+
+struct AstImportDecl {
+    static constexpr u32 kMaxSelectedNames = 16;
+    struct SelectedName {
+        Str name{};
+        bool has_alias = false;
+        Str alias{};
+    };
+    Span span{};
+    Str path{};
+    bool selective = false;
+    bool has_namespace_alias = false;
+    Str namespace_alias{};
+    FixedVec<SelectedName, kMaxSelectedNames> selected_names;
+};
+
+struct AstUsingDecl {
+    static constexpr u32 kMaxTargetParts = 8;
+    Span span{};
+    Str name{};
+    FixedVec<Str, kMaxTargetParts> target_parts;
+};
+
+struct AstImplDecl {
+    static constexpr u32 kMaxProtocols = 4;
+    static constexpr u32 kMaxMethods = 8;
+    Span span{};
+    AstTypeRef target{};
+    FixedVec<Str, kMaxProtocols> protocol_namespaces;
+    FixedVec<Str, kMaxProtocols> protocols;
+    FixedVec<AstFunctionDecl, kMaxMethods> methods;
+};
+
+struct AstRouteDecl {
+    Span span{};
+    Span body_span{};
+    u8 method = 0;
+    Str path{};
+    static constexpr u32 kMaxStatements = 16;
+    FixedVec<AstStatement, kMaxStatements> statements;
+};
+
+struct AstItem {
+    AstItemKind kind = AstItemKind::Upstream;
+    Span span{};
+    AstUpstreamDecl upstream{};
+    AstImportDecl import_decl{};
+    AstFunctionDecl func{};
+    AstStructDecl struct_decl{};
+    AstVariantDecl variant{};
+    AstProtocolDecl protocol{};
+    AstUsingDecl using_decl{};
+    AstImplDecl impl_decl{};
+    AstRouteDecl route{};
+};
+
+struct AstFile {
+    static constexpr u32 kMaxItems = 128;
+    static constexpr u32 kMaxExprPool = 128;
+    static constexpr u32 kMaxStmtPool = 64;
+    static constexpr u32 kMaxTypePool = 256;
+    FixedVec<AstItem, kMaxItems> items;
+    FixedVec<AstExpr, kMaxExprPool> expr_pool;
+    FixedVec<AstStatement, kMaxStmtPool> stmt_pool;
+    FixedVec<AstTypeRef, kMaxTypePool> type_pool;
+    bool has_package_decl = false;
+    Span package_span{};
+    Str package_name{};
+
+    AstFile() = default;
+    AstFile(const AstFile& other)
+        : items(other.items), expr_pool(other.expr_pool), stmt_pool(other.stmt_pool), type_pool(other.type_pool) {
+        rebase_from(other);
+    }
+    AstFile& operator=(const AstFile& other) {
+        if (this == &other) return *this;
+        items = other.items;
+        expr_pool = other.expr_pool;
+        stmt_pool = other.stmt_pool;
+        type_pool = other.type_pool;
+        rebase_from(other);
+        return *this;
+    }
+    AstFile(AstFile&& other) noexcept
+        : items(other.items), expr_pool(other.expr_pool), stmt_pool(other.stmt_pool), type_pool(other.type_pool) {
+        rebase_from(other);
+    }
+    AstFile& operator=(AstFile&& other) noexcept {
+        if (this == &other) return *this;
+        items = other.items;
+        expr_pool = other.expr_pool;
+        stmt_pool = other.stmt_pool;
+        type_pool = other.type_pool;
+        rebase_from(other);
+        return *this;
+    }
+
+private:
+    void rebase_type_ptr(const AstFile& other, AstTypeRef*& ptr) {
+        if (ptr == nullptr) return;
+        const auto begin = &other.type_pool.data[0];
+        const auto end = begin + other.type_pool.len;
+        if (ptr < begin || ptr >= end) return;
+        const u32 index = static_cast<u32>(ptr - begin);
+        ptr = &type_pool.data[index];
+    }
+
+    void rebase_expr_ptr(const AstFile& other, AstExpr*& ptr) {
+        if (ptr == nullptr) return;
+        const auto begin = &other.expr_pool.data[0];
+        const auto end = begin + other.expr_pool.len;
+        if (ptr < begin || ptr >= end) return;
+        const u32 index = static_cast<u32>(ptr - begin);
+        ptr = &expr_pool.data[index];
+    }
+
+    void rebase_stmt_ptr(const AstFile& other, AstStatement*& ptr) {
+        if (ptr == nullptr) return;
+        const auto begin = &other.stmt_pool.data[0];
+        const auto end = begin + other.stmt_pool.len;
+        if (ptr < begin || ptr >= end) return;
+        const u32 index = static_cast<u32>(ptr - begin);
+        ptr = &stmt_pool.data[index];
+    }
+
+    void rebase_type_ref(const AstFile& other, AstTypeRef& type) {
+        for (u32 i = 0; i < type.tuple_elem_types.len; i++) {
+            rebase_type_ptr(other, type.tuple_elem_types[i]);
+        }
+        for (u32 i = 0; i < type.type_args.len; i++) {
+            rebase_type_ptr(other, type.type_args[i]);
+        }
+    }
+
+    void rebase_expr(const AstFile& other, AstExpr& expr) {
+        rebase_expr_ptr(other, expr.lhs);
+        rebase_expr_ptr(other, expr.rhs);
+        for (u32 i = 0; i < expr.type_args.len; i++) {
+            rebase_type_ref(other, expr.type_args[i]);
+        }
+        for (u32 i = 0; i < expr.field_inits.len; i++) {
+            rebase_expr_ptr(other, expr.field_inits[i].value);
+        }
+        for (u32 i = 0; i < expr.args.len; i++) {
+            rebase_expr_ptr(other, expr.args[i]);
+        }
+    }
+
+    void rebase_stmt(const AstFile& other, AstStatement& stmt) {
+        if (stmt.has_type) rebase_type_ref(other, stmt.type);
+        rebase_expr(other, stmt.expr);
+        rebase_stmt_ptr(other, stmt.then_stmt);
+        rebase_stmt_ptr(other, stmt.else_stmt);
+        for (u32 i = 0; i < stmt.block_stmts.len; i++) {
+            rebase_stmt_ptr(other, stmt.block_stmts[i]);
+        }
+        for (u32 i = 0; i < stmt.match_arms.len; i++) {
+            rebase_expr(other, stmt.match_arms[i].pattern);
+            rebase_stmt_ptr(other, stmt.match_arms[i].stmt);
+        }
+    }
+
+    void rebase_func(const AstFile& other, AstFunctionDecl& func) {
+        if (func.has_return_type) rebase_type_ref(other, func.return_type);
+        for (u32 i = 0; i < func.params.len; i++) {
+            rebase_type_ref(other, func.params[i].type);
+        }
+        rebase_stmt_ptr(other, func.body);
+    }
+
+    void rebase_struct(const AstFile& other, AstStructDecl& decl) {
+        for (u32 i = 0; i < decl.fields.len; i++) {
+            rebase_type_ref(other, decl.fields[i].type);
+        }
+    }
+
+    void rebase_variant(const AstFile& other, AstVariantDecl& decl) {
+        for (u32 i = 0; i < decl.cases.len; i++) {
+            if (decl.cases[i].has_payload) rebase_type_ref(other, decl.cases[i].payload_type);
+        }
+    }
+
+    void rebase_protocol(const AstFile& other, AstProtocolDecl& decl) {
+        for (u32 i = 0; i < decl.methods.len; i++) {
+            auto& method = decl.methods[i];
+            if (method.has_return_type) rebase_type_ref(other, method.return_type);
+            for (u32 pi = 0; pi < method.params.len; pi++) {
+                rebase_type_ref(other, method.params[pi].type);
+            }
+            rebase_stmt_ptr(other, method.default_body);
+        }
+    }
+
+    void rebase_impl(const AstFile& other, AstImplDecl& decl) {
+        rebase_type_ref(other, decl.target);
+        for (u32 i = 0; i < decl.methods.len; i++) {
+            rebase_func(other, decl.methods[i]);
+        }
+    }
+
+    void rebase_from(const AstFile& other) {
+        for (u32 i = 0; i < type_pool.len; i++) rebase_type_ref(other, type_pool[i]);
+        for (u32 i = 0; i < expr_pool.len; i++) rebase_expr(other, expr_pool[i]);
+        for (u32 i = 0; i < stmt_pool.len; i++) rebase_stmt(other, stmt_pool[i]);
+        for (u32 i = 0; i < items.len; i++) {
+            switch (items[i].kind) {
+                case AstItemKind::Func: rebase_func(other, items[i].func); break;
+                case AstItemKind::Struct: rebase_struct(other, items[i].struct_decl); break;
+                case AstItemKind::Variant: rebase_variant(other, items[i].variant); break;
+                case AstItemKind::Protocol: rebase_protocol(other, items[i].protocol); break;
+                case AstItemKind::Impl: rebase_impl(other, items[i].impl_decl); break;
+                case AstItemKind::Route:
+                    for (u32 j = 0; j < items[i].route.statements.len; j++) {
+                        rebase_stmt(other, items[i].route.statements[j]);
+                    }
+                    break;
+                default: break;
+            }
+        }
+    }
+};
+
+}  // namespace rut

--- a/include/rut/compiler/diagnostic.h
+++ b/include/rut/compiler/diagnostic.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "core/expected.h"
+#include "rut/common/types.h"
+
+namespace rut {
+
+enum class FrontendError : u8 {
+    UnexpectedChar,
+    UnterminatedString,
+    InvalidInteger,
+    UnexpectedToken,
+    UnexpectedEof,
+    TooManyTokens,
+    TooManyItems,
+    InvalidStatusCode,
+    DuplicateUpstream,
+    UnknownUpstream,
+    OutOfMemory,
+    UnsupportedSyntax,
+};
+
+struct Span {
+    u32 start = 0;
+    u32 end = 0;
+    u32 line = 1;
+    u32 col = 1;
+};
+
+struct Diagnostic {
+    FrontendError code = FrontendError::UnexpectedToken;
+    Span span{};
+    Str detail{};
+};
+
+template <typename T>
+using FrontendResult = core::Expected<T, Diagnostic>;
+
+inline auto frontend_error(FrontendError code, Span span = {}, Str detail = {}) {
+    return core::make_unexpected(Diagnostic{code, span, detail});
+}
+
+}  // namespace rut

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -1,0 +1,820 @@
+#pragma once
+
+#include "rut/common/types.h"
+
+#include <deque>
+#include <string>
+#include "rut/compiler/diagnostic.h"
+
+namespace rut {
+
+enum class HirProtocolKind : u8 {
+    Custom,
+    Error,
+    Eq,
+    Ord,
+};
+
+struct HirUpstream {
+    Span span{};
+    Str name{};
+    u16 id = 0;
+};
+struct HirImport {
+    Span span{};
+    Str path{};
+    bool selective = false;
+    bool has_namespace_alias = false;
+    Str namespace_alias{};
+    bool has_package_decl = false;
+    bool same_package = false;
+    Str package_name{};
+};
+
+struct HirAlias {
+    static constexpr u32 kMaxTargetParts = 8;
+    Span span{};
+    Str name{};
+    FixedVec<Str, kMaxTargetParts> target_parts;
+};
+
+
+enum class HirExprKind : u8 {
+    BoolLit,
+    IntLit,
+    StrLit,
+    Tuple,
+    TupleSlot,
+    VariantCase,
+    IfElse,
+    Call,
+    StructInit,
+    Field,
+    ReqHeader,
+    Nil,
+    Error,
+    LocalRef,
+    Eq,
+    Lt,
+    Gt,
+    Or,
+    NoError,
+    HasValue,
+    ValueOf,
+    MissingOf,
+    MatchPayload,
+    ProtocolCall,
+};
+
+enum class HirTypeKind : u8 {
+    Unknown,
+    Bool,
+    I32,
+    Str,
+    Generic,
+    Variant,
+    Tuple,
+    Struct,
+};
+
+inline constexpr u32 kMaxTupleSlots = 10;
+
+struct HirTypeShape {
+    HirTypeKind type = HirTypeKind::Unknown;
+    bool is_concrete = false;
+    u32 generic_index = 0xffffffffu;
+    u32 variant_index = 0xffffffffu;
+    u32 struct_index = 0xffffffffu;
+    u32 tuple_len = 0;
+    u32 tuple_elem_shape_indices[kMaxTupleSlots]{};
+};
+
+struct HirProtocol {
+    static constexpr u32 kMaxMethods = 8;
+    struct MethodDecl {
+        struct ParamDecl {
+            Str type_name{};
+            HirTypeKind type = HirTypeKind::Unknown;
+            u32 generic_index = 0xffffffffu;
+            u32 variant_index = 0xffffffffu;
+            u32 struct_index = 0xffffffffu;
+            u32 tuple_len = 0;
+            HirTypeKind tuple_types[kMaxTupleSlots]{};
+            u32 tuple_variant_indices[kMaxTupleSlots]{};
+            u32 tuple_struct_indices[kMaxTupleSlots]{};
+            u32 shape_index = 0xffffffffu;
+        };
+        Str name{};
+        FixedVec<ParamDecl, 8> params;
+        bool has_return_type = false;
+        Str return_type_name{};
+        HirTypeKind return_type = HirTypeKind::Unknown;
+        u32 return_generic_index = 0xffffffffu;
+        u32 return_variant_index = 0xffffffffu;
+        u32 return_struct_index = 0xffffffffu;
+        u32 return_tuple_len = 0;
+        HirTypeKind return_tuple_types[kMaxTupleSlots]{};
+        u32 return_tuple_variant_indices[kMaxTupleSlots]{};
+        u32 return_tuple_struct_indices[kMaxTupleSlots]{};
+        u32 return_shape_index = 0xffffffffu;
+        u32 function_index = 0xffffffffu;
+    };
+    Span span{};
+    Str name{};
+    HirProtocolKind kind = HirProtocolKind::Custom;
+    FixedVec<MethodDecl, kMaxMethods> methods;
+};
+
+struct HirConformance {
+    Span span{};
+    u32 protocol_index = 0xffffffffu;
+    HirTypeKind type = HirTypeKind::Unknown;
+    u32 variant_index = 0xffffffffu;
+    u32 struct_index = 0xffffffffu;
+    u32 tuple_len = 0;
+    HirTypeKind tuple_types[kMaxTupleSlots]{};
+    u32 tuple_variant_indices[kMaxTupleSlots]{};
+    u32 tuple_struct_indices[kMaxTupleSlots]{};
+    bool is_generic_template = false;
+};
+
+struct HirVariant {
+    static constexpr u32 kMaxTypeParams = 4;
+    struct TypeArgRef {
+        HirTypeKind type = HirTypeKind::Unknown;
+        u32 generic_index = 0xffffffffu;
+        u32 variant_index = 0xffffffffu;
+        u32 struct_index = 0xffffffffu;
+        u32 tuple_len = 0;
+        HirTypeKind tuple_types[kMaxTupleSlots]{};
+        u32 tuple_variant_indices[kMaxTupleSlots]{};
+        u32 tuple_struct_indices[kMaxTupleSlots]{};
+        u32 shape_index = 0xffffffffu;
+    };
+    struct CaseDecl {
+        Str name{};
+        HirTypeKind payload_type = HirTypeKind::Unknown;
+        bool has_payload = false;
+        u32 payload_generic_index = 0xffffffffu;
+        u32 payload_variant_index = 0xffffffffu;
+        u32 payload_struct_index = 0xffffffffu;
+        u32 payload_tuple_len = 0;
+        HirTypeKind payload_tuple_types[kMaxTupleSlots]{};
+        u32 payload_tuple_variant_indices[kMaxTupleSlots]{};
+        u32 payload_tuple_struct_indices[kMaxTupleSlots]{};
+        u32 payload_template_variant_index = 0xffffffffu;
+        u32 payload_template_struct_index = 0xffffffffu;
+        u32 payload_type_arg_count = 0;
+        TypeArgRef payload_type_args[kMaxTypeParams]{};
+        u32 payload_shape_index = 0xffffffffu;
+    };
+
+    Span span{};
+    Str name{};
+    FixedVec<Str, kMaxTypeParams> type_params;
+    u32 template_variant_index = 0xffffffffu;
+    u32 instance_type_arg_count = 0;
+    HirTypeKind instance_type_args[kMaxTypeParams]{};
+    u32 instance_generic_indices[kMaxTypeParams]{};
+    u32 instance_variant_indices[kMaxTypeParams]{};
+    u32 instance_struct_indices[kMaxTypeParams]{};
+    u32 instance_tuple_lens[kMaxTypeParams]{};
+    HirTypeKind instance_tuple_types[kMaxTypeParams][kMaxTupleSlots]{};
+    u32 instance_tuple_variant_indices[kMaxTypeParams][kMaxTupleSlots]{};
+    u32 instance_tuple_struct_indices[kMaxTypeParams][kMaxTupleSlots]{};
+    u32 instance_shape_indices[kMaxTypeParams]{};
+    static constexpr u32 kMaxCases = 16;
+    FixedVec<CaseDecl, kMaxCases> cases;
+};
+
+struct HirStruct {
+    static constexpr u32 kMaxTypeParams = 4;
+    using TypeArgRef = HirVariant::TypeArgRef;
+    struct FieldDecl {
+        Str name{};
+        Str type_name{};
+        HirTypeKind type = HirTypeKind::Unknown;
+        bool is_error_type = false;
+        u32 generic_index = 0xffffffffu;
+        u32 variant_index = 0xffffffffu;
+        u32 struct_index = 0xffffffffu;
+        u32 tuple_len = 0;
+        HirTypeKind tuple_types[kMaxTupleSlots]{};
+        u32 tuple_variant_indices[kMaxTupleSlots]{};
+        u32 tuple_struct_indices[kMaxTupleSlots]{};
+        u32 template_variant_index = 0xffffffffu;
+        u32 template_struct_index = 0xffffffffu;
+        u32 type_arg_count = 0;
+        TypeArgRef type_args[kMaxTypeParams]{};
+        u32 shape_index = 0xffffffffu;
+    };
+
+    Span span{};
+    Str name{};
+    bool conforms_error = false;
+    FixedVec<Str, kMaxTypeParams> type_params;
+    u32 template_struct_index = 0xffffffffu;
+    u32 instance_type_arg_count = 0;
+    HirTypeKind instance_type_args[kMaxTypeParams]{};
+    u32 instance_generic_indices[kMaxTypeParams]{};
+    u32 instance_variant_indices[kMaxTypeParams]{};
+    u32 instance_struct_indices[kMaxTypeParams]{};
+    u32 instance_tuple_lens[kMaxTypeParams]{};
+    HirTypeKind instance_tuple_types[kMaxTypeParams][kMaxTupleSlots]{};
+    u32 instance_tuple_variant_indices[kMaxTypeParams][kMaxTupleSlots]{};
+    u32 instance_tuple_struct_indices[kMaxTypeParams][kMaxTupleSlots]{};
+    u32 instance_shape_indices[kMaxTypeParams]{};
+    static constexpr u32 kMaxFields = 8;
+    FixedVec<FieldDecl, kMaxFields> fields;
+};
+
+struct HirExpr {
+    struct FieldInit {
+        Str name{};
+        HirExpr* value = nullptr;
+    };
+
+    HirExprKind kind = HirExprKind::BoolLit;
+    HirTypeKind type = HirTypeKind::Unknown;
+    Span span{};
+    bool may_nil = false;
+    bool may_error = false;
+    bool bool_value = false;
+    i32 int_value = 0;
+    Str str_value{};
+    Str msg{};
+    u32 local_index = 0;
+    u32 generic_index = 0xffffffffu;
+    bool generic_has_error_constraint = false;
+    bool generic_has_eq_constraint = false;
+    bool generic_has_ord_constraint = false;
+    static constexpr u32 kMaxGenericProtocols = 4;
+    u32 generic_protocol_index = 0xffffffffu;
+    u32 generic_protocol_count = 0;
+    u32 generic_protocol_indices[kMaxGenericProtocols]{};
+    u32 protocol_index = 0xffffffffu;
+    u32 variant_index = 0;
+    u32 struct_index = 0xffffffffu;
+    u32 case_index = 0;
+    u32 tuple_len = 0;
+    HirTypeKind tuple_types[kMaxTupleSlots]{};
+    u32 tuple_variant_indices[kMaxTupleSlots]{};
+    u32 tuple_struct_indices[kMaxTupleSlots]{};
+    u32 shape_index = 0xffffffffu;
+    u32 error_struct_index = 0xffffffffu;
+    u32 error_variant_index = 0xffffffffu;
+    u32 error_case_index = 0xffffffffu;
+    HirExpr* lhs = nullptr;
+    HirExpr* rhs = nullptr;
+    static constexpr u32 kMaxFieldInits = 8;
+    static constexpr u32 kMaxArgs = 8;
+    FixedVec<FieldInit, kMaxFieldInits> field_inits;
+    FixedVec<HirExpr*, kMaxArgs> args;
+};
+
+struct HirFunction {
+    static constexpr u32 kMaxTypeParams = 4;
+    struct TypeParamDecl {
+        static constexpr u32 kMaxConstraints = 4;
+        Str name{};
+        bool has_constraint = false;
+        Str constraint{};
+        HirProtocolKind constraint_kind = HirProtocolKind::Custom;
+        bool has_error_constraint = false;
+        bool has_eq_constraint = false;
+        bool has_ord_constraint = false;
+        u32 custom_protocol_count = 0;
+        Str constraints[kMaxConstraints]{};
+        HirProtocolKind constraint_kinds[kMaxConstraints]{};
+        u32 custom_protocol_indices[kMaxConstraints]{};
+    };
+    struct ParamDecl {
+        Str name{};
+        HirTypeKind type = HirTypeKind::Unknown;
+        u32 generic_index = 0xffffffffu;
+        bool generic_has_error_constraint = false;
+        bool generic_has_eq_constraint = false;
+        bool generic_has_ord_constraint = false;
+        u32 generic_protocol_index = 0xffffffffu;
+        u32 generic_protocol_count = 0;
+        u32 generic_protocol_indices[HirExpr::kMaxGenericProtocols]{};
+        u32 template_variant_index = 0xffffffffu;
+        u32 template_struct_index = 0xffffffffu;
+        u32 type_arg_count = 0;
+        HirVariant::TypeArgRef type_args[kMaxTypeParams]{};
+        u32 variant_index = 0xffffffffu;
+        u32 struct_index = 0xffffffffu;
+        u32 tuple_len = 0;
+        HirTypeKind tuple_types[kMaxTupleSlots]{};
+        u32 tuple_variant_indices[kMaxTupleSlots]{};
+        u32 tuple_struct_indices[kMaxTupleSlots]{};
+        u32 shape_index = 0xffffffffu;
+    };
+
+    Span span{};
+    Str name{};
+    HirTypeKind return_type = HirTypeKind::Unknown;
+    u32 return_generic_index = 0xffffffffu;
+    u32 return_template_variant_index = 0xffffffffu;
+    u32 return_template_struct_index = 0xffffffffu;
+    u32 return_type_arg_count = 0;
+    HirVariant::TypeArgRef return_type_args[kMaxTypeParams]{};
+    u32 return_variant_index = 0xffffffffu;
+    u32 return_struct_index = 0xffffffffu;
+    u32 return_tuple_len = 0;
+    HirTypeKind return_tuple_types[kMaxTupleSlots]{};
+    u32 return_tuple_variant_indices[kMaxTupleSlots]{};
+    u32 return_tuple_struct_indices[kMaxTupleSlots]{};
+    u32 return_shape_index = 0xffffffffu;
+    static constexpr u32 kMaxParams = 8;
+    static constexpr u32 kMaxExprs = 64;
+    FixedVec<TypeParamDecl, kMaxTypeParams> type_params;
+    FixedVec<ParamDecl, kMaxParams> params;
+    FixedVec<HirExpr, kMaxExprs> exprs;
+    HirExpr body{};
+
+    HirFunction() = default;
+    HirFunction(const HirFunction& other)
+        : span(other.span),
+          name(other.name),
+          return_type(other.return_type),
+          return_generic_index(other.return_generic_index),
+          return_template_variant_index(other.return_template_variant_index),
+          return_template_struct_index(other.return_template_struct_index),
+          return_type_arg_count(other.return_type_arg_count),
+          return_variant_index(other.return_variant_index),
+          return_struct_index(other.return_struct_index),
+          return_tuple_len(other.return_tuple_len),
+          return_shape_index(other.return_shape_index),
+          type_params(other.type_params),
+          params(other.params),
+          exprs(other.exprs),
+          body(other.body) {
+        for (u32 i = 0; i < other.return_tuple_len; i++) {
+            return_tuple_types[i] = other.return_tuple_types[i];
+            return_tuple_variant_indices[i] = other.return_tuple_variant_indices[i];
+            return_tuple_struct_indices[i] = other.return_tuple_struct_indices[i];
+        }
+        for (u32 i = 0; i < other.return_type_arg_count; i++) {
+            return_type_args[i] = other.return_type_args[i];
+        }
+        rebase_from(other);
+    }
+    HirFunction& operator=(const HirFunction& other) {
+        if (this == &other) return *this;
+        span = other.span;
+        name = other.name;
+        return_type = other.return_type;
+        return_generic_index = other.return_generic_index;
+        return_template_variant_index = other.return_template_variant_index;
+        return_template_struct_index = other.return_template_struct_index;
+        return_type_arg_count = other.return_type_arg_count;
+        return_variant_index = other.return_variant_index;
+        return_struct_index = other.return_struct_index;
+        return_tuple_len = other.return_tuple_len;
+        return_shape_index = other.return_shape_index;
+        for (u32 i = 0; i < other.return_tuple_len; i++) {
+            return_tuple_types[i] = other.return_tuple_types[i];
+            return_tuple_variant_indices[i] = other.return_tuple_variant_indices[i];
+            return_tuple_struct_indices[i] = other.return_tuple_struct_indices[i];
+        }
+        for (u32 i = 0; i < other.return_type_arg_count; i++) {
+            return_type_args[i] = other.return_type_args[i];
+        }
+        type_params = other.type_params;
+        params = other.params;
+        exprs = other.exprs;
+        body = other.body;
+        rebase_from(other);
+        return *this;
+    }
+    HirFunction(HirFunction&& other) noexcept
+        : span(other.span),
+          name(other.name),
+          return_type(other.return_type),
+          return_generic_index(other.return_generic_index),
+          return_template_variant_index(other.return_template_variant_index),
+          return_template_struct_index(other.return_template_struct_index),
+          return_type_arg_count(other.return_type_arg_count),
+          return_variant_index(other.return_variant_index),
+          return_struct_index(other.return_struct_index),
+          return_tuple_len(other.return_tuple_len),
+          return_shape_index(other.return_shape_index),
+          type_params(other.type_params),
+          params(other.params),
+          exprs(other.exprs),
+          body(other.body) {
+        for (u32 i = 0; i < other.return_tuple_len; i++) {
+            return_tuple_types[i] = other.return_tuple_types[i];
+            return_tuple_variant_indices[i] = other.return_tuple_variant_indices[i];
+            return_tuple_struct_indices[i] = other.return_tuple_struct_indices[i];
+        }
+        for (u32 i = 0; i < other.return_type_arg_count; i++) {
+            return_type_args[i] = other.return_type_args[i];
+        }
+        rebase_from(other);
+    }
+    HirFunction& operator=(HirFunction&& other) noexcept {
+        if (this == &other) return *this;
+        span = other.span;
+        name = other.name;
+        return_type = other.return_type;
+        return_generic_index = other.return_generic_index;
+        return_template_variant_index = other.return_template_variant_index;
+        return_template_struct_index = other.return_template_struct_index;
+        return_type_arg_count = other.return_type_arg_count;
+        return_variant_index = other.return_variant_index;
+        return_struct_index = other.return_struct_index;
+        return_tuple_len = other.return_tuple_len;
+        return_shape_index = other.return_shape_index;
+        for (u32 i = 0; i < other.return_tuple_len; i++) {
+            return_tuple_types[i] = other.return_tuple_types[i];
+            return_tuple_variant_indices[i] = other.return_tuple_variant_indices[i];
+            return_tuple_struct_indices[i] = other.return_tuple_struct_indices[i];
+        }
+        for (u32 i = 0; i < other.return_type_arg_count; i++) {
+            return_type_args[i] = other.return_type_args[i];
+        }
+        type_params = other.type_params;
+        params = other.params;
+        exprs = other.exprs;
+        body = other.body;
+        rebase_from(other);
+        return *this;
+    }
+
+private:
+    void rebase_expr_ptr(const HirFunction& other, HirExpr*& ptr) {
+        if (ptr == nullptr) return;
+        const auto begin = &other.exprs.data[0];
+        const auto end = begin + other.exprs.len;
+        if (ptr < begin || ptr >= end) return;
+        const u32 index = static_cast<u32>(ptr - begin);
+        ptr = &exprs.data[index];
+    }
+
+    void rebase_expr(HirExpr& expr, const HirFunction& other) {
+        rebase_expr_ptr(other, expr.lhs);
+        rebase_expr_ptr(other, expr.rhs);
+        for (u32 i = 0; i < expr.field_inits.len; i++) {
+            rebase_expr_ptr(other, expr.field_inits[i].value);
+        }
+        for (u32 i = 0; i < expr.args.len; i++) {
+            rebase_expr_ptr(other, expr.args[i]);
+        }
+    }
+
+    void rebase_from(const HirFunction& other) {
+        for (u32 i = 0; i < exprs.len; i++) rebase_expr(exprs[i], other);
+        rebase_expr(body, other);
+    }
+};
+
+struct HirLocal {
+    Span span{};
+    Str name{};
+    u32 ref_index = 0;
+    HirTypeKind type = HirTypeKind::Unknown;
+    u32 generic_index = 0xffffffffu;
+    bool generic_has_error_constraint = false;
+    bool generic_has_eq_constraint = false;
+    bool generic_has_ord_constraint = false;
+    u32 generic_protocol_index = 0xffffffffu;
+    u32 generic_protocol_count = 0;
+    u32 generic_protocol_indices[HirExpr::kMaxGenericProtocols]{};
+    bool may_nil = false;
+    bool may_error = false;
+    u32 variant_index = 0;
+    u32 struct_index = 0xffffffffu;
+    u32 tuple_len = 0;
+    HirTypeKind tuple_types[kMaxTupleSlots]{};
+    u32 tuple_variant_indices[kMaxTupleSlots]{};
+    u32 tuple_struct_indices[kMaxTupleSlots]{};
+    u32 shape_index = 0xffffffffu;
+    u32 error_struct_index = 0xffffffffu;
+    u32 error_variant_index = 0xffffffffu;
+    HirExpr init{};
+};
+
+enum class HirTerminatorKind : u8 {
+    ReturnStatus,
+    ForwardUpstream,
+};
+
+struct HirTerminator {
+    HirTerminatorKind kind = HirTerminatorKind::ReturnStatus;
+    Span span{};
+    i32 status_code = 0;
+    u32 upstream_index = 0;
+};
+
+struct HirGuardBody {
+    enum class BodyKind : u8 {
+        Direct,
+        If,
+    };
+
+    BodyKind body_kind = BodyKind::Direct;
+    HirExpr cond{};
+    HirTerminator then_term{};
+    HirTerminator else_term{};
+    HirTerminator direct_term{};
+};
+
+struct HirGuardMatchArm {
+    Span span{};
+    bool is_wildcard = false;
+    HirExpr pattern{};
+    HirTerminator direct_term{};
+};
+
+struct HirGuard {
+    enum class FailKind : u8 {
+        Term,
+        Match,
+        Body,
+    };
+
+    static constexpr u32 kMaxFailMatchArms = 8;
+    Span span{};
+    HirExpr cond{};
+    FailKind fail_kind = FailKind::Term;
+    HirTerminator fail_term{};
+    HirExpr fail_match_expr{};
+    u32 fail_match_start = 0;
+    u32 fail_match_count = 0;
+    HirGuardBody fail_body{};
+};
+
+struct HirMatchArm {
+    enum class BodyKind : u8 {
+        Direct,
+        If,
+    };
+
+    Span span{};
+    bool is_wildcard = false;
+    HirExpr pattern{};
+    bool bind_payload = false;
+    Str bind_name{};
+    HirTypeKind bind_type = HirTypeKind::Unknown;
+    u32 bind_variant_index = 0xffffffffu;
+    u32 bind_struct_index = 0xffffffffu;
+    u32 bind_tuple_len = 0;
+    HirTypeKind bind_tuple_types[kMaxTupleSlots]{};
+    u32 bind_tuple_variant_indices[kMaxTupleSlots]{};
+    u32 bind_tuple_struct_indices[kMaxTupleSlots]{};
+    BodyKind body_kind = BodyKind::Direct;
+    static constexpr u32 kMaxPreludeGuards = 4;
+    FixedVec<HirGuard, kMaxPreludeGuards> guards;
+    HirExpr cond{};
+    HirTerminator then_term{};
+    HirTerminator else_term{};
+    HirTerminator direct_term{};
+};
+
+enum class HirControlKind : u8 {
+    Direct,
+    If,
+    Match,
+};
+
+struct HirControl {
+    HirControlKind kind = HirControlKind::Direct;
+    static constexpr u32 kMaxMatchArms = 8;
+    HirExpr cond{};
+    HirExpr match_expr{};
+    FixedVec<HirMatchArm, kMaxMatchArms> match_arms;
+    HirTerminator then_term{};
+    HirTerminator else_term{};
+    HirTerminator direct_term{};
+};
+
+struct HirRoute {
+    Span span{};
+    u8 method = 0;
+    Str path{};
+    static constexpr u32 kMaxLocals = 16;
+    static constexpr u32 kMaxGuards = 8;
+    static constexpr u32 kMaxExprs = 64;
+    FixedVec<HirExpr, kMaxExprs> exprs;
+    FixedVec<HirLocal, kMaxLocals> locals;
+    FixedVec<HirGuard, kMaxGuards> guards;
+    HirControl control{};
+    u32 error_variant_index = 0xffffffffu;
+
+    HirRoute() = default;
+    HirRoute(const HirRoute& other)
+        : span(other.span),
+          method(other.method),
+          path(other.path),
+          exprs(other.exprs),
+          locals(other.locals),
+          guards(other.guards),
+          control(other.control),
+          error_variant_index(other.error_variant_index) {
+        rebase_from(other);
+    }
+    HirRoute& operator=(const HirRoute& other) {
+        if (this == &other) return *this;
+        span = other.span;
+        method = other.method;
+        path = other.path;
+        exprs = other.exprs;
+        locals = other.locals;
+        guards = other.guards;
+        control = other.control;
+        error_variant_index = other.error_variant_index;
+        rebase_from(other);
+        return *this;
+    }
+    HirRoute(HirRoute&& other) noexcept
+        : span(other.span),
+          method(other.method),
+          path(other.path),
+          exprs(other.exprs),
+          locals(other.locals),
+          guards(other.guards),
+          control(other.control),
+          error_variant_index(other.error_variant_index) {
+        rebase_from(other);
+    }
+    HirRoute& operator=(HirRoute&& other) noexcept {
+        if (this == &other) return *this;
+        span = other.span;
+        method = other.method;
+        path = other.path;
+        exprs = other.exprs;
+        locals = other.locals;
+        guards = other.guards;
+        control = other.control;
+        error_variant_index = other.error_variant_index;
+        rebase_from(other);
+        return *this;
+    }
+
+private:
+    void rebase_expr_ptr(const HirRoute& other, HirExpr*& ptr) {
+        if (ptr == nullptr) return;
+        const auto begin = &other.exprs.data[0];
+        const auto end = begin + other.exprs.len;
+        if (ptr < begin || ptr >= end) return;
+        const u32 index = static_cast<u32>(ptr - begin);
+        ptr = &exprs.data[index];
+    }
+
+    void rebase_expr(HirExpr& expr, const HirRoute& other) {
+        rebase_expr_ptr(other, expr.lhs);
+        rebase_expr_ptr(other, expr.rhs);
+        for (u32 i = 0; i < expr.field_inits.len; i++) {
+            rebase_expr_ptr(other, expr.field_inits[i].value);
+        }
+        for (u32 i = 0; i < expr.args.len; i++) {
+            rebase_expr_ptr(other, expr.args[i]);
+        }
+    }
+
+    void rebase_from(const HirRoute& other) {
+        for (u32 i = 0; i < exprs.len; i++) rebase_expr(exprs[i], other);
+        for (u32 i = 0; i < locals.len; i++) rebase_expr(locals[i].init, other);
+        for (u32 i = 0; i < guards.len; i++) {
+            rebase_expr(guards[i].cond, other);
+            rebase_expr(guards[i].fail_match_expr, other);
+            rebase_expr(guards[i].fail_body.cond, other);
+        }
+        rebase_expr(control.cond, other);
+        rebase_expr(control.match_expr, other);
+        for (u32 i = 0; i < control.match_arms.len; i++) {
+            rebase_expr(control.match_arms[i].pattern, other);
+            for (u32 gi = 0; gi < control.match_arms[i].guards.len; gi++) {
+                rebase_expr(control.match_arms[i].guards[gi].cond, other);
+            }
+            rebase_expr(control.match_arms[i].cond, other);
+        }
+    }
+};
+
+struct HirImplMethod {
+    Str name{};
+    u32 function_index = 0xffffffffu;
+};
+
+struct HirImpl {
+    static constexpr u32 kMaxMethods = 8;
+    Span span{};
+    u32 protocol_index = 0xffffffffu;
+    HirTypeKind type = HirTypeKind::Unknown;
+    u32 struct_index = 0xffffffffu;
+    bool is_generic_template = false;
+    FixedVec<HirImplMethod, kMaxMethods> methods;
+};
+
+struct HirModule {
+    static constexpr u32 kMaxUpstreams = 32;
+    static constexpr u32 kMaxImports = 64;
+    static constexpr u32 kMaxAliases = 64;
+    static constexpr u32 kMaxFunctions = 64;
+    static constexpr u32 kMaxStructs = 64;
+    static constexpr u32 kMaxVariants = 64;
+    static constexpr u32 kMaxProtocols = 32;
+    static constexpr u32 kMaxConformances = 64;
+    static constexpr u32 kMaxImpls = 64;
+    static constexpr u32 kMaxRoutes = 96;
+    static constexpr u32 kMaxGuardMatchArms = 64;
+    static constexpr u32 kMaxTypeShapes = 512;
+
+    FixedVec<HirUpstream, kMaxUpstreams> upstreams;
+    FixedVec<HirImport, kMaxImports> imports;
+    FixedVec<HirAlias, kMaxAliases> aliases;
+    FixedVec<HirFunction, kMaxFunctions> functions;
+    FixedVec<HirStruct, kMaxStructs> structs;
+    FixedVec<HirVariant, kMaxVariants> variants;
+    FixedVec<HirProtocol, kMaxProtocols> protocols;
+    FixedVec<HirConformance, kMaxConformances> conformances;
+    FixedVec<HirImpl, kMaxImpls> impls;
+    FixedVec<HirGuardMatchArm, kMaxGuardMatchArms> guard_match_arms;
+    FixedVec<HirRoute, kMaxRoutes> routes;
+    FixedVec<HirTypeShape, kMaxTypeShapes> type_shapes;
+    std::deque<std::string> owned_strings;
+    bool has_package_decl = false;
+    Span package_span{};
+    Str package_name{};
+
+    HirModule() = default;
+    HirModule(const HirModule& other)
+        : upstreams(other.upstreams),
+          imports(other.imports),
+          aliases(other.aliases),
+          functions(other.functions),
+          structs(other.structs),
+          variants(other.variants),
+          protocols(other.protocols),
+          conformances(other.conformances),
+          impls(other.impls),
+          guard_match_arms(other.guard_match_arms),
+          routes(other.routes),
+          type_shapes(other.type_shapes),
+          owned_strings(other.owned_strings),
+          has_package_decl(other.has_package_decl),
+          package_span(other.package_span),
+          package_name(other.package_name) {}
+    HirModule& operator=(const HirModule& other) {
+        if (this == &other) return *this;
+        upstreams = other.upstreams;
+        imports = other.imports;
+        aliases = other.aliases;
+        functions = other.functions;
+        structs = other.structs;
+        variants = other.variants;
+        protocols = other.protocols;
+        conformances = other.conformances;
+        impls = other.impls;
+        guard_match_arms = other.guard_match_arms;
+        routes = other.routes;
+        type_shapes = other.type_shapes;
+        owned_strings = other.owned_strings;
+        has_package_decl = other.has_package_decl;
+        package_span = other.package_span;
+        package_name = other.package_name;
+        return *this;
+    }
+    HirModule(HirModule&& other) noexcept
+        : upstreams(other.upstreams),
+          imports(other.imports),
+          aliases(other.aliases),
+          functions(other.functions),
+          structs(other.structs),
+          variants(other.variants),
+          protocols(other.protocols),
+          conformances(other.conformances),
+          impls(other.impls),
+          guard_match_arms(other.guard_match_arms),
+          routes(other.routes),
+          type_shapes(other.type_shapes),
+          owned_strings(other.owned_strings),
+          has_package_decl(other.has_package_decl),
+          package_span(other.package_span),
+          package_name(other.package_name) {}
+    HirModule& operator=(HirModule&& other) noexcept {
+        if (this == &other) return *this;
+        upstreams = other.upstreams;
+        imports = other.imports;
+        aliases = other.aliases;
+        functions = other.functions;
+        structs = other.structs;
+        variants = other.variants;
+        protocols = other.protocols;
+        conformances = other.conformances;
+        impls = other.impls;
+        guard_match_arms = other.guard_match_arms;
+        routes = other.routes;
+        type_shapes = other.type_shapes;
+        owned_strings = other.owned_strings;
+        has_package_decl = other.has_package_decl;
+        package_span = other.package_span;
+        package_name = other.package_name;
+        return *this;
+    }
+};
+
+}  // namespace rut

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include "rut/common/types.h"
-
+#include "rut/compiler/diagnostic.h"
 #include <deque>
 #include <string>
-#include "rut/compiler/diagnostic.h"
 
 namespace rut {
 
@@ -37,7 +36,6 @@ struct HirAlias {
     Str name{};
     FixedVec<Str, kMaxTargetParts> target_parts;
 };
-
 
 enum class HirExprKind : u8 {
     BoolLit,

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -117,6 +117,10 @@ struct HirProtocol {
         u32 return_tuple_variant_indices[kMaxTupleSlots]{};
         u32 return_tuple_struct_indices[kMaxTupleSlots]{};
         u32 return_shape_index = 0xffffffffu;
+        bool return_may_nil = false;
+        bool return_may_error = false;
+        u32 return_error_struct_index = 0xffffffffu;
+        u32 return_error_variant_index = 0xffffffffu;
         u32 function_index = 0xffffffffu;
     };
     Span span{};
@@ -140,6 +144,7 @@ struct HirConformance {
 
 struct HirVariant {
     static constexpr u32 kMaxTypeParams = 4;
+    static constexpr u32 kMaxGenericProtocols = 4;
     struct TypeArgRef {
         HirTypeKind type = HirTypeKind::Unknown;
         u32 generic_index = 0xffffffffu;
@@ -156,6 +161,12 @@ struct HirVariant {
         HirTypeKind payload_type = HirTypeKind::Unknown;
         bool has_payload = false;
         u32 payload_generic_index = 0xffffffffu;
+        bool payload_generic_has_error_constraint = false;
+        bool payload_generic_has_eq_constraint = false;
+        bool payload_generic_has_ord_constraint = false;
+        u32 payload_generic_protocol_index = 0xffffffffu;
+        u32 payload_generic_protocol_count = 0;
+        u32 payload_generic_protocol_indices[kMaxGenericProtocols]{};
         u32 payload_variant_index = 0xffffffffu;
         u32 payload_struct_index = 0xffffffffu;
         u32 payload_tuple_len = 0;
@@ -189,6 +200,7 @@ struct HirVariant {
 
 struct HirStruct {
     static constexpr u32 kMaxTypeParams = 4;
+    static constexpr u32 kMaxGenericProtocols = 4;
     using TypeArgRef = HirVariant::TypeArgRef;
     struct FieldDecl {
         Str name{};
@@ -196,6 +208,12 @@ struct HirStruct {
         HirTypeKind type = HirTypeKind::Unknown;
         bool is_error_type = false;
         u32 generic_index = 0xffffffffu;
+        bool generic_has_error_constraint = false;
+        bool generic_has_eq_constraint = false;
+        bool generic_has_ord_constraint = false;
+        u32 generic_protocol_index = 0xffffffffu;
+        u32 generic_protocol_count = 0;
+        u32 generic_protocol_indices[kMaxGenericProtocols]{};
         u32 variant_index = 0xffffffffu;
         u32 struct_index = 0xffffffffu;
         u32 tuple_len = 0;
@@ -591,15 +609,23 @@ struct HirControl {
 };
 
 struct HirRoute {
+    struct DecoratorRef {
+        Span span{};
+        Str name{};
+        u32 function_index = 0xffffffffu;  // resolved in analyze; 0xffffffffu = unresolved
+    };
+
     Span span{};
     u8 method = 0;
     Str path{};
     static constexpr u32 kMaxLocals = 16;
     static constexpr u32 kMaxGuards = 8;
     static constexpr u32 kMaxExprs = 64;
+    static constexpr u32 kMaxDecorators = 8;
     FixedVec<HirExpr, kMaxExprs> exprs;
     FixedVec<HirLocal, kMaxLocals> locals;
     FixedVec<HirGuard, kMaxGuards> guards;
+    FixedVec<DecoratorRef, kMaxDecorators> decorators;
     HirControl control{};
     u32 error_variant_index = 0xffffffffu;
 
@@ -611,6 +637,7 @@ struct HirRoute {
           exprs(other.exprs),
           locals(other.locals),
           guards(other.guards),
+          decorators(other.decorators),
           control(other.control),
           error_variant_index(other.error_variant_index) {
         rebase_from(other);
@@ -623,6 +650,7 @@ struct HirRoute {
         exprs = other.exprs;
         locals = other.locals;
         guards = other.guards;
+        decorators = other.decorators;
         control = other.control;
         error_variant_index = other.error_variant_index;
         rebase_from(other);
@@ -635,6 +663,7 @@ struct HirRoute {
           exprs(other.exprs),
           locals(other.locals),
           guards(other.guards),
+          decorators(other.decorators),
           control(other.control),
           error_variant_index(other.error_variant_index) {
         rebase_from(other);
@@ -647,6 +676,7 @@ struct HirRoute {
         exprs = other.exprs;
         locals = other.locals;
         guards = other.guards;
+        decorators = other.decorators;
         control = other.control;
         error_variant_index = other.error_variant_index;
         rebase_from(other);

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -327,6 +327,7 @@ struct HirFunction {
         u32 tuple_variant_indices[kMaxTupleSlots]{};
         u32 tuple_struct_indices[kMaxTupleSlots]{};
         u32 shape_index = 0xffffffffu;
+        bool has_underscore_label = false;
     };
 
     Span span{};
@@ -519,10 +520,20 @@ enum class HirTerminatorKind : u8 {
     ForwardUpstream,
 };
 
+// Where the runtime status value comes from, when kind == ReturnStatus.
+// Literal: status_code is the i32 to return (compile-time constant).
+// LocalRef: read the value of route.locals[local_ref_index] at runtime.
+enum class HirTerminatorSourceKind : u8 {
+    Literal,
+    LocalRef,
+};
+
 struct HirTerminator {
     HirTerminatorKind kind = HirTerminatorKind::ReturnStatus;
     Span span{};
+    HirTerminatorSourceKind source_kind = HirTerminatorSourceKind::Literal;
     i32 status_code = 0;
+    u32 local_ref_index = 0xffffffffu;
     u32 upstream_index = 0;
 };
 

--- a/include/rut/compiler/lexer.h
+++ b/include/rut/compiler/lexer.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "core/expected.h"
 #include "rut/common/types.h"
+#include "rut/compiler/diagnostic.h"
 
 namespace rut {
 
@@ -18,6 +20,11 @@ enum class TokenType : u8 {
     KwVar,
     KwConst,
     KwGuard,
+    KwCase,
+    KwError,
+    KwProtocol,
+    KwImpl,
+    KwVariant,
     KwStruct,
     KwRoute,
     KwMatch,
@@ -33,6 +40,7 @@ enum class TokenType : u8 {
     KwForward,
     KwWebsocket,
     KwImport,
+    KwPackage,
     KwUsing,
     KwAs,
     KwFire,
@@ -108,8 +116,19 @@ enum class TokenType : u8 {
 struct Token {
     TokenType type;
     Str text;
+    u32 start;
+    u32 end;
     u32 line;
     u32 col;
 };
+
+struct LexedTokens {
+    static constexpr u32 kMaxTokens = 512;
+    FixedVec<Token, kMaxTokens> tokens;
+};
+
+using LexResult = core::Expected<LexedTokens, Diagnostic>;
+
+LexResult lex(Str source);
 
 }  // namespace rut

--- a/include/rut/compiler/lower_rir.h
+++ b/include/rut/compiler/lower_rir.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "rut/compiler/diagnostic.h"
+#include "rut/compiler/mir.h"
+#include "rut/compiler/rir.h"
+#include "rut/runtime/arena.h"
+
+namespace rut {
+
+struct FrontendRirModule {
+    MmapArena arena;
+    rir::Module module{};
+    Str source_name{};
+
+    bool init(u32 func_cap, u32 struct_cap = 1);
+    void destroy();
+};
+
+FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out);
+
+}

--- a/include/rut/compiler/lower_rir.h
+++ b/include/rut/compiler/lower_rir.h
@@ -18,4 +18,4 @@ struct FrontendRirModule {
 
 FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out);
 
-}
+}  // namespace rut

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -1,0 +1,336 @@
+#pragma once
+
+#include "rut/common/types.h"
+#include "rut/compiler/diagnostic.h"
+
+namespace rut {
+
+inline constexpr u32 kMaxMirTupleSlots = 10;
+
+enum class MirTerminatorKind : u8 {
+    Branch,
+    ReturnStatus,
+    ForwardUpstream,
+};
+
+enum class MirValueKind : u8 {
+    BoolConst,
+    IntConst,
+    StrConst,
+    Tuple,
+    TupleSlot,
+    VariantCase,
+    IfElse,
+    StructInit,
+    Field,
+    ReqHeader,
+    Nil,
+    Error,
+    LocalRef,
+    Eq,
+    Lt,
+    Gt,
+    Or,
+    NoError,
+    HasValue,
+    ValueOf,
+    MissingOf,
+    MatchPayload,
+};
+
+enum class MirTypeKind : u8 {
+    Unknown,
+    Bool,
+    I32,
+    Str,
+    Variant,
+    Tuple,
+    Struct,
+};
+
+struct MirTypeShape {
+    MirTypeKind type = MirTypeKind::Unknown;
+    bool is_concrete = false;
+    bool carrier_ready = false;
+    u32 generic_index = 0xffffffffu;
+    u32 variant_index = 0xffffffffu;
+    u32 struct_index = 0xffffffffu;
+    u32 tuple_len = 0;
+    u32 tuple_elem_shape_indices[kMaxMirTupleSlots]{};
+};
+
+struct MirVariant {
+    static constexpr u32 kMaxTypeParams = 4;
+    struct CaseDecl {
+        Str name{};
+        MirTypeKind payload_type = MirTypeKind::Unknown;
+        bool has_payload = false;
+        u32 payload_shape_index = 0xffffffffu;
+        u32 payload_variant_index = 0xffffffffu;
+        u32 payload_struct_index = 0xffffffffu;
+        u32 payload_tuple_len = 0;
+        MirTypeKind payload_tuple_types[kMaxMirTupleSlots]{};
+        u32 payload_tuple_variant_indices[kMaxMirTupleSlots]{};
+        u32 payload_tuple_struct_indices[kMaxMirTupleSlots]{};
+    };
+
+    Span span{};
+    Str name{};
+    FixedVec<Str, kMaxTypeParams> type_params;
+    u32 template_variant_index = 0xffffffffu;
+    u32 instance_type_arg_count = 0;
+    MirTypeKind instance_type_args[kMaxTypeParams]{};
+    u32 instance_generic_indices[kMaxTypeParams]{};
+    u32 instance_shape_indices[kMaxTypeParams]{};
+    static constexpr u32 kMaxCases = 16;
+    FixedVec<CaseDecl, kMaxCases> cases;
+};
+
+struct MirStruct {
+    static constexpr u32 kMaxTypeParams = 4;
+    struct FieldDecl {
+        Str name{};
+        Str type_name{};
+        MirTypeKind type = MirTypeKind::Unknown;
+        u32 shape_index = 0xffffffffu;
+        bool is_error_type = false;
+        u32 variant_index = 0xffffffffu;
+        u32 struct_index = 0xffffffffu;
+        u32 tuple_len = 0;
+        MirTypeKind tuple_types[kMaxMirTupleSlots]{};
+        u32 tuple_variant_indices[kMaxMirTupleSlots]{};
+        u32 tuple_struct_indices[kMaxMirTupleSlots]{};
+    };
+
+    Span span{};
+    Str name{};
+    bool conforms_error = false;
+    FixedVec<Str, kMaxTypeParams> type_params;
+    u32 template_struct_index = 0xffffffffu;
+    u32 instance_type_arg_count = 0;
+    MirTypeKind instance_type_args[kMaxTypeParams]{};
+    u32 instance_generic_indices[kMaxTypeParams]{};
+    u32 instance_shape_indices[kMaxTypeParams]{};
+    static constexpr u32 kMaxFields = 8;
+    FixedVec<FieldDecl, kMaxFields> fields;
+};
+
+struct MirValue {
+    struct FieldInit {
+        Str name{};
+        MirValue* value = nullptr;
+    };
+
+    MirValueKind kind = MirValueKind::BoolConst;
+    MirTypeKind type = MirTypeKind::Unknown;
+    u32 shape_index = 0xffffffffu;
+    bool may_nil = false;
+    bool may_error = false;
+    bool bool_value = false;
+    i32 int_value = 0;
+    Str str_value{};
+    Str msg{};
+    u32 local_index = 0;
+    u32 variant_index = 0;
+    u32 struct_index = 0xffffffffu;
+    u32 case_index = 0;
+    u32 tuple_len = 0;
+    MirTypeKind tuple_types[kMaxMirTupleSlots]{};
+    u32 tuple_variant_indices[kMaxMirTupleSlots]{};
+    u32 tuple_struct_indices[kMaxMirTupleSlots]{};
+    u32 error_struct_index = 0xffffffffu;
+    u32 error_variant_index = 0xffffffffu;
+    u32 error_case_index = 0xffffffffu;
+    MirValue* lhs = nullptr;
+    MirValue* rhs = nullptr;
+    static constexpr u32 kMaxFieldInits = 8;
+    static constexpr u32 kMaxArgs = 8;
+    FixedVec<FieldInit, kMaxFieldInits> field_inits;
+    FixedVec<MirValue*, kMaxArgs> args;
+};
+
+struct MirLocal {
+    Span span{};
+    Str name{};
+    u32 ref_index = 0;
+    MirTypeKind type = MirTypeKind::Bool;
+    u32 shape_index = 0xffffffffu;
+    bool may_nil = false;
+    bool may_error = false;
+    u32 variant_index = 0;
+    u32 struct_index = 0xffffffffu;
+    u32 tuple_len = 0;
+    MirTypeKind tuple_types[kMaxMirTupleSlots]{};
+    u32 tuple_variant_indices[kMaxMirTupleSlots]{};
+    u32 tuple_struct_indices[kMaxMirTupleSlots]{};
+    u32 error_struct_index = 0xffffffffu;
+    u32 error_variant_index = 0xffffffffu;
+    MirValue init{};
+};
+
+struct MirTerminator {
+    MirTerminatorKind kind = MirTerminatorKind::ReturnStatus;
+    Span span{};
+    i32 status_code = 0;
+    u32 upstream_index = 0;
+    bool use_cmp = false;
+    MirValue cond{};
+    MirValue lhs{};
+    MirValue rhs{};
+    u32 then_block = 0;
+    u32 else_block = 0;
+};
+
+struct MirBlock {
+    Str label{};
+    MirTerminator term{};
+};
+
+struct MirFunction {
+    Span span{};
+    u8 method = 0;
+    Str path{};
+    Str name{};
+    static constexpr u32 kMaxLocals = 16;
+    static constexpr u32 kMaxBlocks = 16;
+    static constexpr u32 kMaxValues = 64;
+    FixedVec<MirValue, kMaxValues> values;
+    FixedVec<MirLocal, kMaxLocals> locals;
+    FixedVec<MirBlock, kMaxBlocks> blocks;
+    u32 error_variant_index = 0xffffffffu;
+
+    MirFunction() = default;
+    MirFunction(const MirFunction& other)
+        : span(other.span),
+          method(other.method),
+          path(other.path),
+          name(other.name),
+          values(other.values),
+          locals(other.locals),
+          blocks(other.blocks),
+          error_variant_index(other.error_variant_index) {
+        rebase_from(other);
+    }
+    MirFunction& operator=(const MirFunction& other) {
+        if (this == &other) return *this;
+        span = other.span;
+        method = other.method;
+        path = other.path;
+        name = other.name;
+        values = other.values;
+        locals = other.locals;
+        blocks = other.blocks;
+        error_variant_index = other.error_variant_index;
+        rebase_from(other);
+        return *this;
+    }
+    MirFunction(MirFunction&& other) noexcept
+        : span(other.span),
+          method(other.method),
+          path(other.path),
+          name(other.name),
+          values(other.values),
+          locals(other.locals),
+          blocks(other.blocks),
+          error_variant_index(other.error_variant_index) {
+        rebase_from(other);
+    }
+    MirFunction& operator=(MirFunction&& other) noexcept {
+        if (this == &other) return *this;
+        span = other.span;
+        method = other.method;
+        path = other.path;
+        name = other.name;
+        values = other.values;
+        locals = other.locals;
+        blocks = other.blocks;
+        error_variant_index = other.error_variant_index;
+        rebase_from(other);
+        return *this;
+    }
+
+private:
+    void rebase_value_ptr(const MirFunction& other, MirValue*& ptr) {
+        if (ptr == nullptr) return;
+        const auto begin = &other.values.data[0];
+        const auto end = begin + other.values.len;
+        if (ptr < begin || ptr >= end) return;
+        const u32 index = static_cast<u32>(ptr - begin);
+        ptr = &values.data[index];
+    }
+
+    void rebase_value(MirValue& value, const MirFunction& other) {
+        rebase_value_ptr(other, value.lhs);
+        rebase_value_ptr(other, value.rhs);
+        for (u32 i = 0; i < value.field_inits.len; i++) {
+            rebase_value_ptr(other, value.field_inits[i].value);
+        }
+        for (u32 i = 0; i < value.args.len; i++) {
+            rebase_value_ptr(other, value.args[i]);
+        }
+    }
+
+    void rebase_from(const MirFunction& other) {
+        for (u32 i = 0; i < values.len; i++) rebase_value(values[i], other);
+        for (u32 i = 0; i < locals.len; i++) rebase_value(locals[i].init, other);
+        for (u32 i = 0; i < blocks.len; i++) {
+            rebase_value(blocks[i].term.cond, other);
+            rebase_value(blocks[i].term.lhs, other);
+            rebase_value(blocks[i].term.rhs, other);
+        }
+    }
+};
+
+struct MirUpstream {
+    Span span{};
+    Str name{};
+    u16 id = 0;
+};
+
+struct MirModule {
+    static constexpr u32 kMaxUpstreams = 32;
+    static constexpr u32 kMaxStructs = 64;
+    static constexpr u32 kMaxVariants = 32;
+    static constexpr u32 kMaxFunctions = 96;
+    static constexpr u32 kMaxTypeShapes = 256;
+
+    FixedVec<MirUpstream, kMaxUpstreams> upstreams;
+    FixedVec<MirStruct, kMaxStructs> structs;
+    FixedVec<MirVariant, kMaxVariants> variants;
+    FixedVec<MirFunction, kMaxFunctions> functions;
+    FixedVec<MirTypeShape, kMaxTypeShapes> type_shapes;
+
+    MirModule() = default;
+    MirModule(const MirModule& other)
+        : upstreams(other.upstreams),
+          structs(other.structs),
+          variants(other.variants),
+          functions(other.functions),
+          type_shapes(other.type_shapes) {}
+    MirModule& operator=(const MirModule& other) {
+        if (this == &other) return *this;
+        upstreams = other.upstreams;
+        structs = other.structs;
+        variants = other.variants;
+        functions = other.functions;
+        type_shapes = other.type_shapes;
+        return *this;
+    }
+    MirModule(MirModule&& other) noexcept
+        : upstreams(other.upstreams),
+          structs(other.structs),
+          variants(other.variants),
+          functions(other.functions),
+          type_shapes(other.type_shapes) {}
+    MirModule& operator=(MirModule&& other) noexcept {
+        if (this == &other) return *this;
+        upstreams = other.upstreams;
+        structs = other.structs;
+        variants = other.variants;
+        functions = other.functions;
+        type_shapes = other.type_shapes;
+        return *this;
+    }
+};
+
+}  // namespace rut

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -168,10 +168,17 @@ struct MirLocal {
     MirValue init{};
 };
 
+enum class MirTerminatorSourceKind : u8 {
+    Literal,
+    LocalRef,
+};
+
 struct MirTerminator {
     MirTerminatorKind kind = MirTerminatorKind::ReturnStatus;
     Span span{};
+    MirTerminatorSourceKind source_kind = MirTerminatorSourceKind::Literal;
     i32 status_code = 0;
+    u32 local_ref_index = 0xffffffffu;
     u32 upstream_index = 0;
     bool use_cmp = false;
     MirValue cond{};

--- a/include/rut/compiler/mir_build.h
+++ b/include/rut/compiler/mir_build.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "rut/compiler/hir.h"
+#include "rut/compiler/mir.h"
+
+namespace rut {
+
+FrontendResult<MirModule*> build_mir(const HirModule& module);
+
+}

--- a/include/rut/compiler/parser.h
+++ b/include/rut/compiler/parser.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "rut/compiler/ast.h"
+#include "rut/compiler/lexer.h"
+
+namespace rut {
+
+FrontendResult<AstFile*> parse_file(const LexedTokens& tokens);
+
+}

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -186,8 +186,13 @@ enum class Opcode : u8 {
     ArrayGet,      // %r = array.get %arr, %idx      → T
 
     // ── Optional operations ──
+    OptNil,     // %r = opt.nil                    → Optional(T)
+    OptWrap,    // %r = opt.wrap %v               → Optional(T)
     OptIsNil,   // %r = opt.is_nil %v              → bool
     OptUnwrap,  // %r = opt.unwrap %v              → inner type
+
+    // ── Value selection ──
+    Select,  // %r = select %cond, %then, %else  → T
 
     // ── Instrumentation (compiler-inserted) ──
     TraceFuncEnter,

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -487,7 +487,7 @@ struct Builder {
             bool orderable = k == TypeKind::I32 || k == TypeKind::I64 || k == TypeKind::U32 ||
                              k == TypeKind::U64 || k == TypeKind::F64 || k == TypeKind::ByteSize ||
                              k == TypeKind::Duration || k == TypeKind::Time ||
-                             k == TypeKind::StatusCode;
+                             k == TypeKind::StatusCode || k == TypeKind::Str;
             if (!orderable) return err(RirError::InvalidState);
         }
         auto* ty = TRY(make_type(TypeKind::Bool));
@@ -528,12 +528,43 @@ struct Builder {
 
     // ── Optional operations ─────────────────────────────────────────
 
+    Result<ValueId> emit_opt_nil(const Type* inner_type, SourceLoc loc = {}) {
+        if (!inner_type) return err(RirError::InvalidState);
+        auto* ty = TRY(make_type(TypeKind::Optional, inner_type));
+        return TRY(emit(Opcode::OptNil, ty, loc)).vid;
+    }
+
+    Result<ValueId> emit_opt_wrap(ValueId val, SourceLoc loc = {}) {
+        if (!valid_val(val)) return err(RirError::InvalidState);
+        auto* inner = cur_func->values[val.id].type;
+        if (!inner) return err(RirError::InvalidState);
+        auto* ty = TRY(make_type(TypeKind::Optional, inner));
+        auto [inst, vid] = TRY(emit(Opcode::OptWrap, ty, loc));
+        inst->operands[0] = val;
+        inst->operand_count = 1;
+        return vid;
+    }
+
     Result<ValueId> emit_opt_is_nil(ValueId opt, SourceLoc loc = {}) {
         if (!val_has_type(opt, TypeKind::Optional)) return err(RirError::InvalidState);
         auto* ty = TRY(make_type(TypeKind::Bool));
         auto [inst, vid] = TRY(emit(Opcode::OptIsNil, ty, loc));
         inst->operands[0] = opt;
         inst->operand_count = 1;
+        return vid;
+    }
+
+    Result<ValueId> emit_select(ValueId cond, ValueId then_val, ValueId else_val, SourceLoc loc = {}) {
+        if (!val_has_type(cond, TypeKind::Bool)) return err(RirError::InvalidState);
+        if (!valid_val(then_val) || !valid_val(else_val)) return err(RirError::InvalidState);
+        auto* then_ty = cur_func->values[then_val.id].type;
+        auto* else_ty = cur_func->values[else_val.id].type;
+        if (!types_equal(then_ty, else_ty)) return err(RirError::InvalidState);
+        auto [inst, vid] = TRY(emit(Opcode::Select, then_ty, loc));
+        inst->operands[0] = cond;
+        inst->operands[1] = then_val;
+        inst->operands[2] = else_val;
+        inst->operand_count = 3;
         return vid;
     }
 
@@ -577,6 +608,36 @@ struct Builder {
         inst->operand_count = 1;
         inst->imm.struct_ref.name = field_name;
         inst->imm.struct_ref.type = field_type;
+        return vid;
+    }
+
+    Result<ValueId> emit_struct_create(StructDef* sd,
+                                       const ValueId* values,
+                                       u32 count,
+                                       SourceLoc loc = {}) {
+        if (!sd || (!values && count != 0)) return err(RirError::InvalidState);
+        if (count != sd->field_count) return err(RirError::InvalidState);
+        for (u32 i = 0; i < count; i++) {
+            if (!valid_val(values[i])) return err(RirError::InvalidState);
+            auto* got = cur_func->values[values[i].id].type;
+            if (!types_equal(got, sd->fields()[i].type)) return err(RirError::InvalidState);
+        }
+        auto* ty = TRY(make_type(TypeKind::Struct, nullptr, sd));
+        auto [inst, vid] = TRY(emit(Opcode::StructCreate, ty, loc));
+        inst->operand_count = count;
+        if (count <= kMaxInlineOperands) {
+            for (u32 i = 0; i < count; i++) inst->operands[i] = values[i];
+        } else {
+            inst->extra_operands = static_cast<ValueId*>(
+                mod->arena->alloc(sizeof(ValueId) * (count - kMaxInlineOperands)));
+            if (!inst->extra_operands) return err(RirError::OutOfMemory);
+            for (u32 i = 0; i < count; i++) {
+                if (i < kMaxInlineOperands) inst->operands[i] = values[i];
+                else inst->extra_operands[i - kMaxInlineOperands] = values[i];
+            }
+        }
+        inst->imm.struct_ref.name = sd->name;
+        inst->imm.struct_ref.type = ty;
         return vid;
     }
 

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -689,6 +689,17 @@ struct Builder {
         return {};
     }
 
+    // Runtime-value form: status code is read from a SSA value (e.g. result
+    // of a decorator call) instead of a compile-time literal. Codegen reads
+    // the value via inst.operands[0] (see codegen.cc RetStatus handling).
+    VoidResult emit_ret_status(ValueId code, SourceLoc loc = {}) {
+        if (!valid_val(code)) return err(RirError::InvalidState);
+        auto r = TRY(emit(Opcode::RetStatus, nullptr, loc));
+        r.inst->operands[0] = code;
+        r.inst->operand_count = 1;
+        return {};
+    }
+
     VoidResult emit_ret_forward(ValueId upstream, SourceLoc loc = {}) {
         if (!valid_val(upstream)) return err(RirError::InvalidState);
         // Upstream operand must be an integer type (upstream id).

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -554,7 +554,10 @@ struct Builder {
         return vid;
     }
 
-    Result<ValueId> emit_select(ValueId cond, ValueId then_val, ValueId else_val, SourceLoc loc = {}) {
+    Result<ValueId> emit_select(ValueId cond,
+                                ValueId then_val,
+                                ValueId else_val,
+                                SourceLoc loc = {}) {
         if (!val_has_type(cond, TypeKind::Bool)) return err(RirError::InvalidState);
         if (!valid_val(then_val) || !valid_val(else_val)) return err(RirError::InvalidState);
         auto* then_ty = cur_func->values[then_val.id].type;
@@ -632,8 +635,10 @@ struct Builder {
                 mod->arena->alloc(sizeof(ValueId) * (count - kMaxInlineOperands)));
             if (!inst->extra_operands) return err(RirError::OutOfMemory);
             for (u32 i = 0; i < count; i++) {
-                if (i < kMaxInlineOperands) inst->operands[i] = values[i];
-                else inst->extra_operands[i - kMaxInlineOperands] = values[i];
+                if (i < kMaxInlineOperands)
+                    inst->operands[i] = values[i];
+                else
+                    inst->extra_operands[i - kMaxInlineOperands] = values[i];
             }
         }
         inst->imm.struct_ref.name = sd->name;

--- a/include/rut/jit/runtime_helpers.h
+++ b/include/rut/jit/runtime_helpers.h
@@ -44,6 +44,12 @@ rut::u32 rut_helper_req_remote_addr(void* conn);
 // Check if string s has prefix pfx. Returns 1 (true) or 0 (false).
 rut::u8 rut_helper_str_has_prefix(const char* s, rut::u32 s_len, const char* pfx, rut::u32 pfx_len);
 
+// Check if two strings are equal. Returns 1 (true) or 0 (false).
+rut::u8 rut_helper_str_eq(const char* a, rut::u32 a_len, const char* b, rut::u32 b_len);
+
+// Lexicographic string comparison. Returns <0, 0, >0 like strcmp.
+rut::i32 rut_helper_str_cmp(const char* a, rut::u32 a_len, const char* b, rut::u32 b_len);
+
 // Trim prefix from string. If s starts with pfx, out = remainder.
 // Otherwise out = s unchanged.
 void rut_helper_str_trim_prefix(const char* s,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,9 +176,14 @@ target_include_directories(rut_jit PUBLIC
     ${LLVM_INCLUDE_DIRS}
 )
 
-# LLVM on this system is a single shared lib (-lLLVM-N).
-# llvm_map_components_to_libnames resolves to the shared lib automatically.
-llvm_map_components_to_libnames(LLVM_LIBS core orcjit orcshared orctargetprocess native support)
+# Prefer the monolithic shared LLVM dylib when the packaged config exposes it.
+# This avoids depending on broken per-component static archives in environments
+# where LLVM is installed in shared mode.
+if(LLVM_LINK_LLVM_DYLIB AND TARGET LLVM)
+    set(LLVM_LIBS LLVM)
+else()
+    llvm_map_components_to_libnames(LLVM_LIBS core orcjit orcshared orctargetprocess native support)
+endif()
 target_link_libraries(rut_jit ${LLVM_LIBS})
 
 # JIT .cc files may need LLVM definitions that conflict with -fno-rtti.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,10 @@ endif()
 # Compiler library
 add_library(rut_compiler STATIC
     compiler/lexer.cc
+    compiler/parser.cc
+    compiler/analyze.cc
+    compiler/mir_build.cc
+    compiler/lower_rir.cc
     compiler/rir_printer.cc
 )
 

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6997,10 +6997,15 @@ static FrontendResult<void> load_imported_modules(
         if (!lexed) return core::make_unexpected(lexed.error());
         auto ast = parse_file(lexed.value());
         if (!ast) return core::make_unexpected(ast.error());
+        // parse_file returns a raw pointer via unique_ptr::release(); take
+        // ownership immediately so the imported AstFile is freed after analyze
+        // consumes it. Without this wrapper an import-heavy test suite leaks
+        // ~58 MB per imported file (confirmed via RSS growth).
+        std::unique_ptr<AstFile> ast_owned(ast.value());
         auto kept_path = stash_owned_string(owned_strings, normalized);
         g_import_analysis_counter++;
         auto imported =
-            analyze_file_internal(*ast.value(), kept_path, import_stack, &owned_strings);
+            analyze_file_internal(*ast_owned, kept_path, import_stack, &owned_strings);
         if (!imported) return core::make_unexpected(imported.error());
         imported_storage.push_back(std::unique_ptr<HirModule>(imported.value()));
         ImportedModuleInfo info{};

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -1032,6 +1032,28 @@ static u32 find_function_index(const HirModule& mod, Str name) {
     return mod.functions.len;
 }
 
+// Validates a function's signature for use as a route decorator (middleware).
+// Rules:
+//   - At least one parameter (the implicit Request slot).
+//   - First parameter declared with `_ name: Type` (Swift omitted-label).
+//     Strict from day one — relaxing later is non-breaking, tightening is.
+//   - Return type must be i32. The runtime convention: 0 = pass through to
+//     the next pre-middleware/handler, non-zero = reject and short-circuit
+//     return that value as the HTTP status code.
+//
+// Deliberately does NOT check that the first param's *type* is `Request` —
+// HirTypeKind has no Request yet (only Bool/I32/Str/Variant/Struct/Tuple/
+// Generic/Unknown). Extend when the runtime Request type lands.
+static FrontendResult<u32> validate_decorator_signature(const HirFunction& fn, Span decorator_span) {
+    if (fn.params.len == 0)
+        return frontend_error(FrontendError::UnsupportedSyntax, decorator_span, fn.name);
+    if (!fn.params[0].has_underscore_label)
+        return frontend_error(FrontendError::UnsupportedSyntax, decorator_span, fn.params[0].name);
+    if (fn.return_type != HirTypeKind::I32)
+        return frontend_error(FrontendError::UnsupportedSyntax, decorator_span, fn.name);
+    return 0u;
+}
+
 static const HirAlias* find_alias(const HirModule& mod, Str name) {
     for (u32 i = 0; i < mod.aliases.len; i++) {
         if (mod.aliases[i].name.eq(name)) return &mod.aliases[i];
@@ -7428,6 +7450,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             }
             HirFunction::ParamDecl param{};
             param.name = ast_func.params[pi].name;
+            param.has_underscore_label = ast_func.params[pi].has_underscore_label;
             const auto& param_ref = ast_func.params[pi].type;
             if (!param_ref.is_tuple && param_ref.type_arg_names.len != 0) {
                 u32 template_variant_index = 0xffffffffu;
@@ -7960,6 +7983,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             }
             HirFunction::ParamDecl param{};
             param.name = item.func.params[pi].name;
+            param.has_underscore_label = item.func.params[pi].has_underscore_label;
             const auto& param_ref = item.func.params[pi].type;
             if (!param_ref.is_tuple && param_ref.type_arg_names.len != 0) {
                 u32 template_variant_index = 0xffffffffu;
@@ -9066,6 +9090,103 @@ resolve_concrete_impl_target:
                         &route.control.match_arms[ai].cond, route.error_variant_index);
                 }
             }
+        }
+
+        // Resolve route decorators (@auth, @requestId, ...) to function indices,
+        // validate signatures, then inline each decorator's body into a synthetic
+        // local + guard pair. Pre-middleware short-circuit is achieved by guards:
+        // each guard checks `local == 0`; on non-zero, fail_term returns the
+        // local's runtime value (HirTerminatorSourceKind::LocalRef).
+        const u32 first_decorator_guard_index = route.guards.len;
+        for (u32 di = 0; di < item.route.decorators.len; di++) {
+            const auto& ast_deco = item.route.decorators[di];
+            const u32 fn_index = find_function_index(mod, ast_deco.name);
+            if (fn_index == mod.functions.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, ast_deco.span, ast_deco.name);
+            auto sig_check = validate_decorator_signature(mod.functions[fn_index], ast_deco.span);
+            if (!sig_check) return core::make_unexpected(sig_check.error());
+
+            // Inline the decorator's body and bind the result to a synthetic local.
+            // The implicit `req` parameter (slot 0) is filled with IntConst(0) — a
+            // placeholder until the runtime Request type lands. Decorators that need
+            // request data should use `req.header(...)` sugar (parser-level construct
+            // independent of the param value).
+            HirExpr placeholder_req{};
+            placeholder_req.kind = HirExprKind::IntLit;
+            placeholder_req.type = HirTypeKind::I32;
+            placeholder_req.int_value = 0;
+            placeholder_req.span = ast_deco.span;
+            HirExpr deco_args[1] = {placeholder_req};
+            const auto& deco_fn = mod.functions[fn_index];
+            auto inlined =
+                instantiate_function_expr(deco_fn.body, &route, mod, deco_args, 1u, nullptr, 0u);
+            if (!inlined) return core::make_unexpected(inlined.error());
+
+            HirLocal deco_local{};
+            deco_local.span = ast_deco.span;
+            deco_local.name = intern_generated_name(
+                std::string("_deco_") + std::to_string(di) + "_" + std::string(ast_deco.name.ptr, ast_deco.name.len));
+            deco_local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
+            deco_local.type = HirTypeKind::I32;
+            deco_local.init = inlined.value();
+            const u32 deco_ref = deco_local.ref_index;
+            if (!route.locals.push(deco_local))
+                return frontend_error(FrontendError::TooManyItems, ast_deco.span);
+
+            // guard cond: Eq(LocalRef(deco_ref), IntConst(0)) — true means "pass through"
+            HirExpr lhs_local{};
+            lhs_local.kind = HirExprKind::LocalRef;
+            lhs_local.type = HirTypeKind::I32;
+            lhs_local.local_index = deco_ref;
+            lhs_local.span = ast_deco.span;
+            HirExpr rhs_zero{};
+            rhs_zero.kind = HirExprKind::IntLit;
+            rhs_zero.type = HirTypeKind::I32;
+            rhs_zero.int_value = 0;
+            rhs_zero.span = ast_deco.span;
+            HirGuard deco_guard{};
+            deco_guard.span = ast_deco.span;
+            deco_guard.cond.kind = HirExprKind::Eq;
+            deco_guard.cond.type = HirTypeKind::Bool;
+            deco_guard.cond.span = ast_deco.span;
+            // Allocate Eq operands from route's expression pool so they survive HirRoute
+            // copy/move (which rebases pointers via rebase_expr).
+            if (route.exprs.len + 2 > HirRoute::kMaxExprs)
+                return frontend_error(FrontendError::TooManyItems, ast_deco.span);
+            route.exprs.push(lhs_local);
+            deco_guard.cond.lhs = &route.exprs[route.exprs.len - 1];
+            route.exprs.push(rhs_zero);
+            deco_guard.cond.rhs = &route.exprs[route.exprs.len - 1];
+            // fail_term: ReturnStatus reading from the synthetic local at runtime.
+            deco_guard.fail_kind = HirGuard::FailKind::Term;
+            deco_guard.fail_term.kind = HirTerminatorKind::ReturnStatus;
+            deco_guard.fail_term.source_kind = HirTerminatorSourceKind::LocalRef;
+            deco_guard.fail_term.local_ref_index = deco_ref;
+            deco_guard.fail_term.span = ast_deco.span;
+            if (!route.guards.push(deco_guard))
+                return frontend_error(FrontendError::TooManyItems, ast_deco.span);
+
+            HirRoute::DecoratorRef ref{};
+            ref.span = ast_deco.span;
+            ref.name = ast_deco.name;
+            ref.function_index = fn_index;
+            if (!route.decorators.push(ref))
+                return frontend_error(FrontendError::TooManyItems, ast_deco.span);
+        }
+
+        // Decorator guards must run BEFORE any user-written top-level guard so a
+        // rejected decorator short-circuits before user logic. We appended them
+        // at the end above; rotate so they sit in front while preserving the
+        // user guards' relative order. HirGuards are value-copied; their cond
+        // expressions point into route.exprs (stable storage), so rotating in
+        // place doesn't invalidate any pointers.
+        const u32 num_user_guards = first_decorator_guard_index;
+        const u32 num_deco_guards = route.guards.len - first_decorator_guard_index;
+        if (num_deco_guards > 0 && num_user_guards > 0) {
+            HirGuard tmp[HirRoute::kMaxGuards];
+            for (u32 i = 0; i < route.guards.len; i++) tmp[i] = route.guards[i];
+            for (u32 i = 0; i < num_deco_guards; i++) route.guards[i] = tmp[num_user_guards + i];
+            for (u32 i = 0; i < num_user_guards; i++) route.guards[num_deco_guards + i] = tmp[i];
         }
 
         if (!mod.routes.push(route))

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -7004,8 +7004,7 @@ static FrontendResult<void> load_imported_modules(
         std::unique_ptr<AstFile> ast_owned(ast.value());
         auto kept_path = stash_owned_string(owned_strings, normalized);
         g_import_analysis_counter++;
-        auto imported =
-            analyze_file_internal(*ast_owned, kept_path, import_stack, &owned_strings);
+        auto imported = analyze_file_internal(*ast_owned, kept_path, import_stack, &owned_strings);
         if (!imported) return core::make_unexpected(imported.error());
         imported_storage.push_back(std::unique_ptr<HirModule>(imported.value()));
         ImportedModuleInfo info{};

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -4,6 +4,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -26,15 +27,15 @@ static std::string str_to_std_string(Str s) {
     return std::string(s.ptr, s.len);
 }
 
-static Str stash_owned_string(std::deque<std::string>* store, const std::string& value) {
-    store->push_back(value);
-    const auto& kept = store->back();
+static Str stash_owned_string(std::deque<std::string>& store, const std::string& value) {
+    store.push_back(value);
+    const auto& kept = store.back();
     return {kept.c_str(), static_cast<u32>(kept.size())};
 }
 
 static bool type_shape_is_simple_importable(const HirTypeKind type,
-                                            u32 /*variant_index*/,
-                                            u32 /*struct_index*/,
+                                            u32 variant_index,
+                                            u32 struct_index,
                                             u32 tuple_len,
                                             const HirTypeKind* tuple_types,
                                             const u32* tuple_variant_indices,
@@ -46,19 +47,19 @@ static bool type_shape_is_simple_importable(const HirTypeKind type,
         case HirTypeKind::Generic:
         case HirTypeKind::Unknown:
             return true;
+        case HirTypeKind::Struct:
+            return struct_index != 0xffffffffu;
+        case HirTypeKind::Variant:
+            return variant_index != 0xffffffffu;
         case HirTypeKind::Tuple:
             for (u32 i = 0; i < tuple_len; i++) {
-                if (tuple_types[i] == HirTypeKind::Struct && tuple_struct_indices != nullptr &&
-                    tuple_struct_indices[i] != 0xffffffffu)
+                if (tuple_types[i] == HirTypeKind::Struct && tuple_struct_indices[i] != 0xffffffffu)
                     continue;
-                if (tuple_types[i] == HirTypeKind::Variant &&
-                    tuple_variant_indices != nullptr &&
-                    tuple_variant_indices[i] != 0xffffffffu)
+                if (tuple_types[i] == HirTypeKind::Variant && tuple_variant_indices[i] != 0xffffffffu)
                     continue;
                 if (!type_shape_is_simple_importable(tuple_types[i],
                                                     tuple_variant_indices[i],
-                                                    tuple_struct_indices != nullptr ? tuple_struct_indices[i]
-                                                                                    : 0xffffffffu,
+                                                    tuple_struct_indices[i],
                                                     0,
                                                     nullptr,
                                                     nullptr,
@@ -71,10 +72,10 @@ static bool type_shape_is_simple_importable(const HirTypeKind type,
     }
 }
 
-static bool read_text_file(const std::filesystem::path& path, std::string* out) {
+static bool read_text_file(const std::filesystem::path& path, std::string& out) {
     std::ifstream in(path, std::ios::binary);
     if (!in) return false;
-    *out = std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    out = std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     return true;
 }
 
@@ -161,6 +162,13 @@ enum class KnownValueState : u8 {
 struct MatchPayloadBinding {
     Str name{};
     HirTypeKind type = HirTypeKind::Unknown;
+    u32 generic_index = 0xffffffffu;
+    bool generic_has_error_constraint = false;
+    bool generic_has_eq_constraint = false;
+    bool generic_has_ord_constraint = false;
+    u32 generic_protocol_index = 0xffffffffu;
+    u32 generic_protocol_count = 0;
+    u32 generic_protocol_indices[HirExpr::kMaxGenericProtocols]{};
     u32 variant_index = 0xffffffffu;
     u32 struct_index = 0xffffffffu;
     u32 shape_index = 0xffffffffu;
@@ -194,6 +202,12 @@ struct GenericBinding {
     bool bound = false;
     HirTypeKind type = HirTypeKind::Unknown;
     u32 generic_index = 0xffffffffu;
+    bool generic_has_error_constraint = false;
+    bool generic_has_eq_constraint = false;
+    bool generic_has_ord_constraint = false;
+    u32 generic_protocol_index = 0xffffffffu;
+    u32 generic_protocol_count = 0;
+    u32 generic_protocol_indices[HirExpr::kMaxGenericProtocols]{};
     u32 variant_index = 0xffffffffu;
     u32 struct_index = 0xffffffffu;
     u32 shape_index = 0xffffffffu;
@@ -217,8 +231,8 @@ static FrontendResult<HirTypeKind> instantiate_deferred_named_type(const HirModu
                                                                    u32 type_arg_count,
                                                                    const GenericBinding* bindings,
                                                                    u32 binding_count,
-                                                                   u32* out_variant_index,
-                                                                   u32* out_struct_index,
+                                                                   u32& out_variant_index,
+                                                                   u32& out_struct_index,
                                                                    Span span);
 
 static FrontendResult<void> fill_bound_binding_from_type_metadata(GenericBinding* binding,
@@ -284,9 +298,7 @@ static bool hir_type_shape_satisfies_eq_constraint(const HirModule& mod,
                 if (!hir_type_shape_satisfies_eq_constraint(mod,
                                                             tuple_types[i],
                                                             tuple_variant_indices[i],
-                                                            tuple_struct_indices != nullptr
-                                                                ? tuple_struct_indices[i]
-                                                                : 0xffffffffu,
+                                                            tuple_struct_indices[i],
                                                             0,
                                                             nullptr,
                                                             nullptr,
@@ -386,9 +398,7 @@ static bool hir_type_shape_satisfies_ord_constraint(const HirModule& mod,
                 if (!hir_type_shape_satisfies_ord_constraint(mod,
                                                              tuple_types[i],
                                                              tuple_variant_indices[i],
-                                                             tuple_struct_indices != nullptr
-                                                                 ? tuple_struct_indices[i]
-                                                                 : 0xffffffffu,
+                                                             tuple_struct_indices[i],
                                                              0,
                                                              nullptr,
                                                              nullptr,
@@ -539,8 +549,8 @@ static FrontendResult<u32> instantiate_variant(HirModule* mod,
                                                                  case_decl.payload_type_arg_count,
                                                                  bindings,
                                                                  binding_count,
-                                                                 &concrete_variant_index,
-                                                                 &concrete_struct_index,
+                                                                 concrete_variant_index,
+                                                                 concrete_struct_index,
                                                                  span);
             if (!concrete_kind) return core::make_unexpected(concrete_kind.error());
             case_decl.payload_type = concrete_kind.value();
@@ -558,6 +568,16 @@ static FrontendResult<u32> instantiate_variant(HirModule* mod,
             case_decl.payload_generic_index =
                 bindings[source_generic_index].type == HirTypeKind::Generic ? bindings[source_generic_index].generic_index
                                                                           : 0xffffffffu;
+            case_decl.payload_generic_has_error_constraint =
+                bindings[source_generic_index].generic_has_error_constraint;
+            case_decl.payload_generic_has_eq_constraint = bindings[source_generic_index].generic_has_eq_constraint;
+            case_decl.payload_generic_has_ord_constraint = bindings[source_generic_index].generic_has_ord_constraint;
+            case_decl.payload_generic_protocol_index = bindings[source_generic_index].generic_protocol_index;
+            case_decl.payload_generic_protocol_count = bindings[source_generic_index].generic_protocol_count;
+            for (u32 cpi = 0; cpi < case_decl.payload_generic_protocol_count; cpi++) {
+                case_decl.payload_generic_protocol_indices[cpi] =
+                    bindings[source_generic_index].generic_protocol_indices[cpi];
+            }
             case_decl.payload_variant_index = bindings[source_generic_index].variant_index;
             case_decl.payload_struct_index = bindings[source_generic_index].struct_index;
             case_decl.payload_tuple_len = bindings[source_generic_index].tuple_len;
@@ -599,11 +619,11 @@ static FrontendResult<HirTypeKind> instantiate_deferred_named_type(const HirModu
                                                                    u32 type_arg_count,
                                                                    const GenericBinding* bindings,
                                                                    u32 binding_count,
-                                                                   u32* out_variant_index,
-                                                                   u32* out_struct_index,
+                                                                   u32& out_variant_index,
+                                                                   u32& out_struct_index,
                                                                    Span span) {
-    if (out_variant_index) *out_variant_index = 0xffffffffu;
-    if (out_struct_index) *out_struct_index = 0xffffffffu;
+    out_variant_index = 0xffffffffu;
+    out_struct_index = 0xffffffffu;
     GenericBinding concrete_args[HirFunction::kMaxTypeParams]{};
     for (u32 i = 0; i < type_arg_count; i++) {
         if (type_args[i].generic_index != 0xffffffffu) {
@@ -633,7 +653,7 @@ static FrontendResult<HirTypeKind> instantiate_deferred_named_type(const HirModu
                                                   type_arg_count,
                                                   span);
         if (!concrete_index) return core::make_unexpected(concrete_index.error());
-        if (out_variant_index) *out_variant_index = concrete_index.value();
+        out_variant_index = concrete_index.value();
         return HirTypeKind::Variant;
     }
     if (declared_kind == HirTypeKind::Struct) {
@@ -643,7 +663,7 @@ static FrontendResult<HirTypeKind> instantiate_deferred_named_type(const HirModu
                                                  type_arg_count,
                                                  span);
         if (!concrete_index) return core::make_unexpected(concrete_index.error());
-        if (out_struct_index) *out_struct_index = concrete_index.value();
+        out_struct_index = concrete_index.value();
         return HirTypeKind::Struct;
     }
     return frontend_error(FrontendError::UnsupportedSyntax, span);
@@ -717,8 +737,8 @@ static FrontendResult<u32> instantiate_struct(HirModule* mod,
                                                                  field.type_arg_count,
                                                                  bindings,
                                                                  binding_count,
-                                                                 &concrete_variant_index,
-                                                                 &concrete_struct_index,
+                                                                 concrete_variant_index,
+                                                                 concrete_struct_index,
                                                                  span);
             if (!concrete_kind) return core::make_unexpected(concrete_kind.error());
             field.type = concrete_kind.value();
@@ -736,6 +756,13 @@ static FrontendResult<u32> instantiate_struct(HirModule* mod,
             field.generic_index =
                 bindings[source_generic_index].type == HirTypeKind::Generic ? bindings[source_generic_index].generic_index
                                                                            : 0xffffffffu;
+            field.generic_has_error_constraint = bindings[source_generic_index].generic_has_error_constraint;
+            field.generic_has_eq_constraint = bindings[source_generic_index].generic_has_eq_constraint;
+            field.generic_has_ord_constraint = bindings[source_generic_index].generic_has_ord_constraint;
+            field.generic_protocol_index = bindings[source_generic_index].generic_protocol_index;
+            field.generic_protocol_count = bindings[source_generic_index].generic_protocol_count;
+            for (u32 cpi = 0; cpi < field.generic_protocol_count; cpi++)
+                field.generic_protocol_indices[cpi] = bindings[source_generic_index].generic_protocol_indices[cpi];
             field.variant_index = bindings[source_generic_index].variant_index;
             field.struct_index = bindings[source_generic_index].struct_index;
             field.tuple_len = bindings[source_generic_index].tuple_len;
@@ -805,8 +832,8 @@ static FrontendResult<void> refresh_concrete_struct_instances(HirModule* mod) {
                                                                      field.type_arg_count,
                                                                      bindings,
                                                                      binding_count,
-                                                                     &concrete_variant_index,
-                                                                     &concrete_struct_index,
+                                                                     concrete_variant_index,
+                                                                     concrete_struct_index,
                                                                      refreshed.span);
                 if (!concrete_kind) return core::make_unexpected(concrete_kind.error());
                 field.type = concrete_kind.value();
@@ -820,6 +847,13 @@ static FrontendResult<void> refresh_concrete_struct_instances(HirModule* mod) {
                 if (field.generic_index >= binding_count)
                     return frontend_error(FrontendError::UnsupportedSyntax, refreshed.span);
                 field.type = bindings[field.generic_index].type;
+                field.generic_has_error_constraint = bindings[field.generic_index].generic_has_error_constraint;
+                field.generic_has_eq_constraint = bindings[field.generic_index].generic_has_eq_constraint;
+                field.generic_has_ord_constraint = bindings[field.generic_index].generic_has_ord_constraint;
+                field.generic_protocol_index = bindings[field.generic_index].generic_protocol_index;
+                field.generic_protocol_count = bindings[field.generic_index].generic_protocol_count;
+                for (u32 cpi = 0; cpi < field.generic_protocol_count; cpi++)
+                    field.generic_protocol_indices[cpi] = bindings[field.generic_index].generic_protocol_indices[cpi];
                 field.variant_index = bindings[field.generic_index].variant_index;
                 field.struct_index = bindings[field.generic_index].struct_index;
                 field.tuple_len = bindings[field.generic_index].tuple_len;
@@ -855,6 +889,22 @@ static FrontendResult<void> refresh_concrete_struct_instances(HirModule* mod) {
         mod->structs[si] = refreshed;
     }
     return {};
+}
+
+static void copy_binding_constraints_from_type_params(
+    GenericBinding* binding,
+    const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>& type_params) {
+    if (binding->type != HirTypeKind::Generic) return;
+    if (binding->generic_index >= type_params.len) return;
+    const auto& type_param = type_params[binding->generic_index];
+    binding->generic_has_error_constraint = type_param.has_error_constraint;
+    binding->generic_has_eq_constraint = type_param.has_eq_constraint;
+    binding->generic_has_ord_constraint = type_param.has_ord_constraint;
+    binding->generic_protocol_index =
+        type_param.custom_protocol_count != 0 ? type_param.custom_protocol_indices[0] : 0xffffffffu;
+    binding->generic_protocol_count = type_param.custom_protocol_count;
+    for (u32 cpi = 0; cpi < binding->generic_protocol_count; cpi++)
+        binding->generic_protocol_indices[cpi] = type_param.custom_protocol_indices[cpi];
 }
 
 static FrontendResult<void> refresh_concrete_variant_instances(HirModule* mod) {
@@ -898,8 +948,8 @@ static FrontendResult<void> refresh_concrete_variant_instances(HirModule* mod) {
                                                                      case_decl.payload_type_arg_count,
                                                                      bindings,
                                                                      binding_count,
-                                                                     &concrete_variant_index,
-                                                                     &concrete_struct_index,
+                                                                     concrete_variant_index,
+                                                                     concrete_struct_index,
                                                                      refreshed.span);
                 if (!concrete_kind) return core::make_unexpected(concrete_kind.error());
                 case_decl.payload_type = concrete_kind.value();
@@ -918,6 +968,16 @@ static FrontendResult<void> refresh_concrete_variant_instances(HirModule* mod) {
                     bindings[source_generic_index].type == HirTypeKind::Generic
                         ? bindings[source_generic_index].generic_index
                         : 0xffffffffu;
+                case_decl.payload_generic_has_error_constraint =
+                    bindings[source_generic_index].generic_has_error_constraint;
+                case_decl.payload_generic_has_eq_constraint = bindings[source_generic_index].generic_has_eq_constraint;
+                case_decl.payload_generic_has_ord_constraint = bindings[source_generic_index].generic_has_ord_constraint;
+                case_decl.payload_generic_protocol_index = bindings[source_generic_index].generic_protocol_index;
+                case_decl.payload_generic_protocol_count = bindings[source_generic_index].generic_protocol_count;
+                for (u32 cpi = 0; cpi < case_decl.payload_generic_protocol_count; cpi++) {
+                    case_decl.payload_generic_protocol_indices[cpi] =
+                        bindings[source_generic_index].generic_protocol_indices[cpi];
+                }
                 case_decl.payload_variant_index = bindings[source_generic_index].variant_index;
                 case_decl.payload_struct_index = bindings[source_generic_index].struct_index;
                 case_decl.payload_tuple_len = bindings[source_generic_index].tuple_len;
@@ -1100,7 +1160,7 @@ static FrontendResult<void> validate_import_namespace_bindings(const AstFile& fi
     return {};
 }
 
-static bool resolve_import_namespace_member(const HirModule& mod, const AstExpr& expr, Str* out_member) {
+static bool resolve_import_namespace_member(const HirModule& mod, const AstExpr& expr, Str& out_member) {
     if (expr.kind != AstExprKind::Field || expr.lhs == nullptr) return false;
     if (expr.lhs->kind != AstExprKind::Ident) return false;
     for (u32 i = 0; i < mod.imports.len; i++) {
@@ -1109,24 +1169,24 @@ static bool resolve_import_namespace_member(const HirModule& mod, const AstExpr&
         if (!import_namespace_matches(imported.path, imported.has_namespace_alias, imported.namespace_alias, expr.lhs->name))
             continue;
         if (imported.has_namespace_alias)
-            *out_member = intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" + str_to_std_string(expr.name));
+            out_member = intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" + str_to_std_string(expr.name));
         else
-            *out_member = expr.name;
+            out_member = expr.name;
         return true;
     }
     return false;
 }
 
-static bool resolve_import_namespace_type_name(const HirModule& mod, Str ns, Str member, Str* out_name) {
+static bool resolve_import_namespace_type_name(const HirModule& mod, Str ns, Str member, Str& out_name) {
     for (u32 i = 0; i < mod.imports.len; i++) {
         const auto& imported = mod.imports[i];
         if (imported.selective) continue;
         if (!import_namespace_matches(imported.path, imported.has_namespace_alias, imported.namespace_alias, ns))
             continue;
         if (imported.has_namespace_alias)
-            *out_name = intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" + str_to_std_string(member));
+            out_name = intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" + str_to_std_string(member));
         else
-            *out_name = member;
+            out_name = member;
         return true;
     }
     return false;
@@ -1170,13 +1230,13 @@ static FrontendResult<bool> fill_impl_generic_bindings(const HirModule& mod,
                                                        const HirImpl& impl,
                                                        u32 concrete_struct_index,
                                                        GenericBinding* out,
-                                                       u32* out_count) {
-    *out_count = 0;
+                                                       u32& out_count) {
+    out_count = 0;
     if (!impl.is_generic_template) return true;
     if (concrete_struct_index >= mod.structs.len) return false;
     const auto& st = mod.structs[concrete_struct_index];
     if (st.template_struct_index != impl.struct_index) return false;
-    *out_count = st.instance_type_arg_count;
+    out_count = st.instance_type_arg_count;
     for (u32 i = 0; i < st.instance_type_arg_count; i++) {
         auto filled = fill_bound_binding_from_type_metadata(&out[i],
                                                             const_cast<HirModule*>(&mod),
@@ -1278,6 +1338,38 @@ static FrontendResult<Str> make_impl_function_name(Str protocol_name,
     return Str{buf, len};
 }
 
+static FrontendResult<Str> make_impl_target_name(const AstTypeRef& ref) {
+    std::function<std::string(const AstTypeRef&)> build = [&](const AstTypeRef& cur) -> std::string {
+        if (cur.is_tuple) {
+            std::string out = "tuple";
+            for (u32 i = 0; i < cur.tuple_elem_types.len; i++) {
+                out += "_";
+                if (cur.tuple_elem_types[i] != nullptr) out += build(*cur.tuple_elem_types[i]);
+                else out += str_to_std_string(cur.tuple_elem_names[i]);
+            }
+            return out;
+        }
+        std::string out;
+        if (cur.namespace_name.len != 0) {
+            out += str_to_std_string(cur.namespace_name);
+            out += "__";
+        }
+        out += str_to_std_string(cur.name);
+        for (u32 i = 0; i < cur.type_arg_names.len; i++) {
+            AstTypeRef arg{};
+            if (i < cur.type_args.len && cur.type_args[i] != nullptr) arg = *cur.type_args[i];
+            else {
+                arg.name = cur.type_arg_names[i];
+                if (i < cur.type_arg_namespaces.len) arg.namespace_name = cur.type_arg_namespaces[i];
+            }
+            out += "_";
+            out += build(arg);
+        }
+        return out;
+    };
+    return intern_generated_name(build(ref));
+}
+
 static HirProtocolKind resolve_protocol_kind(const HirModule& mod, Str name) {
     if (name.eq({"Error", 5})) return HirProtocolKind::Error;
     if (name.eq({"Eq", 2})) return HirProtocolKind::Eq;
@@ -1296,21 +1388,21 @@ static u32 find_generic_param_index(const FixedVec<HirFunction::TypeParamDecl, H
 
 static HirTypeKind resolve_named_type(const HirModule& mod,
                                       Str name,
-                                      u32* variant_index = nullptr,
-                                      u32* struct_index = nullptr) {
-    if (variant_index) *variant_index = 0xffffffffu;
-    if (struct_index) *struct_index = 0xffffffffu;
+                                      u32& variant_index,
+                                      u32& struct_index) {
+    variant_index = 0xffffffffu;
+    struct_index = 0xffffffffu;
     if (name.eq({"bool", 4})) return HirTypeKind::Bool;
     if (name.eq({"i32", 3})) return HirTypeKind::I32;
     if (name.eq({"str", 3})) return HirTypeKind::Str;
     const u32 idx = find_variant_index(mod, name);
     if (idx < mod.variants.len) {
-        if (variant_index) *variant_index = idx;
+        variant_index = idx;
         return HirTypeKind::Variant;
     }
     const u32 struct_idx = find_struct_index(mod, name);
     if (struct_idx < mod.structs.len) {
-        if (struct_index) *struct_index = struct_idx;
+        struct_index = struct_idx;
         return HirTypeKind::Struct;
     }
     return HirTypeKind::Unknown;
@@ -1335,21 +1427,21 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
                                                          const AstTypeRef& ref,
                                                          const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>* type_params,
                                                          u32* generic_index,
-                                                         u32* variant_index,
-                                                         u32* struct_index,
-                                                         u32* tuple_len,
+                                                         u32& variant_index,
+                                                         u32& struct_index,
+                                                         u32& tuple_len,
                                                          HirTypeKind* tuple_types,
                                                          u32* tuple_variant_indices,
                                                          u32* tuple_struct_indices,
                                                          Span span) {
     if (generic_index) *generic_index = 0xffffffffu;
-    if (variant_index) *variant_index = 0xffffffffu;
-    if (struct_index) *struct_index = 0xffffffffu;
-    if (tuple_len) *tuple_len = 0;
+    variant_index = 0xffffffffu;
+    struct_index = 0xffffffffu;
+    tuple_len = 0;
     if (!ref.is_tuple) {
         Str resolved_name = ref.name;
         if (ref.namespace_name.len != 0) {
-            if (!resolve_import_namespace_type_name(mod, ref.namespace_name, ref.name, &resolved_name))
+            if (!resolve_import_namespace_type_name(mod, ref.namespace_name, ref.name, resolved_name))
                 return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
         }
         if (type_params != nullptr && ref.namespace_name.len == 0) {
@@ -1364,9 +1456,9 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
         const auto kind = resolve_named_type(mod, resolved_name, variant_index, struct_index);
         if (kind == HirTypeKind::Unknown)
             return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
-        if (kind == HirTypeKind::Variant && *variant_index < mod.variants.len &&
-            mod.variants[*variant_index].type_params.len != 0) {
-            if (ref.type_arg_names.len != mod.variants[*variant_index].type_params.len)
+        if (kind == HirTypeKind::Variant && variant_index < mod.variants.len &&
+            mod.variants[variant_index].type_params.len != 0) {
+            if (ref.type_arg_names.len != mod.variants[variant_index].type_params.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
             GenericBinding bindings[HirVariant::kMaxTypeParams]{};
             for (u32 i = 0; i < ref.type_arg_names.len; i++) {
@@ -1381,9 +1473,9 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
                                                       type_arg_ref,
                                                       type_params,
                                                       nullptr,
-                                                      &type_variant_index,
-                                                      &type_struct_index,
-                                                      &elem_tuple_len,
+                                                      type_variant_index,
+                                                      type_struct_index,
+                                                      elem_tuple_len,
                                                       elem_tuple_types,
                                                       elem_tuple_variant_indices,
                                                       elem_tuple_struct_indices,
@@ -1406,14 +1498,14 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
                 if (!filled) return core::make_unexpected(filled.error());
             }
             auto concrete_index =
-                instantiate_variant(const_cast<HirModule*>(&mod), *variant_index, bindings, ref.type_arg_names.len, span);
+                instantiate_variant(const_cast<HirModule*>(&mod), variant_index, bindings, ref.type_arg_names.len, span);
             if (!concrete_index) return core::make_unexpected(concrete_index.error());
-            *variant_index = concrete_index.value();
+            variant_index = concrete_index.value();
             return HirTypeKind::Variant;
         }
-        if (kind == HirTypeKind::Struct && *struct_index < mod.structs.len &&
-            mod.structs[*struct_index].type_params.len != 0) {
-            if (ref.type_arg_names.len != mod.structs[*struct_index].type_params.len)
+        if (kind == HirTypeKind::Struct && struct_index < mod.structs.len &&
+            mod.structs[struct_index].type_params.len != 0) {
+            if (ref.type_arg_names.len != mod.structs[struct_index].type_params.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
             GenericBinding bindings[HirStruct::kMaxTypeParams]{};
             for (u32 i = 0; i < ref.type_arg_names.len; i++) {
@@ -1428,9 +1520,9 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
                                                       type_arg_ref,
                                                       type_params,
                                                       nullptr,
-                                                      &type_variant_index,
-                                                      &type_struct_index,
-                                                      &elem_tuple_len,
+                                                      type_variant_index,
+                                                      type_struct_index,
+                                                      elem_tuple_len,
                                                       elem_tuple_types,
                                                       elem_tuple_variant_indices,
                                                       elem_tuple_struct_indices,
@@ -1453,9 +1545,9 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
                 if (!filled) return core::make_unexpected(filled.error());
             }
             auto concrete_index =
-                instantiate_struct(const_cast<HirModule*>(&mod), *struct_index, bindings, ref.type_arg_names.len, span);
+                instantiate_struct(const_cast<HirModule*>(&mod), struct_index, bindings, ref.type_arg_names.len, span);
             if (!concrete_index) return core::make_unexpected(concrete_index.error());
-            *struct_index = concrete_index.value();
+            struct_index = concrete_index.value();
             return HirTypeKind::Struct;
         }
         if (ref.type_arg_names.len != 0)
@@ -1465,7 +1557,7 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
     if (ref.tuple_elem_names.len < 2 && ref.tuple_elem_types.len < 2)
         return frontend_error(FrontendError::UnsupportedSyntax, span);
     const u32 elem_count = ref.tuple_elem_types.len != 0 ? ref.tuple_elem_types.len : ref.tuple_elem_names.len;
-    if (tuple_len) *tuple_len = elem_count;
+    tuple_len = elem_count;
     for (u32 i = 0; i < elem_count; i++) {
         u32 elem_variant_index = 0xffffffffu;
         u32 elem_struct_index = 0xffffffffu;
@@ -1478,9 +1570,9 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
                                           elem_ref,
                                           type_params,
                                           nullptr,
-                                          &elem_variant_index,
-                                          &elem_struct_index,
-                                          &elem_tuple_len,
+                                          elem_variant_index,
+                                          elem_struct_index,
+                                          elem_tuple_len,
                                           elem_tuple_types,
                                           elem_tuple_variant_indices,
                                           elem_tuple_struct_indices,
@@ -1490,8 +1582,7 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
             return frontend_error(FrontendError::UnsupportedSyntax, span, elem_ref.name);
         tuple_types[i] = kind.value();
         tuple_variant_indices[i] = kind.value() == HirTypeKind::Variant ? elem_variant_index : 0xffffffffu;
-        if (tuple_struct_indices != nullptr)
-            tuple_struct_indices[i] = kind.value() == HirTypeKind::Struct ? elem_struct_index : 0xffffffffu;
+        tuple_struct_indices[i] = kind.value() == HirTypeKind::Struct ? elem_struct_index : 0xffffffffu;
     }
     return HirTypeKind::Tuple;
 }
@@ -1701,7 +1792,7 @@ static HirExpr make_expected_type_expr(HirTypeKind type,
                                        const HirTypeKind* tuple_types,
                                        const u32* tuple_variant_indices,
                                        const u32* tuple_struct_indices,
-                                       u32 shape_index = 0xffffffffu) {
+                                       u32 shape_index) {
     HirExpr expected{};
     expected.type = type;
     expected.variant_index = variant_index;
@@ -1724,7 +1815,7 @@ static HirExpr make_instance_arg_expr(HirTypeKind type,
                                       const HirTypeKind* tuple_types,
                                       const u32* tuple_variant_indices,
                                       const u32* tuple_struct_indices,
-                                      u32 shape_index = 0xffffffffu) {
+                                      u32 shape_index) {
     HirExpr out{};
     out.type = type;
     out.generic_index = generic_index;
@@ -1777,6 +1868,13 @@ static bool bind_generic_shape(GenericBinding* generic_bindings,
         binding.bound = true;
         binding.type = actual.type;
         binding.generic_index = actual.type == HirTypeKind::Generic ? actual.generic_index : 0xffffffffu;
+        binding.generic_has_error_constraint = actual.generic_has_error_constraint;
+        binding.generic_has_eq_constraint = actual.generic_has_eq_constraint;
+        binding.generic_has_ord_constraint = actual.generic_has_ord_constraint;
+        binding.generic_protocol_index = actual.generic_protocol_index;
+        binding.generic_protocol_count = actual.generic_protocol_count;
+        for (u32 cpi = 0; cpi < binding.generic_protocol_count; cpi++)
+            binding.generic_protocol_indices[cpi] = actual.generic_protocol_indices[cpi];
         binding.variant_index = actual.type == HirTypeKind::Variant ? actual.variant_index : 0xffffffffu;
         binding.struct_index = actual.type == HirTypeKind::Struct ? actual.struct_index : 0xffffffffu;
         binding.shape_index = actual.shape_index;
@@ -1791,6 +1889,13 @@ static bool bind_generic_shape(GenericBinding* generic_bindings,
     HirExpr expected{};
     expected.type = binding.type;
     expected.generic_index = binding.generic_index;
+    expected.generic_has_error_constraint = binding.generic_has_error_constraint;
+    expected.generic_has_eq_constraint = binding.generic_has_eq_constraint;
+    expected.generic_has_ord_constraint = binding.generic_has_ord_constraint;
+    expected.generic_protocol_index = binding.generic_protocol_index;
+    expected.generic_protocol_count = binding.generic_protocol_count;
+    for (u32 cpi = 0; cpi < expected.generic_protocol_count; cpi++)
+        expected.generic_protocol_indices[cpi] = binding.generic_protocol_indices[cpi];
     expected.variant_index = binding.variant_index;
     expected.struct_index = binding.struct_index;
     expected.shape_index = binding.shape_index;
@@ -1898,9 +2003,9 @@ static FrontendResult<void> apply_declared_type_to_expr(HirExpr* expr,
                               stmt.type,
                               nullptr,
                               nullptr,
-                              &variant_index,
-                              &struct_index,
-                              &tuple_len,
+                              variant_index,
+                              struct_index,
+                              tuple_len,
                               tuple_types,
                               tuple_variant_indices,
                               tuple_struct_indices,
@@ -1946,30 +2051,30 @@ static FrontendResult<void> apply_declared_type_to_expr(HirExpr* expr,
 static KnownValueState known_value_state(const HirExpr& expr,
                                          const HirLocal* locals,
                                          u32 local_count,
-                                         u32 depth = 0);
+                                         u32 depth);
 static bool const_eval_expr(const HirExpr& expr,
                             const HirLocal* locals,
                             u32 local_count,
                             ConstValue* out,
-                            u32 depth = 0);
+                            u32 depth);
 static KnownErrorCase known_error_case(const HirExpr& expr,
                                        const HirLocal* locals,
                                        u32 local_count,
-                                       u32 depth = 0);
+                                       u32 depth);
 static Str known_error_name(const HirExpr& expr,
                             const HirLocal* locals,
                             u32 local_count,
-                            u32 depth = 0);
+                            u32 depth);
 static const HirExpr* known_error_expr(const HirExpr& expr,
                                        const HirLocal* locals,
                                        u32 local_count,
-                                       u32 depth = 0);
+                                       u32 depth);
 static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                             HirRoute* route,
                                             const HirModule& mod,
                                             const HirLocal* locals,
                                             u32 local_count,
-                                            const MatchPayloadBinding* binding = nullptr);
+                                            const MatchPayloadBinding* binding);
 static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
                                                          HirRoute* route,
                                                          const HirModule& mod,
@@ -1991,12 +2096,12 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
 static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                                                  HirRoute* route,
                                                  const HirModule& mod,
-                                                 const MatchPayloadBinding* binding = nullptr);
+                                                 const MatchPayloadBinding* binding);
 static FrontendResult<void> collect_named_error_cases(const HirExpr& expr,
-                                                      FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases);
+                                                      FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases);
 static FrontendResult<void> collect_named_error_cases_ast(
     const AstStatement& stmt,
-    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases);
+    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases);
 static void patch_named_error_variant(HirExpr* expr,
                                       u32 variant_index,
                                       const FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases);
@@ -2006,7 +2111,7 @@ static FrontendResult<HirExpr> analyze_known_error_field(const HirExpr& base,
                                                          const HirModule& mod,
                                                          const HirLocal* locals,
                                                          u32 local_count,
-                                                         u32 depth = 0);
+                                                         u32 depth);
 static FrontendResult<void> analyze_guard_fail_body(const AstStatement& stmt,
                                                     HirGuardBody* body,
                                                     HirRoute* route,
@@ -2041,7 +2146,7 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         ns_field.lhs = expr.lhs;
         ns_field.name = expr.name;
         ns_field.span = expr.span;
-        if (!resolve_import_namespace_member(mod, ns_field, &qualified_member))
+        if (!resolve_import_namespace_member(mod, ns_field, qualified_member))
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
         AstExpr call_expr{};
         call_expr.kind = AstExprKind::Call;
@@ -2051,7 +2156,7 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         return analyze_call_expr(call_expr, route, mod, locals, local_count, binding, nullptr);
     }
     Str qualified_type_name{};
-    if (resolve_import_namespace_member(mod, *expr.lhs, &qualified_type_name)) {
+    if (resolve_import_namespace_member(mod, *expr.lhs, qualified_type_name)) {
         AstExpr variant_expr{};
         variant_expr.kind = AstExprKind::VariantCase;
         variant_expr.span = expr.span;
@@ -2217,6 +2322,10 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
                     out.tuple_variant_indices[i] = matched_req->return_tuple_variant_indices[i];
                     out.tuple_struct_indices[i] = matched_req->return_tuple_struct_indices[i];
                 }
+                out.may_nil = matched_req->return_may_nil;
+                out.may_error = matched_req->return_may_error;
+                out.error_struct_index = matched_req->return_error_struct_index;
+                out.error_variant_index = matched_req->return_error_variant_index;
             }
             return out;
         }
@@ -2350,13 +2459,13 @@ static u32 next_local_ref_index(const HirRoute* route, const HirLocal* locals, u
 }
 
 static FrontendResult<void> insert_scoped_local(HirLocal* locals,
-                                                u32* local_count,
+                                                u32& local_count,
                                                 u32 capacity,
                                                 const HirLocal& local,
                                                 Span span) {
     if (local.ref_index >= capacity)
         return frontend_error(FrontendError::TooManyItems, span);
-    if (*local_count <= local.ref_index) *local_count = local.ref_index + 1;
+    if (local_count <= local.ref_index) local_count = local.ref_index + 1;
     locals[local.ref_index] = local;
     return {};
 }
@@ -2581,7 +2690,7 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
         u32 impl_binding_count = 0;
         if (impl != nullptr) {
             auto impl_filled =
-                fill_impl_generic_bindings(mod, *impl, recv->struct_index, impl_bindings, &impl_binding_count);
+                fill_impl_generic_bindings(mod, *impl, recv->struct_index, impl_bindings, impl_binding_count);
             if (!impl_filled) return core::make_unexpected(impl_filled.error());
             if (!impl_filled.value())
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
@@ -2611,6 +2720,58 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
                                                  impl_bindings,
                                                  impl_binding_count);
         if (!inlined) return core::make_unexpected(inlined.error());
+        if (fn.return_type != HirTypeKind::Unknown &&
+            (inlined->kind == HirExprKind::Nil || inlined->kind == HirExprKind::Error)) {
+            HirExpr expected{};
+            expected.type = fn.return_type;
+            expected.generic_index = fn.return_generic_index;
+            expected.shape_index = fn.return_shape_index;
+            expected.variant_index = fn.return_variant_index;
+            expected.struct_index = fn.return_struct_index;
+            expected.tuple_len = fn.return_tuple_len;
+            for (u32 i = 0; i < fn.return_tuple_len; i++) {
+                expected.tuple_types[i] = fn.return_tuple_types[i];
+                expected.tuple_variant_indices[i] = fn.return_tuple_variant_indices[i];
+                expected.tuple_struct_indices[i] = fn.return_tuple_struct_indices[i];
+            }
+            if (fn.return_generic_index < fn.type_params.len) {
+                expected.generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
+                expected.generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
+                expected.generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+                expected.generic_protocol_index =
+                    fn.type_params[fn.return_generic_index].custom_protocol_count != 0
+                        ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
+                        : 0xffffffffu;
+                expected.generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+                for (u32 cpi = 0; cpi < expected.generic_protocol_count; cpi++)
+                    expected.generic_protocol_indices[cpi] =
+                        fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
+            }
+            auto concrete = apply_generic_binding_to_expr(expected, impl_bindings, impl_binding_count);
+            auto concretized =
+                concretize_named_instance_shape(&concrete, mod, impl_bindings, impl_binding_count);
+            if (!concretized) return core::make_unexpected(concretized.error());
+            inlined->type = concrete.type;
+            inlined->generic_index = concrete.generic_index;
+            inlined->generic_has_error_constraint = concrete.generic_has_error_constraint;
+            inlined->generic_has_eq_constraint = concrete.generic_has_eq_constraint;
+            inlined->generic_has_ord_constraint = concrete.generic_has_ord_constraint;
+            inlined->generic_protocol_index = concrete.generic_protocol_index;
+            inlined->generic_protocol_count = concrete.generic_protocol_count;
+            for (u32 cpi = 0; cpi < concrete.generic_protocol_count; cpi++)
+                inlined->generic_protocol_indices[cpi] = concrete.generic_protocol_indices[cpi];
+            inlined->variant_index = concrete.variant_index;
+            inlined->struct_index = concrete.struct_index;
+            inlined->shape_index = concrete.shape_index;
+            inlined->tuple_len = concrete.tuple_len;
+            for (u32 i = 0; i < concrete.tuple_len; i++) {
+                inlined->tuple_types[i] = concrete.tuple_types[i];
+                inlined->tuple_variant_indices[i] = concrete.tuple_variant_indices[i];
+                inlined->tuple_struct_indices[i] = concrete.tuple_struct_indices[i];
+            }
+            inlined->may_nil = inlined->kind == HirExprKind::Nil;
+            inlined->may_error = inlined->kind == HirExprKind::Error;
+        }
         inlined->span = expr.span;
         return inlined.value();
     }
@@ -2637,6 +2798,31 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
         out_slot.lhs = &route->exprs[route->exprs.len - 1];
         out_slot.span = expr.span;
         return out_slot;
+    }
+
+    if (expr.kind == HirExprKind::Or) {
+        if (expr.lhs == nullptr || expr.rhs == nullptr)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        auto lhs =
+            instantiate_function_expr(*expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!lhs->may_nil && !lhs->may_error) {
+            HirExpr out_lhs = lhs.value();
+            out_lhs.span = expr.span;
+            return out_lhs;
+        }
+        auto rhs =
+            instantiate_function_expr(*expr.rhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        HirExpr out_or = expr;
+        if (!route->exprs.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        out_or.lhs = &route->exprs[route->exprs.len - 1];
+        if (!route->exprs.push(rhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        out_or.rhs = &route->exprs[route->exprs.len - 1];
+        out_or.span = expr.span;
+        return out_or;
     }
 
     if (expr.lhs != nullptr) {
@@ -2762,7 +2948,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                                                           const HirModule& mod,
                                                           const HirLocal* locals,
                                                           u32 local_count,
-                                                          const MatchPayloadBinding* binding = nullptr) {
+                                                          const MatchPayloadBinding* binding) {
     auto merge_expr_shape = [&](const HirExpr& lhs, const HirExpr& rhs, HirExpr* out) -> bool {
         HirTypeKind merged_type = lhs.type;
         u32 merged_generic_index = lhs.generic_index;
@@ -2946,7 +3132,6 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
             }
             out.error_struct_index = merged_shape.error_struct_index;
             out.error_variant_index = merged_shape.error_variant_index;
-            out.shape_index = merged_shape.shape_index;
             out.span = stmt.span;
             if (!scratch->exprs.push(cond))
                 return frontend_error(FrontendError::TooManyItems, arm.span);
@@ -3031,7 +3216,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
         auto subject = analyze_expr(stmt.expr, scratch, mod, locals, local_count, nullptr);
         if (!subject) return core::make_unexpected(subject.error());
         ConstValue subject_value{};
-        if (!const_eval_expr(subject.value(), locals, local_count, &subject_value))
+        if (!const_eval_expr(subject.value(), locals, local_count, &subject_value, 0))
             return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
 
         if (!scratch->exprs.push(subject.value()))
@@ -3068,6 +3253,24 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 arm.pattern.lhs != nullptr) {
                 selected_binding.name = arm.pattern.lhs->name;
                 selected_binding.type = mod.variants[pattern->variant_index].cases[pattern->case_index].payload_type;
+                selected_binding.generic_index =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_index;
+                selected_binding.generic_has_error_constraint =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_error_constraint;
+                selected_binding.generic_has_eq_constraint =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_eq_constraint;
+                selected_binding.generic_has_ord_constraint =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_ord_constraint;
+                selected_binding.generic_protocol_index =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_protocol_index;
+                selected_binding.generic_protocol_count =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_protocol_count;
+                for (u32 cpi = 0; cpi < selected_binding.generic_protocol_count; cpi++) {
+                    selected_binding.generic_protocol_indices[cpi] =
+                        mod.variants[pattern->variant_index]
+                            .cases[pattern->case_index]
+                            .payload_generic_protocol_indices[cpi];
+                }
                 selected_binding.variant_index =
                     mod.variants[pattern->variant_index].cases[pattern->case_index].payload_variant_index;
                 selected_binding.struct_index =
@@ -3157,6 +3360,14 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 if (case_decl.has_payload && arm.pattern.lhs != nullptr) {
                     arm_binding.name = arm.pattern.lhs->name;
                     arm_binding.type = case_decl.payload_type;
+                    arm_binding.generic_index = case_decl.payload_generic_index;
+                    arm_binding.generic_has_error_constraint = case_decl.payload_generic_has_error_constraint;
+                    arm_binding.generic_has_eq_constraint = case_decl.payload_generic_has_eq_constraint;
+                    arm_binding.generic_has_ord_constraint = case_decl.payload_generic_has_ord_constraint;
+                    arm_binding.generic_protocol_index = case_decl.payload_generic_protocol_index;
+                    arm_binding.generic_protocol_count = case_decl.payload_generic_protocol_count;
+                    for (u32 cpi = 0; cpi < arm_binding.generic_protocol_count; cpi++)
+                        arm_binding.generic_protocol_indices[cpi] = case_decl.payload_generic_protocol_indices[cpi];
                     arm_binding.variant_index = case_decl.payload_variant_index;
                     arm_binding.struct_index = case_decl.payload_struct_index;
                     arm_binding.shape_index = case_decl.payload_shape_index;
@@ -3295,7 +3506,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 local.shape_index = init->shape_index;
                 local.init = init.value();
                 auto inserted =
-                    insert_scoped_local(next_locals, &next_count, HirRoute::kMaxLocals, local, inner.span);
+                    insert_scoped_local(next_locals, next_count, HirRoute::kMaxLocals, local, inner.span);
                 if (!inserted) return core::make_unexpected(inserted.error());
                 if (!scratch->locals.push(local))
                     return frontend_error(FrontendError::TooManyItems, inner.span);
@@ -3311,7 +3522,8 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 for (u32 i = 0; i < cur_local_count; i++) succ_locals[i] = cur_locals[i];
                 u32 succ_count = cur_local_count;
                 if (inner.bind_value) {
-                    if (known_value_state(bound.value(), cur_locals, cur_local_count) == KnownValueState::Error)
+                    if (known_value_state(bound.value(), cur_locals, cur_local_count, 0) ==
+                        KnownValueState::Error)
                         return frontend_error(FrontendError::UnsupportedSyntax, inner.expr.span);
                     HirLocal local{};
                     local.span = inner.span;
@@ -3343,7 +3555,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                     if (!init) return core::make_unexpected(init.error());
                     local.init = init.value();
                     auto inserted =
-                        insert_scoped_local(succ_locals, &succ_count, HirRoute::kMaxLocals, local, inner.span);
+                        insert_scoped_local(succ_locals, succ_count, HirRoute::kMaxLocals, local, inner.span);
                     if (!inserted) return core::make_unexpected(inserted.error());
                     if (!scratch->locals.push(local))
                         return frontend_error(FrontendError::TooManyItems, inner.span);
@@ -3379,6 +3591,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 out.may_error = merged_shape.may_error;
                 out.variant_index = merged_shape.variant_index;
                 out.struct_index = merged_shape.struct_index;
+                out.shape_index = merged_shape.shape_index;
                 out.tuple_len = merged_shape.tuple_len;
                 for (u32 i = 0; i < merged_shape.tuple_len; i++) {
                     out.tuple_types[i] = merged_shape.tuple_types[i];
@@ -3446,10 +3659,10 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         if (expr.lhs != nullptr) {
             if (expr.lhs->kind == AstExprKind::Ident) {
                 if (!has_import_namespace(mod, expr.lhs->name) ||
-                    !resolve_import_namespace_type_name(mod, expr.lhs->name, expr.name, &resolved_struct_name))
+                    !resolve_import_namespace_type_name(mod, expr.lhs->name, expr.name, resolved_struct_name))
                     return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
             } else {
-                if (!resolve_import_namespace_member(mod, *expr.lhs, &resolved_struct_name))
+                if (!resolve_import_namespace_member(mod, *expr.lhs, resolved_struct_name))
                     return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
             }
         }
@@ -3473,9 +3686,9 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                                           expr.type_args[i],
                                                           nullptr,
                                                           nullptr,
-                                                          &type_variant_index,
-                                                          &type_struct_index,
-                                                          &tuple_len,
+                                                          type_variant_index,
+                                                          type_struct_index,
+                                                          tuple_len,
                                                           tuple_types,
                                                           tuple_variant_indices,
                                                           tuple_struct_indices,
@@ -3563,6 +3776,18 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         out.type = HirTypeKind::Struct;
         out.struct_index = concrete_struct_index;
         out.str_value = resolved_struct_name;
+        auto struct_shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                                  out.type,
+                                                  out.generic_index,
+                                                  out.variant_index,
+                                                  out.struct_index,
+                                                  out.tuple_len,
+                                                  out.tuple_types,
+                                                  out.tuple_variant_indices,
+                                                  out.tuple_struct_indices,
+                                                  expr.span);
+        if (!struct_shape) return core::make_unexpected(struct_shape.error());
+        out.shape_index = struct_shape.value();
         for (u32 fi = 0; fi < expr.field_inits.len; fi++) {
             for (u32 seen = 0; seen < fi; seen++) {
                 if (expr.field_inits[seen].name.eq(expr.field_inits[fi].name))
@@ -3625,7 +3850,7 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
             }
         }
         Str qualified_type_name{};
-        if (resolve_import_namespace_member(mod, *expr.lhs, &qualified_type_name)) {
+        if (resolve_import_namespace_member(mod, *expr.lhs, qualified_type_name)) {
             AstExpr variant_expr{};
             variant_expr.kind = AstExprKind::VariantCase;
             variant_expr.span = expr.span;
@@ -3636,10 +3861,10 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         }
         auto base = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
         if (!base) return core::make_unexpected(base.error());
-        const auto known_state = known_value_state(base.value(), locals, local_count);
+        const auto known_state = known_value_state(base.value(), locals, local_count, 0);
         if (known_state == KnownValueState::Error &&
             !expr.name.eq({"file", 4}) && !expr.name.eq({"func", 4}))
-            return analyze_known_error_field(base.value(), expr.name, expr.span, mod, locals, local_count);
+            return analyze_known_error_field(base.value(), expr.name, expr.span, mod, locals, local_count, 0);
         if (base->type == HirTypeKind::Struct && !base->may_error) {
             if (base->struct_index >= mod.structs.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
@@ -3648,6 +3873,14 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
             out.kind = HirExprKind::Field;
             out.span = expr.span;
             out.type = field->type;
+            out.generic_index = field->generic_index;
+            out.generic_has_error_constraint = field->generic_has_error_constraint;
+            out.generic_has_eq_constraint = field->generic_has_eq_constraint;
+            out.generic_has_ord_constraint = field->generic_has_ord_constraint;
+            out.generic_protocol_index = field->generic_protocol_index;
+            out.generic_protocol_count = field->generic_protocol_count;
+            for (u32 cpi = 0; cpi < out.generic_protocol_count; cpi++)
+                out.generic_protocol_indices[cpi] = field->generic_protocol_indices[cpi];
             out.variant_index = field->variant_index;
             out.struct_index = field->struct_index;
             out.shape_index = field->shape_index;
@@ -3661,7 +3894,6 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                 return frontend_error(FrontendError::TooManyItems, expr.span);
             out.lhs = &route->exprs[route->exprs.len - 1];
             out.str_value = expr.name;
-            out.struct_index = base->struct_index;
             return out;
         }
         if (base->type == HirTypeKind::Generic && !base->may_error) {
@@ -3699,6 +3931,14 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         out.kind = HirExprKind::Field;
         out.span = expr.span;
         out.type = field->type;
+        out.generic_index = field->generic_index;
+        out.generic_has_error_constraint = field->generic_has_error_constraint;
+        out.generic_has_eq_constraint = field->generic_has_eq_constraint;
+        out.generic_has_ord_constraint = field->generic_has_ord_constraint;
+        out.generic_protocol_index = field->generic_protocol_index;
+        out.generic_protocol_count = field->generic_protocol_count;
+        for (u32 cpi = 0; cpi < out.generic_protocol_count; cpi++)
+            out.generic_protocol_indices[cpi] = field->generic_protocol_indices[cpi];
         out.variant_index = field->variant_index;
         out.struct_index = field->struct_index;
         out.shape_index = field->shape_index;
@@ -3753,9 +3993,9 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                                           expr.type_args[i],
                                                           nullptr,
                                                           nullptr,
-                                                          &type_variant_index,
-                                                          &type_struct_index,
-                                                          &tuple_len,
+                                                          type_variant_index,
+                                                          type_struct_index,
+                                                          tuple_len,
                                                           tuple_types,
                                                           tuple_variant_indices,
                                                           tuple_struct_indices,
@@ -3860,6 +4100,18 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         out.case_index = case_index;
         out.int_value = static_cast<i32>(case_index);
         out.str_value = expr.str_value;
+        auto variant_shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                                   out.type,
+                                                   out.generic_index,
+                                                   out.variant_index,
+                                                   out.struct_index,
+                                                   out.tuple_len,
+                                                   out.tuple_types,
+                                                   out.tuple_variant_indices,
+                                                   out.tuple_struct_indices,
+                                                   expr.span);
+        if (!variant_shape) return core::make_unexpected(variant_shape.error());
+        out.shape_index = variant_shape.value();
         return out;
     }
     if (expr.kind == AstExprKind::Tuple) {
@@ -4032,7 +4284,7 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
             folded.may_error = false;
             return folded;
         }
-        const auto lhs_state = known_value_state(lhs.value(), locals, local_count);
+        const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
         if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
             HirExpr folded = rhs.value();
             folded.span = expr.span;
@@ -4053,6 +4305,13 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         out.type = lhs->type == HirTypeKind::Unknown ? rhs->type : lhs->type;
         out.lhs = lhs_ptr;
         out.rhs = rhs_ptr;
+        auto shape = intern_hir_type_shape(const_cast<HirModule*>(&mod), out.type,
+                                           out.generic_index, out.variant_index,
+                                           out.struct_index, out.tuple_len, out.tuple_types,
+                                           out.tuple_variant_indices, out.tuple_struct_indices,
+                                           expr.span);
+        if (!shape) return core::make_unexpected(shape.error());
+        out.shape_index = shape.value();
         return out;
     }
     if (expr.kind == AstExprKind::Pipe) {
@@ -4127,6 +4386,7 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
             out.may_error = locals[i].may_error;
             out.local_index = locals[i].ref_index;
             out.variant_index = locals[i].variant_index;
+            out.shape_index = locals[i].shape_index;
             out.error_struct_index = locals[i].error_struct_index;
             out.struct_index = locals[i].struct_index;
             out.error_variant_index = locals[i].error_variant_index;
@@ -4143,6 +4403,14 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
     if (binding && binding->subject && expr.name.eq(binding->name)) {
         out.kind = HirExprKind::MatchPayload;
         out.type = binding->type;
+        out.generic_index = binding->generic_index;
+        out.generic_has_error_constraint = binding->generic_has_error_constraint;
+        out.generic_has_eq_constraint = binding->generic_has_eq_constraint;
+        out.generic_has_ord_constraint = binding->generic_has_ord_constraint;
+        out.generic_protocol_index = binding->generic_protocol_index;
+        out.generic_protocol_count = binding->generic_protocol_count;
+        for (u32 cpi = 0; cpi < binding->generic_protocol_count; cpi++)
+            out.generic_protocol_indices[cpi] = binding->generic_protocol_indices[cpi];
         out.variant_index = binding->variant_index;
         out.struct_index = binding->struct_index;
         out.shape_index = binding->shape_index;
@@ -4189,9 +4457,9 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
                                               expr.type_args[i],
                                               nullptr,
                                               nullptr,
-                                              &variant_index,
-                                              &struct_index,
-                                              &tuple_len,
+                                              variant_index,
+                                              struct_index,
+                                              tuple_len,
                                               tuple_types,
                                               tuple_variant_indices,
                                               tuple_struct_indices,
@@ -4269,20 +4537,18 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         out.type = source.tuple_types[slot_index];
         if (out.type == HirTypeKind::Struct) out.struct_index = source.tuple_struct_indices[slot_index];
         else out.variant_index = source.tuple_variant_indices[slot_index];
-        if (out.type != HirTypeKind::Tuple) {
-            auto shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
-                                               out.type,
-                                               out.generic_index,
-                                               out.variant_index,
-                                               out.struct_index,
-                                               out.tuple_len,
-                                               out.tuple_types,
-                                               out.tuple_variant_indices,
-                                               out.tuple_struct_indices,
-                                               span);
-            if (!shape) return core::make_unexpected(shape.error());
-            out.shape_index = shape.value();
-        }
+        auto shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                           out.type,
+                                           out.generic_index,
+                                           out.variant_index,
+                                           out.struct_index,
+                                           out.tuple_len,
+                                           out.tuple_types,
+                                           out.tuple_variant_indices,
+                                           out.tuple_struct_indices,
+                                           span);
+        if (!shape) return core::make_unexpected(shape.error());
+        out.shape_index = shape.value();
         out.span = span;
         out.int_value = static_cast<i32>(slot_index);
         out.lhs = const_cast<HirExpr*>(&source);
@@ -4295,7 +4561,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         return expected;
     };
     if (pipe_lhs != nullptr) {
-        const auto lhs_state = known_value_state(*pipe_lhs, locals, local_count);
+        const auto lhs_state = known_value_state(*pipe_lhs, locals, local_count, 0);
         if (lhs_state == KnownValueState::Nil) {
             HirExpr folded{};
             folded.kind = HirExprKind::Nil;
@@ -4324,7 +4590,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             return folded;
         }
         if (lhs_state == KnownValueState::Error) {
-            const HirExpr* err_expr = known_error_expr(*pipe_lhs, locals, local_count);
+            const HirExpr* err_expr = known_error_expr(*pipe_lhs, locals, local_count, 0);
             if (!err_expr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
             HirExpr folded = *err_expr;
             auto ret = concrete_return_expr();
@@ -4601,18 +4867,18 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
     return inlined.value();
 }
 
-static bool push_named_error_case(FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases, Str name) {
-    for (u32 i = 0; i < cases->len; i++) {
-        if ((*cases)[i].name.eq(name)) return true;
+static bool push_named_error_case(FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases, Str name) {
+    for (u32 i = 0; i < cases.len; i++) {
+        if (cases[i].name.eq(name)) return true;
     }
     RouteNamedErrorCase entry{};
     entry.name = name;
-    return cases->push(entry);
+    return cases.push(entry);
 }
 
 static FrontendResult<void> collect_named_error_cases_ast_expr(
     const AstExpr& expr,
-    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases) {
+    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
     if (expr.kind == AstExprKind::Error && expr.lhs != nullptr && expr.lhs->kind == AstExprKind::VariantCase &&
         expr.lhs->name.len == 0 && expr.lhs->str_value.len != 0) {
         if (!push_named_error_case(cases, expr.lhs->str_value))
@@ -4639,7 +4905,7 @@ static FrontendResult<void> collect_named_error_cases_ast_expr(
 
 static FrontendResult<void> collect_named_error_cases_ast(
     const AstStatement& stmt,
-    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases) {
+    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
     auto expr_cases = collect_named_error_cases_ast_expr(stmt.expr, cases);
     if (!expr_cases) return expr_cases;
     if (stmt.then_stmt != nullptr) {
@@ -4666,7 +4932,7 @@ static FrontendResult<void> collect_named_error_cases_ast(
 }
 
 static FrontendResult<void> collect_named_error_cases(const HirExpr& expr,
-                                                      FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases) {
+                                                      FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
     if (expr.kind == HirExprKind::Error && expr.error_variant_index == 0xffffffffu && expr.str_value.len != 0) {
         if (!push_named_error_case(cases, expr.str_value))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -4934,7 +5200,7 @@ static FrontendResult<HirExpr> analyze_guard_cond(const AstExpr& expr,
                                                   const HirModule& mod,
                                                   const HirLocal* locals,
                                                   u32 local_count) {
-    auto analyzed = analyze_expr(expr, route, mod, locals, local_count);
+    auto analyzed = analyze_expr(expr, route, mod, locals, local_count, nullptr);
     if (!analyzed) return core::make_unexpected(analyzed.error());
 
     HirExpr cond{};
@@ -4947,7 +5213,7 @@ static FrontendResult<HirExpr> analyze_guard_cond(const AstExpr& expr,
         return cond;
     }
 
-    const auto state = known_value_state(analyzed.value(), locals, local_count);
+    const auto state = known_value_state(analyzed.value(), locals, local_count, 0);
     if (state == KnownValueState::Error) {
         cond.bool_value = false;
         return cond;
@@ -5082,7 +5348,7 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
                 if (!arm->guards.push(guard))
                     return frontend_error(FrontendError::TooManyItems, inner.span);
                 if (inner.bind_value) {
-                    if (known_value_state(bound.value(), scoped_locals.data, scoped_locals.len) ==
+                    if (known_value_state(bound.value(), scoped_locals.data, scoped_locals.len, 0) ==
                         KnownValueState::Error)
                         return frontend_error(FrontendError::UnsupportedSyntax, inner.expr.span);
                     HirLocal local{};
@@ -5249,7 +5515,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         auto cond = analyze_expr(stmt.expr, route, mod, locals, local_count, binding);
         if (!cond) return core::make_unexpected(cond.error());
         ConstValue value{};
-        if (!const_eval_expr(cond.value(), locals, local_count, &value) || value.type != HirTypeKind::Bool)
+        if (!const_eval_expr(cond.value(), locals, local_count, &value, 0) ||
+            value.type != HirTypeKind::Bool)
             return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
         return analyze_control_stmt(value.bool_value ? *stmt.then_stmt : *stmt.else_stmt, route, mod, binding);
     }
@@ -5258,7 +5525,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         auto subject = analyze_expr(stmt.expr, route, mod, locals, local_count, binding);
         if (!subject) return core::make_unexpected(subject.error());
         ConstValue subject_value{};
-        if (!const_eval_expr(subject.value(), locals, local_count, &subject_value))
+        if (!const_eval_expr(subject.value(), locals, local_count, &subject_value, 0))
             return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
         if (!route->exprs.push(subject.value()))
             return frontend_error(FrontendError::TooManyItems, stmt.span);
@@ -5296,6 +5563,24 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 selected_binding = {};
                 selected_binding.name = arm.pattern.lhs->name;
                 selected_binding.type = mod.variants[pattern->variant_index].cases[pattern->case_index].payload_type;
+                selected_binding.generic_index =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_index;
+                selected_binding.generic_has_error_constraint =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_error_constraint;
+                selected_binding.generic_has_eq_constraint =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_eq_constraint;
+                selected_binding.generic_has_ord_constraint =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_ord_constraint;
+                selected_binding.generic_protocol_index =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_protocol_index;
+                selected_binding.generic_protocol_count =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_protocol_count;
+                for (u32 cpi = 0; cpi < selected_binding.generic_protocol_count; cpi++) {
+                    selected_binding.generic_protocol_indices[cpi] =
+                        mod.variants[pattern->variant_index]
+                            .cases[pattern->case_index]
+                            .payload_generic_protocol_indices[cpi];
+                }
                 selected_binding.variant_index =
                     mod.variants[pattern->variant_index].cases[pattern->case_index].payload_variant_index;
                 selected_binding.struct_index =
@@ -5389,8 +5674,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
     if (stmt.kind == AstStmtKind::Match) {
         auto subject = analyze_expr(stmt.expr, route, mod, locals, local_count, binding);
         if (!subject) return core::make_unexpected(subject.error());
-        const auto state = known_value_state(subject.value(), locals, local_count);
-        const auto err_name = known_error_name(subject.value(), locals, local_count);
+        const auto state = known_value_state(subject.value(), locals, local_count, 0);
+        const auto err_name = known_error_name(subject.value(), locals, local_count, 0);
         const bool subject_is_error_kind =
             subject->type != HirTypeKind::Variant && subject->may_error &&
             (subject->error_variant_index != 0xffffffffu ||
@@ -5402,7 +5687,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 const AstStatement::MatchArm* wildcard_arm = nullptr;
                 const AstStatement::MatchArm* selected_arm = nullptr;
                 if (state == KnownValueState::Error) {
-                    const auto err_case = known_error_case(subject.value(), locals, local_count);
+                    const auto err_case = known_error_case(subject.value(), locals, local_count, 0);
                     if (!err_case.known)
                         if (err_name.len == 0)
                             return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
@@ -5500,6 +5785,14 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         }
                         arm_binding.name = hir_arm.bind_name;
                         arm_binding.type = hir_arm.bind_type;
+                        arm_binding.generic_index = case_decl.payload_generic_index;
+                        arm_binding.generic_has_error_constraint = case_decl.payload_generic_has_error_constraint;
+                        arm_binding.generic_has_eq_constraint = case_decl.payload_generic_has_eq_constraint;
+                        arm_binding.generic_has_ord_constraint = case_decl.payload_generic_has_ord_constraint;
+                        arm_binding.generic_protocol_index = case_decl.payload_generic_protocol_index;
+                        arm_binding.generic_protocol_count = case_decl.payload_generic_protocol_count;
+                        for (u32 cpi = 0; cpi < arm_binding.generic_protocol_count; cpi++)
+                            arm_binding.generic_protocol_indices[cpi] = case_decl.payload_generic_protocol_indices[cpi];
                         arm_binding.variant_index = hir_arm.bind_variant_index;
                         arm_binding.struct_index = hir_arm.bind_struct_index;
                         arm_binding.shape_index = case_decl.payload_shape_index;
@@ -5546,9 +5839,9 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
 
 
 static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
-                                                    Str source_path,
-                                                    std::vector<std::string>* import_stack,
-                                                    std::deque<std::string>* shared_owned_strings = nullptr);
+                                                        Str source_path,
+                                                        std::vector<std::string>& import_stack,
+                                                        std::deque<std::string>* shared_owned_strings);
 
 static Str import_visible_name(const ImportedModuleInfo& imported, Str original_name) {
     if (imported.has_namespace_alias) {
@@ -5609,6 +5902,106 @@ static FrontendResult<void> validate_imported_selected_names(const FixedVec<Impo
 
 static FrontendResult<void> merge_imported_functions(HirModule* mod,
                                                   const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    auto refresh_imported_function_signature_shapes = [&](HirFunction* fn, Span span) -> FrontendResult<void> {
+        for (u32 pi = 0; pi < fn->params.len; pi++) {
+            auto& param = fn->params[pi];
+            for (u32 ai = 0; ai < param.type_arg_count; ai++) {
+                auto shape = intern_hir_type_shape(mod,
+                                                   param.type_args[ai].type,
+                                                   param.type_args[ai].generic_index,
+                                                   param.type_args[ai].variant_index,
+                                                   param.type_args[ai].struct_index,
+                                                   param.type_args[ai].tuple_len,
+                                                   param.type_args[ai].tuple_types,
+                                                   param.type_args[ai].tuple_variant_indices,
+                                                   param.type_args[ai].tuple_struct_indices,
+                                                   span);
+                if (!shape) return core::make_unexpected(shape.error());
+                param.type_args[ai].shape_index = shape.value();
+            }
+            auto shape = intern_hir_type_shape(mod,
+                                               param.type,
+                                               param.generic_index,
+                                               param.variant_index,
+                                               param.struct_index,
+                                               param.tuple_len,
+                                               param.tuple_types,
+                                               param.tuple_variant_indices,
+                                               param.tuple_struct_indices,
+                                               span);
+            if (!shape) return core::make_unexpected(shape.error());
+            param.shape_index = shape.value();
+        }
+        for (u32 ai = 0; ai < fn->return_type_arg_count; ai++) {
+            auto shape = intern_hir_type_shape(mod,
+                                               fn->return_type_args[ai].type,
+                                               fn->return_type_args[ai].generic_index,
+                                               fn->return_type_args[ai].variant_index,
+                                               fn->return_type_args[ai].struct_index,
+                                               fn->return_type_args[ai].tuple_len,
+                                               fn->return_type_args[ai].tuple_types,
+                                               fn->return_type_args[ai].tuple_variant_indices,
+                                               fn->return_type_args[ai].tuple_struct_indices,
+                                               span);
+            if (!shape) return core::make_unexpected(shape.error());
+            fn->return_type_args[ai].shape_index = shape.value();
+        }
+        if (fn->return_type != HirTypeKind::Unknown) {
+            auto shape = intern_hir_type_shape(mod,
+                                               fn->return_type,
+                                               fn->return_generic_index,
+                                               fn->return_variant_index,
+                                               fn->return_struct_index,
+                                               fn->return_tuple_len,
+                                               fn->return_tuple_types,
+                                               fn->return_tuple_variant_indices,
+                                               fn->return_tuple_struct_indices,
+                                               span);
+            if (!shape) return core::make_unexpected(shape.error());
+            fn->return_shape_index = shape.value();
+        }
+        return {};
+    };
+    auto refresh_imported_expr_shape = [&](HirExpr* expr, Span span) -> FrontendResult<void> {
+        const bool should_refresh =
+            expr->shape_index != 0xffffffffu ||
+            expr->kind == HirExprKind::StructInit ||
+            expr->kind == HirExprKind::VariantCase ||
+            expr->kind == HirExprKind::Tuple ||
+            expr->kind == HirExprKind::TupleSlot ||
+            expr->kind == HirExprKind::Field ||
+            expr->kind == HirExprKind::IfElse ||
+            expr->kind == HirExprKind::Or ||
+            expr->kind == HirExprKind::LocalRef ||
+            expr->kind == HirExprKind::MatchPayload ||
+            expr->kind == HirExprKind::ValueOf ||
+            expr->kind == HirExprKind::MissingOf ||
+            expr->kind == HirExprKind::ProtocolCall;
+        if (!should_refresh || expr->type == HirTypeKind::Unknown) return {};
+        auto shape = intern_hir_type_shape(mod,
+                                           expr->type,
+                                           expr->generic_index,
+                                           expr->variant_index,
+                                           expr->struct_index,
+                                           expr->tuple_len,
+                                           expr->tuple_types,
+                                           expr->tuple_variant_indices,
+                                           expr->tuple_struct_indices,
+                                           span);
+        if (!shape) return core::make_unexpected(shape.error());
+        expr->shape_index = shape.value();
+        return {};
+    };
+    auto refresh_imported_function_body_shapes = [&](HirFunction* fn, Span span) -> FrontendResult<void> {
+        for (u32 ei = 0; ei < fn->exprs.len; ei++) {
+            auto refreshed = refresh_imported_expr_shape(&fn->exprs[ei], span);
+            if (!refreshed) return core::make_unexpected(refreshed.error());
+        }
+        auto refreshed = refresh_imported_expr_shape(&fn->body, span);
+        if (!refreshed) return core::make_unexpected(refreshed.error());
+        return {};
+    };
+
     for (u32 ii = 0; ii < imports.len; ii++) {
         const auto& imported = imports[ii];
         for (u32 fi = 0; fi < imported.module->functions.len; fi++) {
@@ -5623,13 +6016,22 @@ static FrontendResult<void> merge_imported_functions(HirModule* mod,
             if (!imported.selective && !imported.has_namespace_alias) {
                 if (find_function_index(*mod, fn.name) != mod->functions.len)
                     return frontend_error(FrontendError::UnsupportedSyntax, imported.span, fn.name);
-                if (!mod->functions.push(fn))
+                HirFunction imported_fn = fn;
+                auto refreshed = refresh_imported_function_signature_shapes(&imported_fn, imported.span);
+                if (!refreshed) return core::make_unexpected(refreshed.error());
+                refreshed = refresh_imported_function_body_shapes(&imported_fn, imported.span);
+                if (!refreshed) return core::make_unexpected(refreshed.error());
+                if (!mod->functions.push(imported_fn))
                     return frontend_error(FrontendError::TooManyItems, imported.span);
                 continue;
             }
             if (imported.has_namespace_alias) {
                 HirFunction imported_fn = fn;
                 imported_fn.name = import_visible_name(imported, fn.name);
+                auto refreshed = refresh_imported_function_signature_shapes(&imported_fn, imported.span);
+                if (!refreshed) return core::make_unexpected(refreshed.error());
+                refreshed = refresh_imported_function_body_shapes(&imported_fn, imported.span);
+                if (!refreshed) return core::make_unexpected(refreshed.error());
                 if (find_function_index(*mod, imported_fn.name) != mod->functions.len)
                     return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_fn.name);
                 if (!mod->functions.push(imported_fn))
@@ -5641,6 +6043,10 @@ static FrontendResult<void> merge_imported_functions(HirModule* mod,
                 if (!selected.name.eq(fn.name)) continue;
                 HirFunction imported_fn = fn;
                 if (selected.has_alias) imported_fn.name = selected.alias;
+                auto refreshed = refresh_imported_function_signature_shapes(&imported_fn, imported.span);
+                if (!refreshed) return core::make_unexpected(refreshed.error());
+                refreshed = refresh_imported_function_body_shapes(&imported_fn, imported.span);
+                if (!refreshed) return core::make_unexpected(refreshed.error());
                 if (find_function_index(*mod, imported_fn.name) != mod->functions.len)
                     return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_fn.name);
                 if (!mod->functions.push(imported_fn))
@@ -5653,6 +6059,21 @@ static FrontendResult<void> merge_imported_functions(HirModule* mod,
 
 static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
                                                      const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    auto refresh_type_arg_shape = [&](HirVariant::TypeArgRef* arg, Span span) -> FrontendResult<void> {
+        auto shape = intern_hir_type_shape(mod,
+                                           arg->type,
+                                           arg->generic_index,
+                                           arg->variant_index,
+                                           arg->struct_index,
+                                           arg->tuple_len,
+                                           arg->tuple_types,
+                                           arg->tuple_variant_indices,
+                                           arg->tuple_struct_indices,
+                                           span);
+        if (!shape) return core::make_unexpected(shape.error());
+        arg->shape_index = shape.value();
+        return {};
+    };
     for (u32 ii = 0; ii < imports.len; ii++) {
         const auto& imported = imports[ii];
         for (u32 pi = 0; pi < imported.module->protocols.len; pi++) {
@@ -5667,6 +6088,37 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
             }
             HirProtocol imported_proto = proto;
             imported_proto.name = import_visible_name(imported, proto.name);
+            for (u32 mi = 0; mi < imported_proto.methods.len; mi++) {
+                auto& method = imported_proto.methods[mi];
+                for (u32 ai = 0; ai < method.params.len; ai++) {
+                    auto shape = intern_hir_type_shape(mod,
+                                                       method.params[ai].type,
+                                                       method.params[ai].generic_index,
+                                                       method.params[ai].variant_index,
+                                                       method.params[ai].struct_index,
+                                                       method.params[ai].tuple_len,
+                                                       method.params[ai].tuple_types,
+                                                       method.params[ai].tuple_variant_indices,
+                                                       method.params[ai].tuple_struct_indices,
+                                                       imported.span);
+                    if (!shape) return core::make_unexpected(shape.error());
+                    method.params[ai].shape_index = shape.value();
+                }
+                if (method.has_return_type && method.return_type != HirTypeKind::Unknown) {
+                    auto shape = intern_hir_type_shape(mod,
+                                                       method.return_type,
+                                                       method.return_generic_index,
+                                                       method.return_variant_index,
+                                                       method.return_struct_index,
+                                                       method.return_tuple_len,
+                                                       method.return_tuple_types,
+                                                       method.return_tuple_variant_indices,
+                                                       method.return_tuple_struct_indices,
+                                                       imported.span);
+                    if (!shape) return core::make_unexpected(shape.error());
+                    method.return_shape_index = shape.value();
+                }
+            }
             if (find_protocol_index(*mod, imported_proto.name) != mod->protocols.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_proto.name);
             if (!mod->protocols.push(imported_proto))
@@ -5684,6 +6136,25 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
             }
             HirStruct imported_struct = st;
             imported_struct.name = import_visible_name(imported, st.name);
+            for (u32 fi = 0; fi < imported_struct.fields.len; fi++) {
+                if (imported_struct.fields[fi].is_error_type) continue;
+                for (u32 ai = 0; ai < imported_struct.fields[fi].type_arg_count; ai++) {
+                    auto refreshed = refresh_type_arg_shape(&imported_struct.fields[fi].type_args[ai], imported.span);
+                    if (!refreshed) return core::make_unexpected(refreshed.error());
+                }
+                auto shape = intern_hir_type_shape(mod,
+                                                   imported_struct.fields[fi].type,
+                                                   imported_struct.fields[fi].generic_index,
+                                                   imported_struct.fields[fi].variant_index,
+                                                   imported_struct.fields[fi].struct_index,
+                                                   imported_struct.fields[fi].tuple_len,
+                                                   imported_struct.fields[fi].tuple_types,
+                                                   imported_struct.fields[fi].tuple_variant_indices,
+                                                   imported_struct.fields[fi].tuple_struct_indices,
+                                                   imported.span);
+                if (!shape) return core::make_unexpected(shape.error());
+                imported_struct.fields[fi].shape_index = shape.value();
+            }
             if (find_struct_index(*mod, imported_struct.name) != mod->structs.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_struct.name);
             bool ok = true;
@@ -5717,6 +6188,26 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
             }
             HirVariant imported_variant = variant;
             imported_variant.name = import_visible_name(imported, variant.name);
+            for (u32 ci = 0; ci < imported_variant.cases.len; ci++) {
+                if (!imported_variant.cases[ci].has_payload) continue;
+                for (u32 ai = 0; ai < imported_variant.cases[ci].payload_type_arg_count; ai++) {
+                    auto refreshed =
+                        refresh_type_arg_shape(&imported_variant.cases[ci].payload_type_args[ai], imported.span);
+                    if (!refreshed) return core::make_unexpected(refreshed.error());
+                }
+                auto shape = intern_hir_type_shape(mod,
+                                                   imported_variant.cases[ci].payload_type,
+                                                   imported_variant.cases[ci].payload_generic_index,
+                                                   imported_variant.cases[ci].payload_variant_index,
+                                                   imported_variant.cases[ci].payload_struct_index,
+                                                   imported_variant.cases[ci].payload_tuple_len,
+                                                   imported_variant.cases[ci].payload_tuple_types,
+                                                   imported_variant.cases[ci].payload_tuple_variant_indices,
+                                                   imported_variant.cases[ci].payload_tuple_struct_indices,
+                                                   imported.span);
+                if (!shape) return core::make_unexpected(shape.error());
+                imported_variant.cases[ci].payload_shape_index = shape.value();
+            }
             if (find_variant_index(*mod, imported_variant.name) != mod->variants.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_variant.name);
             bool ok = true;
@@ -5742,17 +6233,230 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
     return {};
 }
 
+static FrontendResult<void> refresh_imported_protocol_method_functions(
+    HirModule* mod,
+    const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    for (u32 ii = 0; ii < imports.len; ii++) {
+        const auto& imported = imports[ii];
+        for (u32 pi = 0; pi < imported.module->protocols.len; pi++) {
+            const auto& imported_proto = imported.module->protocols[pi];
+            if (imported_proto.kind != HirProtocolKind::Custom) continue;
+            if (imported.selective) {
+                bool selected = false;
+                for (u32 si = 0; si < imported.selected_names.len; si++) {
+                    if (imported.selected_names[si].name.eq(imported_proto.name)) {
+                        selected = true;
+                        break;
+                    }
+                }
+                if (!selected) continue;
+            }
+            const Str visible_name = import_visible_name(imported, imported_proto.name);
+            const u32 proto_index = find_protocol_index(*mod, visible_name);
+            if (proto_index >= mod->protocols.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, visible_name);
+            auto& proto = mod->protocols[proto_index];
+            for (u32 mi = 0; mi < imported_proto.methods.len; mi++) {
+                const auto& imported_method = imported_proto.methods[mi];
+                auto* method = find_protocol_method_mut(proto, imported_method.name);
+                if (method == nullptr)
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_method.name);
+                if (imported_method.function_index == 0xffffffffu) continue;
+                if (imported_method.function_index >= imported.module->functions.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_method.name);
+                const Str fn_name = imported.module->functions[imported_method.function_index].name;
+                const u32 mapped_fn_index = find_function_index(*mod, fn_name);
+                if (mapped_fn_index >= mod->functions.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, fn_name);
+                method->function_index = mapped_fn_index;
+                method->return_may_nil = mod->functions[mapped_fn_index].body.may_nil;
+                method->return_may_error = mod->functions[mapped_fn_index].body.may_error;
+                method->return_error_struct_index = mod->functions[mapped_fn_index].body.error_struct_index;
+                method->return_error_variant_index = mod->functions[mapped_fn_index].body.error_variant_index;
+            }
+        }
+    }
+    return {};
+}
+
 static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
-                                               const ImportedModuleInfo& imported,
-                                               const HirModule& imported_mod,
-                                               const HirImpl& imported_impl,
-                                               HirTypeKind* out_type,
-                                               u32* out_struct_index,
-                                               bool* out_is_generic_template,
-                                               Span span) {
-    *out_type = imported_impl.type;
-    *out_is_generic_template = imported_impl.is_generic_template;
-    *out_struct_index = imported_impl.struct_index;
+                                                       const ImportedModuleInfo& imported,
+                                                       const HirModule& imported_mod,
+                                                       const HirImpl& imported_impl,
+                                                       HirTypeKind& out_type,
+                                                       u32& out_struct_index,
+                                                       bool& out_is_generic_template,
+                                                       Span span) {
+    std::function<FrontendResult<void>(HirTypeKind,
+                                       u32,
+                                       u32,
+                                       u32,
+                                       const HirTypeKind*,
+                                       const u32*,
+                                       const u32*,
+                                       u32&,
+                                       u32&,
+                                       u32*,
+                                       u32*)>
+        remap_imported_type_metadata;
+    std::function<FrontendResult<void>(u32, u32&)> remap_imported_struct_index;
+    std::function<FrontendResult<void>(u32, u32&)> remap_imported_variant_index;
+
+    remap_imported_struct_index = [&](u32 imported_struct_index, u32& mapped_struct_index) -> FrontendResult<void> {
+        if (imported_struct_index >= imported_mod.structs.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
+        const auto& imported_struct = imported_mod.structs[imported_struct_index];
+        if (imported_struct.template_struct_index == 0xffffffffu) {
+            mapped_struct_index = find_struct_index(*mod, import_visible_name(imported, imported_struct.name));
+            if (mapped_struct_index >= mod->structs.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, span, imported_struct.name);
+            return {};
+        }
+        if (imported_struct.template_struct_index >= imported_mod.structs.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
+        u32 mapped_template_index = 0xffffffffu;
+        auto remapped_template = remap_imported_struct_index(imported_struct.template_struct_index, mapped_template_index);
+        if (!remapped_template) return core::make_unexpected(remapped_template.error());
+        GenericBinding bindings[HirStruct::kMaxTypeParams]{};
+        for (u32 ai = 0; ai < imported_struct.instance_type_arg_count; ai++) {
+            u32 mapped_variant_index = 0xffffffffu;
+            u32 mapped_arg_struct_index = 0xffffffffu;
+            u32 mapped_tuple_variant_indices[kMaxTupleSlots]{};
+            u32 mapped_tuple_struct_indices[kMaxTupleSlots]{};
+            for (u32 ti = 0; ti < imported_struct.instance_tuple_lens[ai]; ti++) {
+                mapped_tuple_variant_indices[ti] = 0xffffffffu;
+                mapped_tuple_struct_indices[ti] = 0xffffffffu;
+            }
+            auto remapped = remap_imported_type_metadata(imported_struct.instance_type_args[ai],
+                                                         imported_struct.instance_variant_indices[ai],
+                                                         imported_struct.instance_struct_indices[ai],
+                                                         imported_struct.instance_tuple_lens[ai],
+                                                         imported_struct.instance_tuple_types[ai],
+                                                         imported_struct.instance_tuple_variant_indices[ai],
+                                                         imported_struct.instance_tuple_struct_indices[ai],
+                                                         mapped_variant_index,
+                                                         mapped_arg_struct_index,
+                                                         mapped_tuple_variant_indices,
+                                                         mapped_tuple_struct_indices);
+            if (!remapped) return core::make_unexpected(remapped.error());
+            auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
+                                                                mod,
+                                                                imported_struct.instance_type_args[ai],
+                                                                imported_struct.instance_generic_indices[ai],
+                                                                mapped_variant_index,
+                                                                mapped_arg_struct_index,
+                                                                imported_struct.instance_tuple_lens[ai],
+                                                                imported_struct.instance_tuple_types[ai],
+                                                                mapped_tuple_variant_indices,
+                                                                mapped_tuple_struct_indices,
+                                                                0xffffffffu,
+                                                                span);
+            if (!filled) return core::make_unexpected(filled.error());
+        }
+        auto concrete =
+            instantiate_struct(mod, mapped_template_index, bindings, imported_struct.instance_type_arg_count, span);
+        if (!concrete) return core::make_unexpected(concrete.error());
+        mapped_struct_index = concrete.value();
+        return {};
+    };
+    remap_imported_variant_index = [&](u32 imported_variant_index, u32& mapped_variant_index) -> FrontendResult<void> {
+        if (imported_variant_index >= imported_mod.variants.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
+        const auto& imported_variant = imported_mod.variants[imported_variant_index];
+        if (imported_variant.template_variant_index == 0xffffffffu) {
+            mapped_variant_index = find_variant_index(*mod, import_visible_name(imported, imported_variant.name));
+            if (mapped_variant_index >= mod->variants.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, span, imported_variant.name);
+            return {};
+        }
+        if (imported_variant.template_variant_index >= imported_mod.variants.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
+        u32 mapped_template_index = 0xffffffffu;
+        auto remapped_template =
+            remap_imported_variant_index(imported_variant.template_variant_index, mapped_template_index);
+        if (!remapped_template) return core::make_unexpected(remapped_template.error());
+        GenericBinding bindings[HirVariant::kMaxTypeParams]{};
+        for (u32 ai = 0; ai < imported_variant.instance_type_arg_count; ai++) {
+            u32 mapped_arg_variant_index = 0xffffffffu;
+            u32 mapped_struct_index = 0xffffffffu;
+            u32 mapped_tuple_variant_indices[kMaxTupleSlots]{};
+            u32 mapped_tuple_struct_indices[kMaxTupleSlots]{};
+            for (u32 ti = 0; ti < imported_variant.instance_tuple_lens[ai]; ti++) {
+                mapped_tuple_variant_indices[ti] = 0xffffffffu;
+                mapped_tuple_struct_indices[ti] = 0xffffffffu;
+            }
+            auto remapped = remap_imported_type_metadata(imported_variant.instance_type_args[ai],
+                                                         imported_variant.instance_variant_indices[ai],
+                                                         imported_variant.instance_struct_indices[ai],
+                                                         imported_variant.instance_tuple_lens[ai],
+                                                         imported_variant.instance_tuple_types[ai],
+                                                         imported_variant.instance_tuple_variant_indices[ai],
+                                                         imported_variant.instance_tuple_struct_indices[ai],
+                                                         mapped_arg_variant_index,
+                                                         mapped_struct_index,
+                                                         mapped_tuple_variant_indices,
+                                                         mapped_tuple_struct_indices);
+            if (!remapped) return core::make_unexpected(remapped.error());
+            auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
+                                                                mod,
+                                                                imported_variant.instance_type_args[ai],
+                                                                imported_variant.instance_generic_indices[ai],
+                                                                mapped_arg_variant_index,
+                                                                mapped_struct_index,
+                                                                imported_variant.instance_tuple_lens[ai],
+                                                                imported_variant.instance_tuple_types[ai],
+                                                                mapped_tuple_variant_indices,
+                                                                mapped_tuple_struct_indices,
+                                                                0xffffffffu,
+                                                                span);
+            if (!filled) return core::make_unexpected(filled.error());
+        }
+        auto concrete = instantiate_variant(
+            mod, mapped_template_index, bindings, imported_variant.instance_type_arg_count, span);
+        if (!concrete) return core::make_unexpected(concrete.error());
+        mapped_variant_index = concrete.value();
+        return {};
+    };
+    remap_imported_type_metadata = [&](HirTypeKind imported_type,
+                                       u32 imported_variant_index,
+                                       u32 imported_struct_index,
+                                       u32 tuple_len,
+                                       const HirTypeKind* tuple_types,
+                                       const u32* tuple_variant_indices,
+                                       const u32* tuple_struct_indices,
+                                       u32& mapped_variant_index,
+                                       u32& mapped_struct_index,
+                                       u32* mapped_tuple_variant_indices,
+                                       u32* mapped_tuple_struct_indices) -> FrontendResult<void> {
+        mapped_variant_index = 0xffffffffu;
+        mapped_struct_index = 0xffffffffu;
+        for (u32 ti = 0; ti < tuple_len; ti++) {
+            mapped_tuple_variant_indices[ti] = 0xffffffffu;
+            mapped_tuple_struct_indices[ti] = 0xffffffffu;
+            if (tuple_types[ti] == HirTypeKind::Variant && tuple_variant_indices[ti] != 0xffffffffu) {
+                auto remapped_tuple_variant =
+                    remap_imported_variant_index(tuple_variant_indices[ti], mapped_tuple_variant_indices[ti]);
+                if (!remapped_tuple_variant) return core::make_unexpected(remapped_tuple_variant.error());
+            }
+            if (tuple_types[ti] == HirTypeKind::Struct && tuple_struct_indices[ti] != 0xffffffffu) {
+                auto remapped_tuple_struct =
+                    remap_imported_struct_index(tuple_struct_indices[ti], mapped_tuple_struct_indices[ti]);
+                if (!remapped_tuple_struct) return core::make_unexpected(remapped_tuple_struct.error());
+            }
+        }
+        if (imported_type == HirTypeKind::Variant && imported_variant_index != 0xffffffffu) {
+            auto remapped_variant = remap_imported_variant_index(imported_variant_index, mapped_variant_index);
+            if (!remapped_variant) return core::make_unexpected(remapped_variant.error());
+        }
+        if (imported_type == HirTypeKind::Struct && imported_struct_index != 0xffffffffu) {
+            auto remapped_struct = remap_imported_struct_index(imported_struct_index, mapped_struct_index);
+            if (!remapped_struct) return core::make_unexpected(remapped_struct.error());
+        }
+        return {};
+    };
+    out_type = imported_impl.type;
+    out_is_generic_template = imported_impl.is_generic_template;
+    out_struct_index = imported_impl.struct_index;
     if (imported_impl.type != HirTypeKind::Struct) return {};
     if (imported_impl.struct_index >= imported_mod.structs.len)
         return frontend_error(FrontendError::UnsupportedSyntax, span);
@@ -5761,7 +6465,7 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
         const u32 mapped = find_struct_index(*mod, import_visible_name(imported, imported_target.name));
         if (mapped >= mod->structs.len)
             return frontend_error(FrontendError::UnsupportedSyntax, span, imported_target.name);
-        *out_struct_index = mapped;
+        out_struct_index = mapped;
         return {};
     }
     if (imported_target.template_struct_index >= imported_mod.structs.len)
@@ -5773,47 +6477,39 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
     GenericBinding bindings[HirStruct::kMaxTypeParams]{};
     const u32 binding_count = imported_target.instance_type_arg_count;
     for (u32 bi = 0; bi < binding_count; bi++) {
-        bindings[bi].bound = true;
-        bindings[bi].generic_index = imported_target.instance_generic_indices[bi];
-        if (imported_target.instance_variant_indices[bi] != 0xffffffffu) {
-            if (imported_target.instance_variant_indices[bi] >= imported_mod.variants.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, span);
-            const auto& imported_variant = imported_mod.variants[imported_target.instance_variant_indices[bi]];
-            const u32 mapped_variant = find_variant_index(*mod, import_visible_name(imported, imported_variant.name));
-            if (mapped_variant >= mod->variants.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, span, imported_variant.name);
-            bindings[bi].variant_index = mapped_variant;
-        } else {
-            bindings[bi].variant_index = 0xffffffffu;
-        }
-        if (imported_target.instance_struct_indices[bi] != 0xffffffffu) {
-            if (imported_target.instance_struct_indices[bi] >= imported_mod.structs.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, span);
-            const auto& imported_struct = imported_mod.structs[imported_target.instance_struct_indices[bi]];
-            const u32 mapped_struct = find_struct_index(*mod, import_visible_name(imported, imported_struct.name));
-            if (mapped_struct >= mod->structs.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, span, imported_struct.name);
-            bindings[bi].struct_index = mapped_struct;
-        } else {
-            bindings[bi].struct_index = 0xffffffffu;
-        }
+        u32 mapped_tuple_variant_indices[kMaxTupleSlots]{};
+        u32 mapped_tuple_struct_indices[kMaxTupleSlots]{};
+        u32 mapped_variant_index = 0xffffffffu;
+        u32 mapped_arg_struct_index = 0xffffffffu;
+        auto remapped = remap_imported_type_metadata(imported_target.instance_type_args[bi],
+                                                     imported_target.instance_variant_indices[bi],
+                                                     imported_target.instance_struct_indices[bi],
+                                                     imported_target.instance_tuple_lens[bi],
+                                                     imported_target.instance_tuple_types[bi],
+                                                     imported_target.instance_tuple_variant_indices[bi],
+                                                     imported_target.instance_tuple_struct_indices[bi],
+                                                     mapped_variant_index,
+                                                     mapped_arg_struct_index,
+                                                     mapped_tuple_variant_indices,
+                                                     mapped_tuple_struct_indices);
+        if (!remapped) return core::make_unexpected(remapped.error());
         auto filled = fill_bound_binding_from_type_metadata(&bindings[bi],
                                                             mod,
                                                             imported_target.instance_type_args[bi],
                                                             imported_target.instance_generic_indices[bi],
-                                                            bindings[bi].variant_index,
-                                                            bindings[bi].struct_index,
+                                                            mapped_variant_index,
+                                                            mapped_arg_struct_index,
                                                             imported_target.instance_tuple_lens[bi],
                                                             imported_target.instance_tuple_types[bi],
-                                                            imported_target.instance_tuple_variant_indices[bi],
-                                                            imported_target.instance_tuple_struct_indices[bi],
-                                                            imported_target.instance_shape_indices[bi],
+                                                            mapped_tuple_variant_indices,
+                                                            mapped_tuple_struct_indices,
+                                                            0xffffffffu,
                                                             span);
         if (!filled) return core::make_unexpected(filled.error());
     }
     auto concrete = instantiate_struct(mod, mapped_template, bindings, binding_count, span);
     if (!concrete) return core::make_unexpected(concrete.error());
-    *out_struct_index = concrete.value();
+    out_struct_index = concrete.value();
     return {};
 }
 
@@ -5843,9 +6539,9 @@ static FrontendResult<void> merge_imported_impls(HirModule* mod,
                                                        imported,
                                                        *imported.module,
                                                        imported_impl,
-                                                       &mapped_type,
-                                                       &mapped_struct_index,
-                                                       &mapped_is_generic_template,
+                                                       mapped_type,
+                                                       mapped_struct_index,
+                                                       mapped_is_generic_template,
                                                        imported.span);
             if (!remapped) return core::make_unexpected(remapped.error());
             for (u32 existing_i = 0; existing_i < mod->impls.len; existing_i++) {
@@ -5898,12 +6594,12 @@ static FrontendResult<void> merge_imported_impls(HirModule* mod,
     return {};
 }
 
-static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, AstFile::kMaxItems>* out,
-                                             const AstFile& file,
-                                             Str source_path,
-                                             std::deque<std::string>* owned_strings,
-                                             std::vector<std::string>* import_stack,
-                                             std::vector<std::unique_ptr<HirModule>>* imported_storage) {
+static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& out,
+                                                  const AstFile& file,
+                                                  Str source_path,
+                                                  std::deque<std::string>& owned_strings,
+                                                  std::vector<std::string>& import_stack,
+                                                  std::vector<std::unique_ptr<HirModule>>& imported_storage) {
     if (source_path.len == 0) return {};
     const auto base_dir = std::filesystem::path(str_to_std_string(source_path)).parent_path();
     for (u32 i = 0; i < file.items.len; i++) {
@@ -5911,11 +6607,11 @@ static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, A
         if (item.kind != AstItemKind::Import) continue;
         const auto normalized = (base_dir / str_to_std_string(item.import_decl.path)).lexically_normal().string();
         ImportedModuleInfo* existing_info = nullptr;
-        for (u32 ii = 0; ii < out->len; ii++) {
-            if (out->operator[](ii).path.eq({normalized.c_str(), static_cast<u32>(normalized.size())}) &&
-                out->operator[](ii).has_namespace_alias == item.import_decl.has_namespace_alias &&
-                (!out->operator[](ii).has_namespace_alias || out->operator[](ii).namespace_alias.eq(item.import_decl.namespace_alias))) {
-                existing_info = &out->operator[](ii);
+        for (u32 ii = 0; ii < out.len; ii++) {
+            if (out[ii].path.eq({normalized.c_str(), static_cast<u32>(normalized.size())}) &&
+                out[ii].has_namespace_alias == item.import_decl.has_namespace_alias &&
+                (!out[ii].has_namespace_alias || out[ii].namespace_alias.eq(item.import_decl.namespace_alias))) {
+                existing_info = &out[ii];
                 break;
             }
         }
@@ -5945,7 +6641,7 @@ static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, A
             continue;
         }
         std::string content;
-        if (!read_text_file(normalized, &content))
+        if (!read_text_file(normalized, content))
             return frontend_error(FrontendError::UnsupportedSyntax, item.import_decl.span, item.import_decl.path);
         auto kept_source = stash_owned_string(owned_strings, content);
         auto lexed = lex(kept_source);
@@ -5954,13 +6650,13 @@ static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, A
         if (!ast) return core::make_unexpected(ast.error());
         auto kept_path = stash_owned_string(owned_strings, normalized);
         g_import_analysis_counter++;
-        auto imported = analyze_file_internal(*ast.value(), kept_path, import_stack, owned_strings);
+        auto imported = analyze_file_internal(*ast.value(), kept_path, import_stack, &owned_strings);
         if (!imported) return core::make_unexpected(imported.error());
-        imported_storage->push_back(std::unique_ptr<HirModule>(imported.value()));
+        imported_storage.push_back(std::unique_ptr<HirModule>(imported.value()));
         ImportedModuleInfo info{};
         info.span = item.import_decl.span;
         info.path = kept_path;
-        info.module = imported_storage->back().get();
+        info.module = imported_storage.back().get();
         info.selective = item.import_decl.selective;
         info.has_namespace_alias = item.import_decl.has_namespace_alias;
         info.namespace_alias = item.import_decl.namespace_alias;
@@ -5968,16 +6664,16 @@ static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, A
             if (!info.selected_names.push(item.import_decl.selected_names[si]))
                 return frontend_error(FrontendError::TooManyItems, item.import_decl.span);
         }
-        if (!out->push(info))
+        if (!out.push(info))
             return frontend_error(FrontendError::TooManyItems, item.import_decl.span);
     }
     return {};
 }
 
 static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
-                                                    Str source_path,
-                                                    std::vector<std::string>* import_stack,
-                                                    std::deque<std::string>* shared_owned_strings) {
+                                                        Str source_path,
+                                                        std::vector<std::string>& import_stack,
+                                                        std::deque<std::string>* shared_owned_strings) {
     auto mod_ptr = std::make_unique<HirModule>();
     HirModule& mod = *mod_ptr;
     mod.has_package_decl = file.has_package_decl;
@@ -5986,13 +6682,11 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
     std::string normalized_source;
     if (source_path.len != 0) {
         normalized_source = std::filesystem::path(str_to_std_string(source_path)).lexically_normal().string();
-        if (import_stack != nullptr) {
-            for (const auto& existing : *import_stack) {
-                if (existing == normalized_source)
-                    return frontend_error(FrontendError::UnsupportedSyntax, {}, source_path);
-            }
-            import_stack->push_back(normalized_source);
+        for (const auto& existing : import_stack) {
+            if (existing == normalized_source)
+                return frontend_error(FrontendError::UnsupportedSyntax, {}, source_path);
         }
+        import_stack.push_back(normalized_source);
     }
 
     for (u32 i = 0; i < file.items.len; i++) {
@@ -6021,7 +6715,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
     auto* owned_strings = shared_owned_strings != nullptr ? shared_owned_strings : &mod.owned_strings;
     std::vector<std::unique_ptr<HirModule>> imported_storage;
     FixedVec<ImportedModuleInfo, AstFile::kMaxItems> imported_modules;
-    auto loaded_imports = load_imported_modules(&imported_modules, file, source_path, owned_strings, import_stack, &imported_storage);
+    auto loaded_imports =
+        load_imported_modules(imported_modules, file, source_path, *owned_strings, import_stack, imported_storage);
     if (!loaded_imports) return core::make_unexpected(loaded_imports.error());
     auto validated_namespaces = validate_import_namespaces(imported_modules);
     if (!validated_namespaces) return core::make_unexpected(validated_namespaces.error());
@@ -6101,9 +6796,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                         item.protocol.methods[mi].params[pi].type,
                                                         nullptr,
                                                         &param.generic_index,
-                                                        &param.variant_index,
-                                                        &param.struct_index,
-                                                        &param.tuple_len,
+                                                        param.variant_index,
+                                                        param.struct_index,
+                                                        param.tuple_len,
                                                         param.tuple_types,
                                                         param.tuple_variant_indices,
                                                         param.tuple_struct_indices,
@@ -6132,9 +6827,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                          item.protocol.methods[mi].return_type,
                                                          nullptr,
                                                          &method.return_generic_index,
-                                                         &method.return_variant_index,
-                                                         &method.return_struct_index,
-                                                         &method.return_tuple_len,
+                                                         method.return_variant_index,
+                                                         method.return_struct_index,
+                                                         method.return_tuple_len,
                                                          method.return_tuple_types,
                                                          method.return_tuple_variant_indices,
                                                          method.return_tuple_struct_indices,
@@ -6219,7 +6914,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     u32 template_variant_index = 0xffffffffu;
                     u32 template_struct_index = 0xffffffffu;
                     const auto named_kind =
-                        resolve_named_type(mod, payload_ref.name, &template_variant_index, &template_struct_index);
+                        resolve_named_type(mod, payload_ref.name, template_variant_index, template_struct_index);
                     const bool is_generic_named =
                         (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
                          mod.variants[template_variant_index].type_params.len == payload_ref.type_arg_names.len) ||
@@ -6237,9 +6932,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                                   arg_ref,
                                                                   &variant_type_params,
                                                                   &case_decl.payload_type_args[ai].generic_index,
-                                                                  &case_decl.payload_type_args[ai].variant_index,
-                                                                  &case_decl.payload_type_args[ai].struct_index,
-                                                                  &case_decl.payload_type_args[ai].tuple_len,
+                                                                  case_decl.payload_type_args[ai].variant_index,
+                                                                  case_decl.payload_type_args[ai].struct_index,
+                                                                  case_decl.payload_type_args[ai].tuple_len,
                                                                   case_decl.payload_type_args[ai].tuple_types,
                                                                   case_decl.payload_type_args[ai].tuple_variant_indices,
                                                                   case_decl.payload_type_args[ai].tuple_struct_indices,
@@ -6318,9 +7013,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                           payload_ref,
                                                           &variant_type_params,
                                                           &case_decl.payload_generic_index,
-                                                          &case_decl.payload_variant_index,
-                                                          &case_decl.payload_struct_index,
-                                                          &case_decl.payload_tuple_len,
+                                                          case_decl.payload_variant_index,
+                                                          case_decl.payload_struct_index,
+                                                          case_decl.payload_tuple_len,
                                                           case_decl.payload_tuple_types,
                                                           case_decl.payload_tuple_variant_indices,
                                                           case_decl.payload_tuple_struct_indices,
@@ -6378,7 +7073,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     u32 template_variant_index = 0xffffffffu;
                     u32 template_struct_index = 0xffffffffu;
                     const auto named_kind =
-                        resolve_named_type(mod, type_ref.name, &template_variant_index, &template_struct_index);
+                        resolve_named_type(mod, type_ref.name, template_variant_index, template_struct_index);
                     const bool is_generic_named =
                         (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
                          mod.variants[template_variant_index].type_params.len == type_ref.type_arg_names.len) ||
@@ -6396,9 +7091,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                                   arg_ref,
                                                                   &struct_type_params,
                                                                   &field.type_args[ai].generic_index,
-                                                                  &field.type_args[ai].variant_index,
-                                                                  &field.type_args[ai].struct_index,
-                                                                  &field.type_args[ai].tuple_len,
+                                                                  field.type_args[ai].variant_index,
+                                                                  field.type_args[ai].struct_index,
+                                                                  field.type_args[ai].tuple_len,
                                                                   field.type_args[ai].tuple_types,
                                                                   field.type_args[ai].tuple_variant_indices,
                                                                   field.type_args[ai].tuple_struct_indices,
@@ -6472,15 +7167,28 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                       type_ref,
                                                       &struct_type_params,
                                                       &field.generic_index,
-                                                      &variant_index,
-                                                      &struct_index,
-                                                      &tuple_len,
+                                                      variant_index,
+                                                      struct_index,
+                                                      tuple_len,
                                                       tuple_types,
                                                       tuple_variant_indices,
                                                       tuple_struct_indices,
                                                       item.struct_decl.span);
                 if (!resolved) return core::make_unexpected(resolved.error());
                 field.type = resolved.value();
+                if (field.type == HirTypeKind::Generic && field.generic_index < struct_type_params.len) {
+                    field.generic_has_error_constraint = struct_type_params[field.generic_index].has_error_constraint;
+                    field.generic_has_eq_constraint = struct_type_params[field.generic_index].has_eq_constraint;
+                    field.generic_has_ord_constraint = struct_type_params[field.generic_index].has_ord_constraint;
+                    field.generic_protocol_index =
+                        struct_type_params[field.generic_index].custom_protocol_count != 0
+                            ? struct_type_params[field.generic_index].custom_protocol_indices[0]
+                            : 0xffffffffu;
+                    field.generic_protocol_count = struct_type_params[field.generic_index].custom_protocol_count;
+                    for (u32 cpi = 0; cpi < field.generic_protocol_count; cpi++)
+                        field.generic_protocol_indices[cpi] =
+                            struct_type_params[field.generic_index].custom_protocol_indices[cpi];
+                }
                 field.variant_index = variant_index;
                 field.struct_index = struct_index;
                 field.tuple_len = tuple_len;
@@ -6537,21 +7245,23 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
 
     auto imported = merge_imported_functions(&mod, imported_modules);
     if (!imported) return core::make_unexpected(imported.error());
+    auto imported_proto_methods = refresh_imported_protocol_method_functions(&mod, imported_modules);
+    if (!imported_proto_methods) return core::make_unexpected(imported_proto_methods.error());
     auto imported_impls = merge_imported_impls(&mod, imported_modules);
     if (!imported_impls) return core::make_unexpected(imported_impls.error());
 
     auto refreshed_structs = refresh_concrete_struct_instances(&mod);
     if (!refreshed_structs) {
-        if (source_path.len != 0 && import_stack != nullptr && !import_stack->empty()) import_stack->pop_back();
+    if (source_path.len != 0 && !import_stack.empty()) import_stack.pop_back();
         return core::make_unexpected(refreshed_structs.error());
     }
     auto refreshed_variants = refresh_concrete_variant_instances(&mod);
     if (!refreshed_variants) {
-        if (source_path.len != 0 && import_stack != nullptr && !import_stack->empty()) import_stack->pop_back();
+        if (source_path.len != 0 && !import_stack.empty()) import_stack.pop_back();
         return core::make_unexpected(refreshed_variants.error());
     }
 
-    auto declare_function_like = [&](const AstFunctionDecl& ast_func, Span span, Str fn_name, const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>* extra_type_params = nullptr) -> FrontendResult<HirFunction> {
+    auto declare_function_like = [&](const AstFunctionDecl& ast_func, Span span, Str fn_name, const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>* extra_type_params) -> FrontendResult<HirFunction> {
         HirFunction fn{};
         fn.span = span;
         fn.name = fn_name;
@@ -6578,7 +7288,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                         if (!resolve_import_namespace_type_name(mod,
                                                                 ast_func.type_params[ti].constraint_namespaces[ci],
                                                                 constraint,
-                                                                &resolved_constraint))
+                                                                resolved_constraint))
                             return frontend_error(FrontendError::UnsupportedSyntax, span, constraint);
                     }
                     const auto kind = resolve_protocol_kind(mod, resolved_constraint);
@@ -6606,7 +7316,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             if (!ret_ref.is_tuple && ret_ref.type_arg_names.len != 0) {
                 u32 template_variant_index = 0xffffffffu;
                 u32 template_struct_index = 0xffffffffu;
-                const auto named_kind = resolve_named_type(mod, ret_ref.name, &template_variant_index, &template_struct_index);
+                const auto named_kind =
+                    resolve_named_type(mod, ret_ref.name, template_variant_index, template_struct_index);
                 const bool is_generic_named =
                     (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
                      mod.variants[template_variant_index].type_params.len == ret_ref.type_arg_names.len) ||
@@ -6623,9 +7334,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                         AstTypeRef arg_ref = get_ast_type_arg_ref(ret_ref, ai);
                         auto arg_type = resolve_func_type_ref(mod, arg_ref, &fn.type_params,
                                                               &fn.return_type_args[ai].generic_index,
-                                                              &fn.return_type_args[ai].variant_index,
-                                                              &fn.return_type_args[ai].struct_index,
-                                                              &fn.return_type_args[ai].tuple_len,
+                                                              fn.return_type_args[ai].variant_index,
+                                                              fn.return_type_args[ai].struct_index,
+                                                              fn.return_type_args[ai].tuple_len,
                                                               fn.return_type_args[ai].tuple_types,
                                                               fn.return_type_args[ai].tuple_variant_indices,
                                                               fn.return_type_args[ai].tuple_struct_indices,
@@ -6657,6 +7368,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                                             fn.return_type_args[ai].shape_index,
                                                                             span);
                         if (!filled) return core::make_unexpected(filled.error());
+                        copy_binding_constraints_from_type_params(&bindings[ai], fn.type_params);
                         if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
                     }
                     if (has_generic_arg) {
@@ -6672,9 +7384,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     } else {
                         auto ret_type = resolve_func_type_ref(mod, ret_ref, &fn.type_params,
                                                               &fn.return_generic_index,
-                                                              &fn.return_variant_index,
-                                                              &fn.return_struct_index,
-                                                              &fn.return_tuple_len,
+                                                              fn.return_variant_index,
+                                                              fn.return_struct_index,
+                                                              fn.return_tuple_len,
                                                               fn.return_tuple_types,
                                                               fn.return_tuple_variant_indices,
                                                               fn.return_tuple_struct_indices,
@@ -6685,9 +7397,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 } else {
                     auto ret_type = resolve_func_type_ref(mod, ret_ref, &fn.type_params,
                                                           &fn.return_generic_index,
-                                                          &fn.return_variant_index,
-                                                          &fn.return_struct_index,
-                                                          &fn.return_tuple_len,
+                                                          fn.return_variant_index,
+                                                          fn.return_struct_index,
+                                                          fn.return_tuple_len,
                                                           fn.return_tuple_types,
                                                           fn.return_tuple_variant_indices,
                                                           fn.return_tuple_struct_indices,
@@ -6698,9 +7410,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             } else {
                 auto ret_type = resolve_func_type_ref(mod, ast_func.return_type, &fn.type_params,
                                                       &fn.return_generic_index,
-                                                      &fn.return_variant_index,
-                                                      &fn.return_struct_index,
-                                                      &fn.return_tuple_len,
+                                                      fn.return_variant_index,
+                                                      fn.return_struct_index,
+                                                      fn.return_tuple_len,
                                                       fn.return_tuple_types,
                                                       fn.return_tuple_variant_indices,
                                                       fn.return_tuple_struct_indices,
@@ -6720,7 +7432,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             if (!param_ref.is_tuple && param_ref.type_arg_names.len != 0) {
                 u32 template_variant_index = 0xffffffffu;
                 u32 template_struct_index = 0xffffffffu;
-                const auto named_kind = resolve_named_type(mod, param_ref.name, &template_variant_index, &template_struct_index);
+                const auto named_kind =
+                    resolve_named_type(mod, param_ref.name, template_variant_index, template_struct_index);
                 const bool is_generic_named =
                     (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
                      mod.variants[template_variant_index].type_params.len == param_ref.type_arg_names.len) ||
@@ -6737,9 +7450,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                         AstTypeRef arg_ref = get_ast_type_arg_ref(param_ref, ai);
                         auto arg_type = resolve_func_type_ref(mod, arg_ref, &fn.type_params,
                                                               &param.type_args[ai].generic_index,
-                                                              &param.type_args[ai].variant_index,
-                                                              &param.type_args[ai].struct_index,
-                                                              &param.type_args[ai].tuple_len,
+                                                              param.type_args[ai].variant_index,
+                                                              param.type_args[ai].struct_index,
+                                                              param.type_args[ai].tuple_len,
                                                               param.type_args[ai].tuple_types,
                                                               param.type_args[ai].tuple_variant_indices,
                                                               param.type_args[ai].tuple_struct_indices,
@@ -6771,6 +7484,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                                             param.type_args[ai].shape_index,
                                                                             span);
                         if (!filled) return core::make_unexpected(filled.error());
+                        copy_binding_constraints_from_type_params(&bindings[ai], fn.type_params);
                         if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
                     }
                     if (has_generic_arg) {
@@ -6786,9 +7500,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     } else {
                         auto param_type = resolve_func_type_ref(mod, param_ref, &fn.type_params,
                                                                 &param.generic_index,
-                                                                &param.variant_index,
-                                                                &param.struct_index,
-                                                                &param.tuple_len,
+                                                                param.variant_index,
+                                                                param.struct_index,
+                                                                param.tuple_len,
                                                                 param.tuple_types,
                                                                 param.tuple_variant_indices,
                                                                 param.tuple_struct_indices,
@@ -6799,9 +7513,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 } else {
                     auto param_type = resolve_func_type_ref(mod, param_ref, &fn.type_params,
                                                             &param.generic_index,
-                                                            &param.variant_index,
-                                                            &param.struct_index,
-                                                            &param.tuple_len,
+                                                            param.variant_index,
+                                                            param.struct_index,
+                                                            param.tuple_len,
                                                             param.tuple_types,
                                                             param.tuple_variant_indices,
                                                             param.tuple_struct_indices,
@@ -6812,9 +7526,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             } else {
                 auto param_type = resolve_func_type_ref(mod, param_ref, &fn.type_params,
                                                         &param.generic_index,
-                                                        &param.variant_index,
-                                                        &param.struct_index,
-                                                        &param.tuple_len,
+                                                        param.variant_index,
+                                                        param.struct_index,
+                                                        param.tuple_len,
                                                         param.tuple_types,
                                                         param.tuple_variant_indices,
                                                         param.tuple_struct_indices,
@@ -6870,7 +7584,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
     auto analyze_function_body_like = [&](HirFunction& fn, const AstFunctionDecl& ast_func, Span span) -> FrontendResult<void> {
         HirRoute scratch{};
         FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> ast_named_error_cases;
-        auto ast_collected = collect_named_error_cases_ast(*ast_func.body, &ast_named_error_cases);
+        auto ast_collected = collect_named_error_cases_ast(*ast_func.body, ast_named_error_cases);
         if (!ast_collected) return core::make_unexpected(ast_collected.error());
         if (ast_named_error_cases.len != 0) {
             HirVariant error_variant{};
@@ -6934,10 +7648,10 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         if (!body) return core::make_unexpected(body.error());
         FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> named_error_cases;
         for (u32 li = 0; li < scratch.locals.len; li++) {
-            auto collected = collect_named_error_cases(scratch.locals[li].init, &named_error_cases);
+            auto collected = collect_named_error_cases(scratch.locals[li].init, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
         }
-        auto collected = collect_named_error_cases(body.value(), &named_error_cases);
+        auto collected = collect_named_error_cases(body.value(), named_error_cases);
         if (!collected) return core::make_unexpected(collected.error());
         if (named_error_cases.len != 0 && scratch.error_variant_index == 0xffffffffu) {
             HirVariant error_variant{};
@@ -7086,7 +7800,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                         if (!resolve_import_namespace_type_name(mod,
                                                                 item.func.type_params[ti].constraint_namespaces[ci],
                                                                 constraint,
-                                                                &resolved_constraint)) {
+                                                                resolved_constraint)) {
                             return frontend_error(
                                 FrontendError::UnsupportedSyntax, item.func.span, constraint);
                         }
@@ -7119,7 +7833,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 u32 template_variant_index = 0xffffffffu;
                 u32 template_struct_index = 0xffffffffu;
                 const auto named_kind =
-                    resolve_named_type(mod, ret_ref.name, &template_variant_index, &template_struct_index);
+                    resolve_named_type(mod, ret_ref.name, template_variant_index, template_struct_index);
                 const bool is_generic_named =
                     (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
                      mod.variants[template_variant_index].type_params.len == ret_ref.type_arg_names.len) ||
@@ -7138,9 +7852,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                               arg_ref,
                                                               &fn.type_params,
                                                               &fn.return_type_args[ai].generic_index,
-                                                              &fn.return_type_args[ai].variant_index,
-                                                              &fn.return_type_args[ai].struct_index,
-                                                              &fn.return_type_args[ai].tuple_len,
+                                                              fn.return_type_args[ai].variant_index,
+                                                              fn.return_type_args[ai].struct_index,
+                                                              fn.return_type_args[ai].tuple_len,
                                                               fn.return_type_args[ai].tuple_types,
                                                               fn.return_type_args[ai].tuple_variant_indices,
                                                               fn.return_type_args[ai].tuple_struct_indices,
@@ -7172,6 +7886,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                                             fn.return_type_args[ai].shape_index,
                                                                             item.func.span);
                         if (!filled) return core::make_unexpected(filled.error());
+                        copy_binding_constraints_from_type_params(&bindings[ai], fn.type_params);
                         if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
                     }
                     if (has_generic_arg) {
@@ -7197,9 +7912,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                               ret_ref,
                                                               &fn.type_params,
                                                               &fn.return_generic_index,
-                                                              &fn.return_variant_index,
-                                                              &fn.return_struct_index,
-                                                              &fn.return_tuple_len,
+                                                              fn.return_variant_index,
+                                                              fn.return_struct_index,
+                                                              fn.return_tuple_len,
                                                               fn.return_tuple_types,
                                                               fn.return_tuple_variant_indices,
                                                               fn.return_tuple_struct_indices,
@@ -7212,9 +7927,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                           ret_ref,
                                                           &fn.type_params,
                                                           &fn.return_generic_index,
-                                                          &fn.return_variant_index,
-                                                          &fn.return_struct_index,
-                                                          &fn.return_tuple_len,
+                                                          fn.return_variant_index,
+                                                          fn.return_struct_index,
+                                                          fn.return_tuple_len,
                                                           fn.return_tuple_types,
                                                           fn.return_tuple_variant_indices,
                                                           fn.return_tuple_struct_indices,
@@ -7227,9 +7942,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                       ret_ref,
                                                       &fn.type_params,
                                                       &fn.return_generic_index,
-                                                      &fn.return_variant_index,
-                                                      &fn.return_struct_index,
-                                                      &fn.return_tuple_len,
+                                                      fn.return_variant_index,
+                                                      fn.return_struct_index,
+                                                      fn.return_tuple_len,
                                                       fn.return_tuple_types,
                                                       fn.return_tuple_variant_indices,
                                                       fn.return_tuple_struct_indices,
@@ -7250,7 +7965,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 u32 template_variant_index = 0xffffffffu;
                 u32 template_struct_index = 0xffffffffu;
                 const auto named_kind =
-                    resolve_named_type(mod, param_ref.name, &template_variant_index, &template_struct_index);
+                    resolve_named_type(mod, param_ref.name, template_variant_index, template_struct_index);
                 const bool is_generic_named =
                     (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
                      mod.variants[template_variant_index].type_params.len == param_ref.type_arg_names.len) ||
@@ -7269,9 +7984,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                               arg_ref,
                                                               &fn.type_params,
                                                               &param.type_args[ai].generic_index,
-                                                              &param.type_args[ai].variant_index,
-                                                              &param.type_args[ai].struct_index,
-                                                              &param.type_args[ai].tuple_len,
+                                                              param.type_args[ai].variant_index,
+                                                              param.type_args[ai].struct_index,
+                                                              param.type_args[ai].tuple_len,
                                                               param.type_args[ai].tuple_types,
                                                               param.type_args[ai].tuple_variant_indices,
                                                               param.type_args[ai].tuple_struct_indices,
@@ -7303,6 +8018,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                                             param.type_args[ai].shape_index,
                                                                             item.func.span);
                         if (!filled) return core::make_unexpected(filled.error());
+                        copy_binding_constraints_from_type_params(&bindings[ai], fn.type_params);
                         if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
                     }
                     if (has_generic_arg) {
@@ -7328,9 +8044,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                                 param_ref,
                                                                 &fn.type_params,
                                                                 &param.generic_index,
-                                                                &param.variant_index,
-                                                                &param.struct_index,
-                                                                &param.tuple_len,
+                                                                param.variant_index,
+                                                                param.struct_index,
+                                                                param.tuple_len,
                                                                 param.tuple_types,
                                                                 param.tuple_variant_indices,
                                                                 param.tuple_struct_indices,
@@ -7343,9 +8059,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                             param_ref,
                                                             &fn.type_params,
                                                             &param.generic_index,
-                                                            &param.variant_index,
-                                                            &param.struct_index,
-                                                            &param.tuple_len,
+                                                            param.variant_index,
+                                                            param.struct_index,
+                                                            param.tuple_len,
                                                             param.tuple_types,
                                                             param.tuple_variant_indices,
                                                             param.tuple_struct_indices,
@@ -7358,9 +8074,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                         param_ref,
                                                         &fn.type_params,
                                                         &param.generic_index,
-                                                        &param.variant_index,
-                                                        &param.struct_index,
-                                                        &param.tuple_len,
+                                                        param.variant_index,
+                                                        param.struct_index,
+                                                        param.tuple_len,
                                                         param.tuple_types,
                                                         param.tuple_variant_indices,
                                                         param.tuple_struct_indices,
@@ -7464,15 +8180,15 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
     }
 
     auto resolve_impl_target = [&](const AstImplDecl& decl,
-                                  HirTypeKind* out_type,
-                                  u32* out_struct_index,
-                                  bool* out_is_generic_template,
-                                  FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>* out_type_params)
+                                  HirTypeKind& out_type,
+                                  u32& out_struct_index,
+                                  bool& out_is_generic_template,
+                                  FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>& out_type_params)
         -> FrontendResult<void> {
-        *out_type = HirTypeKind::Unknown;
-        *out_struct_index = 0xffffffffu;
-        *out_is_generic_template = false;
-        out_type_params->len = 0;
+        out_type = HirTypeKind::Unknown;
+        out_struct_index = 0xffffffffu;
+        out_is_generic_template = false;
+        out_type_params.len = 0;
         if (!decl.target.is_tuple) {
             const u32 templ_struct_index = find_struct_index(mod, decl.target.name);
             if (templ_struct_index < mod.structs.len && mod.structs[templ_struct_index].type_params.len != 0 &&
@@ -7485,8 +8201,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     u32 concrete_struct_index = 0xffffffffu;
                     if (resolve_named_type(mod,
                                            decl.target.type_arg_names[i],
-                                           &concrete_variant_index,
-                                           &concrete_struct_index) != HirTypeKind::Unknown) {
+                                           concrete_variant_index,
+                                           concrete_struct_index) != HirTypeKind::Unknown) {
                         all_are_placeholders = false;
                         break;
                     }
@@ -7496,13 +8212,13 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     }
                 }
                 if (!all_are_placeholders) goto resolve_concrete_impl_target;
-                *out_type = HirTypeKind::Struct;
-                *out_struct_index = templ_struct_index;
-                *out_is_generic_template = true;
+                out_type = HirTypeKind::Struct;
+                out_struct_index = templ_struct_index;
+                out_is_generic_template = true;
                 for (u32 i = 0; i < decl.target.type_arg_names.len; i++) {
                     HirFunction::TypeParamDecl tp{};
                     tp.name = decl.target.type_arg_names[i];
-                    if (!out_type_params->push(tp))
+                    if (!out_type_params.push(tp))
                         return frontend_error(FrontendError::TooManyItems, decl.span);
                 }
                 return {};
@@ -7518,15 +8234,15 @@ resolve_concrete_impl_target:
                                                  decl.target,
                                                  nullptr,
                                                  nullptr,
-                                                 &target_variant_index,
+                                                 target_variant_index,
                                                  out_struct_index,
-                                                 &target_tuple_len,
+                                                 target_tuple_len,
                                                  target_tuple_types,
                                                  target_tuple_variant_indices,
                                                  target_tuple_struct_indices,
                                                  decl.span);
         if (!target_type) return core::make_unexpected(target_type.error());
-        *out_type = target_type.value();
+        out_type = target_type.value();
         return {};
     };
 
@@ -7540,7 +8256,7 @@ resolve_concrete_impl_target:
         bool target_is_generic_template = false;
         FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> impl_target_type_params;
         auto resolved_target = resolve_impl_target(
-            item.impl_decl, &target_type, &target_struct_index, &target_is_generic_template, &impl_target_type_params);
+            item.impl_decl, target_type, target_struct_index, target_is_generic_template, impl_target_type_params);
         if (!resolved_target) return core::make_unexpected(resolved_target.error());
         if (!(target_type == HirTypeKind::Bool || target_type == HirTypeKind::I32 ||
               target_type == HirTypeKind::Str || target_type == HirTypeKind::Struct))
@@ -7555,7 +8271,7 @@ resolve_concrete_impl_target:
                 if (!resolve_import_namespace_type_name(mod,
                                                         item.impl_decl.protocol_namespaces[pi],
                                                         proto_name,
-                                                        &resolved_proto_name))
+                                                        resolved_proto_name))
                     return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
             }
             const u32 protocol_index = find_protocol_index(mod, resolved_proto_name);
@@ -7652,9 +8368,9 @@ resolve_concrete_impl_target:
                                                          method_ast.params[pi + 1].type,
                                                          nullptr,
                                                          nullptr,
-                                                         &method_variant_index,
-                                                         &method_struct_index,
-                                                         &method_tuple_len,
+                                                         method_variant_index,
+                                                         method_struct_index,
+                                                         method_tuple_len,
                                                          method_tuple_types,
                                                          method_tuple_variant_indices,
                                                          method_tuple_struct_indices,
@@ -7710,9 +8426,9 @@ resolve_concrete_impl_target:
                                                          method_ast.return_type,
                                                          nullptr,
                                                          nullptr,
-                                                         &method_variant_index,
-                                                         &method_struct_index,
-                                                         &method_tuple_len,
+                                                         method_variant_index,
+                                                         method_struct_index,
+                                                         method_tuple_len,
                                                          method_tuple_types,
                                                          method_tuple_variant_indices,
                                                          method_tuple_struct_indices,
@@ -7755,8 +8471,10 @@ resolve_concrete_impl_target:
                 if (!same_hir_type_shape(mod, actual, expected))
                     return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
             }
-            Str type_name = item.impl_decl.target.name;
-            auto mangled = make_impl_function_name(mod.protocols[impl.protocol_index].name, type_name, method_ast.name);
+            auto type_name = make_impl_target_name(item.impl_decl.target);
+            if (!type_name) return core::make_unexpected(type_name.error());
+            auto mangled =
+                make_impl_function_name(mod.protocols[impl.protocol_index].name, type_name.value(), method_ast.name);
             if (!mangled) return core::make_unexpected(mangled.error());
             if (find_function_index(mod, mangled.value()) != mod.functions.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, mangled.value());
@@ -7806,7 +8524,7 @@ resolve_concrete_impl_target:
         HirFunction& fn = mod.functions[fn_index];
         HirRoute scratch{};
         FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> ast_named_error_cases;
-        auto ast_collected = collect_named_error_cases_ast(*item.func.body, &ast_named_error_cases);
+        auto ast_collected = collect_named_error_cases_ast(*item.func.body, ast_named_error_cases);
         if (!ast_collected) return core::make_unexpected(ast_collected.error());
         if (ast_named_error_cases.len != 0) {
             HirVariant error_variant{};
@@ -7870,10 +8588,10 @@ resolve_concrete_impl_target:
         if (!body) return core::make_unexpected(body.error());
         FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> named_error_cases;
         for (u32 li = 0; li < scratch.locals.len; li++) {
-            auto collected = collect_named_error_cases(scratch.locals[li].init, &named_error_cases);
+            auto collected = collect_named_error_cases(scratch.locals[li].init, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
         }
-        auto collected = collect_named_error_cases(body.value(), &named_error_cases);
+        auto collected = collect_named_error_cases(body.value(), named_error_cases);
         if (!collected) return core::make_unexpected(collected.error());
         if (named_error_cases.len != 0 && scratch.error_variant_index == 0xffffffffu) {
             HirVariant error_variant{};
@@ -8016,6 +8734,10 @@ resolve_concrete_impl_target:
             synthetic.body = method_ast.default_body;
             auto body_ok = analyze_function_body_like(mod.functions[method->function_index], synthetic, synthetic.span);
             if (!body_ok) return core::make_unexpected(body_ok.error());
+            method->return_may_nil = mod.functions[method->function_index].body.may_nil;
+            method->return_may_error = mod.functions[method->function_index].body.may_error;
+            method->return_error_struct_index = mod.functions[method->function_index].body.error_struct_index;
+            method->return_error_variant_index = mod.functions[method->function_index].body.error_variant_index;
         }
     }
 
@@ -8027,7 +8749,7 @@ resolve_concrete_impl_target:
         bool target_is_generic_template = false;
         FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> impl_target_type_params;
         auto resolved_target = resolve_impl_target(
-            item.impl_decl, &target_type, &target_struct_index, &target_is_generic_template, &impl_target_type_params);
+            item.impl_decl, target_type, target_struct_index, target_is_generic_template, impl_target_type_params);
         if (!resolved_target) return core::make_unexpected(resolved_target.error());
         for (u32 mi = 0; mi < item.impl_decl.methods.len; mi++) {
             const auto& method_ast = item.impl_decl.methods[mi];
@@ -8038,7 +8760,7 @@ resolve_concrete_impl_target:
                     if (!resolve_import_namespace_type_name(mod,
                                                             item.impl_decl.protocol_namespaces[pi],
                                                             item.impl_decl.protocols[pi],
-                                                            &resolved_proto_name))
+                                                            resolved_proto_name))
                         return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, item.impl_decl.protocols[pi]);
                 }
                 const u32 protocol_index = find_protocol_index(mod, resolved_proto_name);
@@ -8085,7 +8807,7 @@ resolve_concrete_impl_target:
                 local.span = stmt.span;
                 local.name = stmt.name;
                 local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
-                auto init = analyze_expr(stmt.expr, &route, mod, route.locals.data, route.locals.len);
+                auto init = analyze_expr(stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!init) return core::make_unexpected(init.error());
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, stmt);
                 if (!typed) return core::make_unexpected(typed.error());
@@ -8121,7 +8843,7 @@ resolve_concrete_impl_target:
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 HirGuard guard{};
                 guard.span = stmt.span;
-                auto bound = analyze_expr(stmt.expr, &route, mod, route.locals.data, route.locals.len);
+                auto bound = analyze_expr(stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!bound) return core::make_unexpected(bound.error());
                 auto cond = analyze_guard_cond(stmt.expr, &route, mod, route.locals.data, route.locals.len);
                 if (!cond) return core::make_unexpected(cond.error());
@@ -8170,7 +8892,7 @@ resolve_concrete_impl_target:
                     }
                 }
                 if (stmt.bind_value) {
-                    if (known_value_state(bound.value(), route.locals.data, route.locals.len) ==
+                    if (known_value_state(bound.value(), route.locals.data, route.locals.len, 0) ==
                         KnownValueState::Error)
                         return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
                     HirLocal local{};
@@ -8222,45 +8944,45 @@ resolve_concrete_impl_target:
 
         FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> named_error_cases;
         for (u32 li = 0; li < route.locals.len; li++) {
-            auto collected = collect_named_error_cases(route.locals[li].init, &named_error_cases);
+            auto collected = collect_named_error_cases(route.locals[li].init, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
         }
         for (u32 gi = 0; gi < route.guards.len; gi++) {
-            auto collected = collect_named_error_cases(route.guards[gi].cond, &named_error_cases);
+            auto collected = collect_named_error_cases(route.guards[gi].cond, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
-            collected = collect_named_error_cases(route.guards[gi].fail_match_expr, &named_error_cases);
+            collected = collect_named_error_cases(route.guards[gi].fail_match_expr, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
             for (u32 ai = 0; ai < route.guards[gi].fail_match_count; ai++) {
                 collected = collect_named_error_cases(
-                    mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern, &named_error_cases);
+                    mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern, named_error_cases);
                 if (!collected) return core::make_unexpected(collected.error());
             }
         }
         if (route.control.kind == HirControlKind::If) {
-            auto collected = collect_named_error_cases(route.control.cond, &named_error_cases);
+            auto collected = collect_named_error_cases(route.control.cond, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
         } else if (route.control.kind == HirControlKind::Match) {
-            auto collected = collect_named_error_cases(route.control.match_expr, &named_error_cases);
+            auto collected = collect_named_error_cases(route.control.match_expr, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
             for (u32 ai = 0; ai < route.control.match_arms.len; ai++) {
-                collected = collect_named_error_cases(route.control.match_arms[ai].pattern, &named_error_cases);
+                collected = collect_named_error_cases(route.control.match_arms[ai].pattern, named_error_cases);
                 if (!collected) return core::make_unexpected(collected.error());
                 for (u32 gi = 0; gi < route.control.match_arms[ai].guards.len; gi++) {
                     collected =
-                        collect_named_error_cases(route.control.match_arms[ai].guards[gi].cond, &named_error_cases);
+                        collect_named_error_cases(route.control.match_arms[ai].guards[gi].cond, named_error_cases);
                     if (!collected) return core::make_unexpected(collected.error());
                     collected = collect_named_error_cases(
-                        route.control.match_arms[ai].guards[gi].fail_match_expr, &named_error_cases);
+                        route.control.match_arms[ai].guards[gi].fail_match_expr, named_error_cases);
                     if (!collected) return core::make_unexpected(collected.error());
                     for (u32 fai = 0; fai < route.control.match_arms[ai].guards[gi].fail_match_count; fai++) {
                         collected = collect_named_error_cases(
                             mod.guard_match_arms[route.control.match_arms[ai].guards[gi].fail_match_start + fai]
                                 .pattern,
-                            &named_error_cases);
+                            named_error_cases);
                         if (!collected) return core::make_unexpected(collected.error());
                     }
                 }
-                collected = collect_named_error_cases(route.control.match_arms[ai].cond, &named_error_cases);
+                collected = collect_named_error_cases(route.control.match_arms[ai].cond, named_error_cases);
                 if (!collected) return core::make_unexpected(collected.error());
             }
         }
@@ -8350,14 +9072,13 @@ resolve_concrete_impl_target:
             return frontend_error(FrontendError::TooManyItems, item.route.span);
     }
 
-    if (source_path.len != 0 && import_stack != nullptr && !import_stack->empty())
-        import_stack->pop_back();
+    if (source_path.len != 0 && !import_stack.empty()) import_stack.pop_back();
     return mod_ptr.release();
 }
 
 FrontendResult<HirModule*> analyze_file(const AstFile& file, Str source_path) {
     std::vector<std::string> import_stack;
-    return analyze_file_internal(file, source_path, &import_stack);
+    return analyze_file_internal(file, source_path, import_stack, nullptr);
 }
 
 FrontendResult<HirModule*> analyze_file(const AstFile& file) {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -1,14 +1,14 @@
 #include "rut/compiler/analyze.h"
+
 #include "rut/compiler/lexer.h"
 #include "rut/compiler/parser.h"
-
+#include <deque>
 #include <filesystem>
 #include <fstream>
 #include <functional>
 #include <memory>
 #include <string>
 #include <vector>
-#include <deque>
 
 namespace rut {
 
@@ -55,15 +55,16 @@ static bool type_shape_is_simple_importable(const HirTypeKind type,
             for (u32 i = 0; i < tuple_len; i++) {
                 if (tuple_types[i] == HirTypeKind::Struct && tuple_struct_indices[i] != 0xffffffffu)
                     continue;
-                if (tuple_types[i] == HirTypeKind::Variant && tuple_variant_indices[i] != 0xffffffffu)
+                if (tuple_types[i] == HirTypeKind::Variant &&
+                    tuple_variant_indices[i] != 0xffffffffu)
                     continue;
                 if (!type_shape_is_simple_importable(tuple_types[i],
-                                                    tuple_variant_indices[i],
-                                                    tuple_struct_indices[i],
-                                                    0,
-                                                    nullptr,
-                                                    nullptr,
-                                                    nullptr))
+                                                     tuple_variant_indices[i],
+                                                     tuple_struct_indices[i],
+                                                     0,
+                                                     nullptr,
+                                                     nullptr,
+                                                     nullptr))
                     return false;
             }
             return true;
@@ -107,7 +108,8 @@ static FrontendResult<u32> intern_hir_type_shape(HirModule* mod,
     shape.variant_index = variant_index;
     shape.struct_index = struct_index;
     shape.tuple_len = tuple_len;
-    shape.is_concrete = type == HirTypeKind::Bool || type == HirTypeKind::I32 || type == HirTypeKind::Str;
+    shape.is_concrete =
+        type == HirTypeKind::Bool || type == HirTypeKind::I32 || type == HirTypeKind::Str;
     if (type == HirTypeKind::Variant) shape.is_concrete = variant_index != 0xffffffffu;
     if (type == HirTypeKind::Struct) shape.is_concrete = struct_index != 0xffffffffu;
     if (type == HirTypeKind::Tuple) {
@@ -136,8 +138,7 @@ static FrontendResult<u32> intern_hir_type_shape(HirModule* mod,
     for (u32 i = 0; i < mod->type_shapes.len; i++) {
         if (same_type_shape_node(mod->type_shapes[i], shape)) return i;
     }
-    if (!mod->type_shapes.push(shape))
-        return frontend_error(FrontendError::TooManyItems, span);
+    if (!mod->type_shapes.push(shape)) return frontend_error(FrontendError::TooManyItems, span);
     return mod->type_shapes.len - 1;
 }
 
@@ -223,17 +224,18 @@ static FrontendResult<u32> instantiate_struct(HirModule* mod,
                                               u32 binding_count,
                                               Span span);
 
-static FrontendResult<HirTypeKind> instantiate_deferred_named_type(const HirModule& mod,
-                                                                   HirTypeKind declared_kind,
-                                                                   u32 template_variant_index,
-                                                                   u32 template_struct_index,
-                                                                   const HirVariant::TypeArgRef* type_args,
-                                                                   u32 type_arg_count,
-                                                                   const GenericBinding* bindings,
-                                                                   u32 binding_count,
-                                                                   u32& out_variant_index,
-                                                                   u32& out_struct_index,
-                                                                   Span span);
+static FrontendResult<HirTypeKind> instantiate_deferred_named_type(
+    const HirModule& mod,
+    HirTypeKind declared_kind,
+    u32 template_variant_index,
+    u32 template_struct_index,
+    const HirVariant::TypeArgRef* type_args,
+    u32 type_arg_count,
+    const GenericBinding* bindings,
+    u32 binding_count,
+    u32& out_variant_index,
+    u32& out_struct_index,
+    Span span);
 
 static FrontendResult<void> fill_bound_binding_from_type_metadata(GenericBinding* binding,
                                                                   HirModule* mod,
@@ -262,8 +264,8 @@ static bool conformance_matches_binding(const HirModule& mod,
 }
 
 static bool generic_binding_satisfies_custom_protocol(const HirModule& mod,
-                                                    const GenericBinding& binding,
-                                                    u32 protocol_index) {
+                                                      const GenericBinding& binding,
+                                                      u32 protocol_index) {
     for (u32 i = 0; i < mod.conformances.len; i++) {
         const auto& c = mod.conformances[i];
         if (c.protocol_index != protocol_index) continue;
@@ -272,7 +274,8 @@ static bool generic_binding_satisfies_custom_protocol(const HirModule& mod,
     return false;
 }
 
-static bool generic_binding_satisfies_error_constraint(const HirModule& mod, const GenericBinding& binding) {
+static bool generic_binding_satisfies_error_constraint(const HirModule& mod,
+                                                       const GenericBinding& binding) {
     if (binding.type == HirTypeKind::Struct && binding.struct_index < mod.structs.len)
         return mod.structs[binding.struct_index].conforms_error;
     return false;
@@ -364,7 +367,8 @@ static bool hir_type_shape_satisfies_eq_constraint(const HirModule& mod,
     }
 }
 
-static bool generic_binding_satisfies_eq_constraint(const HirModule& mod, const GenericBinding& binding) {
+static bool generic_binding_satisfies_eq_constraint(const HirModule& mod,
+                                                    const GenericBinding& binding) {
     bool struct_visiting[HirModule::kMaxStructs]{};
     bool variant_visiting[HirModule::kMaxVariants]{};
     return hir_type_shape_satisfies_eq_constraint(mod,
@@ -466,7 +470,8 @@ static bool hir_type_shape_satisfies_ord_constraint(const HirModule& mod,
     }
 }
 
-static bool generic_binding_satisfies_ord_constraint(const HirModule& mod, const GenericBinding& binding) {
+static bool generic_binding_satisfies_ord_constraint(const HirModule& mod,
+                                                     const GenericBinding& binding) {
     bool struct_visiting[HirModule::kMaxStructs]{};
     bool variant_visiting[HirModule::kMaxVariants]{};
     return hir_type_shape_satisfies_ord_constraint(mod,
@@ -492,14 +497,19 @@ static bool same_variant_instance_shape(const HirVariant& variant,
         if (variant.instance_generic_indices[i] != bindings[i].generic_index) return false;
         if (variant.instance_variant_indices[i] != bindings[i].variant_index) return false;
         if (variant.instance_struct_indices[i] != bindings[i].struct_index) return false;
-        if (variant.instance_shape_indices[i] != 0xffffffffu && bindings[i].shape_index != 0xffffffffu &&
+        if (variant.instance_shape_indices[i] != 0xffffffffu &&
+            bindings[i].shape_index != 0xffffffffu &&
             variant.instance_shape_indices[i] != bindings[i].shape_index)
             return false;
         if (variant.instance_tuple_lens[i] != bindings[i].tuple_len) return false;
         for (u32 ti = 0; ti < bindings[i].tuple_len; ti++) {
             if (variant.instance_tuple_types[i][ti] != bindings[i].tuple_types[ti]) return false;
-            if (variant.instance_tuple_variant_indices[i][ti] != bindings[i].tuple_variant_indices[ti]) return false;
-            if (variant.instance_tuple_struct_indices[i][ti] != bindings[i].tuple_struct_indices[ti]) return false;
+            if (variant.instance_tuple_variant_indices[i][ti] !=
+                bindings[i].tuple_variant_indices[ti])
+                return false;
+            if (variant.instance_tuple_struct_indices[i][ti] !=
+                bindings[i].tuple_struct_indices[ti])
+                return false;
         }
     }
     return true;
@@ -511,7 +521,8 @@ static FrontendResult<u32> instantiate_variant(HirModule* mod,
                                                u32 binding_count,
                                                Span span) {
     for (u32 i = 0; i < mod->variants.len; i++) {
-        if (same_variant_instance_shape(mod->variants[i], template_variant_index, bindings, binding_count))
+        if (same_variant_instance_shape(
+                mod->variants[i], template_variant_index, bindings, binding_count))
             return i;
     }
     if (template_variant_index >= mod->variants.len)
@@ -541,17 +552,18 @@ static FrontendResult<u32> instantiate_variant(HirModule* mod,
             case_decl.payload_template_struct_index != 0xffffffffu) {
             u32 concrete_variant_index = 0xffffffffu;
             u32 concrete_struct_index = 0xffffffffu;
-            auto concrete_kind = instantiate_deferred_named_type(*mod,
-                                                                 case_decl.payload_type,
-                                                                 case_decl.payload_template_variant_index,
-                                                                 case_decl.payload_template_struct_index,
-                                                                 case_decl.payload_type_args,
-                                                                 case_decl.payload_type_arg_count,
-                                                                 bindings,
-                                                                 binding_count,
-                                                                 concrete_variant_index,
-                                                                 concrete_struct_index,
-                                                                 span);
+            auto concrete_kind =
+                instantiate_deferred_named_type(*mod,
+                                                case_decl.payload_type,
+                                                case_decl.payload_template_variant_index,
+                                                case_decl.payload_template_struct_index,
+                                                case_decl.payload_type_args,
+                                                case_decl.payload_type_arg_count,
+                                                bindings,
+                                                binding_count,
+                                                concrete_variant_index,
+                                                concrete_struct_index,
+                                                span);
             if (!concrete_kind) return core::make_unexpected(concrete_kind.error());
             case_decl.payload_type = concrete_kind.value();
             case_decl.payload_variant_index = concrete_variant_index;
@@ -566,14 +578,19 @@ static FrontendResult<u32> instantiate_variant(HirModule* mod,
             const u32 source_generic_index = case_decl.payload_generic_index;
             case_decl.payload_type = bindings[source_generic_index].type;
             case_decl.payload_generic_index =
-                bindings[source_generic_index].type == HirTypeKind::Generic ? bindings[source_generic_index].generic_index
-                                                                          : 0xffffffffu;
+                bindings[source_generic_index].type == HirTypeKind::Generic
+                    ? bindings[source_generic_index].generic_index
+                    : 0xffffffffu;
             case_decl.payload_generic_has_error_constraint =
                 bindings[source_generic_index].generic_has_error_constraint;
-            case_decl.payload_generic_has_eq_constraint = bindings[source_generic_index].generic_has_eq_constraint;
-            case_decl.payload_generic_has_ord_constraint = bindings[source_generic_index].generic_has_ord_constraint;
-            case_decl.payload_generic_protocol_index = bindings[source_generic_index].generic_protocol_index;
-            case_decl.payload_generic_protocol_count = bindings[source_generic_index].generic_protocol_count;
+            case_decl.payload_generic_has_eq_constraint =
+                bindings[source_generic_index].generic_has_eq_constraint;
+            case_decl.payload_generic_has_ord_constraint =
+                bindings[source_generic_index].generic_has_ord_constraint;
+            case_decl.payload_generic_protocol_index =
+                bindings[source_generic_index].generic_protocol_index;
+            case_decl.payload_generic_protocol_count =
+                bindings[source_generic_index].generic_protocol_count;
             for (u32 cpi = 0; cpi < case_decl.payload_generic_protocol_count; cpi++) {
                 case_decl.payload_generic_protocol_indices[cpi] =
                     bindings[source_generic_index].generic_protocol_indices[cpi];
@@ -606,22 +623,22 @@ static FrontendResult<u32> instantiate_variant(HirModule* mod,
         if (!concrete.cases.push(case_decl))
             return frontend_error(FrontendError::TooManyItems, span);
     }
-    if (!mod->variants.push(concrete))
-        return frontend_error(FrontendError::TooManyItems, span);
+    if (!mod->variants.push(concrete)) return frontend_error(FrontendError::TooManyItems, span);
     return mod->variants.len - 1;
 }
 
-static FrontendResult<HirTypeKind> instantiate_deferred_named_type(const HirModule& mod,
-                                                                   HirTypeKind declared_kind,
-                                                                   u32 template_variant_index,
-                                                                   u32 template_struct_index,
-                                                                   const HirVariant::TypeArgRef* type_args,
-                                                                   u32 type_arg_count,
-                                                                   const GenericBinding* bindings,
-                                                                   u32 binding_count,
-                                                                   u32& out_variant_index,
-                                                                   u32& out_struct_index,
-                                                                   Span span) {
+static FrontendResult<HirTypeKind> instantiate_deferred_named_type(
+    const HirModule& mod,
+    HirTypeKind declared_kind,
+    u32 template_variant_index,
+    u32 template_struct_index,
+    const HirVariant::TypeArgRef* type_args,
+    u32 type_arg_count,
+    const GenericBinding* bindings,
+    u32 binding_count,
+    u32& out_variant_index,
+    u32& out_struct_index,
+    Span span) {
     out_variant_index = 0xffffffffu;
     out_struct_index = 0xffffffffu;
     GenericBinding concrete_args[HirFunction::kMaxTypeParams]{};
@@ -686,8 +703,10 @@ static bool same_struct_instance_shape(const HirStruct& st,
         if (st.instance_tuple_lens[i] != bindings[i].tuple_len) return false;
         for (u32 ti = 0; ti < bindings[i].tuple_len; ti++) {
             if (st.instance_tuple_types[i][ti] != bindings[i].tuple_types[ti]) return false;
-            if (st.instance_tuple_variant_indices[i][ti] != bindings[i].tuple_variant_indices[ti]) return false;
-            if (st.instance_tuple_struct_indices[i][ti] != bindings[i].tuple_struct_indices[ti]) return false;
+            if (st.instance_tuple_variant_indices[i][ti] != bindings[i].tuple_variant_indices[ti])
+                return false;
+            if (st.instance_tuple_struct_indices[i][ti] != bindings[i].tuple_struct_indices[ti])
+                return false;
         }
     }
     return true;
@@ -699,7 +718,8 @@ static FrontendResult<u32> instantiate_struct(HirModule* mod,
                                               u32 binding_count,
                                               Span span) {
     for (u32 i = 0; i < mod->structs.len; i++) {
-        if (same_struct_instance_shape(mod->structs[i], template_struct_index, bindings, binding_count))
+        if (same_struct_instance_shape(
+                mod->structs[i], template_struct_index, bindings, binding_count))
             return i;
     }
     if (template_struct_index >= mod->structs.len)
@@ -726,7 +746,8 @@ static FrontendResult<u32> instantiate_struct(HirModule* mod,
     }
     for (u32 fi = 0; fi < templ.fields.len; fi++) {
         HirStruct::FieldDecl field = templ.fields[fi];
-        if (field.template_variant_index != 0xffffffffu || field.template_struct_index != 0xffffffffu) {
+        if (field.template_variant_index != 0xffffffffu ||
+            field.template_struct_index != 0xffffffffu) {
             u32 concrete_variant_index = 0xffffffffu;
             u32 concrete_struct_index = 0xffffffffu;
             auto concrete_kind = instantiate_deferred_named_type(*mod,
@@ -753,23 +774,29 @@ static FrontendResult<u32> instantiate_struct(HirModule* mod,
                 return frontend_error(FrontendError::UnsupportedSyntax, span);
             const u32 source_generic_index = field.generic_index;
             field.type = bindings[source_generic_index].type;
-            field.generic_index =
-                bindings[source_generic_index].type == HirTypeKind::Generic ? bindings[source_generic_index].generic_index
-                                                                           : 0xffffffffu;
-            field.generic_has_error_constraint = bindings[source_generic_index].generic_has_error_constraint;
-            field.generic_has_eq_constraint = bindings[source_generic_index].generic_has_eq_constraint;
-            field.generic_has_ord_constraint = bindings[source_generic_index].generic_has_ord_constraint;
+            field.generic_index = bindings[source_generic_index].type == HirTypeKind::Generic
+                                      ? bindings[source_generic_index].generic_index
+                                      : 0xffffffffu;
+            field.generic_has_error_constraint =
+                bindings[source_generic_index].generic_has_error_constraint;
+            field.generic_has_eq_constraint =
+                bindings[source_generic_index].generic_has_eq_constraint;
+            field.generic_has_ord_constraint =
+                bindings[source_generic_index].generic_has_ord_constraint;
             field.generic_protocol_index = bindings[source_generic_index].generic_protocol_index;
             field.generic_protocol_count = bindings[source_generic_index].generic_protocol_count;
             for (u32 cpi = 0; cpi < field.generic_protocol_count; cpi++)
-                field.generic_protocol_indices[cpi] = bindings[source_generic_index].generic_protocol_indices[cpi];
+                field.generic_protocol_indices[cpi] =
+                    bindings[source_generic_index].generic_protocol_indices[cpi];
             field.variant_index = bindings[source_generic_index].variant_index;
             field.struct_index = bindings[source_generic_index].struct_index;
             field.tuple_len = bindings[source_generic_index].tuple_len;
             for (u32 ti = 0; ti < field.tuple_len; ti++) {
                 field.tuple_types[ti] = bindings[source_generic_index].tuple_types[ti];
-                field.tuple_variant_indices[ti] = bindings[source_generic_index].tuple_variant_indices[ti];
-                field.tuple_struct_indices[ti] = bindings[source_generic_index].tuple_struct_indices[ti];
+                field.tuple_variant_indices[ti] =
+                    bindings[source_generic_index].tuple_variant_indices[ti];
+                field.tuple_struct_indices[ti] =
+                    bindings[source_generic_index].tuple_struct_indices[ti];
             }
         }
         auto field_shape = intern_hir_type_shape(mod,
@@ -784,11 +811,9 @@ static FrontendResult<u32> instantiate_struct(HirModule* mod,
                                                  span);
         if (!field_shape) return core::make_unexpected(field_shape.error());
         field.shape_index = field_shape.value();
-        if (!concrete.fields.push(field))
-            return frontend_error(FrontendError::TooManyItems, span);
+        if (!concrete.fields.push(field)) return frontend_error(FrontendError::TooManyItems, span);
     }
-    if (!mod->structs.push(concrete))
-        return frontend_error(FrontendError::TooManyItems, span);
+    if (!mod->structs.push(concrete)) return frontend_error(FrontendError::TooManyItems, span);
     return mod->structs.len - 1;
 }
 
@@ -804,24 +829,26 @@ static FrontendResult<void> refresh_concrete_struct_instances(HirModule* mod) {
         GenericBinding bindings[HirFunction::kMaxTypeParams]{};
         const u32 binding_count = refreshed.instance_type_arg_count;
         for (u32 bi = 0; bi < binding_count; bi++) {
-            auto filled = fill_bound_binding_from_type_metadata(&bindings[bi],
-                                                                mod,
-                                                                refreshed.instance_type_args[bi],
-                                                                refreshed.instance_generic_indices[bi],
-                                                                refreshed.instance_variant_indices[bi],
-                                                                refreshed.instance_struct_indices[bi],
-                                                                refreshed.instance_tuple_lens[bi],
-                                                                refreshed.instance_tuple_types[bi],
-                                                                refreshed.instance_tuple_variant_indices[bi],
-                                                                refreshed.instance_tuple_struct_indices[bi],
-                                                                refreshed.instance_shape_indices[bi],
-                                                                refreshed.span);
+            auto filled =
+                fill_bound_binding_from_type_metadata(&bindings[bi],
+                                                      mod,
+                                                      refreshed.instance_type_args[bi],
+                                                      refreshed.instance_generic_indices[bi],
+                                                      refreshed.instance_variant_indices[bi],
+                                                      refreshed.instance_struct_indices[bi],
+                                                      refreshed.instance_tuple_lens[bi],
+                                                      refreshed.instance_tuple_types[bi],
+                                                      refreshed.instance_tuple_variant_indices[bi],
+                                                      refreshed.instance_tuple_struct_indices[bi],
+                                                      refreshed.instance_shape_indices[bi],
+                                                      refreshed.span);
             if (!filled) return core::make_unexpected(filled.error());
             refreshed.instance_shape_indices[bi] = bindings[bi].shape_index;
         }
         for (u32 fi = 0; fi < templ.fields.len; fi++) {
             HirStruct::FieldDecl field = templ.fields[fi];
-            if (field.template_variant_index != 0xffffffffu || field.template_struct_index != 0xffffffffu) {
+            if (field.template_variant_index != 0xffffffffu ||
+                field.template_struct_index != 0xffffffffu) {
                 u32 concrete_variant_index = 0xffffffffu;
                 u32 concrete_struct_index = 0xffffffffu;
                 auto concrete_kind = instantiate_deferred_named_type(*mod,
@@ -847,20 +874,26 @@ static FrontendResult<void> refresh_concrete_struct_instances(HirModule* mod) {
                 if (field.generic_index >= binding_count)
                     return frontend_error(FrontendError::UnsupportedSyntax, refreshed.span);
                 field.type = bindings[field.generic_index].type;
-                field.generic_has_error_constraint = bindings[field.generic_index].generic_has_error_constraint;
-                field.generic_has_eq_constraint = bindings[field.generic_index].generic_has_eq_constraint;
-                field.generic_has_ord_constraint = bindings[field.generic_index].generic_has_ord_constraint;
+                field.generic_has_error_constraint =
+                    bindings[field.generic_index].generic_has_error_constraint;
+                field.generic_has_eq_constraint =
+                    bindings[field.generic_index].generic_has_eq_constraint;
+                field.generic_has_ord_constraint =
+                    bindings[field.generic_index].generic_has_ord_constraint;
                 field.generic_protocol_index = bindings[field.generic_index].generic_protocol_index;
                 field.generic_protocol_count = bindings[field.generic_index].generic_protocol_count;
                 for (u32 cpi = 0; cpi < field.generic_protocol_count; cpi++)
-                    field.generic_protocol_indices[cpi] = bindings[field.generic_index].generic_protocol_indices[cpi];
+                    field.generic_protocol_indices[cpi] =
+                        bindings[field.generic_index].generic_protocol_indices[cpi];
                 field.variant_index = bindings[field.generic_index].variant_index;
                 field.struct_index = bindings[field.generic_index].struct_index;
                 field.tuple_len = bindings[field.generic_index].tuple_len;
                 for (u32 ti = 0; ti < field.tuple_len; ti++) {
                     field.tuple_types[ti] = bindings[field.generic_index].tuple_types[ti];
-                    field.tuple_variant_indices[ti] = bindings[field.generic_index].tuple_variant_indices[ti];
-                    field.tuple_struct_indices[ti] = bindings[field.generic_index].tuple_struct_indices[ti];
+                    field.tuple_variant_indices[ti] =
+                        bindings[field.generic_index].tuple_variant_indices[ti];
+                    field.tuple_struct_indices[ti] =
+                        bindings[field.generic_index].tuple_struct_indices[ti];
                 }
                 field.generic_index = 0xffffffffu;
             }
@@ -919,18 +952,19 @@ static FrontendResult<void> refresh_concrete_variant_instances(HirModule* mod) {
         GenericBinding bindings[HirFunction::kMaxTypeParams]{};
         const u32 binding_count = refreshed.instance_type_arg_count;
         for (u32 bi = 0; bi < binding_count; bi++) {
-            auto filled = fill_bound_binding_from_type_metadata(&bindings[bi],
-                                                                mod,
-                                                                refreshed.instance_type_args[bi],
-                                                                refreshed.instance_generic_indices[bi],
-                                                                refreshed.instance_variant_indices[bi],
-                                                                refreshed.instance_struct_indices[bi],
-                                                                refreshed.instance_tuple_lens[bi],
-                                                                refreshed.instance_tuple_types[bi],
-                                                                refreshed.instance_tuple_variant_indices[bi],
-                                                                refreshed.instance_tuple_struct_indices[bi],
-                                                                refreshed.instance_shape_indices[bi],
-                                                                refreshed.span);
+            auto filled =
+                fill_bound_binding_from_type_metadata(&bindings[bi],
+                                                      mod,
+                                                      refreshed.instance_type_args[bi],
+                                                      refreshed.instance_generic_indices[bi],
+                                                      refreshed.instance_variant_indices[bi],
+                                                      refreshed.instance_struct_indices[bi],
+                                                      refreshed.instance_tuple_lens[bi],
+                                                      refreshed.instance_tuple_types[bi],
+                                                      refreshed.instance_tuple_variant_indices[bi],
+                                                      refreshed.instance_tuple_struct_indices[bi],
+                                                      refreshed.instance_shape_indices[bi],
+                                                      refreshed.span);
             if (!filled) return core::make_unexpected(filled.error());
             refreshed.instance_shape_indices[bi] = bindings[bi].shape_index;
         }
@@ -940,17 +974,18 @@ static FrontendResult<void> refresh_concrete_variant_instances(HirModule* mod) {
                 case_decl.payload_template_struct_index != 0xffffffffu) {
                 u32 concrete_variant_index = 0xffffffffu;
                 u32 concrete_struct_index = 0xffffffffu;
-                auto concrete_kind = instantiate_deferred_named_type(*mod,
-                                                                     case_decl.payload_type,
-                                                                     case_decl.payload_template_variant_index,
-                                                                     case_decl.payload_template_struct_index,
-                                                                     case_decl.payload_type_args,
-                                                                     case_decl.payload_type_arg_count,
-                                                                     bindings,
-                                                                     binding_count,
-                                                                     concrete_variant_index,
-                                                                     concrete_struct_index,
-                                                                     refreshed.span);
+                auto concrete_kind =
+                    instantiate_deferred_named_type(*mod,
+                                                    case_decl.payload_type,
+                                                    case_decl.payload_template_variant_index,
+                                                    case_decl.payload_template_struct_index,
+                                                    case_decl.payload_type_args,
+                                                    case_decl.payload_type_arg_count,
+                                                    bindings,
+                                                    binding_count,
+                                                    concrete_variant_index,
+                                                    concrete_struct_index,
+                                                    refreshed.span);
                 if (!concrete_kind) return core::make_unexpected(concrete_kind.error());
                 case_decl.payload_type = concrete_kind.value();
                 case_decl.payload_variant_index = concrete_variant_index;
@@ -970,10 +1005,14 @@ static FrontendResult<void> refresh_concrete_variant_instances(HirModule* mod) {
                         : 0xffffffffu;
                 case_decl.payload_generic_has_error_constraint =
                     bindings[source_generic_index].generic_has_error_constraint;
-                case_decl.payload_generic_has_eq_constraint = bindings[source_generic_index].generic_has_eq_constraint;
-                case_decl.payload_generic_has_ord_constraint = bindings[source_generic_index].generic_has_ord_constraint;
-                case_decl.payload_generic_protocol_index = bindings[source_generic_index].generic_protocol_index;
-                case_decl.payload_generic_protocol_count = bindings[source_generic_index].generic_protocol_count;
+                case_decl.payload_generic_has_eq_constraint =
+                    bindings[source_generic_index].generic_has_eq_constraint;
+                case_decl.payload_generic_has_ord_constraint =
+                    bindings[source_generic_index].generic_has_ord_constraint;
+                case_decl.payload_generic_protocol_index =
+                    bindings[source_generic_index].generic_protocol_index;
+                case_decl.payload_generic_protocol_count =
+                    bindings[source_generic_index].generic_protocol_count;
                 for (u32 cpi = 0; cpi < case_decl.payload_generic_protocol_count; cpi++) {
                     case_decl.payload_generic_protocol_indices[cpi] =
                         bindings[source_generic_index].generic_protocol_indices[cpi];
@@ -982,7 +1021,8 @@ static FrontendResult<void> refresh_concrete_variant_instances(HirModule* mod) {
                 case_decl.payload_struct_index = bindings[source_generic_index].struct_index;
                 case_decl.payload_tuple_len = bindings[source_generic_index].tuple_len;
                 for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
-                    case_decl.payload_tuple_types[ti] = bindings[source_generic_index].tuple_types[ti];
+                    case_decl.payload_tuple_types[ti] =
+                        bindings[source_generic_index].tuple_types[ti];
                     case_decl.payload_tuple_variant_indices[ti] =
                         bindings[source_generic_index].tuple_variant_indices[ti];
                     case_decl.payload_tuple_struct_indices[ti] =
@@ -1044,7 +1084,8 @@ static u32 find_function_index(const HirModule& mod, Str name) {
 // Deliberately does NOT check that the first param's *type* is `Request` —
 // HirTypeKind has no Request yet (only Bool/I32/Str/Variant/Struct/Tuple/
 // Generic/Unknown). Extend when the runtime Request type lands.
-static FrontendResult<u32> validate_decorator_signature(const HirFunction& fn, Span decorator_span) {
+static FrontendResult<u32> validate_decorator_signature(const HirFunction& fn,
+                                                        Span decorator_span) {
     if (fn.params.len == 0)
         return frontend_error(FrontendError::UnsupportedSyntax, decorator_span, fn.name);
     if (!fn.params[0].has_underscore_label)
@@ -1076,7 +1117,8 @@ static Str import_namespace_name(Str path, bool has_alias, Str alias) {
         if (ptr[i] == '/' || ptr[i] == '\\') start = i + 1;
     }
     u32 end = len;
-    if (end >= 4 && ptr[end - 4] == '.' && ptr[end - 3] == 'r' && ptr[end - 2] == 'u' && ptr[end - 1] == 't')
+    if (end >= 4 && ptr[end - 4] == '.' && ptr[end - 3] == 'r' && ptr[end - 2] == 'u' &&
+        ptr[end - 1] == 't')
         end -= 4;
     if (end < start) return {};
     return {ptr + start, end - start};
@@ -1089,18 +1131,26 @@ static bool import_namespace_matches(Str path, bool has_alias, Str alias, Str ns
 
 static bool has_import_namespace(const HirModule& mod, Str ns) {
     for (u32 i = 0; i < mod.imports.len; i++) {
-        if (!mod.imports[i].selective && import_namespace_matches(mod.imports[i].path, mod.imports[i].has_namespace_alias, mod.imports[i].namespace_alias, ns)) return true;
+        if (!mod.imports[i].selective &&
+            import_namespace_matches(mod.imports[i].path,
+                                     mod.imports[i].has_namespace_alias,
+                                     mod.imports[i].namespace_alias,
+                                     ns))
+            return true;
     }
     return false;
 }
 
-static FrontendResult<void> validate_import_namespaces(const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+static FrontendResult<void> validate_import_namespaces(
+    const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
     for (u32 i = 0; i < imports.len; i++) {
         if (imports[i].selective) continue;
-        const auto lhs = import_namespace_name(imports[i].path, imports[i].has_namespace_alias, imports[i].namespace_alias);
+        const auto lhs = import_namespace_name(
+            imports[i].path, imports[i].has_namespace_alias, imports[i].namespace_alias);
         for (u32 j = i + 1; j < imports.len; j++) {
             if (imports[j].selective) continue;
-            const auto rhs = import_namespace_name(imports[j].path, imports[j].has_namespace_alias, imports[j].namespace_alias);
+            const auto rhs = import_namespace_name(
+                imports[j].path, imports[j].has_namespace_alias, imports[j].namespace_alias);
             if (!imports[i].path.eq(imports[j].path) && lhs.eq(rhs))
                 return frontend_error(FrontendError::UnsupportedSyntax, imports[j].span, rhs);
         }
@@ -1108,36 +1158,41 @@ static FrontendResult<void> validate_import_namespaces(const FixedVec<ImportedMo
     return {};
 }
 
-static FrontendResult<void> validate_import_namespace_bindings(const AstFile& file,
-                                                               const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+static FrontendResult<void> validate_import_namespace_bindings(
+    const AstFile& file, const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
     for (u32 ii = 0; ii < imports.len; ii++) {
         if (imports[ii].selective) continue;
-        const auto ns = import_namespace_name(imports[ii].path, imports[ii].has_namespace_alias, imports[ii].namespace_alias);
+        const auto ns = import_namespace_name(
+            imports[ii].path, imports[ii].has_namespace_alias, imports[ii].namespace_alias);
         for (u32 i = 0; i < file.items.len; i++) {
             const auto& item = file.items[i];
             switch (item.kind) {
-            case AstItemKind::Func:
-                if (item.func.name.eq(ns))
-                    return frontend_error(FrontendError::UnsupportedSyntax, item.func.span, ns);
-                break;
-            case AstItemKind::Struct:
-                if (item.struct_decl.name.eq(ns))
-                    return frontend_error(FrontendError::UnsupportedSyntax, item.struct_decl.span, ns);
-                break;
-            case AstItemKind::Variant:
-                if (item.variant.name.eq(ns))
-                    return frontend_error(FrontendError::UnsupportedSyntax, item.variant.span, ns);
-                break;
-            case AstItemKind::Protocol:
-                if (item.protocol.name.eq(ns))
-                    return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, ns);
-                break;
-            case AstItemKind::Using:
-                if (item.using_decl.name.eq(ns))
-                    return frontend_error(FrontendError::UnsupportedSyntax, item.using_decl.span, ns);
-                break;
-            default:
-                break;
+                case AstItemKind::Func:
+                    if (item.func.name.eq(ns))
+                        return frontend_error(FrontendError::UnsupportedSyntax, item.func.span, ns);
+                    break;
+                case AstItemKind::Struct:
+                    if (item.struct_decl.name.eq(ns))
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, item.struct_decl.span, ns);
+                    break;
+                case AstItemKind::Variant:
+                    if (item.variant.name.eq(ns))
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, item.variant.span, ns);
+                    break;
+                case AstItemKind::Protocol:
+                    if (item.protocol.name.eq(ns))
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, item.protocol.span, ns);
+                    break;
+                case AstItemKind::Using:
+                    if (item.using_decl.name.eq(ns))
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, item.using_decl.span, ns);
+                    break;
+                default:
+                    break;
             }
         }
         for (u32 jj = 0; jj < imports.len; jj++) {
@@ -1145,7 +1200,9 @@ static FrontendResult<void> validate_import_namespace_bindings(const AstFile& fi
             const auto& other = imports[jj];
             if (!other.selective) {
                 if (other.has_namespace_alias) continue;
-                if (import_namespace_name(other.path, other.has_namespace_alias, other.namespace_alias).eq(ns))
+                if (import_namespace_name(
+                        other.path, other.has_namespace_alias, other.namespace_alias)
+                        .eq(ns))
                     return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
                 for (u32 fi = 0; fi < other.module->functions.len; fi++) {
                     const auto& fn = other.module->functions[fi];
@@ -1153,27 +1210,33 @@ static FrontendResult<void> validate_import_namespace_bindings(const AstFile& fi
                         (fn.name.len >= 7 && __builtin_memcmp(fn.name.ptr, "__impl_", 7) == 0) ||
                         (fn.name.len >= 8 && __builtin_memcmp(fn.name.ptr, "__proto_", 8) == 0);
                     if (!hidden_runtime_fn && fn.name.eq(ns))
-                        return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, imports[ii].span, ns);
                 }
                 for (u32 pi = 0; pi < other.module->protocols.len; pi++) {
                     const auto& proto = other.module->protocols[pi];
                     if (proto.kind == HirProtocolKind::Custom && proto.name.eq(ns))
-                        return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, imports[ii].span, ns);
                 }
                 for (u32 si = 0; si < other.module->structs.len; si++) {
                     const auto& st = other.module->structs[si];
                     if (st.template_struct_index == 0xffffffffu && st.name.eq(ns))
-                        return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, imports[ii].span, ns);
                 }
                 for (u32 vi = 0; vi < other.module->variants.len; vi++) {
                     const auto& variant = other.module->variants[vi];
                     if (variant.template_variant_index == 0xffffffffu && variant.name.eq(ns))
-                        return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, imports[ii].span, ns);
                 }
                 continue;
             }
             for (u32 si = 0; si < other.selected_names.len; si++) {
-                const auto visible = other.selected_names[si].has_alias ? other.selected_names[si].alias : other.selected_names[si].name;
+                const auto visible = other.selected_names[si].has_alias
+                                         ? other.selected_names[si].alias
+                                         : other.selected_names[si].name;
                 if (visible.eq(ns))
                     return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
             }
@@ -1182,16 +1245,22 @@ static FrontendResult<void> validate_import_namespace_bindings(const AstFile& fi
     return {};
 }
 
-static bool resolve_import_namespace_member(const HirModule& mod, const AstExpr& expr, Str& out_member) {
+static bool resolve_import_namespace_member(const HirModule& mod,
+                                            const AstExpr& expr,
+                                            Str& out_member) {
     if (expr.kind != AstExprKind::Field || expr.lhs == nullptr) return false;
     if (expr.lhs->kind != AstExprKind::Ident) return false;
     for (u32 i = 0; i < mod.imports.len; i++) {
         const auto& imported = mod.imports[i];
         if (imported.selective) continue;
-        if (!import_namespace_matches(imported.path, imported.has_namespace_alias, imported.namespace_alias, expr.lhs->name))
+        if (!import_namespace_matches(imported.path,
+                                      imported.has_namespace_alias,
+                                      imported.namespace_alias,
+                                      expr.lhs->name))
             continue;
         if (imported.has_namespace_alias)
-            out_member = intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" + str_to_std_string(expr.name));
+            out_member = intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" +
+                                               str_to_std_string(expr.name));
         else
             out_member = expr.name;
         return true;
@@ -1199,14 +1268,19 @@ static bool resolve_import_namespace_member(const HirModule& mod, const AstExpr&
     return false;
 }
 
-static bool resolve_import_namespace_type_name(const HirModule& mod, Str ns, Str member, Str& out_name) {
+static bool resolve_import_namespace_type_name(const HirModule& mod,
+                                               Str ns,
+                                               Str member,
+                                               Str& out_name) {
     for (u32 i = 0; i < mod.imports.len; i++) {
         const auto& imported = mod.imports[i];
         if (imported.selective) continue;
-        if (!import_namespace_matches(imported.path, imported.has_namespace_alias, imported.namespace_alias, ns))
+        if (!import_namespace_matches(
+                imported.path, imported.has_namespace_alias, imported.namespace_alias, ns))
             continue;
         if (imported.has_namespace_alias)
-            out_name = intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" + str_to_std_string(member));
+            out_name = intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" +
+                                             str_to_std_string(member));
         else
             out_name = member;
         return true;
@@ -1236,9 +1310,9 @@ static HirProtocol::MethodDecl* find_protocol_method_mut(HirProtocol& proto, Str
 }
 
 static bool impl_matches_type(const HirModule& mod,
-                             const HirImpl& impl,
-                             HirTypeKind type,
-                             u32 struct_index) {
+                              const HirImpl& impl,
+                              HirTypeKind type,
+                              u32 struct_index) {
     if (impl.type != type) return false;
     if (type == HirTypeKind::Struct) {
         if (!impl.is_generic_template) return impl.struct_index == struct_index;
@@ -1337,17 +1411,19 @@ static bool impl_targets_overlap(const HirModule& mod,
 }
 
 static bool impl_matches_exact_target(const HirImpl& impl,
-                               HirTypeKind type,
-                               u32 struct_index,
-                               bool is_generic_template) {
-    return impl.type == type && impl.struct_index == struct_index && impl.is_generic_template == is_generic_template;
+                                      HirTypeKind type,
+                                      u32 struct_index,
+                                      bool is_generic_template) {
+    return impl.type == type && impl.struct_index == struct_index &&
+           impl.is_generic_template == is_generic_template;
 }
 
 static FrontendResult<Str> make_impl_function_name(Str protocol_name,
                                                    Str type_name,
                                                    Str method_name) {
     const char prefix[] = "__impl_";
-    const u32 len = static_cast<u32>(sizeof(prefix) - 1) + protocol_name.len + 1 + type_name.len + 1 + method_name.len;
+    const u32 len = static_cast<u32>(sizeof(prefix) - 1) + protocol_name.len + 1 + type_name.len +
+                    1 + method_name.len;
     auto* buf = new (std::nothrow) char[len];
     if (buf == nullptr) return frontend_error(FrontendError::OutOfMemory, {});
     u32 off = 0;
@@ -1361,13 +1437,16 @@ static FrontendResult<Str> make_impl_function_name(Str protocol_name,
 }
 
 static FrontendResult<Str> make_impl_target_name(const AstTypeRef& ref) {
-    std::function<std::string(const AstTypeRef&)> build = [&](const AstTypeRef& cur) -> std::string {
+    std::function<std::string(const AstTypeRef&)> build =
+        [&](const AstTypeRef& cur) -> std::string {
         if (cur.is_tuple) {
             std::string out = "tuple";
             for (u32 i = 0; i < cur.tuple_elem_types.len; i++) {
                 out += "_";
-                if (cur.tuple_elem_types[i] != nullptr) out += build(*cur.tuple_elem_types[i]);
-                else out += str_to_std_string(cur.tuple_elem_names[i]);
+                if (cur.tuple_elem_types[i] != nullptr)
+                    out += build(*cur.tuple_elem_types[i]);
+                else
+                    out += str_to_std_string(cur.tuple_elem_names[i]);
             }
             return out;
         }
@@ -1379,10 +1458,12 @@ static FrontendResult<Str> make_impl_target_name(const AstTypeRef& ref) {
         out += str_to_std_string(cur.name);
         for (u32 i = 0; i < cur.type_arg_names.len; i++) {
             AstTypeRef arg{};
-            if (i < cur.type_args.len && cur.type_args[i] != nullptr) arg = *cur.type_args[i];
+            if (i < cur.type_args.len && cur.type_args[i] != nullptr)
+                arg = *cur.type_args[i];
             else {
                 arg.name = cur.type_arg_names[i];
-                if (i < cur.type_arg_namespaces.len) arg.namespace_name = cur.type_arg_namespaces[i];
+                if (i < cur.type_arg_namespaces.len)
+                    arg.namespace_name = cur.type_arg_namespaces[i];
             }
             out += "_";
             out += build(arg);
@@ -1400,8 +1481,9 @@ static HirProtocolKind resolve_protocol_kind(const HirModule& mod, Str name) {
     return static_cast<HirProtocolKind>(0xff);
 }
 
-static u32 find_generic_param_index(const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>& type_params,
-                                    Str name) {
+static u32 find_generic_param_index(
+    const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>& type_params,
+    Str name) {
     for (u32 i = 0; i < type_params.len; i++) {
         if (type_params[i].name.eq(name)) return i;
     }
@@ -1439,23 +1521,25 @@ static AstTypeRef get_ast_type_arg_ref(const AstTypeRef& ref, u32 index) {
 }
 
 static AstTypeRef get_ast_tuple_elem_ref(const AstTypeRef& ref, u32 index) {
-    if (index < ref.tuple_elem_types.len && ref.tuple_elem_types[index] != nullptr) return *ref.tuple_elem_types[index];
+    if (index < ref.tuple_elem_types.len && ref.tuple_elem_types[index] != nullptr)
+        return *ref.tuple_elem_types[index];
     AstTypeRef out{};
     if (index < ref.tuple_elem_names.len) out.name = ref.tuple_elem_names[index];
     return out;
 }
 
-static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
-                                                         const AstTypeRef& ref,
-                                                         const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>* type_params,
-                                                         u32* generic_index,
-                                                         u32& variant_index,
-                                                         u32& struct_index,
-                                                         u32& tuple_len,
-                                                         HirTypeKind* tuple_types,
-                                                         u32* tuple_variant_indices,
-                                                         u32* tuple_struct_indices,
-                                                         Span span) {
+static FrontendResult<HirTypeKind> resolve_func_type_ref(
+    const HirModule& mod,
+    const AstTypeRef& ref,
+    const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>* type_params,
+    u32* generic_index,
+    u32& variant_index,
+    u32& struct_index,
+    u32& tuple_len,
+    HirTypeKind* tuple_types,
+    u32* tuple_variant_indices,
+    u32* tuple_struct_indices,
+    Span span) {
     if (generic_index) *generic_index = 0xffffffffu;
     variant_index = 0xffffffffu;
     struct_index = 0xffffffffu;
@@ -1463,7 +1547,8 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
     if (!ref.is_tuple) {
         Str resolved_name = ref.name;
         if (ref.namespace_name.len != 0) {
-            if (!resolve_import_namespace_type_name(mod, ref.namespace_name, ref.name, resolved_name))
+            if (!resolve_import_namespace_type_name(
+                    mod, ref.namespace_name, ref.name, resolved_name))
                 return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
         }
         if (type_params != nullptr && ref.namespace_name.len == 0) {
@@ -1519,8 +1604,11 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
                                                                     span);
                 if (!filled) return core::make_unexpected(filled.error());
             }
-            auto concrete_index =
-                instantiate_variant(const_cast<HirModule*>(&mod), variant_index, bindings, ref.type_arg_names.len, span);
+            auto concrete_index = instantiate_variant(const_cast<HirModule*>(&mod),
+                                                      variant_index,
+                                                      bindings,
+                                                      ref.type_arg_names.len,
+                                                      span);
             if (!concrete_index) return core::make_unexpected(concrete_index.error());
             variant_index = concrete_index.value();
             return HirTypeKind::Variant;
@@ -1566,8 +1654,8 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
                                                                     span);
                 if (!filled) return core::make_unexpected(filled.error());
             }
-            auto concrete_index =
-                instantiate_struct(const_cast<HirModule*>(&mod), struct_index, bindings, ref.type_arg_names.len, span);
+            auto concrete_index = instantiate_struct(
+                const_cast<HirModule*>(&mod), struct_index, bindings, ref.type_arg_names.len, span);
             if (!concrete_index) return core::make_unexpected(concrete_index.error());
             struct_index = concrete_index.value();
             return HirTypeKind::Struct;
@@ -1578,7 +1666,8 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
     }
     if (ref.tuple_elem_names.len < 2 && ref.tuple_elem_types.len < 2)
         return frontend_error(FrontendError::UnsupportedSyntax, span);
-    const u32 elem_count = ref.tuple_elem_types.len != 0 ? ref.tuple_elem_types.len : ref.tuple_elem_names.len;
+    const u32 elem_count =
+        ref.tuple_elem_types.len != 0 ? ref.tuple_elem_types.len : ref.tuple_elem_names.len;
     tuple_len = elem_count;
     for (u32 i = 0; i < elem_count; i++) {
         u32 elem_variant_index = 0xffffffffu;
@@ -1603,8 +1692,10 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
         if (kind.value() == HirTypeKind::Generic || kind.value() == HirTypeKind::Tuple)
             return frontend_error(FrontendError::UnsupportedSyntax, span, elem_ref.name);
         tuple_types[i] = kind.value();
-        tuple_variant_indices[i] = kind.value() == HirTypeKind::Variant ? elem_variant_index : 0xffffffffu;
-        tuple_struct_indices[i] = kind.value() == HirTypeKind::Struct ? elem_struct_index : 0xffffffffu;
+        tuple_variant_indices[i] =
+            kind.value() == HirTypeKind::Variant ? elem_variant_index : 0xffffffffu;
+        tuple_struct_indices[i] =
+            kind.value() == HirTypeKind::Struct ? elem_struct_index : 0xffffffffu;
     }
     return HirTypeKind::Tuple;
 }
@@ -1618,9 +1709,11 @@ static bool same_hir_type_shape(const HirExpr& lhs, const HirExpr& rhs) {
         if (lhs.tuple_len != rhs.tuple_len) return false;
         for (u32 i = 0; i < lhs.tuple_len; i++) {
             if (lhs.tuple_types[i] != rhs.tuple_types[i]) return false;
-            if (lhs.tuple_types[i] == HirTypeKind::Variant && lhs.tuple_variant_indices[i] != rhs.tuple_variant_indices[i])
+            if (lhs.tuple_types[i] == HirTypeKind::Variant &&
+                lhs.tuple_variant_indices[i] != rhs.tuple_variant_indices[i])
                 return false;
-            if (lhs.tuple_types[i] == HirTypeKind::Struct && lhs.tuple_struct_indices[i] != rhs.tuple_struct_indices[i])
+            if (lhs.tuple_types[i] == HirTypeKind::Struct &&
+                lhs.tuple_struct_indices[i] != rhs.tuple_struct_indices[i])
                 return false;
         }
     }
@@ -1630,7 +1723,8 @@ static bool same_hir_type_shape(const HirExpr& lhs, const HirExpr& rhs) {
 static bool same_hir_shape_index(const HirModule& mod, u32 lhs_shape_index, u32 rhs_shape_index) {
     if (lhs_shape_index == rhs_shape_index) return true;
     if (lhs_shape_index == 0xffffffffu || rhs_shape_index == 0xffffffffu) return false;
-    if (lhs_shape_index >= mod.type_shapes.len || rhs_shape_index >= mod.type_shapes.len) return false;
+    if (lhs_shape_index >= mod.type_shapes.len || rhs_shape_index >= mod.type_shapes.len)
+        return false;
     const auto& lhs = mod.type_shapes[lhs_shape_index];
     const auto& rhs = mod.type_shapes[rhs_shape_index];
     if (lhs.type != rhs.type) return false;
@@ -1639,7 +1733,8 @@ static bool same_hir_shape_index(const HirModule& mod, u32 lhs_shape_index, u32 
     if (lhs.struct_index != rhs.struct_index) return false;
     if (lhs.tuple_len != rhs.tuple_len) return false;
     for (u32 i = 0; i < lhs.tuple_len; i++) {
-        if (!same_hir_shape_index(mod, lhs.tuple_elem_shape_indices[i], rhs.tuple_elem_shape_indices[i])) {
+        if (!same_hir_shape_index(
+                mod, lhs.tuple_elem_shape_indices[i], rhs.tuple_elem_shape_indices[i])) {
             return false;
         }
     }
@@ -1731,26 +1826,27 @@ static FrontendResult<void> concretize_named_instance_shape(HirExpr* expr,
                         return frontend_error(FrontendError::UnsupportedSyntax, expr->span);
                     bindings[i] = generic_bindings[gi];
                 } else {
-                    auto filled = fill_bound_binding_from_type_metadata(&bindings[i],
-                                                                        const_cast<HirModule*>(&mod),
-                                                                        variant.instance_type_args[i],
-                                                                        variant.instance_generic_indices[i],
-                                                                        variant.instance_variant_indices[i],
-                                                                        variant.instance_struct_indices[i],
-                                                                        variant.instance_tuple_lens[i],
-                                                                        variant.instance_tuple_types[i],
-                                                                        variant.instance_tuple_variant_indices[i],
-                                                                        variant.instance_tuple_struct_indices[i],
-                                                                        variant.instance_shape_indices[i],
-                                                                        expr->span);
+                    auto filled = fill_bound_binding_from_type_metadata(
+                        &bindings[i],
+                        const_cast<HirModule*>(&mod),
+                        variant.instance_type_args[i],
+                        variant.instance_generic_indices[i],
+                        variant.instance_variant_indices[i],
+                        variant.instance_struct_indices[i],
+                        variant.instance_tuple_lens[i],
+                        variant.instance_tuple_types[i],
+                        variant.instance_tuple_variant_indices[i],
+                        variant.instance_tuple_struct_indices[i],
+                        variant.instance_shape_indices[i],
+                        expr->span);
                     if (!filled) return core::make_unexpected(filled.error());
                 }
             }
             auto concrete = instantiate_variant(const_cast<HirModule*>(&mod),
-                                               variant.template_variant_index,
-                                               bindings,
-                                               variant.instance_type_arg_count,
-                                               expr->span);
+                                                variant.template_variant_index,
+                                                bindings,
+                                                variant.instance_type_arg_count,
+                                                expr->span);
             if (!concrete) return core::make_unexpected(concrete.error());
             expr->variant_index = concrete.value();
         }
@@ -1766,26 +1862,27 @@ static FrontendResult<void> concretize_named_instance_shape(HirExpr* expr,
                         return frontend_error(FrontendError::UnsupportedSyntax, expr->span);
                     bindings[i] = generic_bindings[gi];
                 } else {
-                    auto filled = fill_bound_binding_from_type_metadata(&bindings[i],
-                                                                        const_cast<HirModule*>(&mod),
-                                                                        st.instance_type_args[i],
-                                                                        st.instance_generic_indices[i],
-                                                                        st.instance_variant_indices[i],
-                                                                        st.instance_struct_indices[i],
-                                                                        st.instance_tuple_lens[i],
-                                                                        st.instance_tuple_types[i],
-                                                                        st.instance_tuple_variant_indices[i],
-                                                                        st.instance_tuple_struct_indices[i],
-                                                                        st.instance_shape_indices[i],
-                                                                        expr->span);
+                    auto filled =
+                        fill_bound_binding_from_type_metadata(&bindings[i],
+                                                              const_cast<HirModule*>(&mod),
+                                                              st.instance_type_args[i],
+                                                              st.instance_generic_indices[i],
+                                                              st.instance_variant_indices[i],
+                                                              st.instance_struct_indices[i],
+                                                              st.instance_tuple_lens[i],
+                                                              st.instance_tuple_types[i],
+                                                              st.instance_tuple_variant_indices[i],
+                                                              st.instance_tuple_struct_indices[i],
+                                                              st.instance_shape_indices[i],
+                                                              expr->span);
                     if (!filled) return core::make_unexpected(filled.error());
                 }
             }
             auto concrete = instantiate_struct(const_cast<HirModule*>(&mod),
-                                              st.template_struct_index,
-                                              bindings,
-                                              st.instance_type_arg_count,
-                                              expr->span);
+                                               st.template_struct_index,
+                                               bindings,
+                                               st.instance_type_arg_count,
+                                               expr->span);
             if (!concrete) return core::make_unexpected(concrete.error());
             expr->struct_index = concrete.value();
         }
@@ -1889,7 +1986,8 @@ static bool bind_generic_shape(GenericBinding* generic_bindings,
     if (!binding.bound) {
         binding.bound = true;
         binding.type = actual.type;
-        binding.generic_index = actual.type == HirTypeKind::Generic ? actual.generic_index : 0xffffffffu;
+        binding.generic_index =
+            actual.type == HirTypeKind::Generic ? actual.generic_index : 0xffffffffu;
         binding.generic_has_error_constraint = actual.generic_has_error_constraint;
         binding.generic_has_eq_constraint = actual.generic_has_eq_constraint;
         binding.generic_has_ord_constraint = actual.generic_has_ord_constraint;
@@ -1897,8 +1995,10 @@ static bool bind_generic_shape(GenericBinding* generic_bindings,
         binding.generic_protocol_count = actual.generic_protocol_count;
         for (u32 cpi = 0; cpi < binding.generic_protocol_count; cpi++)
             binding.generic_protocol_indices[cpi] = actual.generic_protocol_indices[cpi];
-        binding.variant_index = actual.type == HirTypeKind::Variant ? actual.variant_index : 0xffffffffu;
-        binding.struct_index = actual.type == HirTypeKind::Struct ? actual.struct_index : 0xffffffffu;
+        binding.variant_index =
+            actual.type == HirTypeKind::Variant ? actual.variant_index : 0xffffffffu;
+        binding.struct_index =
+            actual.type == HirTypeKind::Struct ? actual.struct_index : 0xffffffffu;
         binding.shape_index = actual.shape_index;
         binding.tuple_len = actual.type == HirTypeKind::Tuple ? actual.tuple_len : 0;
         for (u32 i = 0; i < binding.tuple_len; i++) {
@@ -1936,7 +2036,8 @@ static bool bind_named_generic_shape(const HirModule& mod,
                                      const HirExpr& expected,
                                      const HirExpr& actual) {
     if (expected.type == HirTypeKind::Generic)
-        return bind_generic_shape(generic_bindings, generic_binding_count, expected.generic_index, actual);
+        return bind_generic_shape(
+            generic_bindings, generic_binding_count, expected.generic_index, actual);
     if (expected.type == HirTypeKind::Struct) {
         if (actual.type != HirTypeKind::Struct || expected.struct_index >= mod.structs.len ||
             actual.struct_index >= mod.structs.len)
@@ -1967,7 +2068,8 @@ static bool bind_named_generic_shape(const HirModule& mod,
                                                              est.instance_tuple_variant_indices[i],
                                                              est.instance_tuple_struct_indices[i],
                                                              est.instance_shape_indices[i]);
-            if (!bind_named_generic_shape(mod, generic_bindings, generic_binding_count, expected_arg, actual_arg))
+            if (!bind_named_generic_shape(
+                    mod, generic_bindings, generic_binding_count, expected_arg, actual_arg))
                 return false;
         }
         return true;
@@ -2002,7 +2104,8 @@ static bool bind_named_generic_shape(const HirModule& mod,
                                                              est.instance_tuple_variant_indices[i],
                                                              est.instance_tuple_struct_indices[i],
                                                              est.instance_shape_indices[i]);
-            if (!bind_named_generic_shape(mod, generic_bindings, generic_binding_count, expected_arg, actual_arg))
+            if (!bind_named_generic_shape(
+                    mod, generic_bindings, generic_binding_count, expected_arg, actual_arg))
                 return false;
         }
         return true;
@@ -2020,18 +2123,17 @@ static FrontendResult<void> apply_declared_type_to_expr(HirExpr* expr,
     HirTypeKind tuple_types[kMaxTupleSlots]{};
     u32 tuple_variant_indices[kMaxTupleSlots]{};
     u32 tuple_struct_indices[kMaxTupleSlots]{};
-    auto declared =
-        resolve_func_type_ref(mod,
-                              stmt.type,
-                              nullptr,
-                              nullptr,
-                              variant_index,
-                              struct_index,
-                              tuple_len,
-                              tuple_types,
-                              tuple_variant_indices,
-                              tuple_struct_indices,
-                              stmt.span);
+    auto declared = resolve_func_type_ref(mod,
+                                          stmt.type,
+                                          nullptr,
+                                          nullptr,
+                                          variant_index,
+                                          struct_index,
+                                          tuple_len,
+                                          tuple_types,
+                                          tuple_variant_indices,
+                                          tuple_struct_indices,
+                                          stmt.span);
     if (!declared) return core::make_unexpected(declared.error());
     auto declared_shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
                                                 declared.value(),
@@ -2056,15 +2158,14 @@ static FrontendResult<void> apply_declared_type_to_expr(HirExpr* expr,
             expr->tuple_struct_indices[i] = tuple_struct_indices[i];
         }
     }
-    const auto expected = make_expected_type_expr(
-        declared.value(),
-        variant_index,
-        struct_index,
-        tuple_len,
-        tuple_types,
-        tuple_variant_indices,
-        tuple_struct_indices,
-        declared_shape.value());
+    const auto expected = make_expected_type_expr(declared.value(),
+                                                  variant_index,
+                                                  struct_index,
+                                                  tuple_len,
+                                                  tuple_types,
+                                                  tuple_variant_indices,
+                                                  tuple_struct_indices,
+                                                  declared_shape.value());
     if (!same_hir_type_shape(mod, *expr, expected))
         return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
     return {};
@@ -2074,11 +2175,8 @@ static KnownValueState known_value_state(const HirExpr& expr,
                                          const HirLocal* locals,
                                          u32 local_count,
                                          u32 depth);
-static bool const_eval_expr(const HirExpr& expr,
-                            const HirLocal* locals,
-                            u32 local_count,
-                            ConstValue* out,
-                            u32 depth);
+static bool const_eval_expr(
+    const HirExpr& expr, const HirLocal* locals, u32 local_count, ConstValue* out, u32 depth);
 static KnownErrorCase known_error_case(const HirExpr& expr,
                                        const HirLocal* locals,
                                        u32 local_count,
@@ -2104,11 +2202,8 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
                                                          u32 arg_count,
                                                          const GenericBinding* generic_bindings,
                                                          u32 generic_binding_count);
-static FrontendResult<HirExpr> normalize_function_expr(const HirExpr& expr,
-                                                       HirFunction* fn,
-                                                       const HirLocal* locals,
-                                                       u32 local_count,
-                                                       u32 param_count);
+static FrontendResult<HirExpr> normalize_function_expr(
+    const HirExpr& expr, HirFunction* fn, const HirLocal* locals, u32 local_count, u32 param_count);
 static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& stmt,
                                                           HirRoute* scratch,
                                                           const HirModule& mod,
@@ -2119,14 +2214,14 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                                                  HirRoute* route,
                                                  const HirModule& mod,
                                                  const MatchPayloadBinding* binding);
-static FrontendResult<void> collect_named_error_cases(const HirExpr& expr,
-                                                      FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases);
+static FrontendResult<void> collect_named_error_cases(
+    const HirExpr& expr, FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases);
 static FrontendResult<void> collect_named_error_cases_ast(
-    const AstStatement& stmt,
-    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases);
-static void patch_named_error_variant(HirExpr* expr,
-                                      u32 variant_index,
-                                      const FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases);
+    const AstStatement& stmt, FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases);
+static void patch_named_error_variant(
+    HirExpr* expr,
+    u32 variant_index,
+    const FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases);
 static FrontendResult<HirExpr> analyze_known_error_field(const HirExpr& base,
                                                          Str field_name,
                                                          Span span,
@@ -2185,8 +2280,10 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         variant_expr.name = qualified_type_name;
         variant_expr.type_args = expr.lhs->type_args;
         variant_expr.str_value = expr.name;
-        if (expr.args.len == 1) variant_expr.lhs = expr.args[0];
-        else if (expr.args.len > 1) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.args.len == 1)
+            variant_expr.lhs = expr.args[0];
+        else if (expr.args.len > 1)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         auto variant = analyze_expr(variant_expr, route, mod, locals, local_count, binding);
         if (variant) return variant;
     }
@@ -2197,20 +2294,26 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         variant_expr.name = expr.lhs->name;
         variant_expr.type_args = expr.lhs->type_args;
         variant_expr.str_value = expr.name;
-        if (expr.args.len == 1) variant_expr.lhs = expr.args[0];
-        else if (expr.args.len > 1) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.args.len == 1)
+            variant_expr.lhs = expr.args[0];
+        else if (expr.args.len > 1)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         auto variant = analyze_expr(variant_expr, route, mod, locals, local_count, binding);
         if (variant) return variant;
     }
 
-    auto build_cmp = [&](HirExprKind kind, const HirExpr& lhs_expr, const HirExpr& rhs_expr) -> FrontendResult<HirExpr> {
+    auto build_cmp = [&](HirExprKind kind,
+                         const HirExpr& lhs_expr,
+                         const HirExpr& rhs_expr) -> FrontendResult<HirExpr> {
         HirExpr out{};
         out.kind = kind;
         out.type = HirTypeKind::Bool;
         out.span = expr.span;
-        if (!route->exprs.push(lhs_expr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(lhs_expr))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         out.lhs = &route->exprs[route->exprs.len - 1];
-        if (!route->exprs.push(rhs_expr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(rhs_expr))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         out.rhs = &route->exprs[route->exprs.len - 1];
         return out;
     };
@@ -2224,19 +2327,24 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
     auto recv = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
     if (!recv) return core::make_unexpected(recv.error());
     if (expr.args.len == 0 && is_standard_error_field(expr.name) &&
-        (recv->may_error || (recv->type == HirTypeKind::Generic && recv->generic_has_error_constraint))) {
+        (recv->may_error ||
+         (recv->type == HirTypeKind::Generic && recv->generic_has_error_constraint))) {
         return analyze_expr(field_expr, route, mod, locals, local_count, binding);
     }
-    if (recv->may_nil || recv->may_error) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+    if (recv->may_nil || recv->may_error)
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
 
     const bool is_eq_family = expr.name.eq({"eq", 2}) || expr.name.eq({"ne", 2});
-    const bool is_ord_family = expr.name.eq({"lt", 2}) || expr.name.eq({"gt", 2}) || expr.name.eq({"le", 2}) || expr.name.eq({"ge", 2});
+    const bool is_ord_family = expr.name.eq({"lt", 2}) || expr.name.eq({"gt", 2}) ||
+                               expr.name.eq({"le", 2}) || expr.name.eq({"ge", 2});
     if (is_eq_family || is_ord_family) {
         if (expr.args.len != 1) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         auto rhs = analyze_expr(*expr.args[0], route, mod, locals, local_count, binding);
         if (!rhs) return core::make_unexpected(rhs.error());
-        if (rhs->may_nil || rhs->may_error) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-        if (!same_hir_type_shape(mod, *recv, *rhs)) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (rhs->may_nil || rhs->may_error)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (!same_hir_type_shape(mod, *recv, *rhs))
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         if (is_eq_family) {
             if (recv->type == HirTypeKind::Generic) {
                 if (!recv->generic_has_eq_constraint)
@@ -2286,10 +2394,13 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
                     return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
                 }
             }
-            if (expr.name.eq({"lt", 2})) return build_cmp(HirExprKind::Lt, recv.value(), rhs.value());
-            if (expr.name.eq({"gt", 2})) return build_cmp(HirExprKind::Gt, recv.value(), rhs.value());
-            auto strict = expr.name.eq({"le", 2}) ? build_cmp(HirExprKind::Gt, recv.value(), rhs.value())
-                                                   : build_cmp(HirExprKind::Lt, recv.value(), rhs.value());
+            if (expr.name.eq({"lt", 2}))
+                return build_cmp(HirExprKind::Lt, recv.value(), rhs.value());
+            if (expr.name.eq({"gt", 2}))
+                return build_cmp(HirExprKind::Gt, recv.value(), rhs.value());
+            auto strict = expr.name.eq({"le", 2})
+                              ? build_cmp(HirExprKind::Gt, recv.value(), rhs.value())
+                              : build_cmp(HirExprKind::Lt, recv.value(), rhs.value());
             if (!strict) return core::make_unexpected(strict.error());
             HirExpr false_expr{};
             false_expr.kind = HirExprKind::BoolLit;
@@ -2356,8 +2467,9 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
         }
     }
-    if (recv->type == HirTypeKind::Bool || recv->type == HirTypeKind::I32 || recv->type == HirTypeKind::Str ||
-        recv->type == HirTypeKind::Struct || recv->type == HirTypeKind::Variant || recv->type == HirTypeKind::Tuple) {
+    if (recv->type == HirTypeKind::Bool || recv->type == HirTypeKind::I32 ||
+        recv->type == HirTypeKind::Str || recv->type == HirTypeKind::Struct ||
+        recv->type == HirTypeKind::Variant || recv->type == HirTypeKind::Tuple) {
         const auto* impl = find_impl_for_type(mod, recv->type, recv->struct_index, expr.name);
         if (impl != nullptr) {
             const auto* method = find_impl_method(*impl, expr.name);
@@ -2380,8 +2492,10 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         for (u32 ci = 0; ci < mod.conformances.len; ci++) {
             const auto& conf = mod.conformances[ci];
             if (conf.type != recv->type) continue;
-            if (recv->type == HirTypeKind::Struct && conf.struct_index != recv->struct_index) continue;
-            if (recv->type == HirTypeKind::Variant && conf.variant_index != recv->variant_index) continue;
+            if (recv->type == HirTypeKind::Struct && conf.struct_index != recv->struct_index)
+                continue;
+            if (recv->type == HirTypeKind::Variant && conf.variant_index != recv->variant_index)
+                continue;
             if (recv->type == HirTypeKind::Tuple) {
                 if (conf.tuple_len != recv->tuple_len) continue;
                 bool tuple_match = true;
@@ -2436,10 +2550,11 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
                                                  const MatchPayloadBinding* binding,
                                                  const HirExpr* pipe_lhs);
 
-static FrontendResult<HirExpr> make_guard_bound_init(HirRoute* route, const HirExpr& bound, Span span) {
+static FrontendResult<HirExpr> make_guard_bound_init(HirRoute* route,
+                                                     const HirExpr& bound,
+                                                     Span span) {
     if (!bound.may_error) return bound;
-    if (!route->exprs.push(bound))
-        return frontend_error(FrontendError::TooManyItems, span);
+    if (!route->exprs.push(bound)) return frontend_error(FrontendError::TooManyItems, span);
     HirExpr init{};
     init.kind = HirExprKind::ValueOf;
     init.type = bound.type;
@@ -2480,13 +2595,9 @@ static u32 next_local_ref_index(const HirRoute* route, const HirLocal* locals, u
     return next;
 }
 
-static FrontendResult<void> insert_scoped_local(HirLocal* locals,
-                                                u32& local_count,
-                                                u32 capacity,
-                                                const HirLocal& local,
-                                                Span span) {
-    if (local.ref_index >= capacity)
-        return frontend_error(FrontendError::TooManyItems, span);
+static FrontendResult<void> insert_scoped_local(
+    HirLocal* locals, u32& local_count, u32 capacity, const HirLocal& local, Span span) {
+    if (local.ref_index >= capacity) return frontend_error(FrontendError::TooManyItems, span);
     if (local_count <= local.ref_index) local_count = local.ref_index + 1;
     locals[local.ref_index] = local;
     return {};
@@ -2520,16 +2631,13 @@ static FrontendResult<HirExpr> analyze_known_error_field(const HirExpr& base,
                                                          u32 depth) {
     if (depth > 8) return frontend_error(FrontendError::UnsupportedSyntax, span);
     if (base.kind == HirExprKind::LocalRef) {
-        if (base.local_index >= local_count) return frontend_error(FrontendError::UnsupportedSyntax, span);
-        return analyze_known_error_field(locals[base.local_index].init,
-                                         field_name,
-                                         span,
-                                         mod,
-                                         locals,
-                                         local_count,
-                                         depth + 1);
+        if (base.local_index >= local_count)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
+        return analyze_known_error_field(
+            locals[base.local_index].init, field_name, span, mod, locals, local_count, depth + 1);
     }
-    if (base.kind != HirExprKind::Error) return frontend_error(FrontendError::UnsupportedSyntax, span);
+    if (base.kind != HirExprKind::Error)
+        return frontend_error(FrontendError::UnsupportedSyntax, span);
 
     if (field_name.eq({"code", 4})) {
         HirExpr out{};
@@ -2579,10 +2687,11 @@ static FrontendResult<HirExpr> analyze_match_pattern(const AstExpr& pattern_expr
                                                      const HirLocal* locals,
                                                      u32 local_count) {
     if (pattern_expr.kind == AstExprKind::VariantCase) {
-        const bool subject_is_error_kind =
-            subject.type != HirTypeKind::Variant && subject.may_error &&
-            subject.error_variant_index != 0xffffffffu;
-        u32 variant_index = subject_is_error_kind ? subject.error_variant_index : subject.variant_index;
+        const bool subject_is_error_kind = subject.type != HirTypeKind::Variant &&
+                                           subject.may_error &&
+                                           subject.error_variant_index != 0xffffffffu;
+        u32 variant_index =
+            subject_is_error_kind ? subject.error_variant_index : subject.variant_index;
         if (pattern_expr.name.len != 0) {
             variant_index = mod.variants.len;
             for (u32 i = 0; i < mod.variants.len; i++) {
@@ -2592,8 +2701,10 @@ static FrontendResult<HirExpr> analyze_match_pattern(const AstExpr& pattern_expr
                 }
             }
             if (variant_index == mod.variants.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, pattern_expr.span, pattern_expr.name);
-            if ((!subject_is_error_kind && (subject.type != HirTypeKind::Variant || subject.variant_index != variant_index)) ||
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, pattern_expr.span, pattern_expr.name);
+            if ((!subject_is_error_kind && (subject.type != HirTypeKind::Variant ||
+                                            subject.variant_index != variant_index)) ||
                 (subject_is_error_kind && subject.error_variant_index != variant_index))
                 return frontend_error(FrontendError::UnsupportedSyntax, pattern_expr.span);
         } else if (subject.type != HirTypeKind::Variant && !subject_is_error_kind) {
@@ -2609,7 +2720,8 @@ static FrontendResult<HirExpr> analyze_match_pattern(const AstExpr& pattern_expr
             }
         }
         if (case_index == variant.cases.len)
-            return frontend_error(FrontendError::UnsupportedSyntax, pattern_expr.span, pattern_expr.str_value);
+            return frontend_error(
+                FrontendError::UnsupportedSyntax, pattern_expr.span, pattern_expr.str_value);
 
         const auto& case_decl = variant.cases[case_index];
         if (case_decl.has_payload) {
@@ -2660,7 +2772,8 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
                                                          const GenericBinding* generic_bindings,
                                                          u32 generic_binding_count) {
     HirExpr out = apply_generic_binding_to_expr(expr, generic_bindings, generic_binding_count);
-    auto concretized = concretize_named_instance_shape(&out, mod, generic_bindings, generic_binding_count);
+    auto concretized =
+        concretize_named_instance_shape(&out, mod, generic_bindings, generic_binding_count);
     if (!concretized) return core::make_unexpected(concretized.error());
     out.lhs = nullptr;
     out.rhs = nullptr;
@@ -2672,19 +2785,21 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         HirExpr arg = args[expr.local_index];
         arg.span = expr.span;
-        auto concretized = concretize_named_instance_shape(&arg, mod, generic_bindings, generic_binding_count);
+        auto concretized =
+            concretize_named_instance_shape(&arg, mod, generic_bindings, generic_binding_count);
         if (!concretized) return core::make_unexpected(concretized.error());
         return arg;
     }
 
     if (expr.kind == HirExprKind::ProtocolCall) {
-        if (expr.lhs == nullptr)
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-        auto recv = instantiate_function_expr(*expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        if (expr.lhs == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        auto recv = instantiate_function_expr(
+            *expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
         if (!recv) return core::make_unexpected(recv.error());
         if (recv->type == HirTypeKind::Generic)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
-        const HirImpl* impl = find_impl_for_type(mod, recv->type, recv->struct_index, expr.str_value);
+        const HirImpl* impl =
+            find_impl_for_type(mod, recv->type, recv->struct_index, expr.str_value);
         u32 function_index = 0xffffffffu;
         if (impl != nullptr) {
             const auto* method = find_impl_method(*impl, expr.str_value);
@@ -2694,7 +2809,8 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
         } else {
             if (expr.protocol_index >= mod.protocols.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
-            const auto* req = find_protocol_method(mod.protocols[expr.protocol_index], expr.str_value);
+            const auto* req =
+                find_protocol_method(mod.protocols[expr.protocol_index], expr.str_value);
             if (req == nullptr || req->function_index == 0xffffffffu)
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
             function_index = req->function_index;
@@ -2704,15 +2820,21 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
         u32 call_arg_count = 0;
         call_args[call_arg_count++] = recv.value();
         for (u32 i = 0; i < expr.args.len; i++) {
-            auto arg = instantiate_function_expr(*expr.args[i], route, mod, args, arg_count, generic_bindings, generic_binding_count);
+            auto arg = instantiate_function_expr(*expr.args[i],
+                                                 route,
+                                                 mod,
+                                                 args,
+                                                 arg_count,
+                                                 generic_bindings,
+                                                 generic_binding_count);
             if (!arg) return core::make_unexpected(arg.error());
             call_args[call_arg_count++] = arg.value();
         }
         GenericBinding impl_bindings[HirFunction::kMaxTypeParams]{};
         u32 impl_binding_count = 0;
         if (impl != nullptr) {
-            auto impl_filled =
-                fill_impl_generic_bindings(mod, *impl, recv->struct_index, impl_bindings, impl_binding_count);
+            auto impl_filled = fill_impl_generic_bindings(
+                mod, *impl, recv->struct_index, impl_bindings, impl_binding_count);
             if (!impl_filled) return core::make_unexpected(impl_filled.error());
             if (!impl_filled.value())
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
@@ -2734,13 +2856,8 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
                                                                 expr.span);
             if (!filled) return core::make_unexpected(filled.error());
         }
-        auto inlined = instantiate_function_expr(fn.body,
-                                                 route,
-                                                 mod,
-                                                 call_args,
-                                                 call_arg_count,
-                                                 impl_bindings,
-                                                 impl_binding_count);
+        auto inlined = instantiate_function_expr(
+            fn.body, route, mod, call_args, call_arg_count, impl_bindings, impl_binding_count);
         if (!inlined) return core::make_unexpected(inlined.error());
         if (fn.return_type != HirTypeKind::Unknown &&
             (inlined->kind == HirExprKind::Nil || inlined->kind == HirExprKind::Error)) {
@@ -2757,19 +2874,24 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
                 expected.tuple_struct_indices[i] = fn.return_tuple_struct_indices[i];
             }
             if (fn.return_generic_index < fn.type_params.len) {
-                expected.generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
-                expected.generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
-                expected.generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+                expected.generic_has_error_constraint =
+                    fn.type_params[fn.return_generic_index].has_error_constraint;
+                expected.generic_has_eq_constraint =
+                    fn.type_params[fn.return_generic_index].has_eq_constraint;
+                expected.generic_has_ord_constraint =
+                    fn.type_params[fn.return_generic_index].has_ord_constraint;
                 expected.generic_protocol_index =
                     fn.type_params[fn.return_generic_index].custom_protocol_count != 0
                         ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
                         : 0xffffffffu;
-                expected.generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+                expected.generic_protocol_count =
+                    fn.type_params[fn.return_generic_index].custom_protocol_count;
                 for (u32 cpi = 0; cpi < expected.generic_protocol_count; cpi++)
                     expected.generic_protocol_indices[cpi] =
                         fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
             }
-            auto concrete = apply_generic_binding_to_expr(expected, impl_bindings, impl_binding_count);
+            auto concrete =
+                apply_generic_binding_to_expr(expected, impl_bindings, impl_binding_count);
             auto concretized =
                 concretize_named_instance_shape(&concrete, mod, impl_bindings, impl_binding_count);
             if (!concretized) return core::make_unexpected(concretized.error());
@@ -2799,8 +2921,7 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
     }
 
     if (expr.kind == HirExprKind::TupleSlot) {
-        if (expr.lhs == nullptr)
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.lhs == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         auto lhs = instantiate_function_expr(
             *expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
         if (!lhs) return core::make_unexpected(lhs.error());
@@ -2825,16 +2946,16 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
     if (expr.kind == HirExprKind::Or) {
         if (expr.lhs == nullptr || expr.rhs == nullptr)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-        auto lhs =
-            instantiate_function_expr(*expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        auto lhs = instantiate_function_expr(
+            *expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (!lhs->may_nil && !lhs->may_error) {
             HirExpr out_lhs = lhs.value();
             out_lhs.span = expr.span;
             return out_lhs;
         }
-        auto rhs =
-            instantiate_function_expr(*expr.rhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        auto rhs = instantiate_function_expr(
+            *expr.rhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
         if (!rhs) return core::make_unexpected(rhs.error());
         HirExpr out_or = expr;
         if (!route->exprs.push(lhs.value()))
@@ -2848,24 +2969,29 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
     }
 
     if (expr.lhs != nullptr) {
-        auto lhs =
-            instantiate_function_expr(*expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        auto lhs = instantiate_function_expr(
+            *expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (!route->exprs.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
         out.lhs = &route->exprs[route->exprs.len - 1];
     }
     if (expr.rhs != nullptr) {
-        auto rhs =
-            instantiate_function_expr(*expr.rhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        auto rhs = instantiate_function_expr(
+            *expr.rhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
         if (!rhs) return core::make_unexpected(rhs.error());
         if (!route->exprs.push(rhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
         out.rhs = &route->exprs[route->exprs.len - 1];
     }
     for (u32 i = 0; i < expr.field_inits.len; i++) {
-        auto val = instantiate_function_expr(
-            *expr.field_inits[i].value, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        auto val = instantiate_function_expr(*expr.field_inits[i].value,
+                                             route,
+                                             mod,
+                                             args,
+                                             arg_count,
+                                             generic_bindings,
+                                             generic_binding_count);
         if (!val) return core::make_unexpected(val.error());
         if (!route->exprs.push(val.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -2876,8 +3002,8 @@ static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
             return frontend_error(FrontendError::TooManyItems, expr.span);
     }
     for (u32 i = 0; i < expr.args.len; i++) {
-        auto arg =
-            instantiate_function_expr(*expr.args[i], route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        auto arg = instantiate_function_expr(
+            *expr.args[i], route, mod, args, arg_count, generic_bindings, generic_binding_count);
         if (!arg) return core::make_unexpected(arg.error());
         if (!route->exprs.push(arg.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -2903,12 +3029,12 @@ static FrontendResult<HirExpr> normalize_function_expr(const HirExpr& expr,
         if (expr.local_index >= local_count)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         if (expr.local_index < param_count) return expr;
-        return normalize_function_expr(locals[expr.local_index].init, fn, locals, local_count, param_count);
+        return normalize_function_expr(
+            locals[expr.local_index].init, fn, locals, local_count, param_count);
     }
 
     if (expr.kind == HirExprKind::TupleSlot) {
-        if (expr.lhs == nullptr)
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.lhs == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         auto lhs = normalize_function_expr(*expr.lhs, fn, locals, local_count, param_count);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (lhs->type != HirTypeKind::Tuple)
@@ -2943,7 +3069,8 @@ static FrontendResult<HirExpr> normalize_function_expr(const HirExpr& expr,
         out.rhs = &fn->exprs[fn->exprs.len - 1];
     }
     for (u32 i = 0; i < expr.field_inits.len; i++) {
-        auto val = normalize_function_expr(*expr.field_inits[i].value, fn, locals, local_count, param_count);
+        auto val = normalize_function_expr(
+            *expr.field_inits[i].value, fn, locals, local_count, param_count);
         if (!val) return core::make_unexpected(val.error());
         if (!fn->exprs.push(val.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -3024,13 +3151,15 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
         out->generic_has_error_constraint = merged_generic_has_error_constraint;
         out->generic_has_eq_constraint = merged_generic_has_eq_constraint;
         out->generic_has_ord_constraint = merged_generic_has_ord_constraint;
-        out->generic_protocol_index =
-            lhs.generic_protocol_index != 0xffffffffu ? lhs.generic_protocol_index : rhs.generic_protocol_index;
-        out->generic_protocol_count =
-            lhs.generic_protocol_count != 0 ? lhs.generic_protocol_count : rhs.generic_protocol_count;
+        out->generic_protocol_index = lhs.generic_protocol_index != 0xffffffffu
+                                          ? lhs.generic_protocol_index
+                                          : rhs.generic_protocol_index;
+        out->generic_protocol_count = lhs.generic_protocol_count != 0 ? lhs.generic_protocol_count
+                                                                      : rhs.generic_protocol_count;
         for (u32 i = 0; i < out->generic_protocol_count; i++) {
-            out->generic_protocol_indices[i] =
-                lhs.generic_protocol_count != 0 ? lhs.generic_protocol_indices[i] : rhs.generic_protocol_indices[i];
+            out->generic_protocol_indices[i] = lhs.generic_protocol_count != 0
+                                                   ? lhs.generic_protocol_indices[i]
+                                                   : rhs.generic_protocol_indices[i];
         }
         out->variant_index = merged_variant_index;
         out->struct_index = merged_struct_index;
@@ -3052,8 +3181,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
             const HirExpr& subject,
             const HirLocal* cur_locals,
             u32 cur_local_count) -> FrontendResult<HirExpr> {
-        if (!subject.may_error)
-            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        if (!subject.may_error) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
 
         bool seen_wildcard = false;
         bool seen_variant_cases[HirVariant::kMaxCases]{};
@@ -3067,16 +3195,16 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 if (seen_wildcard)
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 seen_wildcard = true;
-                auto body =
-                    analyze_function_body_stmt(*arm.stmt, scratch, mod, cur_locals, cur_local_count, binding);
+                auto body = analyze_function_body_stmt(
+                    *arm.stmt, scratch, mod, cur_locals, cur_local_count, binding);
                 if (!body) return core::make_unexpected(body.error());
                 result = body.value();
                 have_result = true;
                 continue;
             }
 
-            auto pattern =
-                analyze_match_pattern(arm.pattern, subject, scratch, mod, cur_locals, cur_local_count);
+            auto pattern = analyze_match_pattern(
+                arm.pattern, subject, scratch, mod, cur_locals, cur_local_count);
             if (!pattern) return core::make_unexpected(pattern.error());
             if (pattern->kind != HirExprKind::VariantCase)
                 return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
@@ -3091,8 +3219,8 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
             seen_variant_cases[case_index] = true;
             seen_variant_case_count++;
 
-            auto body =
-                analyze_function_body_stmt(*arm.stmt, scratch, mod, cur_locals, cur_local_count, binding);
+            auto body = analyze_function_body_stmt(
+                *arm.stmt, scratch, mod, cur_locals, cur_local_count, binding);
             if (!body) return core::make_unexpected(body.error());
             if (!have_result) {
                 result = body.value();
@@ -3168,10 +3296,8 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
             result = out;
         }
 
-        if (!have_result)
-            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
-        if (!seen_wildcard)
-            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        if (!have_result) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        if (!seen_wildcard) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
         if (subject.error_variant_index != 0xffffffffu) {
             const auto& variant = mod.variants[subject.error_variant_index];
             if (!seen_wildcard && seen_variant_case_count != variant.cases.len)
@@ -3188,9 +3314,11 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
         if (!cond) return core::make_unexpected(cond.error());
         if (cond->type != HirTypeKind::Bool || cond->may_nil || cond->may_error)
             return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
-        auto then_expr = analyze_function_body_stmt(*stmt.then_stmt, scratch, mod, locals, local_count, binding);
+        auto then_expr =
+            analyze_function_body_stmt(*stmt.then_stmt, scratch, mod, locals, local_count, binding);
         if (!then_expr) return core::make_unexpected(then_expr.error());
-        auto else_expr = analyze_function_body_stmt(*stmt.else_stmt, scratch, mod, locals, local_count, binding);
+        auto else_expr =
+            analyze_function_body_stmt(*stmt.else_stmt, scratch, mod, locals, local_count, binding);
         if (!else_expr) return core::make_unexpected(else_expr.error());
         HirExpr merged_shape{};
         if (!merge_expr_shape(then_expr.value(), else_expr.value(), &merged_shape))
@@ -3256,15 +3384,18 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 wildcard_arm = &arm;
                 continue;
             }
-            auto pattern = analyze_match_pattern(arm.pattern, subject.value(), scratch, mod, locals, local_count);
+            auto pattern = analyze_match_pattern(
+                arm.pattern, subject.value(), scratch, mod, locals, local_count);
             if (!pattern) return core::make_unexpected(pattern.error());
 
             bool matched = false;
             if (pattern->kind == HirExprKind::BoolLit && subject_value.type == HirTypeKind::Bool) {
                 matched = pattern->bool_value == subject_value.bool_value;
-            } else if (pattern->kind == HirExprKind::IntLit && subject_value.type == HirTypeKind::I32) {
+            } else if (pattern->kind == HirExprKind::IntLit &&
+                       subject_value.type == HirTypeKind::I32) {
                 matched = pattern->int_value == subject_value.int_value;
-            } else if (pattern->kind == HirExprKind::VariantCase && subject_value.type == HirTypeKind::Variant) {
+            } else if (pattern->kind == HirExprKind::VariantCase &&
+                       subject_value.type == HirTypeKind::Variant) {
                 matched = pattern->variant_index == subject_value.variant_index &&
                           pattern->case_index == subject_value.case_index;
             }
@@ -3274,41 +3405,57 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 mod.variants[pattern->variant_index].cases[pattern->case_index].has_payload &&
                 arm.pattern.lhs != nullptr) {
                 selected_binding.name = arm.pattern.lhs->name;
-                selected_binding.type = mod.variants[pattern->variant_index].cases[pattern->case_index].payload_type;
-                selected_binding.generic_index =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_index;
+                selected_binding.type =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_type;
+                selected_binding.generic_index = mod.variants[pattern->variant_index]
+                                                     .cases[pattern->case_index]
+                                                     .payload_generic_index;
                 selected_binding.generic_has_error_constraint =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_error_constraint;
-                selected_binding.generic_has_eq_constraint =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_eq_constraint;
+                    mod.variants[pattern->variant_index]
+                        .cases[pattern->case_index]
+                        .payload_generic_has_error_constraint;
+                selected_binding.generic_has_eq_constraint = mod.variants[pattern->variant_index]
+                                                                 .cases[pattern->case_index]
+                                                                 .payload_generic_has_eq_constraint;
                 selected_binding.generic_has_ord_constraint =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_ord_constraint;
-                selected_binding.generic_protocol_index =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_protocol_index;
-                selected_binding.generic_protocol_count =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_protocol_count;
+                    mod.variants[pattern->variant_index]
+                        .cases[pattern->case_index]
+                        .payload_generic_has_ord_constraint;
+                selected_binding.generic_protocol_index = mod.variants[pattern->variant_index]
+                                                              .cases[pattern->case_index]
+                                                              .payload_generic_protocol_index;
+                selected_binding.generic_protocol_count = mod.variants[pattern->variant_index]
+                                                              .cases[pattern->case_index]
+                                                              .payload_generic_protocol_count;
                 for (u32 cpi = 0; cpi < selected_binding.generic_protocol_count; cpi++) {
                     selected_binding.generic_protocol_indices[cpi] =
                         mod.variants[pattern->variant_index]
                             .cases[pattern->case_index]
                             .payload_generic_protocol_indices[cpi];
                 }
-                selected_binding.variant_index =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_variant_index;
-                selected_binding.struct_index =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_struct_index;
-                selected_binding.shape_index =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_shape_index;
-                selected_binding.tuple_len =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_tuple_len;
+                selected_binding.variant_index = mod.variants[pattern->variant_index]
+                                                     .cases[pattern->case_index]
+                                                     .payload_variant_index;
+                selected_binding.struct_index = mod.variants[pattern->variant_index]
+                                                    .cases[pattern->case_index]
+                                                    .payload_struct_index;
+                selected_binding.shape_index = mod.variants[pattern->variant_index]
+                                                   .cases[pattern->case_index]
+                                                   .payload_shape_index;
+                selected_binding.tuple_len = mod.variants[pattern->variant_index]
+                                                 .cases[pattern->case_index]
+                                                 .payload_tuple_len;
                 for (u32 ti = 0; ti < selected_binding.tuple_len; ti++) {
-                    selected_binding.tuple_types[ti] =
-                        mod.variants[pattern->variant_index].cases[pattern->case_index].payload_tuple_types[ti];
+                    selected_binding.tuple_types[ti] = mod.variants[pattern->variant_index]
+                                                           .cases[pattern->case_index]
+                                                           .payload_tuple_types[ti];
                     selected_binding.tuple_variant_indices[ti] =
-                        mod.variants[pattern->variant_index].cases[pattern->case_index]
+                        mod.variants[pattern->variant_index]
+                            .cases[pattern->case_index]
                             .payload_tuple_variant_indices[ti];
                     selected_binding.tuple_struct_indices[ti] =
-                        mod.variants[pattern->variant_index].cases[pattern->case_index]
+                        mod.variants[pattern->variant_index]
+                            .cases[pattern->case_index]
                             .payload_tuple_struct_indices[ti];
                 }
                 selected_binding.case_index = pattern->case_index;
@@ -3347,15 +3494,16 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 if (seen_wildcard)
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 seen_wildcard = true;
-                auto body =
-                    analyze_function_body_stmt(*arm.stmt, scratch, mod, locals, local_count, binding);
+                auto body = analyze_function_body_stmt(
+                    *arm.stmt, scratch, mod, locals, local_count, binding);
                 if (!body) return core::make_unexpected(body.error());
                 result = body.value();
                 have_result = true;
                 continue;
             }
 
-            auto pattern = analyze_match_pattern(arm.pattern, subject.value(), scratch, mod, locals, local_count);
+            auto pattern = analyze_match_pattern(
+                arm.pattern, subject.value(), scratch, mod, locals, local_count);
             if (!pattern) return core::make_unexpected(pattern.error());
             if (pattern->kind != HirExprKind::BoolLit && pattern->kind != HirExprKind::IntLit &&
                 pattern->kind != HirExprKind::VariantCase)
@@ -3383,21 +3531,27 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                     arm_binding.name = arm.pattern.lhs->name;
                     arm_binding.type = case_decl.payload_type;
                     arm_binding.generic_index = case_decl.payload_generic_index;
-                    arm_binding.generic_has_error_constraint = case_decl.payload_generic_has_error_constraint;
-                    arm_binding.generic_has_eq_constraint = case_decl.payload_generic_has_eq_constraint;
-                    arm_binding.generic_has_ord_constraint = case_decl.payload_generic_has_ord_constraint;
+                    arm_binding.generic_has_error_constraint =
+                        case_decl.payload_generic_has_error_constraint;
+                    arm_binding.generic_has_eq_constraint =
+                        case_decl.payload_generic_has_eq_constraint;
+                    arm_binding.generic_has_ord_constraint =
+                        case_decl.payload_generic_has_ord_constraint;
                     arm_binding.generic_protocol_index = case_decl.payload_generic_protocol_index;
                     arm_binding.generic_protocol_count = case_decl.payload_generic_protocol_count;
                     for (u32 cpi = 0; cpi < arm_binding.generic_protocol_count; cpi++)
-                        arm_binding.generic_protocol_indices[cpi] = case_decl.payload_generic_protocol_indices[cpi];
+                        arm_binding.generic_protocol_indices[cpi] =
+                            case_decl.payload_generic_protocol_indices[cpi];
                     arm_binding.variant_index = case_decl.payload_variant_index;
                     arm_binding.struct_index = case_decl.payload_struct_index;
                     arm_binding.shape_index = case_decl.payload_shape_index;
                     arm_binding.tuple_len = case_decl.payload_tuple_len;
                     for (u32 ti = 0; ti < arm_binding.tuple_len; ti++) {
                         arm_binding.tuple_types[ti] = case_decl.payload_tuple_types[ti];
-                        arm_binding.tuple_variant_indices[ti] = case_decl.payload_tuple_variant_indices[ti];
-                        arm_binding.tuple_struct_indices[ti] = case_decl.payload_tuple_struct_indices[ti];
+                        arm_binding.tuple_variant_indices[ti] =
+                            case_decl.payload_tuple_variant_indices[ti];
+                        arm_binding.tuple_struct_indices[ti] =
+                            case_decl.payload_tuple_struct_indices[ti];
                     }
                     arm_binding.case_index = case_index;
                     arm_binding.subject = subject_ptr;
@@ -3405,8 +3559,8 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 }
             }
 
-            auto body =
-                analyze_function_body_stmt(*arm.stmt, scratch, mod, locals, local_count, arm_binding_ptr);
+            auto body = analyze_function_body_stmt(
+                *arm.stmt, scratch, mod, locals, local_count, arm_binding_ptr);
             if (!body) return core::make_unexpected(body.error());
             if (!have_result) {
                 result = body.value();
@@ -3466,8 +3620,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
             result = out;
         }
 
-        if (!have_result)
-            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        if (!have_result) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
         if (result.type == HirTypeKind::Unknown && !result.may_nil && !result.may_error)
             return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
         if (!seen_wildcard) {
@@ -3484,14 +3637,17 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
         HirLocal scoped[HirRoute::kMaxLocals]{};
         for (u32 i = 0; i < local_count; i++) scoped[i] = locals[i];
         u32 scoped_count = local_count;
-        auto analyze_block_tail =
-            [&](auto&& self, u32 si, const HirLocal* cur_locals, u32 cur_local_count) -> FrontendResult<HirExpr> {
+        auto analyze_block_tail = [&](auto&& self,
+                                      u32 si,
+                                      const HirLocal* cur_locals,
+                                      u32 cur_local_count) -> FrontendResult<HirExpr> {
             if (si >= stmt.block_stmts.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
             const auto& inner = *stmt.block_stmts[si];
             const bool is_last = si + 1 == stmt.block_stmts.len;
             if (inner.kind == AstStmtKind::Let && !is_last) {
-                auto init = analyze_expr(inner.expr, scratch, mod, cur_locals, cur_local_count, nullptr);
+                auto init =
+                    analyze_expr(inner.expr, scratch, mod, cur_locals, cur_local_count, nullptr);
                 if (!init) return core::make_unexpected(init.error());
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, inner);
                 if (!typed) return core::make_unexpected(typed.error());
@@ -3527,17 +3683,19 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 local.error_variant_index = init->error_variant_index;
                 local.shape_index = init->shape_index;
                 local.init = init.value();
-                auto inserted =
-                    insert_scoped_local(next_locals, next_count, HirRoute::kMaxLocals, local, inner.span);
+                auto inserted = insert_scoped_local(
+                    next_locals, next_count, HirRoute::kMaxLocals, local, inner.span);
                 if (!inserted) return core::make_unexpected(inserted.error());
                 if (!scratch->locals.push(local))
                     return frontend_error(FrontendError::TooManyItems, inner.span);
                 return self(self, si + 1, next_locals, next_count);
             }
             if (inner.kind == AstStmtKind::Guard && !is_last) {
-                auto bound = analyze_expr(inner.expr, scratch, mod, cur_locals, cur_local_count, nullptr);
+                auto bound =
+                    analyze_expr(inner.expr, scratch, mod, cur_locals, cur_local_count, nullptr);
                 if (!bound) return core::make_unexpected(bound.error());
-                auto cond = analyze_guard_cond(inner.expr, scratch, mod, cur_locals, cur_local_count);
+                auto cond =
+                    analyze_guard_cond(inner.expr, scratch, mod, cur_locals, cur_local_count);
                 if (!cond) return core::make_unexpected(cond.error());
 
                 HirLocal succ_locals[HirRoute::kMaxLocals]{};
@@ -3576,8 +3734,8 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                     auto init = make_guard_bound_init(scratch, bound.value(), inner.span);
                     if (!init) return core::make_unexpected(init.error());
                     local.init = init.value();
-                    auto inserted =
-                        insert_scoped_local(succ_locals, succ_count, HirRoute::kMaxLocals, local, inner.span);
+                    auto inserted = insert_scoped_local(
+                        succ_locals, succ_count, HirRoute::kMaxLocals, local, inner.span);
                     if (!inserted) return core::make_unexpected(inserted.error());
                     if (!scratch->locals.push(local))
                         return frontend_error(FrontendError::TooManyItems, inner.span);
@@ -3585,7 +3743,8 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
 
                 auto then_expr = self(self, si + 1, succ_locals, succ_count);
                 if (!then_expr) return core::make_unexpected(then_expr.error());
-                FrontendResult<HirExpr> else_expr = frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                FrontendResult<HirExpr> else_expr =
+                    frontend_error(FrontendError::UnsupportedSyntax, inner.span);
                 if (inner.match_arms.len != 0) {
                     else_expr = analyze_function_guard_match_expr(
                         inner.match_arms, bound.value(), cur_locals, cur_local_count);
@@ -3637,7 +3796,8 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
             }
             if (!is_last && inner.kind != AstStmtKind::Let && inner.kind != AstStmtKind::Guard)
                 return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
-            return analyze_function_body_stmt(inner, scratch, mod, cur_locals, cur_local_count, binding);
+            return analyze_function_body_stmt(
+                inner, scratch, mod, cur_locals, cur_local_count, binding);
         };
         return analyze_block_tail(analyze_block_tail, 0, scoped, scoped_count);
         return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
@@ -3681,7 +3841,8 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         if (expr.lhs != nullptr) {
             if (expr.lhs->kind == AstExprKind::Ident) {
                 if (!has_import_namespace(mod, expr.lhs->name) ||
-                    !resolve_import_namespace_type_name(mod, expr.lhs->name, expr.name, resolved_struct_name))
+                    !resolve_import_namespace_type_name(
+                        mod, expr.lhs->name, expr.name, resolved_struct_name))
                     return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
             } else {
                 if (!resolve_import_namespace_member(mod, *expr.lhs, resolved_struct_name))
@@ -3694,7 +3855,8 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         u32 concrete_struct_index = struct_index;
         if (mod.structs[struct_index].type_params.len != 0) {
             GenericBinding bindings[HirStruct::kMaxTypeParams]{};
-            if (expr.type_args.len != 0 && expr.type_args.len != mod.structs[struct_index].type_params.len)
+            if (expr.type_args.len != 0 &&
+                expr.type_args.len != mod.structs[struct_index].type_params.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
             if (expr.type_args.len != 0) {
                 for (u32 i = 0; i < expr.type_args.len; i++) {
@@ -3716,18 +3878,19 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                                           tuple_struct_indices,
                                                           expr.span);
                     if (!type_arg) return core::make_unexpected(type_arg.error());
-                    auto filled = fill_bound_binding_from_type_metadata(&bindings[i],
-                                                                        const_cast<HirModule*>(&mod),
-                                                                        type_arg.value(),
-                                                                        0xffffffffu,
-                                                                        type_variant_index,
-                                                                        type_struct_index,
-                                                                        tuple_len,
-                                                                        tuple_types,
-                                                                        tuple_variant_indices,
-                                                                        tuple_struct_indices,
-                                                                        0xffffffffu,
-                                                                        expr.span);
+                    auto filled =
+                        fill_bound_binding_from_type_metadata(&bindings[i],
+                                                              const_cast<HirModule*>(&mod),
+                                                              type_arg.value(),
+                                                              0xffffffffu,
+                                                              type_variant_index,
+                                                              type_struct_index,
+                                                              tuple_len,
+                                                              tuple_types,
+                                                              tuple_variant_indices,
+                                                              tuple_struct_indices,
+                                                              0xffffffffu,
+                                                              expr.span);
                     if (!filled) return core::make_unexpected(filled.error());
                 }
             } else {
@@ -3736,19 +3899,22 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                 for (u32 fi = 0; fi < expr.field_inits.len; fi++) {
                     u32 field_index = mod.structs[struct_index].fields.len;
                     for (u32 decl_i = 0; decl_i < mod.structs[struct_index].fields.len; decl_i++) {
-                        if (mod.structs[struct_index].fields[decl_i].name.eq(expr.field_inits[fi].name)) {
+                        if (mod.structs[struct_index].fields[decl_i].name.eq(
+                                expr.field_inits[fi].name)) {
                             field_index = decl_i;
                             break;
                         }
                     }
                     if (field_index == mod.structs[struct_index].fields.len)
-                        return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
                     const auto& field_decl = mod.structs[struct_index].fields[field_index];
-                    auto field_value =
-                        analyze_expr(*expr.field_inits[fi].value, route, mod, locals, local_count, binding);
+                    auto field_value = analyze_expr(
+                        *expr.field_inits[fi].value, route, mod, locals, local_count, binding);
                     if (!field_value) return core::make_unexpected(field_value.error());
                     if (field_value->may_nil || field_value->may_error)
-                        return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              expr.field_inits[fi].value->span);
                     bool bound = false;
                     if (field_decl.generic_index != 0xffffffffu) {
                         bound = bind_generic_shape(bindings,
@@ -3757,14 +3923,15 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                                    field_value.value());
                     } else if (field_decl.template_variant_index != 0xffffffffu ||
                                field_decl.template_struct_index != 0xffffffffu) {
-                        const auto expected = make_expected_type_expr(field_decl.type,
-                                                                      field_decl.variant_index,
-                                                                      field_decl.struct_index,
-                                                                      field_decl.tuple_len,
-                                                                      field_decl.tuple_types,
-                                                                      field_decl.tuple_variant_indices,
-                                                                      field_decl.tuple_struct_indices,
-                                                                      field_decl.shape_index);
+                        const auto expected =
+                            make_expected_type_expr(field_decl.type,
+                                                    field_decl.variant_index,
+                                                    field_decl.struct_index,
+                                                    field_decl.tuple_len,
+                                                    field_decl.tuple_types,
+                                                    field_decl.tuple_variant_indices,
+                                                    field_decl.tuple_struct_indices,
+                                                    field_decl.shape_index);
                         bound = bind_named_generic_shape(mod,
                                                          bindings,
                                                          mod.structs[struct_index].type_params.len,
@@ -3774,19 +3941,19 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                         bound = true;
                     }
                     if (!bound)
-                        return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              expr.field_inits[fi].value->span);
                 }
             }
             for (u32 i = 0; i < mod.structs[struct_index].type_params.len; i++) {
                 if (!bindings[i].bound)
                     return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
             }
-            auto concrete_index =
-                instantiate_struct(const_cast<HirModule*>(&mod),
-                                   struct_index,
-                                   bindings,
-                                   mod.structs[struct_index].type_params.len,
-                                   expr.span);
+            auto concrete_index = instantiate_struct(const_cast<HirModule*>(&mod),
+                                                     struct_index,
+                                                     bindings,
+                                                     mod.structs[struct_index].type_params.len,
+                                                     expr.span);
             if (!concrete_index) return core::make_unexpected(concrete_index.error());
             concrete_struct_index = concrete_index.value();
         } else if (expr.type_args.len != 0) {
@@ -3813,23 +3980,27 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         for (u32 fi = 0; fi < expr.field_inits.len; fi++) {
             for (u32 seen = 0; seen < fi; seen++) {
                 if (expr.field_inits[seen].name.eq(expr.field_inits[fi].name))
-                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
             }
             u32 field_index = mod.structs[concrete_struct_index].fields.len;
             for (u32 decl_i = 0; decl_i < mod.structs[concrete_struct_index].fields.len; decl_i++) {
-                if (mod.structs[concrete_struct_index].fields[decl_i].name.eq(expr.field_inits[fi].name)) {
+                if (mod.structs[concrete_struct_index].fields[decl_i].name.eq(
+                        expr.field_inits[fi].name)) {
                     field_index = decl_i;
                     break;
                 }
             }
             if (field_index == mod.structs[concrete_struct_index].fields.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
             const auto& field_decl = mod.structs[concrete_struct_index].fields[field_index];
             auto field_value =
                 analyze_expr(*expr.field_inits[fi].value, route, mod, locals, local_count, binding);
             if (!field_value) return core::make_unexpected(field_value.error());
             if (field_value->may_nil || field_value->may_error)
-                return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      expr.field_inits[fi].value->span);
             const auto expected = make_expected_type_expr(field_decl.type,
                                                           field_decl.variant_index,
                                                           field_decl.struct_index,
@@ -3839,7 +4010,8 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                                           field_decl.tuple_struct_indices,
                                                           field_decl.shape_index);
             if (!same_hir_type_shape(mod, field_value.value(), expected))
-                return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      expr.field_inits[fi].value->span);
             if (!route->exprs.push(field_value.value()))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
             HirExpr::FieldInit field_init{};
@@ -3884,14 +4056,16 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         auto base = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
         if (!base) return core::make_unexpected(base.error());
         const auto known_state = known_value_state(base.value(), locals, local_count, 0);
-        if (known_state == KnownValueState::Error &&
-            !expr.name.eq({"file", 4}) && !expr.name.eq({"func", 4}))
-            return analyze_known_error_field(base.value(), expr.name, expr.span, mod, locals, local_count, 0);
+        if (known_state == KnownValueState::Error && !expr.name.eq({"file", 4}) &&
+            !expr.name.eq({"func", 4}))
+            return analyze_known_error_field(
+                base.value(), expr.name, expr.span, mod, locals, local_count, 0);
         if (base->type == HirTypeKind::Struct && !base->may_error) {
             if (base->struct_index >= mod.structs.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
             const auto* field = find_struct_field(mod.structs[base->struct_index], expr.name);
-            if (!field) return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            if (!field)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
             out.kind = HirExprKind::Field;
             out.span = expr.span;
             out.type = field->type;
@@ -3925,7 +4099,8 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
             out.kind = HirExprKind::Field;
             out.span = expr.span;
-            out.type = expr.name.eq({"code", 4}) || expr.name.eq({"line", 4}) ? HirTypeKind::I32 : HirTypeKind::Str;
+            out.type = expr.name.eq({"code", 4}) || expr.name.eq({"line", 4}) ? HirTypeKind::I32
+                                                                              : HirTypeKind::Str;
             if (!route->exprs.push(base.value()))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
             out.lhs = &route->exprs[route->exprs.len - 1];
@@ -3937,7 +4112,7 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
             out.kind = HirExprKind::Field;
             out.span = expr.span;
             out.type = expr.name.eq({"code", 4}) || expr.name.eq({"line", 4}) ? HirTypeKind::I32
-                                                                               : HirTypeKind::Str;
+                                                                              : HirTypeKind::Str;
             if (!route->exprs.push(base.value()))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
             out.lhs = &route->exprs[route->exprs.len - 1];
@@ -3978,8 +4153,7 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         return out;
     }
     if (expr.kind == AstExprKind::VariantCase) {
-        if (expr.name.len == 0)
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.name.len == 0) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         u32 variant_index = mod.variants.len;
         for (u32 i = 0; i < mod.variants.len; i++) {
             if (mod.variants[i].name.eq(expr.name)) {
@@ -3991,7 +4165,8 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
         if (mod.variants[variant_index].type_params.len != 0) {
             GenericBinding bindings[HirVariant::kMaxTypeParams]{};
-            if (expr.type_args.len != 0 && expr.type_args.len != mod.variants[variant_index].type_params.len)
+            if (expr.type_args.len != 0 &&
+                expr.type_args.len != mod.variants[variant_index].type_params.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
             u32 template_case_index = mod.variants[variant_index].cases.len;
             for (u32 i = 0; i < mod.variants[variant_index].cases.len; i++) {
@@ -4023,18 +4198,19 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                                           tuple_struct_indices,
                                                           expr.span);
                     if (!type_arg) return core::make_unexpected(type_arg.error());
-                    auto filled = fill_bound_binding_from_type_metadata(&bindings[i],
-                                                                        const_cast<HirModule*>(&mod),
-                                                                        type_arg.value(),
-                                                                        0xffffffffu,
-                                                                        type_variant_index,
-                                                                        type_struct_index,
-                                                                        tuple_len,
-                                                                        tuple_types,
-                                                                        tuple_variant_indices,
-                                                                        tuple_struct_indices,
-                                                                        0xffffffffu,
-                                                                        expr.span);
+                    auto filled =
+                        fill_bound_binding_from_type_metadata(&bindings[i],
+                                                              const_cast<HirModule*>(&mod),
+                                                              type_arg.value(),
+                                                              0xffffffffu,
+                                                              type_variant_index,
+                                                              type_struct_index,
+                                                              tuple_len,
+                                                              tuple_types,
+                                                              tuple_variant_indices,
+                                                              tuple_struct_indices,
+                                                              0xffffffffu,
+                                                              expr.span);
                     if (!filled) return core::make_unexpected(filled.error());
                 }
             } else {
@@ -4052,32 +4228,33 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                                payload.value());
                 } else if (template_case_decl.payload_template_variant_index != 0xffffffffu ||
                            template_case_decl.payload_template_struct_index != 0xffffffffu) {
-                    const auto expected = make_expected_type_expr(template_case_decl.payload_type,
-                                                                  template_case_decl.payload_variant_index,
-                                                                  template_case_decl.payload_struct_index,
-                                                                  template_case_decl.payload_tuple_len,
-                                                                  template_case_decl.payload_tuple_types,
-                                                                  template_case_decl.payload_tuple_variant_indices,
-                                                                  template_case_decl.payload_tuple_struct_indices,
-                                                                  template_case_decl.payload_shape_index);
+                    const auto expected =
+                        make_expected_type_expr(template_case_decl.payload_type,
+                                                template_case_decl.payload_variant_index,
+                                                template_case_decl.payload_struct_index,
+                                                template_case_decl.payload_tuple_len,
+                                                template_case_decl.payload_tuple_types,
+                                                template_case_decl.payload_tuple_variant_indices,
+                                                template_case_decl.payload_tuple_struct_indices,
+                                                template_case_decl.payload_shape_index);
                     bound = bind_named_generic_shape(mod,
                                                      bindings,
                                                      mod.variants[variant_index].type_params.len,
                                                      expected,
                                                      payload.value());
                 }
-                if (!bound)
-                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+                if (!bound) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
                 for (u32 i = 0; i < mod.variants[variant_index].type_params.len; i++) {
                     if (!bindings[i].bound)
-                        return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, expr.span, expr.name);
                 }
             }
             auto concrete_index = instantiate_variant(const_cast<HirModule*>(&mod),
-                                                     variant_index,
-                                                     bindings,
-                                                     mod.variants[variant_index].type_params.len,
-                                                     expr.span);
+                                                      variant_index,
+                                                      bindings,
+                                                      mod.variants[variant_index].type_params.len,
+                                                      expr.span);
             if (!concrete_index) return core::make_unexpected(concrete_index.error());
             variant_index = concrete_index.value();
         } else if (expr.type_args.len != 0) {
@@ -4137,8 +4314,7 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         return out;
     }
     if (expr.kind == AstExprKind::Tuple) {
-        if (expr.args.len < 2)
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.args.len < 2) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         out.kind = HirExprKind::Tuple;
         out.type = HirTypeKind::Tuple;
         out.tuple_len = expr.args.len;
@@ -4212,7 +4388,8 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                 }
                 u32 field_index = mod.structs[struct_index].fields.len;
                 for (u32 decl_i = 0; decl_i < mod.structs[struct_index].fields.len; decl_i++) {
-                    if (mod.structs[struct_index].fields[decl_i].name.eq(expr.field_inits[fi].name)) {
+                    if (mod.structs[struct_index].fields[decl_i].name.eq(
+                            expr.field_inits[fi].name)) {
                         field_index = decl_i;
                         break;
                     }
@@ -4224,11 +4401,12 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                 if (field_decl.name.eq({"err", 3}) && field_decl.is_error_type)
                     return frontend_error(
                         FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
-                auto field_value =
-                    analyze_expr(*expr.field_inits[fi].value, route, mod, locals, local_count, binding);
+                auto field_value = analyze_expr(
+                    *expr.field_inits[fi].value, route, mod, locals, local_count, binding);
                 if (!field_value) return core::make_unexpected(field_value.error());
                 if (field_value->may_nil || field_value->may_error)
-                    return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          expr.field_inits[fi].value->span);
                 const auto expected = make_expected_type_expr(field_decl.type,
                                                               field_decl.variant_index,
                                                               field_decl.struct_index,
@@ -4238,7 +4416,8 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                                               field_decl.tuple_struct_indices,
                                                               field_decl.shape_index);
                 if (!same_hir_type_shape(mod, field_value.value(), expected))
-                    return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          expr.field_inits[fi].value->span);
                 if (!route->exprs.push(field_value.value()))
                     return frontend_error(FrontendError::TooManyItems, expr.span);
                 HirExpr::FieldInit field_init{};
@@ -4266,7 +4445,8 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                     }
                 }
                 if (case_index == variant.cases.len)
-                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.lhs->str_value);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, expr.span, expr.lhs->str_value);
                 out.error_case_index = case_index;
                 out.int_value = static_cast<i32>(case_index);
             }
@@ -4290,7 +4470,8 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         if (!rhs) return core::make_unexpected(rhs.error());
         if (rhs->may_nil || rhs->may_error)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.rhs->span);
-        if (lhs->type != HirTypeKind::Unknown && !same_hir_type_shape(mod, lhs.value(), rhs.value()))
+        if (lhs->type != HirTypeKind::Unknown &&
+            !same_hir_type_shape(mod, lhs.value(), rhs.value()))
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         if (lhs->kind == HirExprKind::Nil) {
             HirExpr folded = rhs.value();
@@ -4319,18 +4500,25 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
             folded.span = expr.span;
             return folded;
         }
-        if (!route->exprs.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
-        if (!route->exprs.push(rhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(rhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
         out.kind = HirExprKind::Or;
         out.type = lhs->type == HirTypeKind::Unknown ? rhs->type : lhs->type;
         out.lhs = lhs_ptr;
         out.rhs = rhs_ptr;
-        auto shape = intern_hir_type_shape(const_cast<HirModule*>(&mod), out.type,
-                                           out.generic_index, out.variant_index,
-                                           out.struct_index, out.tuple_len, out.tuple_types,
-                                           out.tuple_variant_indices, out.tuple_struct_indices,
+        auto shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                           out.type,
+                                           out.generic_index,
+                                           out.variant_index,
+                                           out.struct_index,
+                                           out.tuple_len,
+                                           out.tuple_types,
+                                           out.tuple_variant_indices,
+                                           out.tuple_struct_indices,
                                            expr.span);
         if (!shape) return core::make_unexpected(shape.error());
         out.shape_index = shape.value();
@@ -4345,14 +4533,16 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
             return frontend_error(FrontendError::UnsupportedSyntax, expr.rhs->span);
         return analyze_call_expr(*expr.rhs, route, mod, locals, local_count, binding, &lhs.value());
     }
-    if (expr.kind == AstExprKind::Eq || expr.kind == AstExprKind::Lt || expr.kind == AstExprKind::Gt) {
+    if (expr.kind == AstExprKind::Eq || expr.kind == AstExprKind::Lt ||
+        expr.kind == AstExprKind::Gt) {
         auto lhs = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = analyze_expr(*expr.rhs, route, mod, locals, local_count, binding);
         if (!rhs) return core::make_unexpected(rhs.error());
         if (lhs->may_nil || lhs->may_error || rhs->may_nil || rhs->may_error)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-        if (lhs->type != rhs->type) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (lhs->type != rhs->type)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         if (expr.kind == AstExprKind::Eq) {
             if (lhs->type == HirTypeKind::Generic && !lhs->generic_has_eq_constraint)
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
@@ -4377,11 +4567,15 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                 }
             }
         }
-        if (!route->exprs.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
-        if (!route->exprs.push(rhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(rhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
-        out.kind = expr.kind == AstExprKind::Eq ? HirExprKind::Eq : (expr.kind == AstExprKind::Lt ? HirExprKind::Lt : HirExprKind::Gt);
+        out.kind = expr.kind == AstExprKind::Eq
+                       ? HirExprKind::Eq
+                       : (expr.kind == AstExprKind::Lt ? HirExprKind::Lt : HirExprKind::Gt);
         out.type = HirTypeKind::Bool;
         out.lhs = lhs_ptr;
         out.rhs = rhs_ptr;
@@ -4516,15 +4710,19 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         expected.generic_index = fn.return_generic_index;
         expected.shape_index = fn.return_shape_index;
         if (fn.return_generic_index < fn.type_params.len)
-            expected.generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
+            expected.generic_has_error_constraint =
+                fn.type_params[fn.return_generic_index].has_error_constraint;
         if (fn.return_generic_index < fn.type_params.len) {
-            expected.generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
-            expected.generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+            expected.generic_has_eq_constraint =
+                fn.type_params[fn.return_generic_index].has_eq_constraint;
+            expected.generic_has_ord_constraint =
+                fn.type_params[fn.return_generic_index].has_ord_constraint;
             expected.generic_protocol_index =
                 fn.type_params[fn.return_generic_index].custom_protocol_count != 0
                     ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
                     : 0xffffffffu;
-            expected.generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+            expected.generic_protocol_count =
+                fn.type_params[fn.return_generic_index].custom_protocol_count;
             for (u32 cpi = 0; cpi < expected.generic_protocol_count; cpi++)
                 expected.generic_protocol_indices[cpi] =
                     fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
@@ -4538,11 +4736,13 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             expected.tuple_struct_indices[i] = fn.return_tuple_struct_indices[i];
         }
         auto out = apply_generic_binding_to_expr(expected, generic_bindings, fn.type_params.len);
-        auto concretized = concretize_named_instance_shape(&out, mod, generic_bindings, fn.type_params.len);
+        auto concretized =
+            concretize_named_instance_shape(&out, mod, generic_bindings, fn.type_params.len);
         if (!concretized) return core::make_unexpected(concretized.error());
         return out;
     };
-    auto placeholder_slot_expr = [&](const HirExpr& source, i32 slot, Span span) -> FrontendResult<HirExpr> {
+    auto placeholder_slot_expr =
+        [&](const HirExpr& source, i32 slot, Span span) -> FrontendResult<HirExpr> {
         if (slot <= 0 || slot > static_cast<i32>(kMaxTupleSlots))
             return frontend_error(FrontendError::UnsupportedSyntax, span);
         if (source.type != HirTypeKind::Tuple) {
@@ -4557,8 +4757,10 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         HirExpr out{};
         out.kind = HirExprKind::TupleSlot;
         out.type = source.tuple_types[slot_index];
-        if (out.type == HirTypeKind::Struct) out.struct_index = source.tuple_struct_indices[slot_index];
-        else out.variant_index = source.tuple_variant_indices[slot_index];
+        if (out.type == HirTypeKind::Struct)
+            out.struct_index = source.tuple_struct_indices[slot_index];
+        else
+            out.variant_index = source.tuple_variant_indices[slot_index];
         auto shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
                                            out.type,
                                            out.generic_index,
@@ -4578,7 +4780,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
     };
     auto concrete_param_expr = [&](const HirFunction::ParamDecl& param) -> FrontendResult<HirExpr> {
         auto expected = make_expected_param_expr(param);
-        auto concretized = concretize_named_instance_shape(&expected, mod, generic_bindings, fn.type_params.len);
+        auto concretized =
+            concretize_named_instance_shape(&expected, mod, generic_bindings, fn.type_params.len);
         if (!concretized) return core::make_unexpected(concretized.error());
         return expected;
     };
@@ -4698,27 +4901,37 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
                                             analyzed_args[i]))
                         return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
                     if (fn.type_params[fn.params[i].generic_index].has_error_constraint &&
-                        !generic_binding_satisfies_error_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                        !generic_binding_satisfies_error_constraint(
+                            mod, generic_bindings[fn.params[i].generic_index]))
                         return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
                     if (fn.type_params[fn.params[i].generic_index].has_eq_constraint &&
-                        !generic_binding_satisfies_eq_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                        !generic_binding_satisfies_eq_constraint(
+                            mod, generic_bindings[fn.params[i].generic_index]))
                         return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
                     if (fn.type_params[fn.params[i].generic_index].has_ord_constraint &&
-                        !generic_binding_satisfies_ord_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                        !generic_binding_satisfies_ord_constraint(
+                            mod, generic_bindings[fn.params[i].generic_index]))
                         return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
                     if (fn.type_params[fn.params[i].generic_index].has_constraint &&
-                        fn.type_params[fn.params[i].generic_index].constraint_kind == HirProtocolKind::Custom &&
-                        !generic_binding_satisfies_custom_protocol(mod,
-                                                                   generic_bindings[fn.params[i].generic_index],
-                                                                   find_protocol_index(mod, fn.type_params[fn.params[i].generic_index].constraint)))
-                        return frontend_error(FrontendError::UnsupportedSyntax,
-                                              expr.args[i]->span,
-                                              fn.type_params[fn.params[i].generic_index].constraint);
+                        fn.type_params[fn.params[i].generic_index].constraint_kind ==
+                            HirProtocolKind::Custom &&
+                        !generic_binding_satisfies_custom_protocol(
+                            mod,
+                            generic_bindings[fn.params[i].generic_index],
+                            find_protocol_index(
+                                mod, fn.type_params[fn.params[i].generic_index].constraint)))
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax,
+                            expr.args[i]->span,
+                            fn.type_params[fn.params[i].generic_index].constraint);
                 } else if (fn.params[i].template_variant_index != 0xffffffffu ||
                            fn.params[i].template_struct_index != 0xffffffffu) {
                     const auto expected_shape = make_expected_param_expr(fn.params[i]);
-                    if (!bind_named_generic_shape(
-                            mod, generic_bindings, fn.type_params.len, expected_shape, analyzed_args[i]))
+                    if (!bind_named_generic_shape(mod,
+                                                  generic_bindings,
+                                                  fn.type_params.len,
+                                                  expected_shape,
+                                                  analyzed_args[i]))
                         return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
                     auto expected = concrete_param_expr(fn.params[i]);
                     if (!expected) return core::make_unexpected(expected.error());
@@ -4736,11 +4949,17 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
 
             auto ret = concrete_return_expr();
             if (!ret) return core::make_unexpected(ret.error());
-            if (ret->type != HirTypeKind::I32 && ret->type != HirTypeKind::Str && ret->type != HirTypeKind::Variant)
+            if (ret->type != HirTypeKind::I32 && ret->type != HirTypeKind::Str &&
+                ret->type != HirTypeKind::Variant)
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
 
-            auto then_expr = instantiate_function_expr(
-                fn.body, route, mod, analyzed_args, expr.args.len, generic_bindings, fn.type_params.len);
+            auto then_expr = instantiate_function_expr(fn.body,
+                                                       route,
+                                                       mod,
+                                                       analyzed_args,
+                                                       expr.args.len,
+                                                       generic_bindings,
+                                                       fn.type_params.len);
             if (!then_expr) return core::make_unexpected(then_expr.error());
             if (pipe_lhs->may_error && then_expr->may_error &&
                 (pipe_lhs->error_struct_index != then_expr->error_struct_index ||
@@ -4782,8 +5001,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             missing.shape_index = ret->shape_index;
             missing.may_nil = pipe_lhs->may_nil || then_expr->may_nil;
             missing.may_error = pipe_lhs->may_error || then_expr->may_error;
-            missing.error_struct_index = then_expr->may_error ? then_expr->error_struct_index
-                                                              : pipe_lhs->error_struct_index;
+            missing.error_struct_index =
+                then_expr->may_error ? then_expr->error_struct_index : pipe_lhs->error_struct_index;
             missing.error_variant_index = then_expr->may_error ? then_expr->error_variant_index
                                                                : pipe_lhs->error_variant_index;
             missing.lhs = lhs_ptr;
@@ -4814,8 +5033,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             out.shape_index = ret->shape_index;
             out.may_nil = pipe_lhs->may_nil || then_expr->may_nil;
             out.may_error = pipe_lhs->may_error || then_expr->may_error;
-            out.error_struct_index = then_expr->may_error ? then_expr->error_struct_index
-                                                          : pipe_lhs->error_struct_index;
+            out.error_struct_index =
+                then_expr->may_error ? then_expr->error_struct_index : pipe_lhs->error_struct_index;
             out.error_variant_index = then_expr->may_error ? then_expr->error_variant_index
                                                            : pipe_lhs->error_variant_index;
             out.lhs = cond_ptr;
@@ -4844,22 +5063,30 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             analyzed_args[i] = arg.value();
         }
         if (fn.params[i].type == HirTypeKind::Generic) {
-            if (!bind_generic_shape(generic_bindings, fn.type_params.len, fn.params[i].generic_index, analyzed_args[i]))
+            if (!bind_generic_shape(generic_bindings,
+                                    fn.type_params.len,
+                                    fn.params[i].generic_index,
+                                    analyzed_args[i]))
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
             if (fn.type_params[fn.params[i].generic_index].has_error_constraint &&
-                !generic_binding_satisfies_error_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                !generic_binding_satisfies_error_constraint(
+                    mod, generic_bindings[fn.params[i].generic_index]))
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
             if (fn.type_params[fn.params[i].generic_index].has_eq_constraint &&
-                !generic_binding_satisfies_eq_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                !generic_binding_satisfies_eq_constraint(
+                    mod, generic_bindings[fn.params[i].generic_index]))
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
             if (fn.type_params[fn.params[i].generic_index].has_ord_constraint &&
-                !generic_binding_satisfies_ord_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                !generic_binding_satisfies_ord_constraint(
+                    mod, generic_bindings[fn.params[i].generic_index]))
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
-            for (u32 cpi = 0; cpi < fn.type_params[fn.params[i].generic_index].custom_protocol_count; cpi++) {
-                const u32 proto_index = fn.type_params[fn.params[i].generic_index].custom_protocol_indices[cpi];
-                if (!generic_binding_satisfies_custom_protocol(mod,
-                                                               generic_bindings[fn.params[i].generic_index],
-                                                               proto_index))
+            for (u32 cpi = 0;
+                 cpi < fn.type_params[fn.params[i].generic_index].custom_protocol_count;
+                 cpi++) {
+                const u32 proto_index =
+                    fn.type_params[fn.params[i].generic_index].custom_protocol_indices[cpi];
+                if (!generic_binding_satisfies_custom_protocol(
+                        mod, generic_bindings[fn.params[i].generic_index], proto_index))
                     return frontend_error(FrontendError::UnsupportedSyntax,
                                           expr.args[i]->span,
                                           mod.protocols[proto_index].name);
@@ -4867,7 +5094,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         } else if (fn.params[i].template_variant_index != 0xffffffffu ||
                    fn.params[i].template_struct_index != 0xffffffffu) {
             const auto expected_shape = make_expected_param_expr(fn.params[i]);
-            if (!bind_named_generic_shape(mod, generic_bindings, fn.type_params.len, expected_shape, analyzed_args[i]))
+            if (!bind_named_generic_shape(
+                    mod, generic_bindings, fn.type_params.len, expected_shape, analyzed_args[i]))
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
             auto expected = concrete_param_expr(fn.params[i]);
             if (!expected) return core::make_unexpected(expected.error());
@@ -4882,14 +5110,15 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
     }
     if (pipe_lhs != nullptr && placeholder_count == 0)
         return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-    auto inlined =
-        instantiate_function_expr(fn.body, route, mod, analyzed_args, expr.args.len, generic_bindings, fn.type_params.len);
+    auto inlined = instantiate_function_expr(
+        fn.body, route, mod, analyzed_args, expr.args.len, generic_bindings, fn.type_params.len);
     if (!inlined) return core::make_unexpected(inlined.error());
     inlined->span = expr.span;
     return inlined.value();
 }
 
-static bool push_named_error_case(FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases, Str name) {
+static bool push_named_error_case(FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases,
+                                  Str name) {
     for (u32 i = 0; i < cases.len; i++) {
         if (cases[i].name.eq(name)) return true;
     }
@@ -4899,10 +5128,10 @@ static bool push_named_error_case(FixedVec<RouteNamedErrorCase, HirVariant::kMax
 }
 
 static FrontendResult<void> collect_named_error_cases_ast_expr(
-    const AstExpr& expr,
-    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
-    if (expr.kind == AstExprKind::Error && expr.lhs != nullptr && expr.lhs->kind == AstExprKind::VariantCase &&
-        expr.lhs->name.len == 0 && expr.lhs->str_value.len != 0) {
+    const AstExpr& expr, FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
+    if (expr.kind == AstExprKind::Error && expr.lhs != nullptr &&
+        expr.lhs->kind == AstExprKind::VariantCase && expr.lhs->name.len == 0 &&
+        expr.lhs->str_value.len != 0) {
         if (!push_named_error_case(cases, expr.lhs->str_value))
             return frontend_error(FrontendError::TooManyItems, expr.span);
     }
@@ -4926,8 +5155,7 @@ static FrontendResult<void> collect_named_error_cases_ast_expr(
 }
 
 static FrontendResult<void> collect_named_error_cases_ast(
-    const AstStatement& stmt,
-    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
+    const AstStatement& stmt, FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
     auto expr_cases = collect_named_error_cases_ast_expr(stmt.expr, cases);
     if (!expr_cases) return expr_cases;
     if (stmt.then_stmt != nullptr) {
@@ -4953,9 +5181,10 @@ static FrontendResult<void> collect_named_error_cases_ast(
     return {};
 }
 
-static FrontendResult<void> collect_named_error_cases(const HirExpr& expr,
-                                                      FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
-    if (expr.kind == HirExprKind::Error && expr.error_variant_index == 0xffffffffu && expr.str_value.len != 0) {
+static FrontendResult<void> collect_named_error_cases(
+    const HirExpr& expr, FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
+    if (expr.kind == HirExprKind::Error && expr.error_variant_index == 0xffffffffu &&
+        expr.str_value.len != 0) {
         if (!push_named_error_case(cases, expr.str_value))
             return frontend_error(FrontendError::TooManyItems, expr.span);
     }
@@ -4970,9 +5199,10 @@ static FrontendResult<void> collect_named_error_cases(const HirExpr& expr,
     return {};
 }
 
-static void patch_named_error_variant(HirExpr* expr,
-                                      u32 variant_index,
-                                      const FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
+static void patch_named_error_variant(
+    HirExpr* expr,
+    u32 variant_index,
+    const FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
     if (expr->kind == HirExprKind::VariantCase && expr->variant_index == 0xffffffffu &&
         expr->str_value.len != 0) {
         expr->variant_index = variant_index;
@@ -4984,7 +5214,8 @@ static void patch_named_error_variant(HirExpr* expr,
             }
         }
     }
-    if (expr->kind == HirExprKind::Error && expr->error_variant_index == 0xffffffffu && expr->str_value.len != 0) {
+    if (expr->kind == HirExprKind::Error && expr->error_variant_index == 0xffffffffu &&
+        expr->str_value.len != 0) {
         expr->error_variant_index = variant_index;
         for (u32 i = 0; i < cases.len; i++) {
             if (cases[i].name.eq(expr->str_value)) {
@@ -4999,14 +5230,14 @@ static void patch_named_error_variant(HirExpr* expr,
 }
 
 static void patch_error_variant_refs(HirExpr* expr, u32 variant_index) {
-    if (expr->may_error && expr->error_variant_index == 0xffffffffu && expr->type != HirTypeKind::Variant)
+    if (expr->may_error && expr->error_variant_index == 0xffffffffu &&
+        expr->type != HirTypeKind::Variant)
         expr->error_variant_index = variant_index;
     if (expr->lhs != nullptr) patch_error_variant_refs(expr->lhs, variant_index);
     if (expr->rhs != nullptr) patch_error_variant_refs(expr->rhs, variant_index);
 }
 
-static FrontendResult<HirTerminator> analyze_term(const AstStatement& stmt,
-                                                  const HirModule& mod) {
+static FrontendResult<HirTerminator> analyze_term(const AstStatement& stmt, const HirModule& mod) {
     HirTerminator term{};
     term.span = stmt.span;
     if (stmt.kind == AstStmtKind::ReturnStatus) {
@@ -5078,15 +5309,15 @@ static FrontendResult<void> analyze_guard_match_arms(
             for (u32 i = 0; i < guard->fail_match_count; i++) {
                 const auto& seen = (*guard_match_arms)[guard->fail_match_start + i];
                 if (!seen.is_wildcard &&
-                    ((pattern.variant_index == 0xffffffffu && seen.pattern.str_value.eq(pattern.str_value)) ||
+                    ((pattern.variant_index == 0xffffffffu &&
+                      seen.pattern.str_value.eq(pattern.str_value)) ||
                      (pattern.variant_index != 0xffffffffu &&
                       static_cast<u32>(seen.pattern.int_value) == case_index))) {
                     duplicate = true;
                     break;
                 }
             }
-            if (duplicate)
-                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            if (duplicate) return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
             hir_arm.pattern = pattern;
         } else {
             seen_wildcard = true;
@@ -5159,11 +5390,8 @@ static const HirExpr* known_error_expr(const HirExpr& expr,
     return nullptr;
 }
 
-static bool const_eval_expr(const HirExpr& expr,
-                            const HirLocal* locals,
-                            u32 local_count,
-                            ConstValue* out,
-                            u32 depth) {
+static bool const_eval_expr(
+    const HirExpr& expr, const HirLocal* locals, u32 local_count, ConstValue* out, u32 depth) {
     if (depth > local_count) return false;
     if (expr.kind == HirExprKind::BoolLit) {
         out->type = HirTypeKind::Bool;
@@ -5184,7 +5412,8 @@ static bool const_eval_expr(const HirExpr& expr,
     if (expr.kind == HirExprKind::LocalRef && expr.local_index < local_count) {
         return const_eval_expr(locals[expr.local_index].init, locals, local_count, out, depth + 1);
     }
-    if ((expr.kind == HirExprKind::Eq || expr.kind == HirExprKind::Lt || expr.kind == HirExprKind::Gt) &&
+    if ((expr.kind == HirExprKind::Eq || expr.kind == HirExprKind::Lt ||
+         expr.kind == HirExprKind::Gt) &&
         expr.lhs != nullptr && expr.rhs != nullptr) {
         ConstValue lhs{};
         ConstValue rhs{};
@@ -5269,13 +5498,14 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
             const auto& inner = *stmt.block_stmts[si];
             const bool is_last = si + 1 == stmt.block_stmts.len;
             if (inner.kind == AstStmtKind::Let) {
-                if (is_last)
-                    return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                if (is_last) return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
                 HirLocal local{};
                 local.span = inner.span;
                 local.name = inner.name;
-                local.ref_index = next_local_ref_index(route, scoped_locals.data, scoped_locals.len);
-                auto init = analyze_expr(inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
+                local.ref_index =
+                    next_local_ref_index(route, scoped_locals.data, scoped_locals.len);
+                auto init = analyze_expr(
+                    inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
                 if (!init) return core::make_unexpected(init.error());
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, inner);
                 if (!typed) return core::make_unexpected(typed.error());
@@ -5311,14 +5541,14 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
                 continue;
             }
             if (inner.kind == AstStmtKind::Guard) {
-                if (is_last)
-                    return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                if (is_last) return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
                 HirGuard guard{};
                 guard.span = inner.span;
-                auto bound = analyze_expr(inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
+                auto bound = analyze_expr(
+                    inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
                 if (!bound) return core::make_unexpected(bound.error());
-                auto cond =
-                    analyze_guard_cond(inner.expr, route, mod, scoped_locals.data, scoped_locals.len);
+                auto cond = analyze_guard_cond(
+                    inner.expr, route, mod, scoped_locals.data, scoped_locals.len);
                 if (!cond) return core::make_unexpected(cond.error());
                 guard.cond = cond.value();
                 if (inner.match_arms.len != 0) {
@@ -5370,13 +5600,15 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
                 if (!arm->guards.push(guard))
                     return frontend_error(FrontendError::TooManyItems, inner.span);
                 if (inner.bind_value) {
-                    if (known_value_state(bound.value(), scoped_locals.data, scoped_locals.len, 0) ==
+                    if (known_value_state(
+                            bound.value(), scoped_locals.data, scoped_locals.len, 0) ==
                         KnownValueState::Error)
                         return frontend_error(FrontendError::UnsupportedSyntax, inner.expr.span);
                     HirLocal local{};
                     local.span = inner.span;
                     local.name = inner.name;
-                    local.ref_index = next_local_ref_index(route, scoped_locals.data, scoped_locals.len);
+                    local.ref_index =
+                        next_local_ref_index(route, scoped_locals.data, scoped_locals.len);
                     local.type = bound->type;
                     local.generic_index = bound->generic_index;
                     local.generic_has_error_constraint = bound->generic_has_error_constraint;
@@ -5406,14 +5638,15 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
                         return frontend_error(FrontendError::TooManyItems, inner.span);
                     if (local.ref_index >= HirRoute::kMaxLocals)
                         return frontend_error(FrontendError::TooManyItems, inner.span);
-                    if (scoped_locals.len <= local.ref_index) scoped_locals.len = local.ref_index + 1;
+                    if (scoped_locals.len <= local.ref_index)
+                        scoped_locals.len = local.ref_index + 1;
                     scoped_locals[local.ref_index] = local;
                 }
                 continue;
             }
-            if (!is_last)
-                return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
-            return analyze_match_arm_body(inner, arm, route, mod, scoped_locals.data, scoped_locals.len, binding);
+            if (!is_last) return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+            return analyze_match_arm_body(
+                inner, arm, route, mod, scoped_locals.data, scoped_locals.len, binding);
         }
         return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
     }
@@ -5457,13 +5690,14 @@ static FrontendResult<void> analyze_guard_fail_body(const AstStatement& stmt,
             const auto& inner = *stmt.block_stmts[si];
             const bool is_last = si + 1 == stmt.block_stmts.len;
             if (inner.kind == AstStmtKind::Let) {
-                if (is_last)
-                    return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                if (is_last) return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
                 HirLocal local{};
                 local.span = inner.span;
                 local.name = inner.name;
-                local.ref_index = next_local_ref_index(route, scoped_locals.data, scoped_locals.len);
-                auto init = analyze_expr(inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
+                local.ref_index =
+                    next_local_ref_index(route, scoped_locals.data, scoped_locals.len);
+                auto init = analyze_expr(
+                    inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
                 if (!init) return core::make_unexpected(init.error());
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, inner);
                 if (!typed) return core::make_unexpected(typed.error());
@@ -5498,9 +5732,9 @@ static FrontendResult<void> analyze_guard_fail_body(const AstStatement& stmt,
                 scoped_locals[local.ref_index] = local;
                 continue;
             }
-            if (!is_last)
-                return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
-            return analyze_guard_fail_body(inner, body, route, mod, scoped_locals.data, scoped_locals.len, binding);
+            if (!is_last) return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+            return analyze_guard_fail_body(
+                inner, body, route, mod, scoped_locals.data, scoped_locals.len, binding);
         }
         return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
     }
@@ -5540,7 +5774,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         if (!const_eval_expr(cond.value(), locals, local_count, &value, 0) ||
             value.type != HirTypeKind::Bool)
             return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
-        return analyze_control_stmt(value.bool_value ? *stmt.then_stmt : *stmt.else_stmt, route, mod, binding);
+        return analyze_control_stmt(
+            value.bool_value ? *stmt.then_stmt : *stmt.else_stmt, route, mod, binding);
     }
 
     if (stmt.kind == AstStmtKind::Match && stmt.is_const) {
@@ -5564,15 +5799,18 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 wildcard_arm = &arm;
                 continue;
             }
-            auto pattern = analyze_match_pattern(arm.pattern, subject.value(), route, mod, locals, local_count);
+            auto pattern = analyze_match_pattern(
+                arm.pattern, subject.value(), route, mod, locals, local_count);
             if (!pattern) return core::make_unexpected(pattern.error());
 
             bool matched = false;
             if (pattern->kind == HirExprKind::BoolLit && subject_value.type == HirTypeKind::Bool) {
                 matched = pattern->bool_value == subject_value.bool_value;
-            } else if (pattern->kind == HirExprKind::IntLit && subject_value.type == HirTypeKind::I32) {
+            } else if (pattern->kind == HirExprKind::IntLit &&
+                       subject_value.type == HirTypeKind::I32) {
                 matched = pattern->int_value == subject_value.int_value;
-            } else if (pattern->kind == HirExprKind::VariantCase && subject_value.type == HirTypeKind::Variant) {
+            } else if (pattern->kind == HirExprKind::VariantCase &&
+                       subject_value.type == HirTypeKind::Variant) {
                 matched = pattern->variant_index == subject_value.variant_index &&
                           pattern->case_index == subject_value.case_index;
             }
@@ -5584,41 +5822,57 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 arm.pattern.lhs != nullptr) {
                 selected_binding = {};
                 selected_binding.name = arm.pattern.lhs->name;
-                selected_binding.type = mod.variants[pattern->variant_index].cases[pattern->case_index].payload_type;
-                selected_binding.generic_index =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_index;
+                selected_binding.type =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_type;
+                selected_binding.generic_index = mod.variants[pattern->variant_index]
+                                                     .cases[pattern->case_index]
+                                                     .payload_generic_index;
                 selected_binding.generic_has_error_constraint =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_error_constraint;
-                selected_binding.generic_has_eq_constraint =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_eq_constraint;
+                    mod.variants[pattern->variant_index]
+                        .cases[pattern->case_index]
+                        .payload_generic_has_error_constraint;
+                selected_binding.generic_has_eq_constraint = mod.variants[pattern->variant_index]
+                                                                 .cases[pattern->case_index]
+                                                                 .payload_generic_has_eq_constraint;
                 selected_binding.generic_has_ord_constraint =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_has_ord_constraint;
-                selected_binding.generic_protocol_index =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_protocol_index;
-                selected_binding.generic_protocol_count =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_generic_protocol_count;
+                    mod.variants[pattern->variant_index]
+                        .cases[pattern->case_index]
+                        .payload_generic_has_ord_constraint;
+                selected_binding.generic_protocol_index = mod.variants[pattern->variant_index]
+                                                              .cases[pattern->case_index]
+                                                              .payload_generic_protocol_index;
+                selected_binding.generic_protocol_count = mod.variants[pattern->variant_index]
+                                                              .cases[pattern->case_index]
+                                                              .payload_generic_protocol_count;
                 for (u32 cpi = 0; cpi < selected_binding.generic_protocol_count; cpi++) {
                     selected_binding.generic_protocol_indices[cpi] =
                         mod.variants[pattern->variant_index]
                             .cases[pattern->case_index]
                             .payload_generic_protocol_indices[cpi];
                 }
-                selected_binding.variant_index =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_variant_index;
-                selected_binding.struct_index =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_struct_index;
-                selected_binding.shape_index =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_shape_index;
-                selected_binding.tuple_len =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_tuple_len;
+                selected_binding.variant_index = mod.variants[pattern->variant_index]
+                                                     .cases[pattern->case_index]
+                                                     .payload_variant_index;
+                selected_binding.struct_index = mod.variants[pattern->variant_index]
+                                                    .cases[pattern->case_index]
+                                                    .payload_struct_index;
+                selected_binding.shape_index = mod.variants[pattern->variant_index]
+                                                   .cases[pattern->case_index]
+                                                   .payload_shape_index;
+                selected_binding.tuple_len = mod.variants[pattern->variant_index]
+                                                 .cases[pattern->case_index]
+                                                 .payload_tuple_len;
                 for (u32 ti = 0; ti < selected_binding.tuple_len; ti++) {
-                    selected_binding.tuple_types[ti] =
-                        mod.variants[pattern->variant_index].cases[pattern->case_index].payload_tuple_types[ti];
+                    selected_binding.tuple_types[ti] = mod.variants[pattern->variant_index]
+                                                           .cases[pattern->case_index]
+                                                           .payload_tuple_types[ti];
                     selected_binding.tuple_variant_indices[ti] =
-                        mod.variants[pattern->variant_index].cases[pattern->case_index]
+                        mod.variants[pattern->variant_index]
+                            .cases[pattern->case_index]
                             .payload_tuple_variant_indices[ti];
                     selected_binding.tuple_struct_indices[ti] =
-                        mod.variants[pattern->variant_index].cases[pattern->case_index]
+                        mod.variants[pattern->variant_index]
+                            .cases[pattern->case_index]
                             .payload_tuple_struct_indices[ti];
                 }
                 selected_binding.case_index = pattern->case_index;
@@ -5641,7 +5895,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         if (cond->type != HirTypeKind::Bool)
             return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
         const auto simple_branch = [](const AstStatement& branch) {
-            return branch.kind == AstStmtKind::ReturnStatus || branch.kind == AstStmtKind::ForwardUpstream;
+            return branch.kind == AstStmtKind::ReturnStatus ||
+                   branch.kind == AstStmtKind::ForwardUpstream;
         };
         if (simple_branch(*stmt.then_stmt) && simple_branch(*stmt.else_stmt)) {
             route->control.kind = HirControlKind::If;
@@ -5656,8 +5911,9 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         }
 
         const auto supported_branch = [](const AstStatement& branch) {
-            return branch.kind == AstStmtKind::ReturnStatus || branch.kind == AstStmtKind::ForwardUpstream ||
-                   branch.kind == AstStmtKind::If || branch.kind == AstStmtKind::Block;
+            return branch.kind == AstStmtKind::ReturnStatus ||
+                   branch.kind == AstStmtKind::ForwardUpstream || branch.kind == AstStmtKind::If ||
+                   branch.kind == AstStmtKind::Block;
         };
         if (!supported_branch(*stmt.then_stmt) || !supported_branch(*stmt.else_stmt))
             return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
@@ -5678,7 +5934,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         HirMatchArm then_arm{};
         then_arm.span = stmt.then_stmt->span;
         then_arm.pattern = make_bool_pattern(true, stmt.then_stmt->span);
-        auto then_body = analyze_match_arm_body(*stmt.then_stmt, &then_arm, route, mod, locals, local_count, binding);
+        auto then_body = analyze_match_arm_body(
+            *stmt.then_stmt, &then_arm, route, mod, locals, local_count, binding);
         if (!then_body) return core::make_unexpected(then_body.error());
         if (!route->control.match_arms.push(then_arm))
             return frontend_error(FrontendError::TooManyItems, stmt.then_stmt->span);
@@ -5686,7 +5943,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         HirMatchArm else_arm{};
         else_arm.span = stmt.else_stmt->span;
         else_arm.pattern = make_bool_pattern(false, stmt.else_stmt->span);
-        auto else_body = analyze_match_arm_body(*stmt.else_stmt, &else_arm, route, mod, locals, local_count, binding);
+        auto else_body = analyze_match_arm_body(
+            *stmt.else_stmt, &else_arm, route, mod, locals, local_count, binding);
         if (!else_body) return core::make_unexpected(else_body.error());
         if (!route->control.match_arms.push(else_arm))
             return frontend_error(FrontendError::TooManyItems, stmt.else_stmt->span);
@@ -5698,10 +5956,10 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         if (!subject) return core::make_unexpected(subject.error());
         const auto state = known_value_state(subject.value(), locals, local_count, 0);
         const auto err_name = known_error_name(subject.value(), locals, local_count, 0);
-        const bool subject_is_error_kind =
-            subject->type != HirTypeKind::Variant && subject->may_error &&
-            (subject->error_variant_index != 0xffffffffu ||
-             (state == KnownValueState::Error && err_name.len != 0));
+        const bool subject_is_error_kind = subject->type != HirTypeKind::Variant &&
+                                           subject->may_error &&
+                                           (subject->error_variant_index != 0xffffffffu ||
+                                            (state == KnownValueState::Error && err_name.len != 0));
         if (subject->type != HirTypeKind::Variant && subject->may_error &&
             (subject->error_variant_index != 0xffffffffu ||
              (state == KnownValueState::Error && err_name.len != 0))) {
@@ -5766,11 +6024,10 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
             hir_arm.is_wildcard = arm.is_wildcard;
             MatchPayloadBinding arm_binding{};
             const MatchPayloadBinding* arm_binding_ptr = binding;
-            if (seen_wildcard)
-                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            if (seen_wildcard) return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
             if (!arm.is_wildcard) {
-                auto analyzed_pattern =
-                    analyze_match_pattern(arm.pattern, subject.value(), route, mod, locals, local_count);
+                auto analyzed_pattern = analyze_match_pattern(
+                    arm.pattern, subject.value(), route, mod, locals, local_count);
                 if (!analyzed_pattern) return core::make_unexpected(analyzed_pattern.error());
                 HirExpr pattern = analyzed_pattern.value();
                 if (pattern.kind != HirExprKind::BoolLit && pattern.kind != HirExprKind::IntLit &&
@@ -5780,7 +6037,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     !(subject_is_error_kind && pattern.kind == HirExprKind::VariantCase))
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 if (pattern.type == HirTypeKind::Variant &&
-                    ((subject_is_error_kind && pattern.variant_index != subject->error_variant_index) ||
+                    ((subject_is_error_kind &&
+                      pattern.variant_index != subject->error_variant_index) ||
                      (!subject_is_error_kind && pattern.variant_index != subject->variant_index)))
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 if (pattern.kind == HirExprKind::VariantCase) {
@@ -5802,19 +6060,27 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         hir_arm.bind_tuple_len = case_decl.payload_tuple_len;
                         for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
                             hir_arm.bind_tuple_types[ti] = case_decl.payload_tuple_types[ti];
-                            hir_arm.bind_tuple_variant_indices[ti] = case_decl.payload_tuple_variant_indices[ti];
-                            hir_arm.bind_tuple_struct_indices[ti] = case_decl.payload_tuple_struct_indices[ti];
+                            hir_arm.bind_tuple_variant_indices[ti] =
+                                case_decl.payload_tuple_variant_indices[ti];
+                            hir_arm.bind_tuple_struct_indices[ti] =
+                                case_decl.payload_tuple_struct_indices[ti];
                         }
                         arm_binding.name = hir_arm.bind_name;
                         arm_binding.type = hir_arm.bind_type;
                         arm_binding.generic_index = case_decl.payload_generic_index;
-                        arm_binding.generic_has_error_constraint = case_decl.payload_generic_has_error_constraint;
-                        arm_binding.generic_has_eq_constraint = case_decl.payload_generic_has_eq_constraint;
-                        arm_binding.generic_has_ord_constraint = case_decl.payload_generic_has_ord_constraint;
-                        arm_binding.generic_protocol_index = case_decl.payload_generic_protocol_index;
-                        arm_binding.generic_protocol_count = case_decl.payload_generic_protocol_count;
+                        arm_binding.generic_has_error_constraint =
+                            case_decl.payload_generic_has_error_constraint;
+                        arm_binding.generic_has_eq_constraint =
+                            case_decl.payload_generic_has_eq_constraint;
+                        arm_binding.generic_has_ord_constraint =
+                            case_decl.payload_generic_has_ord_constraint;
+                        arm_binding.generic_protocol_index =
+                            case_decl.payload_generic_protocol_index;
+                        arm_binding.generic_protocol_count =
+                            case_decl.payload_generic_protocol_count;
                         for (u32 cpi = 0; cpi < arm_binding.generic_protocol_count; cpi++)
-                            arm_binding.generic_protocol_indices[cpi] = case_decl.payload_generic_protocol_indices[cpi];
+                            arm_binding.generic_protocol_indices[cpi] =
+                                case_decl.payload_generic_protocol_indices[cpi];
                         arm_binding.variant_index = hir_arm.bind_variant_index;
                         arm_binding.struct_index = hir_arm.bind_struct_index;
                         arm_binding.shape_index = case_decl.payload_shape_index;
@@ -5822,8 +6088,10 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         arm_binding.tuple_len = case_decl.payload_tuple_len;
                         for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
                             arm_binding.tuple_types[ti] = case_decl.payload_tuple_types[ti];
-                            arm_binding.tuple_variant_indices[ti] = case_decl.payload_tuple_variant_indices[ti];
-                            arm_binding.tuple_struct_indices[ti] = case_decl.payload_tuple_struct_indices[ti];
+                            arm_binding.tuple_variant_indices[ti] =
+                                case_decl.payload_tuple_variant_indices[ti];
+                            arm_binding.tuple_struct_indices[ti] =
+                                case_decl.payload_tuple_struct_indices[ti];
                         }
                         arm_binding.subject = &route->control.match_expr;
                         arm_binding_ptr = &arm_binding;
@@ -5859,15 +6127,16 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
 
 }  // namespace
 
-
-static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
-                                                        Str source_path,
-                                                        std::vector<std::string>& import_stack,
-                                                        std::deque<std::string>* shared_owned_strings);
+static FrontendResult<HirModule*> analyze_file_internal(
+    const AstFile& file,
+    Str source_path,
+    std::vector<std::string>& import_stack,
+    std::deque<std::string>* shared_owned_strings);
 
 static Str import_visible_name(const ImportedModuleInfo& imported, Str original_name) {
     if (imported.has_namespace_alias) {
-        return intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" + str_to_std_string(original_name));
+        return intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" +
+                                     str_to_std_string(original_name));
     }
     if (!imported.selective) return original_name;
     for (u32 i = 0; i < imported.selected_names.len; i++) {
@@ -5909,22 +6178,25 @@ static bool imported_module_exports_selected_name(const HirModule& mod, Str name
     return false;
 }
 
-static FrontendResult<void> validate_imported_selected_names(const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+static FrontendResult<void> validate_imported_selected_names(
+    const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
     for (u32 ii = 0; ii < imports.len; ii++) {
         const auto& imported = imports[ii];
         if (!imported.selective) continue;
         for (u32 si = 0; si < imported.selected_names.len; si++) {
             const auto& selected = imported.selected_names[si];
             if (!imported_module_exports_selected_name(*imported.module, selected.name))
-                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, selected.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, imported.span, selected.name);
         }
     }
     return {};
 }
 
-static FrontendResult<void> merge_imported_functions(HirModule* mod,
-                                                  const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
-    auto refresh_imported_function_signature_shapes = [&](HirFunction* fn, Span span) -> FrontendResult<void> {
+static FrontendResult<void> merge_imported_functions(
+    HirModule* mod, const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    auto refresh_imported_function_signature_shapes = [&](HirFunction* fn,
+                                                          Span span) -> FrontendResult<void> {
         for (u32 pi = 0; pi < fn->params.len; pi++) {
             auto& param = fn->params[pi];
             for (u32 ai = 0; ai < param.type_arg_count; ai++) {
@@ -5986,18 +6258,12 @@ static FrontendResult<void> merge_imported_functions(HirModule* mod,
     };
     auto refresh_imported_expr_shape = [&](HirExpr* expr, Span span) -> FrontendResult<void> {
         const bool should_refresh =
-            expr->shape_index != 0xffffffffu ||
-            expr->kind == HirExprKind::StructInit ||
-            expr->kind == HirExprKind::VariantCase ||
-            expr->kind == HirExprKind::Tuple ||
-            expr->kind == HirExprKind::TupleSlot ||
-            expr->kind == HirExprKind::Field ||
-            expr->kind == HirExprKind::IfElse ||
-            expr->kind == HirExprKind::Or ||
-            expr->kind == HirExprKind::LocalRef ||
-            expr->kind == HirExprKind::MatchPayload ||
-            expr->kind == HirExprKind::ValueOf ||
-            expr->kind == HirExprKind::MissingOf ||
+            expr->shape_index != 0xffffffffu || expr->kind == HirExprKind::StructInit ||
+            expr->kind == HirExprKind::VariantCase || expr->kind == HirExprKind::Tuple ||
+            expr->kind == HirExprKind::TupleSlot || expr->kind == HirExprKind::Field ||
+            expr->kind == HirExprKind::IfElse || expr->kind == HirExprKind::Or ||
+            expr->kind == HirExprKind::LocalRef || expr->kind == HirExprKind::MatchPayload ||
+            expr->kind == HirExprKind::ValueOf || expr->kind == HirExprKind::MissingOf ||
             expr->kind == HirExprKind::ProtocolCall;
         if (!should_refresh || expr->type == HirTypeKind::Unknown) return {};
         auto shape = intern_hir_type_shape(mod,
@@ -6014,7 +6280,8 @@ static FrontendResult<void> merge_imported_functions(HirModule* mod,
         expr->shape_index = shape.value();
         return {};
     };
-    auto refresh_imported_function_body_shapes = [&](HirFunction* fn, Span span) -> FrontendResult<void> {
+    auto refresh_imported_function_body_shapes = [&](HirFunction* fn,
+                                                     Span span) -> FrontendResult<void> {
         for (u32 ei = 0; ei < fn->exprs.len; ei++) {
             auto refreshed = refresh_imported_expr_shape(&fn->exprs[ei], span);
             if (!refreshed) return core::make_unexpected(refreshed.error());
@@ -6039,7 +6306,8 @@ static FrontendResult<void> merge_imported_functions(HirModule* mod,
                 if (find_function_index(*mod, fn.name) != mod->functions.len)
                     return frontend_error(FrontendError::UnsupportedSyntax, imported.span, fn.name);
                 HirFunction imported_fn = fn;
-                auto refreshed = refresh_imported_function_signature_shapes(&imported_fn, imported.span);
+                auto refreshed =
+                    refresh_imported_function_signature_shapes(&imported_fn, imported.span);
                 if (!refreshed) return core::make_unexpected(refreshed.error());
                 refreshed = refresh_imported_function_body_shapes(&imported_fn, imported.span);
                 if (!refreshed) return core::make_unexpected(refreshed.error());
@@ -6050,12 +6318,14 @@ static FrontendResult<void> merge_imported_functions(HirModule* mod,
             if (imported.has_namespace_alias) {
                 HirFunction imported_fn = fn;
                 imported_fn.name = import_visible_name(imported, fn.name);
-                auto refreshed = refresh_imported_function_signature_shapes(&imported_fn, imported.span);
+                auto refreshed =
+                    refresh_imported_function_signature_shapes(&imported_fn, imported.span);
                 if (!refreshed) return core::make_unexpected(refreshed.error());
                 refreshed = refresh_imported_function_body_shapes(&imported_fn, imported.span);
                 if (!refreshed) return core::make_unexpected(refreshed.error());
                 if (find_function_index(*mod, imported_fn.name) != mod->functions.len)
-                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_fn.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, imported.span, imported_fn.name);
                 if (!mod->functions.push(imported_fn))
                     return frontend_error(FrontendError::TooManyItems, imported.span);
                 continue;
@@ -6065,12 +6335,14 @@ static FrontendResult<void> merge_imported_functions(HirModule* mod,
                 if (!selected.name.eq(fn.name)) continue;
                 HirFunction imported_fn = fn;
                 if (selected.has_alias) imported_fn.name = selected.alias;
-                auto refreshed = refresh_imported_function_signature_shapes(&imported_fn, imported.span);
+                auto refreshed =
+                    refresh_imported_function_signature_shapes(&imported_fn, imported.span);
                 if (!refreshed) return core::make_unexpected(refreshed.error());
                 refreshed = refresh_imported_function_body_shapes(&imported_fn, imported.span);
                 if (!refreshed) return core::make_unexpected(refreshed.error());
                 if (find_function_index(*mod, imported_fn.name) != mod->functions.len)
-                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_fn.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, imported.span, imported_fn.name);
                 if (!mod->functions.push(imported_fn))
                     return frontend_error(FrontendError::TooManyItems, imported.span);
             }
@@ -6079,9 +6351,10 @@ static FrontendResult<void> merge_imported_functions(HirModule* mod,
     return {};
 }
 
-static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
-                                                     const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
-    auto refresh_type_arg_shape = [&](HirVariant::TypeArgRef* arg, Span span) -> FrontendResult<void> {
+static FrontendResult<void> merge_imported_simple_decls(
+    HirModule* mod, const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    auto refresh_type_arg_shape = [&](HirVariant::TypeArgRef* arg,
+                                      Span span) -> FrontendResult<void> {
         auto shape = intern_hir_type_shape(mod,
                                            arg->type,
                                            arg->generic_index,
@@ -6104,7 +6377,10 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
             if (imported.selective) {
                 bool selected = false;
                 for (u32 si = 0; si < imported.selected_names.len; si++) {
-                    if (imported.selected_names[si].name.eq(proto.name)) { selected = true; break; }
+                    if (imported.selected_names[si].name.eq(proto.name)) {
+                        selected = true;
+                        break;
+                    }
                 }
                 if (!selected) continue;
             }
@@ -6142,7 +6418,8 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
                 }
             }
             if (find_protocol_index(*mod, imported_proto.name) != mod->protocols.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_proto.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, imported.span, imported_proto.name);
             if (!mod->protocols.push(imported_proto))
                 return frontend_error(FrontendError::TooManyItems, imported.span);
         }
@@ -6152,7 +6429,10 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
             if (imported.selective) {
                 bool selected = false;
                 for (u32 xi = 0; xi < imported.selected_names.len; xi++) {
-                    if (imported.selected_names[xi].name.eq(st.name)) { selected = true; break; }
+                    if (imported.selected_names[xi].name.eq(st.name)) {
+                        selected = true;
+                        break;
+                    }
                 }
                 if (!selected) continue;
             }
@@ -6161,7 +6441,8 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
             for (u32 fi = 0; fi < imported_struct.fields.len; fi++) {
                 if (imported_struct.fields[fi].is_error_type) continue;
                 for (u32 ai = 0; ai < imported_struct.fields[fi].type_arg_count; ai++) {
-                    auto refreshed = refresh_type_arg_shape(&imported_struct.fields[fi].type_args[ai], imported.span);
+                    auto refreshed = refresh_type_arg_shape(
+                        &imported_struct.fields[fi].type_args[ai], imported.span);
                     if (!refreshed) return core::make_unexpected(refreshed.error());
                 }
                 auto shape = intern_hir_type_shape(mod,
@@ -6178,7 +6459,8 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
                 imported_struct.fields[fi].shape_index = shape.value();
             }
             if (find_struct_index(*mod, imported_struct.name) != mod->structs.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_struct.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, imported.span, imported_struct.name);
             bool ok = true;
             for (u32 fi = 0; fi < imported_struct.fields.len; fi++) {
                 const auto& field = imported_struct.fields[fi];
@@ -6204,7 +6486,10 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
             if (imported.selective) {
                 bool selected = false;
                 for (u32 xi = 0; xi < imported.selected_names.len; xi++) {
-                    if (imported.selected_names[xi].name.eq(variant.name)) { selected = true; break; }
+                    if (imported.selected_names[xi].name.eq(variant.name)) {
+                        selected = true;
+                        break;
+                    }
                 }
                 if (!selected) continue;
             }
@@ -6213,25 +6498,27 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
             for (u32 ci = 0; ci < imported_variant.cases.len; ci++) {
                 if (!imported_variant.cases[ci].has_payload) continue;
                 for (u32 ai = 0; ai < imported_variant.cases[ci].payload_type_arg_count; ai++) {
-                    auto refreshed =
-                        refresh_type_arg_shape(&imported_variant.cases[ci].payload_type_args[ai], imported.span);
+                    auto refreshed = refresh_type_arg_shape(
+                        &imported_variant.cases[ci].payload_type_args[ai], imported.span);
                     if (!refreshed) return core::make_unexpected(refreshed.error());
                 }
-                auto shape = intern_hir_type_shape(mod,
-                                                   imported_variant.cases[ci].payload_type,
-                                                   imported_variant.cases[ci].payload_generic_index,
-                                                   imported_variant.cases[ci].payload_variant_index,
-                                                   imported_variant.cases[ci].payload_struct_index,
-                                                   imported_variant.cases[ci].payload_tuple_len,
-                                                   imported_variant.cases[ci].payload_tuple_types,
-                                                   imported_variant.cases[ci].payload_tuple_variant_indices,
-                                                   imported_variant.cases[ci].payload_tuple_struct_indices,
-                                                   imported.span);
+                auto shape =
+                    intern_hir_type_shape(mod,
+                                          imported_variant.cases[ci].payload_type,
+                                          imported_variant.cases[ci].payload_generic_index,
+                                          imported_variant.cases[ci].payload_variant_index,
+                                          imported_variant.cases[ci].payload_struct_index,
+                                          imported_variant.cases[ci].payload_tuple_len,
+                                          imported_variant.cases[ci].payload_tuple_types,
+                                          imported_variant.cases[ci].payload_tuple_variant_indices,
+                                          imported_variant.cases[ci].payload_tuple_struct_indices,
+                                          imported.span);
                 if (!shape) return core::make_unexpected(shape.error());
                 imported_variant.cases[ci].payload_shape_index = shape.value();
             }
             if (find_variant_index(*mod, imported_variant.name) != mod->variants.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_variant.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, imported.span, imported_variant.name);
             bool ok = true;
             for (u32 ci = 0; ci < imported_variant.cases.len; ci++) {
                 const auto& c = imported_variant.cases[ci];
@@ -6256,8 +6543,7 @@ static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
 }
 
 static FrontendResult<void> refresh_imported_protocol_method_functions(
-    HirModule* mod,
-    const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    HirModule* mod, const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
     for (u32 ii = 0; ii < imports.len; ii++) {
         const auto& imported = imports[ii];
         for (u32 pi = 0; pi < imported.module->protocols.len; pi++) {
@@ -6276,16 +6562,19 @@ static FrontendResult<void> refresh_imported_protocol_method_functions(
             const Str visible_name = import_visible_name(imported, imported_proto.name);
             const u32 proto_index = find_protocol_index(*mod, visible_name);
             if (proto_index >= mod->protocols.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, visible_name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, imported.span, visible_name);
             auto& proto = mod->protocols[proto_index];
             for (u32 mi = 0; mi < imported_proto.methods.len; mi++) {
                 const auto& imported_method = imported_proto.methods[mi];
                 auto* method = find_protocol_method_mut(proto, imported_method.name);
                 if (method == nullptr)
-                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_method.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, imported.span, imported_method.name);
                 if (imported_method.function_index == 0xffffffffu) continue;
                 if (imported_method.function_index >= imported.module->functions.len)
-                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_method.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, imported.span, imported_method.name);
                 const Str fn_name = imported.module->functions[imported_method.function_index].name;
                 const u32 mapped_fn_index = find_function_index(*mod, fn_name);
                 if (mapped_fn_index >= mod->functions.len)
@@ -6293,8 +6582,10 @@ static FrontendResult<void> refresh_imported_protocol_method_functions(
                 method->function_index = mapped_fn_index;
                 method->return_may_nil = mod->functions[mapped_fn_index].body.may_nil;
                 method->return_may_error = mod->functions[mapped_fn_index].body.may_error;
-                method->return_error_struct_index = mod->functions[mapped_fn_index].body.error_struct_index;
-                method->return_error_variant_index = mod->functions[mapped_fn_index].body.error_variant_index;
+                method->return_error_struct_index =
+                    mod->functions[mapped_fn_index].body.error_struct_index;
+                method->return_error_variant_index =
+                    mod->functions[mapped_fn_index].body.error_variant_index;
             }
         }
     }
@@ -6324,12 +6615,14 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
     std::function<FrontendResult<void>(u32, u32&)> remap_imported_struct_index;
     std::function<FrontendResult<void>(u32, u32&)> remap_imported_variant_index;
 
-    remap_imported_struct_index = [&](u32 imported_struct_index, u32& mapped_struct_index) -> FrontendResult<void> {
+    remap_imported_struct_index = [&](u32 imported_struct_index,
+                                      u32& mapped_struct_index) -> FrontendResult<void> {
         if (imported_struct_index >= imported_mod.structs.len)
             return frontend_error(FrontendError::UnsupportedSyntax, span);
         const auto& imported_struct = imported_mod.structs[imported_struct_index];
         if (imported_struct.template_struct_index == 0xffffffffu) {
-            mapped_struct_index = find_struct_index(*mod, import_visible_name(imported, imported_struct.name));
+            mapped_struct_index =
+                find_struct_index(*mod, import_visible_name(imported, imported_struct.name));
             if (mapped_struct_index >= mod->structs.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, span, imported_struct.name);
             return {};
@@ -6337,7 +6630,8 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
         if (imported_struct.template_struct_index >= imported_mod.structs.len)
             return frontend_error(FrontendError::UnsupportedSyntax, span);
         u32 mapped_template_index = 0xffffffffu;
-        auto remapped_template = remap_imported_struct_index(imported_struct.template_struct_index, mapped_template_index);
+        auto remapped_template = remap_imported_struct_index(imported_struct.template_struct_index,
+                                                             mapped_template_index);
         if (!remapped_template) return core::make_unexpected(remapped_template.error());
         GenericBinding bindings[HirStruct::kMaxTypeParams]{};
         for (u32 ai = 0; ai < imported_struct.instance_type_arg_count; ai++) {
@@ -6349,53 +6643,58 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
                 mapped_tuple_variant_indices[ti] = 0xffffffffu;
                 mapped_tuple_struct_indices[ti] = 0xffffffffu;
             }
-            auto remapped = remap_imported_type_metadata(imported_struct.instance_type_args[ai],
-                                                         imported_struct.instance_variant_indices[ai],
-                                                         imported_struct.instance_struct_indices[ai],
-                                                         imported_struct.instance_tuple_lens[ai],
-                                                         imported_struct.instance_tuple_types[ai],
-                                                         imported_struct.instance_tuple_variant_indices[ai],
-                                                         imported_struct.instance_tuple_struct_indices[ai],
-                                                         mapped_variant_index,
-                                                         mapped_arg_struct_index,
-                                                         mapped_tuple_variant_indices,
-                                                         mapped_tuple_struct_indices);
+            auto remapped =
+                remap_imported_type_metadata(imported_struct.instance_type_args[ai],
+                                             imported_struct.instance_variant_indices[ai],
+                                             imported_struct.instance_struct_indices[ai],
+                                             imported_struct.instance_tuple_lens[ai],
+                                             imported_struct.instance_tuple_types[ai],
+                                             imported_struct.instance_tuple_variant_indices[ai],
+                                             imported_struct.instance_tuple_struct_indices[ai],
+                                             mapped_variant_index,
+                                             mapped_arg_struct_index,
+                                             mapped_tuple_variant_indices,
+                                             mapped_tuple_struct_indices);
             if (!remapped) return core::make_unexpected(remapped.error());
-            auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
-                                                                mod,
-                                                                imported_struct.instance_type_args[ai],
-                                                                imported_struct.instance_generic_indices[ai],
-                                                                mapped_variant_index,
-                                                                mapped_arg_struct_index,
-                                                                imported_struct.instance_tuple_lens[ai],
-                                                                imported_struct.instance_tuple_types[ai],
-                                                                mapped_tuple_variant_indices,
-                                                                mapped_tuple_struct_indices,
-                                                                0xffffffffu,
-                                                                span);
+            auto filled =
+                fill_bound_binding_from_type_metadata(&bindings[ai],
+                                                      mod,
+                                                      imported_struct.instance_type_args[ai],
+                                                      imported_struct.instance_generic_indices[ai],
+                                                      mapped_variant_index,
+                                                      mapped_arg_struct_index,
+                                                      imported_struct.instance_tuple_lens[ai],
+                                                      imported_struct.instance_tuple_types[ai],
+                                                      mapped_tuple_variant_indices,
+                                                      mapped_tuple_struct_indices,
+                                                      0xffffffffu,
+                                                      span);
             if (!filled) return core::make_unexpected(filled.error());
         }
-        auto concrete =
-            instantiate_struct(mod, mapped_template_index, bindings, imported_struct.instance_type_arg_count, span);
+        auto concrete = instantiate_struct(
+            mod, mapped_template_index, bindings, imported_struct.instance_type_arg_count, span);
         if (!concrete) return core::make_unexpected(concrete.error());
         mapped_struct_index = concrete.value();
         return {};
     };
-    remap_imported_variant_index = [&](u32 imported_variant_index, u32& mapped_variant_index) -> FrontendResult<void> {
+    remap_imported_variant_index = [&](u32 imported_variant_index,
+                                       u32& mapped_variant_index) -> FrontendResult<void> {
         if (imported_variant_index >= imported_mod.variants.len)
             return frontend_error(FrontendError::UnsupportedSyntax, span);
         const auto& imported_variant = imported_mod.variants[imported_variant_index];
         if (imported_variant.template_variant_index == 0xffffffffu) {
-            mapped_variant_index = find_variant_index(*mod, import_visible_name(imported, imported_variant.name));
+            mapped_variant_index =
+                find_variant_index(*mod, import_visible_name(imported, imported_variant.name));
             if (mapped_variant_index >= mod->variants.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, span, imported_variant.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, span, imported_variant.name);
             return {};
         }
         if (imported_variant.template_variant_index >= imported_mod.variants.len)
             return frontend_error(FrontendError::UnsupportedSyntax, span);
         u32 mapped_template_index = 0xffffffffu;
-        auto remapped_template =
-            remap_imported_variant_index(imported_variant.template_variant_index, mapped_template_index);
+        auto remapped_template = remap_imported_variant_index(
+            imported_variant.template_variant_index, mapped_template_index);
         if (!remapped_template) return core::make_unexpected(remapped_template.error());
         GenericBinding bindings[HirVariant::kMaxTypeParams]{};
         for (u32 ai = 0; ai < imported_variant.instance_type_arg_count; ai++) {
@@ -6407,30 +6706,32 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
                 mapped_tuple_variant_indices[ti] = 0xffffffffu;
                 mapped_tuple_struct_indices[ti] = 0xffffffffu;
             }
-            auto remapped = remap_imported_type_metadata(imported_variant.instance_type_args[ai],
-                                                         imported_variant.instance_variant_indices[ai],
-                                                         imported_variant.instance_struct_indices[ai],
-                                                         imported_variant.instance_tuple_lens[ai],
-                                                         imported_variant.instance_tuple_types[ai],
-                                                         imported_variant.instance_tuple_variant_indices[ai],
-                                                         imported_variant.instance_tuple_struct_indices[ai],
-                                                         mapped_arg_variant_index,
-                                                         mapped_struct_index,
-                                                         mapped_tuple_variant_indices,
-                                                         mapped_tuple_struct_indices);
+            auto remapped =
+                remap_imported_type_metadata(imported_variant.instance_type_args[ai],
+                                             imported_variant.instance_variant_indices[ai],
+                                             imported_variant.instance_struct_indices[ai],
+                                             imported_variant.instance_tuple_lens[ai],
+                                             imported_variant.instance_tuple_types[ai],
+                                             imported_variant.instance_tuple_variant_indices[ai],
+                                             imported_variant.instance_tuple_struct_indices[ai],
+                                             mapped_arg_variant_index,
+                                             mapped_struct_index,
+                                             mapped_tuple_variant_indices,
+                                             mapped_tuple_struct_indices);
             if (!remapped) return core::make_unexpected(remapped.error());
-            auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
-                                                                mod,
-                                                                imported_variant.instance_type_args[ai],
-                                                                imported_variant.instance_generic_indices[ai],
-                                                                mapped_arg_variant_index,
-                                                                mapped_struct_index,
-                                                                imported_variant.instance_tuple_lens[ai],
-                                                                imported_variant.instance_tuple_types[ai],
-                                                                mapped_tuple_variant_indices,
-                                                                mapped_tuple_struct_indices,
-                                                                0xffffffffu,
-                                                                span);
+            auto filled =
+                fill_bound_binding_from_type_metadata(&bindings[ai],
+                                                      mod,
+                                                      imported_variant.instance_type_args[ai],
+                                                      imported_variant.instance_generic_indices[ai],
+                                                      mapped_arg_variant_index,
+                                                      mapped_struct_index,
+                                                      imported_variant.instance_tuple_lens[ai],
+                                                      imported_variant.instance_tuple_types[ai],
+                                                      mapped_tuple_variant_indices,
+                                                      mapped_tuple_struct_indices,
+                                                      0xffffffffu,
+                                                      span);
             if (!filled) return core::make_unexpected(filled.error());
         }
         auto concrete = instantiate_variant(
@@ -6455,23 +6756,28 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
         for (u32 ti = 0; ti < tuple_len; ti++) {
             mapped_tuple_variant_indices[ti] = 0xffffffffu;
             mapped_tuple_struct_indices[ti] = 0xffffffffu;
-            if (tuple_types[ti] == HirTypeKind::Variant && tuple_variant_indices[ti] != 0xffffffffu) {
-                auto remapped_tuple_variant =
-                    remap_imported_variant_index(tuple_variant_indices[ti], mapped_tuple_variant_indices[ti]);
-                if (!remapped_tuple_variant) return core::make_unexpected(remapped_tuple_variant.error());
+            if (tuple_types[ti] == HirTypeKind::Variant &&
+                tuple_variant_indices[ti] != 0xffffffffu) {
+                auto remapped_tuple_variant = remap_imported_variant_index(
+                    tuple_variant_indices[ti], mapped_tuple_variant_indices[ti]);
+                if (!remapped_tuple_variant)
+                    return core::make_unexpected(remapped_tuple_variant.error());
             }
             if (tuple_types[ti] == HirTypeKind::Struct && tuple_struct_indices[ti] != 0xffffffffu) {
-                auto remapped_tuple_struct =
-                    remap_imported_struct_index(tuple_struct_indices[ti], mapped_tuple_struct_indices[ti]);
-                if (!remapped_tuple_struct) return core::make_unexpected(remapped_tuple_struct.error());
+                auto remapped_tuple_struct = remap_imported_struct_index(
+                    tuple_struct_indices[ti], mapped_tuple_struct_indices[ti]);
+                if (!remapped_tuple_struct)
+                    return core::make_unexpected(remapped_tuple_struct.error());
             }
         }
         if (imported_type == HirTypeKind::Variant && imported_variant_index != 0xffffffffu) {
-            auto remapped_variant = remap_imported_variant_index(imported_variant_index, mapped_variant_index);
+            auto remapped_variant =
+                remap_imported_variant_index(imported_variant_index, mapped_variant_index);
             if (!remapped_variant) return core::make_unexpected(remapped_variant.error());
         }
         if (imported_type == HirTypeKind::Struct && imported_struct_index != 0xffffffffu) {
-            auto remapped_struct = remap_imported_struct_index(imported_struct_index, mapped_struct_index);
+            auto remapped_struct =
+                remap_imported_struct_index(imported_struct_index, mapped_struct_index);
             if (!remapped_struct) return core::make_unexpected(remapped_struct.error());
         }
         return {};
@@ -6484,7 +6790,8 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
         return frontend_error(FrontendError::UnsupportedSyntax, span);
     const auto& imported_target = imported_mod.structs[imported_impl.struct_index];
     if (imported_impl.is_generic_template || imported_target.template_struct_index == 0xffffffffu) {
-        const u32 mapped = find_struct_index(*mod, import_visible_name(imported, imported_target.name));
+        const u32 mapped =
+            find_struct_index(*mod, import_visible_name(imported, imported_target.name));
         if (mapped >= mod->structs.len)
             return frontend_error(FrontendError::UnsupportedSyntax, span, imported_target.name);
         out_struct_index = mapped;
@@ -6493,7 +6800,8 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
     if (imported_target.template_struct_index >= imported_mod.structs.len)
         return frontend_error(FrontendError::UnsupportedSyntax, span);
     const auto& imported_template = imported_mod.structs[imported_target.template_struct_index];
-    const u32 mapped_template = find_struct_index(*mod, import_visible_name(imported, imported_template.name));
+    const u32 mapped_template =
+        find_struct_index(*mod, import_visible_name(imported, imported_template.name));
     if (mapped_template >= mod->structs.len)
         return frontend_error(FrontendError::UnsupportedSyntax, span, imported_template.name);
     GenericBinding bindings[HirStruct::kMaxTypeParams]{};
@@ -6503,30 +6811,32 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
         u32 mapped_tuple_struct_indices[kMaxTupleSlots]{};
         u32 mapped_variant_index = 0xffffffffu;
         u32 mapped_arg_struct_index = 0xffffffffu;
-        auto remapped = remap_imported_type_metadata(imported_target.instance_type_args[bi],
-                                                     imported_target.instance_variant_indices[bi],
-                                                     imported_target.instance_struct_indices[bi],
-                                                     imported_target.instance_tuple_lens[bi],
-                                                     imported_target.instance_tuple_types[bi],
-                                                     imported_target.instance_tuple_variant_indices[bi],
-                                                     imported_target.instance_tuple_struct_indices[bi],
-                                                     mapped_variant_index,
-                                                     mapped_arg_struct_index,
-                                                     mapped_tuple_variant_indices,
-                                                     mapped_tuple_struct_indices);
+        auto remapped =
+            remap_imported_type_metadata(imported_target.instance_type_args[bi],
+                                         imported_target.instance_variant_indices[bi],
+                                         imported_target.instance_struct_indices[bi],
+                                         imported_target.instance_tuple_lens[bi],
+                                         imported_target.instance_tuple_types[bi],
+                                         imported_target.instance_tuple_variant_indices[bi],
+                                         imported_target.instance_tuple_struct_indices[bi],
+                                         mapped_variant_index,
+                                         mapped_arg_struct_index,
+                                         mapped_tuple_variant_indices,
+                                         mapped_tuple_struct_indices);
         if (!remapped) return core::make_unexpected(remapped.error());
-        auto filled = fill_bound_binding_from_type_metadata(&bindings[bi],
-                                                            mod,
-                                                            imported_target.instance_type_args[bi],
-                                                            imported_target.instance_generic_indices[bi],
-                                                            mapped_variant_index,
-                                                            mapped_arg_struct_index,
-                                                            imported_target.instance_tuple_lens[bi],
-                                                            imported_target.instance_tuple_types[bi],
-                                                            mapped_tuple_variant_indices,
-                                                            mapped_tuple_struct_indices,
-                                                            0xffffffffu,
-                                                            span);
+        auto filled =
+            fill_bound_binding_from_type_metadata(&bindings[bi],
+                                                  mod,
+                                                  imported_target.instance_type_args[bi],
+                                                  imported_target.instance_generic_indices[bi],
+                                                  mapped_variant_index,
+                                                  mapped_arg_struct_index,
+                                                  imported_target.instance_tuple_lens[bi],
+                                                  imported_target.instance_tuple_types[bi],
+                                                  mapped_tuple_variant_indices,
+                                                  mapped_tuple_struct_indices,
+                                                  0xffffffffu,
+                                                  span);
         if (!filled) return core::make_unexpected(filled.error());
     }
     auto concrete = instantiate_struct(mod, mapped_template, bindings, binding_count, span);
@@ -6535,25 +6845,31 @@ static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
     return {};
 }
 
-static FrontendResult<void> merge_imported_impls(HirModule* mod,
-                                                 const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+static FrontendResult<void> merge_imported_impls(
+    HirModule* mod, const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
     for (u32 ii = 0; ii < imports.len; ii++) {
         const auto& imported = imports[ii];
         for (u32 impl_i = 0; impl_i < imported.module->impls.len; impl_i++) {
             const auto& imported_impl = imported.module->impls[impl_i];
             if (imported_impl.protocol_index >= imported.module->protocols.len)
                 return frontend_error(FrontendError::UnsupportedSyntax, imported.span);
-            const Str protocol_name = import_visible_name(imported, imported.module->protocols[imported_impl.protocol_index].name);
+            const Str protocol_name = import_visible_name(
+                imported, imported.module->protocols[imported_impl.protocol_index].name);
             if (imported.selective) {
                 bool selected = false;
                 for (u32 si = 0; si < imported.selected_names.len; si++) {
-                    if (imported.selected_names[si].name.eq(imported.module->protocols[imported_impl.protocol_index].name)) { selected = true; break; }
+                    if (imported.selected_names[si].name.eq(
+                            imported.module->protocols[imported_impl.protocol_index].name)) {
+                        selected = true;
+                        break;
+                    }
                 }
                 if (!selected) continue;
             }
             const u32 mapped_protocol_index = find_protocol_index(*mod, protocol_name);
             if (mapped_protocol_index >= mod->protocols.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, protocol_name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, imported.span, protocol_name);
             HirTypeKind mapped_type = HirTypeKind::Unknown;
             u32 mapped_struct_index = 0xffffffffu;
             bool mapped_is_generic_template = false;
@@ -6569,8 +6885,13 @@ static FrontendResult<void> merge_imported_impls(HirModule* mod,
             for (u32 existing_i = 0; existing_i < mod->impls.len; existing_i++) {
                 const auto& existing = mod->impls[existing_i];
                 if (existing.protocol_index == mapped_protocol_index &&
-                    impl_targets_overlap(*mod, existing, mapped_type, mapped_struct_index, mapped_is_generic_template))
-                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, protocol_name);
+                    impl_targets_overlap(*mod,
+                                         existing,
+                                         mapped_type,
+                                         mapped_struct_index,
+                                         mapped_is_generic_template))
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, imported.span, protocol_name);
             }
             HirConformance conf{};
             conf.span = imported_impl.span;
@@ -6580,11 +6901,11 @@ static FrontendResult<void> merge_imported_impls(HirModule* mod,
             conf.is_generic_template = mapped_is_generic_template;
             for (u32 ci = 0; ci < mod->conformances.len; ci++) {
                 const auto& existing = mod->conformances[ci];
-                if (existing.protocol_index == conf.protocol_index &&
-                    existing.type == conf.type &&
+                if (existing.protocol_index == conf.protocol_index && existing.type == conf.type &&
                     existing.struct_index == conf.struct_index &&
                     existing.is_generic_template == conf.is_generic_template)
-                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, protocol_name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, imported.span, protocol_name);
             }
             if (!mod->conformances.push(conf))
                 return frontend_error(FrontendError::TooManyItems, imported.span);
@@ -6598,7 +6919,8 @@ static FrontendResult<void> merge_imported_impls(HirModule* mod,
             for (u32 mi = 0; mi < imported_impl.methods.len; mi++) {
                 const auto& imported_method = imported_impl.methods[mi];
                 if (imported_method.function_index >= imported.module->functions.len)
-                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_method.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, imported.span, imported_method.name);
                 const Str fn_name = imported.module->functions[imported_method.function_index].name;
                 const u32 mapped_fn_index = find_function_index(*mod, fn_name);
                 if (mapped_fn_index >= mod->functions.len)
@@ -6616,23 +6938,26 @@ static FrontendResult<void> merge_imported_impls(HirModule* mod,
     return {};
 }
 
-static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& out,
-                                                  const AstFile& file,
-                                                  Str source_path,
-                                                  std::deque<std::string>& owned_strings,
-                                                  std::vector<std::string>& import_stack,
-                                                  std::vector<std::unique_ptr<HirModule>>& imported_storage) {
+static FrontendResult<void> load_imported_modules(
+    FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& out,
+    const AstFile& file,
+    Str source_path,
+    std::deque<std::string>& owned_strings,
+    std::vector<std::string>& import_stack,
+    std::vector<std::unique_ptr<HirModule>>& imported_storage) {
     if (source_path.len == 0) return {};
     const auto base_dir = std::filesystem::path(str_to_std_string(source_path)).parent_path();
     for (u32 i = 0; i < file.items.len; i++) {
         const auto& item = file.items[i];
         if (item.kind != AstItemKind::Import) continue;
-        const auto normalized = (base_dir / str_to_std_string(item.import_decl.path)).lexically_normal().string();
+        const auto normalized =
+            (base_dir / str_to_std_string(item.import_decl.path)).lexically_normal().string();
         ImportedModuleInfo* existing_info = nullptr;
         for (u32 ii = 0; ii < out.len; ii++) {
             if (out[ii].path.eq({normalized.c_str(), static_cast<u32>(normalized.size())}) &&
                 out[ii].has_namespace_alias == item.import_decl.has_namespace_alias &&
-                (!out[ii].has_namespace_alias || out[ii].namespace_alias.eq(item.import_decl.namespace_alias))) {
+                (!out[ii].has_namespace_alias ||
+                 out[ii].namespace_alias.eq(item.import_decl.namespace_alias))) {
                 existing_info = &out[ii];
                 break;
             }
@@ -6656,7 +6981,8 @@ static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, A
                     }
                     if (!seen) {
                         if (!existing_info->selected_names.push(selected))
-                            return frontend_error(FrontendError::TooManyItems, item.import_decl.span);
+                            return frontend_error(FrontendError::TooManyItems,
+                                                  item.import_decl.span);
                     }
                 }
             }
@@ -6664,7 +6990,8 @@ static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, A
         }
         std::string content;
         if (!read_text_file(normalized, content))
-            return frontend_error(FrontendError::UnsupportedSyntax, item.import_decl.span, item.import_decl.path);
+            return frontend_error(
+                FrontendError::UnsupportedSyntax, item.import_decl.span, item.import_decl.path);
         auto kept_source = stash_owned_string(owned_strings, content);
         auto lexed = lex(kept_source);
         if (!lexed) return core::make_unexpected(lexed.error());
@@ -6672,7 +6999,8 @@ static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, A
         if (!ast) return core::make_unexpected(ast.error());
         auto kept_path = stash_owned_string(owned_strings, normalized);
         g_import_analysis_counter++;
-        auto imported = analyze_file_internal(*ast.value(), kept_path, import_stack, &owned_strings);
+        auto imported =
+            analyze_file_internal(*ast.value(), kept_path, import_stack, &owned_strings);
         if (!imported) return core::make_unexpected(imported.error());
         imported_storage.push_back(std::unique_ptr<HirModule>(imported.value()));
         ImportedModuleInfo info{};
@@ -6692,10 +7020,11 @@ static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, A
     return {};
 }
 
-static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
-                                                        Str source_path,
-                                                        std::vector<std::string>& import_stack,
-                                                        std::deque<std::string>* shared_owned_strings) {
+static FrontendResult<HirModule*> analyze_file_internal(
+    const AstFile& file,
+    Str source_path,
+    std::vector<std::string>& import_stack,
+    std::deque<std::string>* shared_owned_strings) {
     auto mod_ptr = std::make_unique<HirModule>();
     HirModule& mod = *mod_ptr;
     mod.has_package_decl = file.has_package_decl;
@@ -6703,7 +7032,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
     mod.package_name = file.package_name;
     std::string normalized_source;
     if (source_path.len != 0) {
-        normalized_source = std::filesystem::path(str_to_std_string(source_path)).lexically_normal().string();
+        normalized_source =
+            std::filesystem::path(str_to_std_string(source_path)).lexically_normal().string();
         for (const auto& existing : import_stack) {
             if (existing == normalized_source)
                 return frontend_error(FrontendError::UnsupportedSyntax, {}, source_path);
@@ -6716,9 +7046,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         if (item.kind != AstItemKind::Upstream) continue;
         for (u32 j = 0; j < mod.upstreams.len; j++) {
             if (mod.upstreams[j].name.eq(item.upstream.name))
-                return frontend_error(FrontendError::DuplicateUpstream,
-                                      item.upstream.span,
-                                      item.upstream.name);
+                return frontend_error(
+                    FrontendError::DuplicateUpstream, item.upstream.span, item.upstream.name);
         }
         HirUpstream up{};
         up.span = item.upstream.span;
@@ -6729,21 +7058,32 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
     }
 
     {
-        HirProtocol p{}; p.name = {"Error", 5}; p.kind = HirProtocolKind::Error; if (!mod.protocols.push(p)) return frontend_error(FrontendError::TooManyItems, {});
-        HirProtocol q{}; q.name = {"Eq", 2}; q.kind = HirProtocolKind::Eq; if (!mod.protocols.push(q)) return frontend_error(FrontendError::TooManyItems, {});
-        HirProtocol r{}; r.name = {"Ord", 3}; r.kind = HirProtocolKind::Ord; if (!mod.protocols.push(r)) return frontend_error(FrontendError::TooManyItems, {});
+        HirProtocol p{};
+        p.name = {"Error", 5};
+        p.kind = HirProtocolKind::Error;
+        if (!mod.protocols.push(p)) return frontend_error(FrontendError::TooManyItems, {});
+        HirProtocol q{};
+        q.name = {"Eq", 2};
+        q.kind = HirProtocolKind::Eq;
+        if (!mod.protocols.push(q)) return frontend_error(FrontendError::TooManyItems, {});
+        HirProtocol r{};
+        r.name = {"Ord", 3};
+        r.kind = HirProtocolKind::Ord;
+        if (!mod.protocols.push(r)) return frontend_error(FrontendError::TooManyItems, {});
     }
 
-    auto* owned_strings = shared_owned_strings != nullptr ? shared_owned_strings : &mod.owned_strings;
+    auto* owned_strings =
+        shared_owned_strings != nullptr ? shared_owned_strings : &mod.owned_strings;
     std::vector<std::unique_ptr<HirModule>> imported_storage;
     FixedVec<ImportedModuleInfo, AstFile::kMaxItems> imported_modules;
-    auto loaded_imports =
-        load_imported_modules(imported_modules, file, source_path, *owned_strings, import_stack, imported_storage);
+    auto loaded_imports = load_imported_modules(
+        imported_modules, file, source_path, *owned_strings, import_stack, imported_storage);
     if (!loaded_imports) return core::make_unexpected(loaded_imports.error());
     auto validated_namespaces = validate_import_namespaces(imported_modules);
     if (!validated_namespaces) return core::make_unexpected(validated_namespaces.error());
     auto validated_namespace_bindings = validate_import_namespace_bindings(file, imported_modules);
-    if (!validated_namespace_bindings) return core::make_unexpected(validated_namespace_bindings.error());
+    if (!validated_namespace_bindings)
+        return core::make_unexpected(validated_namespace_bindings.error());
     auto validated_imports = validate_imported_selected_names(imported_modules);
     if (!validated_imports) return core::make_unexpected(validated_imports.error());
 
@@ -6754,7 +7094,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         for (u32 ii = 0; ii < mod.imports.len; ii++) {
             if (mod.imports[ii].path.eq(item.import_decl.path) &&
                 mod.imports[ii].has_namespace_alias == item.import_decl.has_namespace_alias &&
-                (!mod.imports[ii].has_namespace_alias || mod.imports[ii].namespace_alias.eq(item.import_decl.namespace_alias))) {
+                (!mod.imports[ii].has_namespace_alias ||
+                 mod.imports[ii].namespace_alias.eq(item.import_decl.namespace_alias))) {
                 exists = true;
                 break;
             }
@@ -6777,14 +7118,14 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             for (u32 ii = 0; ii < imported_modules.len; ii++) {
                 if (!normalized_import_path.empty() &&
                     !imported_modules[ii].path.eq(
-                        {normalized_import_path.c_str(), static_cast<u32>(normalized_import_path.size())}))
+                        {normalized_import_path.c_str(),
+                         static_cast<u32>(normalized_import_path.size())}))
                     continue;
                 imp.has_package_decl = imported_modules[ii].module->has_package_decl;
                 imp.package_name = imported_modules[ii].module->package_name;
-                imp.same_package =
-                    mod.has_package_decl &&
-                    imported_modules[ii].module->has_package_decl &&
-                    mod.package_name.eq(imported_modules[ii].module->package_name);
+                imp.same_package = mod.has_package_decl &&
+                                   imported_modules[ii].module->has_package_decl &&
+                                   mod.package_name.eq(imported_modules[ii].module->package_name);
                 break;
             }
             if (!mod.imports.push(imp))
@@ -6799,7 +7140,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         const auto& item = file.items[i];
         if (item.kind != AstItemKind::Protocol) continue;
         if (find_protocol_index(mod, item.protocol.name) < mod.protocols.len)
-            return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, item.protocol.name);
+            return frontend_error(
+                FrontendError::UnsupportedSyntax, item.protocol.span, item.protocol.name);
         HirProtocol proto{};
         proto.span = item.protocol.span;
         proto.name = item.protocol.name;
@@ -6807,7 +7149,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         for (u32 mi = 0; mi < item.protocol.methods.len; mi++) {
             for (u32 seen = 0; seen < proto.methods.len; seen++) {
                 if (proto.methods[seen].name.eq(item.protocol.methods[mi].name))
-                    return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, item.protocol.methods[mi].name);
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          item.protocol.span,
+                                          item.protocol.methods[mi].name);
             }
             HirProtocol::MethodDecl method{};
             method.name = item.protocol.methods[mi].name;
@@ -6882,9 +7226,11 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         const auto& item = file.items[i];
         if (item.kind != AstItemKind::Struct) continue;
         if (item.struct_decl.name.eq({"Error", 5}))
-            return frontend_error(FrontendError::UnsupportedSyntax, item.struct_decl.span, item.struct_decl.name);
+            return frontend_error(
+                FrontendError::UnsupportedSyntax, item.struct_decl.span, item.struct_decl.name);
         if (find_struct_index(mod, item.struct_decl.name) != mod.structs.len)
-            return frontend_error(FrontendError::UnsupportedSyntax, item.struct_decl.span, item.struct_decl.name);
+            return frontend_error(
+                FrontendError::UnsupportedSyntax, item.struct_decl.span, item.struct_decl.name);
         HirStruct decl{};
         decl.span = item.struct_decl.span;
         decl.name = item.struct_decl.name;
@@ -6897,7 +7243,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         const auto& item = file.items[i];
         if (item.kind != AstItemKind::Variant) continue;
         if (find_variant_index(mod, item.variant.name) != mod.variants.len)
-            return frontend_error(FrontendError::UnsupportedSyntax, item.variant.span, item.variant.name);
+            return frontend_error(
+                FrontendError::UnsupportedSyntax, item.variant.span, item.variant.name);
         HirVariant variant{};
         variant.span = item.variant.span;
         variant.name = item.variant.name;
@@ -6911,7 +7258,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         if (item.kind != AstItemKind::Variant) continue;
         const u32 variant_decl_index = find_variant_index(mod, item.variant.name);
         if (variant_decl_index == mod.variants.len)
-            return frontend_error(FrontendError::UnsupportedSyntax, item.variant.span, item.variant.name);
+            return frontend_error(
+                FrontendError::UnsupportedSyntax, item.variant.span, item.variant.name);
         HirVariant& variant = mod.variants[variant_decl_index];
         for (u32 ci = 0; ci < item.variant.cases.len; ci++) {
             for (u32 seen = 0; seen < variant.cases.len; seen++) {
@@ -6924,7 +7272,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             case_decl.name = item.variant.cases[ci].name;
             case_decl.has_payload = item.variant.cases[ci].has_payload;
             if (case_decl.has_payload) {
-                FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> variant_type_params;
+                FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>
+                    variant_type_params;
                 for (u32 ti = 0; ti < variant.type_params.len; ti++) {
                     HirFunction::TypeParamDecl tp{};
                     tp.name = variant.type_params[ti];
@@ -6935,13 +7284,17 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 if (!payload_ref.is_tuple && payload_ref.type_arg_names.len != 0) {
                     u32 template_variant_index = 0xffffffffu;
                     u32 template_struct_index = 0xffffffffu;
-                    const auto named_kind =
-                        resolve_named_type(mod, payload_ref.name, template_variant_index, template_struct_index);
+                    const auto named_kind = resolve_named_type(
+                        mod, payload_ref.name, template_variant_index, template_struct_index);
                     const bool is_generic_named =
-                        (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
-                         mod.variants[template_variant_index].type_params.len == payload_ref.type_arg_names.len) ||
-                        (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
-                         mod.structs[template_struct_index].type_params.len == payload_ref.type_arg_names.len);
+                        (named_kind == HirTypeKind::Variant &&
+                         template_variant_index < mod.variants.len &&
+                         mod.variants[template_variant_index].type_params.len ==
+                             payload_ref.type_arg_names.len) ||
+                        (named_kind == HirTypeKind::Struct &&
+                         template_struct_index < mod.structs.len &&
+                         mod.structs[template_struct_index].type_params.len ==
+                             payload_ref.type_arg_names.len);
                     if (is_generic_named) {
                         bool has_generic_arg = false;
                         case_decl.payload_type = named_kind;
@@ -6950,29 +7303,31 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                         case_decl.payload_type_arg_count = payload_ref.type_arg_names.len;
                         for (u32 ai = 0; ai < payload_ref.type_arg_names.len; ai++) {
                             AstTypeRef arg_ref = get_ast_type_arg_ref(payload_ref, ai);
-                            auto arg_type = resolve_func_type_ref(mod,
-                                                                  arg_ref,
-                                                                  &variant_type_params,
-                                                                  &case_decl.payload_type_args[ai].generic_index,
-                                                                  case_decl.payload_type_args[ai].variant_index,
-                                                                  case_decl.payload_type_args[ai].struct_index,
-                                                                  case_decl.payload_type_args[ai].tuple_len,
-                                                                  case_decl.payload_type_args[ai].tuple_types,
-                                                                  case_decl.payload_type_args[ai].tuple_variant_indices,
-                                                                  case_decl.payload_type_args[ai].tuple_struct_indices,
-                                                                  item.variant.span);
+                            auto arg_type = resolve_func_type_ref(
+                                mod,
+                                arg_ref,
+                                &variant_type_params,
+                                &case_decl.payload_type_args[ai].generic_index,
+                                case_decl.payload_type_args[ai].variant_index,
+                                case_decl.payload_type_args[ai].struct_index,
+                                case_decl.payload_type_args[ai].tuple_len,
+                                case_decl.payload_type_args[ai].tuple_types,
+                                case_decl.payload_type_args[ai].tuple_variant_indices,
+                                case_decl.payload_type_args[ai].tuple_struct_indices,
+                                item.variant.span);
                             if (!arg_type) return core::make_unexpected(arg_type.error());
                             case_decl.payload_type_args[ai].type = arg_type.value();
-                            auto arg_shape = intern_hir_type_shape(&mod,
-                                                                   case_decl.payload_type_args[ai].type,
-                                                                   case_decl.payload_type_args[ai].generic_index,
-                                                                   case_decl.payload_type_args[ai].variant_index,
-                                                                   case_decl.payload_type_args[ai].struct_index,
-                                                                   case_decl.payload_type_args[ai].tuple_len,
-                                                                   case_decl.payload_type_args[ai].tuple_types,
-                                                                   case_decl.payload_type_args[ai].tuple_variant_indices,
-                                                                   case_decl.payload_type_args[ai].tuple_struct_indices,
-                                                                   item.variant.span);
+                            auto arg_shape = intern_hir_type_shape(
+                                &mod,
+                                case_decl.payload_type_args[ai].type,
+                                case_decl.payload_type_args[ai].generic_index,
+                                case_decl.payload_type_args[ai].variant_index,
+                                case_decl.payload_type_args[ai].struct_index,
+                                case_decl.payload_type_args[ai].tuple_len,
+                                case_decl.payload_type_args[ai].tuple_types,
+                                case_decl.payload_type_args[ai].tuple_variant_indices,
+                                case_decl.payload_type_args[ai].tuple_struct_indices,
+                                item.variant.span);
                             if (!arg_shape) return core::make_unexpected(arg_shape.error());
                             case_decl.payload_type_args[ai].shape_index = arg_shape.value();
                             if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
@@ -6980,18 +7335,19 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                         if (has_generic_arg) {
                             GenericBinding bindings[HirVariant::kMaxTypeParams]{};
                             for (u32 ai = 0; ai < payload_ref.type_arg_names.len; ai++) {
-                                auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
-                                                                                    &mod,
-                                                                                    case_decl.payload_type_args[ai].type,
-                                                                                    case_decl.payload_type_args[ai].generic_index,
-                                                                                    case_decl.payload_type_args[ai].variant_index,
-                                                                                    case_decl.payload_type_args[ai].struct_index,
-                                                                                    case_decl.payload_type_args[ai].tuple_len,
-                                                                                    case_decl.payload_type_args[ai].tuple_types,
-                                                                                    case_decl.payload_type_args[ai].tuple_variant_indices,
-                                                                                    case_decl.payload_type_args[ai].tuple_struct_indices,
-                                                                                    case_decl.payload_type_args[ai].shape_index,
-                                                                                    item.variant.span);
+                                auto filled = fill_bound_binding_from_type_metadata(
+                                    &bindings[ai],
+                                    &mod,
+                                    case_decl.payload_type_args[ai].type,
+                                    case_decl.payload_type_args[ai].generic_index,
+                                    case_decl.payload_type_args[ai].variant_index,
+                                    case_decl.payload_type_args[ai].struct_index,
+                                    case_decl.payload_type_args[ai].tuple_len,
+                                    case_decl.payload_type_args[ai].tuple_types,
+                                    case_decl.payload_type_args[ai].tuple_variant_indices,
+                                    case_decl.payload_type_args[ai].tuple_struct_indices,
+                                    case_decl.payload_type_args[ai].shape_index,
+                                    item.variant.span);
                                 if (!filled) return core::make_unexpected(filled.error());
                             }
                             if (named_kind == HirTypeKind::Variant) {
@@ -7013,20 +7369,22 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                 case_decl.payload_struct_index = concrete.value();
                                 case_decl.payload_variant_index = 0xffffffffu;
                             }
-                            auto payload_shape = intern_hir_type_shape(&mod,
-                                                                       case_decl.payload_type,
-                                                                       case_decl.payload_generic_index,
-                                                                       case_decl.payload_variant_index,
-                                                                       case_decl.payload_struct_index,
-                                                                       case_decl.payload_tuple_len,
-                                                                       case_decl.payload_tuple_types,
-                                                                       case_decl.payload_tuple_variant_indices,
-                                                                       case_decl.payload_tuple_struct_indices,
-                                                                       item.variant.span);
+                            auto payload_shape =
+                                intern_hir_type_shape(&mod,
+                                                      case_decl.payload_type,
+                                                      case_decl.payload_generic_index,
+                                                      case_decl.payload_variant_index,
+                                                      case_decl.payload_struct_index,
+                                                      case_decl.payload_tuple_len,
+                                                      case_decl.payload_tuple_types,
+                                                      case_decl.payload_tuple_variant_indices,
+                                                      case_decl.payload_tuple_struct_indices,
+                                                      item.variant.span);
                             if (!payload_shape) return core::make_unexpected(payload_shape.error());
                             case_decl.payload_shape_index = payload_shape.value();
                             if (!variant.cases.push(case_decl))
-                                return frontend_error(FrontendError::TooManyItems, item.variant.span);
+                                return frontend_error(FrontendError::TooManyItems,
+                                                      item.variant.span);
                             continue;
                         }
                     }
@@ -7067,7 +7425,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         if (item.kind != AstItemKind::Struct) continue;
         const u32 struct_decl_index = find_struct_index(mod, item.struct_decl.name);
         if (struct_decl_index == mod.structs.len)
-            return frontend_error(FrontendError::UnsupportedSyntax, item.struct_decl.span, item.struct_decl.name);
+            return frontend_error(
+                FrontendError::UnsupportedSyntax, item.struct_decl.span, item.struct_decl.name);
         HirStruct& decl = mod.structs[struct_decl_index];
         for (u32 fi = 0; fi < item.struct_decl.fields.len; fi++) {
             for (u32 seen = 0; seen < decl.fields.len; seen++) {
@@ -7083,7 +7442,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 field.type_name = item.struct_decl.fields[fi].type.name;
                 field.is_error_type = true;
             } else {
-                FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> struct_type_params;
+                FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>
+                    struct_type_params;
                 for (u32 ti = 0; ti < decl.type_params.len; ti++) {
                     HirFunction::TypeParamDecl tp{};
                     tp.name = decl.type_params[ti];
@@ -7094,13 +7454,17 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 if (!type_ref.is_tuple && type_ref.type_arg_names.len != 0) {
                     u32 template_variant_index = 0xffffffffu;
                     u32 template_struct_index = 0xffffffffu;
-                    const auto named_kind =
-                        resolve_named_type(mod, type_ref.name, template_variant_index, template_struct_index);
+                    const auto named_kind = resolve_named_type(
+                        mod, type_ref.name, template_variant_index, template_struct_index);
                     const bool is_generic_named =
-                        (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
-                         mod.variants[template_variant_index].type_params.len == type_ref.type_arg_names.len) ||
-                        (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
-                         mod.structs[template_struct_index].type_params.len == type_ref.type_arg_names.len);
+                        (named_kind == HirTypeKind::Variant &&
+                         template_variant_index < mod.variants.len &&
+                         mod.variants[template_variant_index].type_params.len ==
+                             type_ref.type_arg_names.len) ||
+                        (named_kind == HirTypeKind::Struct &&
+                         template_struct_index < mod.structs.len &&
+                         mod.structs[template_struct_index].type_params.len ==
+                             type_ref.type_arg_names.len);
                     if (is_generic_named) {
                         bool has_generic_arg = false;
                         field.type = named_kind;
@@ -7109,29 +7473,31 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                         field.type_arg_count = type_ref.type_arg_names.len;
                         for (u32 ai = 0; ai < type_ref.type_arg_names.len; ai++) {
                             AstTypeRef arg_ref = get_ast_type_arg_ref(type_ref, ai);
-                            auto arg_type = resolve_func_type_ref(mod,
-                                                                  arg_ref,
-                                                                  &struct_type_params,
-                                                                  &field.type_args[ai].generic_index,
-                                                                  field.type_args[ai].variant_index,
-                                                                  field.type_args[ai].struct_index,
-                                                                  field.type_args[ai].tuple_len,
-                                                                  field.type_args[ai].tuple_types,
-                                                                  field.type_args[ai].tuple_variant_indices,
-                                                                  field.type_args[ai].tuple_struct_indices,
-                                                                  item.struct_decl.span);
+                            auto arg_type =
+                                resolve_func_type_ref(mod,
+                                                      arg_ref,
+                                                      &struct_type_params,
+                                                      &field.type_args[ai].generic_index,
+                                                      field.type_args[ai].variant_index,
+                                                      field.type_args[ai].struct_index,
+                                                      field.type_args[ai].tuple_len,
+                                                      field.type_args[ai].tuple_types,
+                                                      field.type_args[ai].tuple_variant_indices,
+                                                      field.type_args[ai].tuple_struct_indices,
+                                                      item.struct_decl.span);
                             if (!arg_type) return core::make_unexpected(arg_type.error());
                             field.type_args[ai].type = arg_type.value();
-                            auto arg_shape = intern_hir_type_shape(&mod,
-                                                                   field.type_args[ai].type,
-                                                                   field.type_args[ai].generic_index,
-                                                                   field.type_args[ai].variant_index,
-                                                                   field.type_args[ai].struct_index,
-                                                                   field.type_args[ai].tuple_len,
-                                                                   field.type_args[ai].tuple_types,
-                                                                   field.type_args[ai].tuple_variant_indices,
-                                                                   field.type_args[ai].tuple_struct_indices,
-                                                                   item.struct_decl.span);
+                            auto arg_shape =
+                                intern_hir_type_shape(&mod,
+                                                      field.type_args[ai].type,
+                                                      field.type_args[ai].generic_index,
+                                                      field.type_args[ai].variant_index,
+                                                      field.type_args[ai].struct_index,
+                                                      field.type_args[ai].tuple_len,
+                                                      field.type_args[ai].tuple_types,
+                                                      field.type_args[ai].tuple_variant_indices,
+                                                      field.type_args[ai].tuple_struct_indices,
+                                                      item.struct_decl.span);
                             if (!arg_shape) return core::make_unexpected(arg_shape.error());
                             field.type_args[ai].shape_index = arg_shape.value();
                             if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
@@ -7139,18 +7505,19 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                         if (has_generic_arg) {
                             GenericBinding bindings[HirStruct::kMaxTypeParams]{};
                             for (u32 ai = 0; ai < type_ref.type_arg_names.len; ai++) {
-                                auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
-                                                                                    &mod,
-                                                                                    field.type_args[ai].type,
-                                                                                    field.type_args[ai].generic_index,
-                                                                                    field.type_args[ai].variant_index,
-                                                                                    field.type_args[ai].struct_index,
-                                                                                    field.type_args[ai].tuple_len,
-                                                                                    field.type_args[ai].tuple_types,
-                                                                                    field.type_args[ai].tuple_variant_indices,
-                                                                                    field.type_args[ai].tuple_struct_indices,
-                                                                                    field.type_args[ai].shape_index,
-                                                                                    item.struct_decl.span);
+                                auto filled = fill_bound_binding_from_type_metadata(
+                                    &bindings[ai],
+                                    &mod,
+                                    field.type_args[ai].type,
+                                    field.type_args[ai].generic_index,
+                                    field.type_args[ai].variant_index,
+                                    field.type_args[ai].struct_index,
+                                    field.type_args[ai].tuple_len,
+                                    field.type_args[ai].tuple_types,
+                                    field.type_args[ai].tuple_variant_indices,
+                                    field.type_args[ai].tuple_struct_indices,
+                                    field.type_args[ai].shape_index,
+                                    item.struct_decl.span);
                                 if (!filled) return core::make_unexpected(filled.error());
                             }
                             if (named_kind == HirTypeKind::Variant) {
@@ -7174,7 +7541,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                             }
                             field.type_name = type_ref.name;
                             if (!decl.fields.push(field))
-                                return frontend_error(FrontendError::TooManyItems, item.struct_decl.span);
+                                return frontend_error(FrontendError::TooManyItems,
+                                                      item.struct_decl.span);
                             continue;
                         }
                     }
@@ -7198,15 +7566,20 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                       item.struct_decl.span);
                 if (!resolved) return core::make_unexpected(resolved.error());
                 field.type = resolved.value();
-                if (field.type == HirTypeKind::Generic && field.generic_index < struct_type_params.len) {
-                    field.generic_has_error_constraint = struct_type_params[field.generic_index].has_error_constraint;
-                    field.generic_has_eq_constraint = struct_type_params[field.generic_index].has_eq_constraint;
-                    field.generic_has_ord_constraint = struct_type_params[field.generic_index].has_ord_constraint;
+                if (field.type == HirTypeKind::Generic &&
+                    field.generic_index < struct_type_params.len) {
+                    field.generic_has_error_constraint =
+                        struct_type_params[field.generic_index].has_error_constraint;
+                    field.generic_has_eq_constraint =
+                        struct_type_params[field.generic_index].has_eq_constraint;
+                    field.generic_has_ord_constraint =
+                        struct_type_params[field.generic_index].has_ord_constraint;
                     field.generic_protocol_index =
                         struct_type_params[field.generic_index].custom_protocol_count != 0
                             ? struct_type_params[field.generic_index].custom_protocol_indices[0]
                             : 0xffffffffu;
-                    field.generic_protocol_count = struct_type_params[field.generic_index].custom_protocol_count;
+                    field.generic_protocol_count =
+                        struct_type_params[field.generic_index].custom_protocol_count;
                     for (u32 cpi = 0; cpi < field.generic_protocol_count; cpi++)
                         field.generic_protocol_indices[cpi] =
                             struct_type_params[field.generic_index].custom_protocol_indices[cpi];
@@ -7252,7 +7625,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         if (item.kind != AstItemKind::Using) continue;
         for (u32 ai = 0; ai < mod.aliases.len; ai++) {
             if (mod.aliases[ai].name.eq(item.using_decl.name))
-                return frontend_error(FrontendError::UnsupportedSyntax, item.using_decl.span, item.using_decl.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.using_decl.span, item.using_decl.name);
         }
         HirAlias alias{};
         alias.span = item.using_decl.span;
@@ -7267,14 +7641,15 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
 
     auto imported = merge_imported_functions(&mod, imported_modules);
     if (!imported) return core::make_unexpected(imported.error());
-    auto imported_proto_methods = refresh_imported_protocol_method_functions(&mod, imported_modules);
+    auto imported_proto_methods =
+        refresh_imported_protocol_method_functions(&mod, imported_modules);
     if (!imported_proto_methods) return core::make_unexpected(imported_proto_methods.error());
     auto imported_impls = merge_imported_impls(&mod, imported_modules);
     if (!imported_impls) return core::make_unexpected(imported_impls.error());
 
     auto refreshed_structs = refresh_concrete_struct_instances(&mod);
     if (!refreshed_structs) {
-    if (source_path.len != 0 && !import_stack.empty()) import_stack.pop_back();
+        if (source_path.len != 0 && !import_stack.empty()) import_stack.pop_back();
         return core::make_unexpected(refreshed_structs.error());
     }
     auto refreshed_variants = refresh_concrete_variant_instances(&mod);
@@ -7283,7 +7658,12 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         return core::make_unexpected(refreshed_variants.error());
     }
 
-    auto declare_function_like = [&](const AstFunctionDecl& ast_func, Span span, Str fn_name, const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>* extra_type_params) -> FrontendResult<HirFunction> {
+    auto declare_function_like =
+        [&](const AstFunctionDecl& ast_func,
+            Span span,
+            Str fn_name,
+            const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>*
+                extra_type_params) -> FrontendResult<HirFunction> {
         HirFunction fn{};
         fn.span = span;
         fn.name = fn_name;
@@ -7296,7 +7676,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         for (u32 ti = 0; ti < ast_func.type_params.len; ti++) {
             for (u32 seen = 0; seen < fn.type_params.len; seen++) {
                 if (fn.type_params[seen].name.eq(ast_func.type_params[ti].name))
-                    return frontend_error(FrontendError::UnsupportedSyntax, span, ast_func.type_params[ti].name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, span, ast_func.type_params[ti].name);
             }
             HirFunction::TypeParamDecl type_param{};
             type_param.name = ast_func.type_params[ti].name;
@@ -7306,12 +7687,15 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 for (u32 ci = 0; ci < ast_func.type_params[ti].constraints.len; ci++) {
                     const auto constraint = ast_func.type_params[ti].constraints[ci];
                     Str resolved_constraint = constraint;
-                    if (ci < ast_func.type_params[ti].constraint_namespaces.len && ast_func.type_params[ti].constraint_namespaces[ci].len != 0) {
-                        if (!resolve_import_namespace_type_name(mod,
-                                                                ast_func.type_params[ti].constraint_namespaces[ci],
-                                                                constraint,
-                                                                resolved_constraint))
-                            return frontend_error(FrontendError::UnsupportedSyntax, span, constraint);
+                    if (ci < ast_func.type_params[ti].constraint_namespaces.len &&
+                        ast_func.type_params[ti].constraint_namespaces[ci].len != 0) {
+                        if (!resolve_import_namespace_type_name(
+                                mod,
+                                ast_func.type_params[ti].constraint_namespaces[ci],
+                                constraint,
+                                resolved_constraint))
+                            return frontend_error(
+                                FrontendError::UnsupportedSyntax, span, constraint);
                     }
                     const auto kind = resolve_protocol_kind(mod, resolved_constraint);
                     if (kind == static_cast<HirProtocolKind>(0xff))
@@ -7324,11 +7708,14 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     if (kind == HirProtocolKind::Custom) {
                         const u32 pi = find_protocol_index(mod, resolved_constraint);
                         if (pi >= mod.protocols.len)
-                            return frontend_error(FrontendError::UnsupportedSyntax, span, constraint);
+                            return frontend_error(
+                                FrontendError::UnsupportedSyntax, span, constraint);
                         type_param.custom_protocol_indices[type_param.custom_protocol_count++] = pi;
                     }
                 }
-                type_param.constraint_kind = ast_func.type_params[ti].constraints.len != 0 ? type_param.constraint_kinds[0] : HirProtocolKind::Custom;
+                type_param.constraint_kind = ast_func.type_params[ti].constraints.len != 0
+                                                 ? type_param.constraint_kinds[0]
+                                                 : HirProtocolKind::Custom;
             }
             if (!fn.type_params.push(type_param))
                 return frontend_error(FrontendError::TooManyItems, span);
@@ -7338,13 +7725,16 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             if (!ret_ref.is_tuple && ret_ref.type_arg_names.len != 0) {
                 u32 template_variant_index = 0xffffffffu;
                 u32 template_struct_index = 0xffffffffu;
-                const auto named_kind =
-                    resolve_named_type(mod, ret_ref.name, template_variant_index, template_struct_index);
+                const auto named_kind = resolve_named_type(
+                    mod, ret_ref.name, template_variant_index, template_struct_index);
                 const bool is_generic_named =
-                    (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
-                     mod.variants[template_variant_index].type_params.len == ret_ref.type_arg_names.len) ||
+                    (named_kind == HirTypeKind::Variant &&
+                     template_variant_index < mod.variants.len &&
+                     mod.variants[template_variant_index].type_params.len ==
+                         ret_ref.type_arg_names.len) ||
                     (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
-                     mod.structs[template_struct_index].type_params.len == ret_ref.type_arg_names.len);
+                     mod.structs[template_struct_index].type_params.len ==
+                         ret_ref.type_arg_names.len);
                 if (is_generic_named) {
                     bool has_generic_arg = false;
                     GenericBinding bindings[HirFunction::kMaxTypeParams]{};
@@ -7354,57 +7744,72 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     fn.return_type_arg_count = ret_ref.type_arg_names.len;
                     for (u32 ai = 0; ai < ret_ref.type_arg_names.len; ai++) {
                         AstTypeRef arg_ref = get_ast_type_arg_ref(ret_ref, ai);
-                        auto arg_type = resolve_func_type_ref(mod, arg_ref, &fn.type_params,
-                                                              &fn.return_type_args[ai].generic_index,
-                                                              fn.return_type_args[ai].variant_index,
-                                                              fn.return_type_args[ai].struct_index,
-                                                              fn.return_type_args[ai].tuple_len,
-                                                              fn.return_type_args[ai].tuple_types,
-                                                              fn.return_type_args[ai].tuple_variant_indices,
-                                                              fn.return_type_args[ai].tuple_struct_indices,
-                                                              span);
+                        auto arg_type =
+                            resolve_func_type_ref(mod,
+                                                  arg_ref,
+                                                  &fn.type_params,
+                                                  &fn.return_type_args[ai].generic_index,
+                                                  fn.return_type_args[ai].variant_index,
+                                                  fn.return_type_args[ai].struct_index,
+                                                  fn.return_type_args[ai].tuple_len,
+                                                  fn.return_type_args[ai].tuple_types,
+                                                  fn.return_type_args[ai].tuple_variant_indices,
+                                                  fn.return_type_args[ai].tuple_struct_indices,
+                                                  span);
                         if (!arg_type) return core::make_unexpected(arg_type.error());
                         fn.return_type_args[ai].type = arg_type.value();
-                        auto arg_shape = intern_hir_type_shape(&mod,
-                                                               fn.return_type_args[ai].type,
-                                                               fn.return_type_args[ai].generic_index,
-                                                               fn.return_type_args[ai].variant_index,
-                                                               fn.return_type_args[ai].struct_index,
-                                                               fn.return_type_args[ai].tuple_len,
-                                                               fn.return_type_args[ai].tuple_types,
-                                                               fn.return_type_args[ai].tuple_variant_indices,
-                                                               fn.return_type_args[ai].tuple_struct_indices,
-                                                               span);
+                        auto arg_shape =
+                            intern_hir_type_shape(&mod,
+                                                  fn.return_type_args[ai].type,
+                                                  fn.return_type_args[ai].generic_index,
+                                                  fn.return_type_args[ai].variant_index,
+                                                  fn.return_type_args[ai].struct_index,
+                                                  fn.return_type_args[ai].tuple_len,
+                                                  fn.return_type_args[ai].tuple_types,
+                                                  fn.return_type_args[ai].tuple_variant_indices,
+                                                  fn.return_type_args[ai].tuple_struct_indices,
+                                                  span);
                         if (!arg_shape) return core::make_unexpected(arg_shape.error());
                         fn.return_type_args[ai].shape_index = arg_shape.value();
-                        auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
-                                                                            &mod,
-                                                                            fn.return_type_args[ai].type,
-                                                                            fn.return_type_args[ai].generic_index,
-                                                                            fn.return_type_args[ai].variant_index,
-                                                                            fn.return_type_args[ai].struct_index,
-                                                                            fn.return_type_args[ai].tuple_len,
-                                                                            fn.return_type_args[ai].tuple_types,
-                                                                            fn.return_type_args[ai].tuple_variant_indices,
-                                                                            fn.return_type_args[ai].tuple_struct_indices,
-                                                                            fn.return_type_args[ai].shape_index,
-                                                                            span);
+                        auto filled = fill_bound_binding_from_type_metadata(
+                            &bindings[ai],
+                            &mod,
+                            fn.return_type_args[ai].type,
+                            fn.return_type_args[ai].generic_index,
+                            fn.return_type_args[ai].variant_index,
+                            fn.return_type_args[ai].struct_index,
+                            fn.return_type_args[ai].tuple_len,
+                            fn.return_type_args[ai].tuple_types,
+                            fn.return_type_args[ai].tuple_variant_indices,
+                            fn.return_type_args[ai].tuple_struct_indices,
+                            fn.return_type_args[ai].shape_index,
+                            span);
                         if (!filled) return core::make_unexpected(filled.error());
                         copy_binding_constraints_from_type_params(&bindings[ai], fn.type_params);
                         if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
                     }
                     if (has_generic_arg) {
                         if (named_kind == HirTypeKind::Variant) {
-                            auto concrete = instantiate_variant(&mod, template_variant_index, bindings, ret_ref.type_arg_names.len, span);
+                            auto concrete = instantiate_variant(&mod,
+                                                                template_variant_index,
+                                                                bindings,
+                                                                ret_ref.type_arg_names.len,
+                                                                span);
                             if (!concrete) return core::make_unexpected(concrete.error());
                             fn.return_variant_index = concrete.value();
                         } else {
-                            auto concrete = instantiate_struct(&mod, template_struct_index, bindings, ret_ref.type_arg_names.len, span);
+                            auto concrete = instantiate_struct(&mod,
+                                                               template_struct_index,
+                                                               bindings,
+                                                               ret_ref.type_arg_names.len,
+                                                               span);
                             if (!concrete) return core::make_unexpected(concrete.error());
                             fn.return_struct_index = concrete.value();
                         }
                     } else {
-                        auto ret_type = resolve_func_type_ref(mod, ret_ref, &fn.type_params,
+                        auto ret_type = resolve_func_type_ref(mod,
+                                                              ret_ref,
+                                                              &fn.type_params,
                                                               &fn.return_generic_index,
                                                               fn.return_variant_index,
                                                               fn.return_struct_index,
@@ -7417,7 +7822,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                         fn.return_type = ret_type.value();
                     }
                 } else {
-                    auto ret_type = resolve_func_type_ref(mod, ret_ref, &fn.type_params,
+                    auto ret_type = resolve_func_type_ref(mod,
+                                                          ret_ref,
+                                                          &fn.type_params,
                                                           &fn.return_generic_index,
                                                           fn.return_variant_index,
                                                           fn.return_struct_index,
@@ -7430,7 +7837,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     fn.return_type = ret_type.value();
                 }
             } else {
-                auto ret_type = resolve_func_type_ref(mod, ast_func.return_type, &fn.type_params,
+                auto ret_type = resolve_func_type_ref(mod,
+                                                      ast_func.return_type,
+                                                      &fn.type_params,
                                                       &fn.return_generic_index,
                                                       fn.return_variant_index,
                                                       fn.return_struct_index,
@@ -7446,7 +7855,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         for (u32 pi = 0; pi < ast_func.params.len; pi++) {
             for (u32 seen = 0; seen < fn.params.len; seen++) {
                 if (fn.params[seen].name.eq(ast_func.params[pi].name))
-                    return frontend_error(FrontendError::UnsupportedSyntax, span, ast_func.params[pi].name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, span, ast_func.params[pi].name);
             }
             HirFunction::ParamDecl param{};
             param.name = ast_func.params[pi].name;
@@ -7455,13 +7865,16 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             if (!param_ref.is_tuple && param_ref.type_arg_names.len != 0) {
                 u32 template_variant_index = 0xffffffffu;
                 u32 template_struct_index = 0xffffffffu;
-                const auto named_kind =
-                    resolve_named_type(mod, param_ref.name, template_variant_index, template_struct_index);
+                const auto named_kind = resolve_named_type(
+                    mod, param_ref.name, template_variant_index, template_struct_index);
                 const bool is_generic_named =
-                    (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
-                     mod.variants[template_variant_index].type_params.len == param_ref.type_arg_names.len) ||
+                    (named_kind == HirTypeKind::Variant &&
+                     template_variant_index < mod.variants.len &&
+                     mod.variants[template_variant_index].type_params.len ==
+                         param_ref.type_arg_names.len) ||
                     (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
-                     mod.structs[template_struct_index].type_params.len == param_ref.type_arg_names.len);
+                     mod.structs[template_struct_index].type_params.len ==
+                         param_ref.type_arg_names.len);
                 if (is_generic_named) {
                     bool has_generic_arg = false;
                     GenericBinding bindings[HirFunction::kMaxTypeParams]{};
@@ -7471,57 +7884,72 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     param.type_arg_count = param_ref.type_arg_names.len;
                     for (u32 ai = 0; ai < param_ref.type_arg_names.len; ai++) {
                         AstTypeRef arg_ref = get_ast_type_arg_ref(param_ref, ai);
-                        auto arg_type = resolve_func_type_ref(mod, arg_ref, &fn.type_params,
-                                                              &param.type_args[ai].generic_index,
-                                                              param.type_args[ai].variant_index,
-                                                              param.type_args[ai].struct_index,
-                                                              param.type_args[ai].tuple_len,
-                                                              param.type_args[ai].tuple_types,
-                                                              param.type_args[ai].tuple_variant_indices,
-                                                              param.type_args[ai].tuple_struct_indices,
-                                                              span);
+                        auto arg_type =
+                            resolve_func_type_ref(mod,
+                                                  arg_ref,
+                                                  &fn.type_params,
+                                                  &param.type_args[ai].generic_index,
+                                                  param.type_args[ai].variant_index,
+                                                  param.type_args[ai].struct_index,
+                                                  param.type_args[ai].tuple_len,
+                                                  param.type_args[ai].tuple_types,
+                                                  param.type_args[ai].tuple_variant_indices,
+                                                  param.type_args[ai].tuple_struct_indices,
+                                                  span);
                         if (!arg_type) return core::make_unexpected(arg_type.error());
                         param.type_args[ai].type = arg_type.value();
-                        auto arg_shape = intern_hir_type_shape(&mod,
-                                                               param.type_args[ai].type,
-                                                               param.type_args[ai].generic_index,
-                                                               param.type_args[ai].variant_index,
-                                                               param.type_args[ai].struct_index,
-                                                               param.type_args[ai].tuple_len,
-                                                               param.type_args[ai].tuple_types,
-                                                               param.type_args[ai].tuple_variant_indices,
-                                                               param.type_args[ai].tuple_struct_indices,
-                                                               span);
+                        auto arg_shape =
+                            intern_hir_type_shape(&mod,
+                                                  param.type_args[ai].type,
+                                                  param.type_args[ai].generic_index,
+                                                  param.type_args[ai].variant_index,
+                                                  param.type_args[ai].struct_index,
+                                                  param.type_args[ai].tuple_len,
+                                                  param.type_args[ai].tuple_types,
+                                                  param.type_args[ai].tuple_variant_indices,
+                                                  param.type_args[ai].tuple_struct_indices,
+                                                  span);
                         if (!arg_shape) return core::make_unexpected(arg_shape.error());
                         param.type_args[ai].shape_index = arg_shape.value();
-                        auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
-                                                                            &mod,
-                                                                            param.type_args[ai].type,
-                                                                            param.type_args[ai].generic_index,
-                                                                            param.type_args[ai].variant_index,
-                                                                            param.type_args[ai].struct_index,
-                                                                            param.type_args[ai].tuple_len,
-                                                                            param.type_args[ai].tuple_types,
-                                                                            param.type_args[ai].tuple_variant_indices,
-                                                                            param.type_args[ai].tuple_struct_indices,
-                                                                            param.type_args[ai].shape_index,
-                                                                            span);
+                        auto filled = fill_bound_binding_from_type_metadata(
+                            &bindings[ai],
+                            &mod,
+                            param.type_args[ai].type,
+                            param.type_args[ai].generic_index,
+                            param.type_args[ai].variant_index,
+                            param.type_args[ai].struct_index,
+                            param.type_args[ai].tuple_len,
+                            param.type_args[ai].tuple_types,
+                            param.type_args[ai].tuple_variant_indices,
+                            param.type_args[ai].tuple_struct_indices,
+                            param.type_args[ai].shape_index,
+                            span);
                         if (!filled) return core::make_unexpected(filled.error());
                         copy_binding_constraints_from_type_params(&bindings[ai], fn.type_params);
                         if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
                     }
                     if (has_generic_arg) {
                         if (named_kind == HirTypeKind::Variant) {
-                            auto concrete = instantiate_variant(&mod, template_variant_index, bindings, param_ref.type_arg_names.len, span);
+                            auto concrete = instantiate_variant(&mod,
+                                                                template_variant_index,
+                                                                bindings,
+                                                                param_ref.type_arg_names.len,
+                                                                span);
                             if (!concrete) return core::make_unexpected(concrete.error());
                             param.variant_index = concrete.value();
                         } else {
-                            auto concrete = instantiate_struct(&mod, template_struct_index, bindings, param_ref.type_arg_names.len, span);
+                            auto concrete = instantiate_struct(&mod,
+                                                               template_struct_index,
+                                                               bindings,
+                                                               param_ref.type_arg_names.len,
+                                                               span);
                             if (!concrete) return core::make_unexpected(concrete.error());
                             param.struct_index = concrete.value();
                         }
                     } else {
-                        auto param_type = resolve_func_type_ref(mod, param_ref, &fn.type_params,
+                        auto param_type = resolve_func_type_ref(mod,
+                                                                param_ref,
+                                                                &fn.type_params,
                                                                 &param.generic_index,
                                                                 param.variant_index,
                                                                 param.struct_index,
@@ -7534,7 +7962,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                         param.type = param_type.value();
                     }
                 } else {
-                    auto param_type = resolve_func_type_ref(mod, param_ref, &fn.type_params,
+                    auto param_type = resolve_func_type_ref(mod,
+                                                            param_ref,
+                                                            &fn.type_params,
                                                             &param.generic_index,
                                                             param.variant_index,
                                                             param.struct_index,
@@ -7547,7 +7977,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     param.type = param_type.value();
                 }
             } else {
-                auto param_type = resolve_func_type_ref(mod, param_ref, &fn.type_params,
+                auto param_type = resolve_func_type_ref(mod,
+                                                        param_ref,
+                                                        &fn.type_params,
                                                         &param.generic_index,
                                                         param.variant_index,
                                                         param.struct_index,
@@ -7560,18 +7992,24 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 param.type = param_type.value();
             }
             if (param.type == HirTypeKind::Generic && param.generic_index < fn.type_params.len)
-                param.generic_has_error_constraint = fn.type_params[param.generic_index].has_error_constraint;
+                param.generic_has_error_constraint =
+                    fn.type_params[param.generic_index].has_error_constraint;
             if (param.type == HirTypeKind::Generic && param.generic_index < fn.type_params.len) {
-                param.generic_has_eq_constraint = fn.type_params[param.generic_index].has_eq_constraint;
-                param.generic_has_ord_constraint = fn.type_params[param.generic_index].has_ord_constraint;
-            param.generic_protocol_index = fn.type_params[param.generic_index].custom_protocol_count != 0 ?
-                fn.type_params[param.generic_index].custom_protocol_indices[0] : 0xffffffffu;
-            param.generic_protocol_count = fn.type_params[param.generic_index].custom_protocol_count;
-            for (u32 cpi = 0; cpi < param.generic_protocol_count; cpi++)
-                param.generic_protocol_indices[cpi] = fn.type_params[param.generic_index].custom_protocol_indices[cpi];
+                param.generic_has_eq_constraint =
+                    fn.type_params[param.generic_index].has_eq_constraint;
+                param.generic_has_ord_constraint =
+                    fn.type_params[param.generic_index].has_ord_constraint;
+                param.generic_protocol_index =
+                    fn.type_params[param.generic_index].custom_protocol_count != 0
+                        ? fn.type_params[param.generic_index].custom_protocol_indices[0]
+                        : 0xffffffffu;
+                param.generic_protocol_count =
+                    fn.type_params[param.generic_index].custom_protocol_count;
+                for (u32 cpi = 0; cpi < param.generic_protocol_count; cpi++)
+                    param.generic_protocol_indices[cpi] =
+                        fn.type_params[param.generic_index].custom_protocol_indices[cpi];
             }
-            if (!fn.params.push(param))
-                return frontend_error(FrontendError::TooManyItems, span);
+            if (!fn.params.push(param)) return frontend_error(FrontendError::TooManyItems, span);
         }
         if (fn.return_type != HirTypeKind::Unknown) {
             auto return_shape = intern_hir_type_shape(&mod,
@@ -7604,7 +8042,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         return fn;
     };
 
-    auto analyze_function_body_like = [&](HirFunction& fn, const AstFunctionDecl& ast_func, Span span) -> FrontendResult<void> {
+    auto analyze_function_body_like =
+        [&](HirFunction& fn, const AstFunctionDecl& ast_func, Span span) -> FrontendResult<void> {
         HirRoute scratch{};
         FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> ast_named_error_cases;
         auto ast_collected = collect_named_error_cases_ast(*ast_func.body, ast_named_error_cases);
@@ -7630,32 +8069,39 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             param_locals[pi].ref_index = pi;
             param_locals[pi].type = fn.params[pi].type;
             param_locals[pi].generic_index = fn.params[pi].generic_index;
-            param_locals[pi].generic_has_error_constraint = fn.params[pi].generic_has_error_constraint;
+            param_locals[pi].generic_has_error_constraint =
+                fn.params[pi].generic_has_error_constraint;
             param_locals[pi].generic_has_eq_constraint = fn.params[pi].generic_has_eq_constraint;
             param_locals[pi].generic_has_ord_constraint = fn.params[pi].generic_has_ord_constraint;
             param_locals[pi].generic_protocol_index = fn.params[pi].generic_protocol_index;
             param_locals[pi].generic_protocol_count = fn.params[pi].generic_protocol_count;
             for (u32 cpi = 0; cpi < param_locals[pi].generic_protocol_count; cpi++)
-                param_locals[pi].generic_protocol_indices[cpi] = fn.params[pi].generic_protocol_indices[cpi];
+                param_locals[pi].generic_protocol_indices[cpi] =
+                    fn.params[pi].generic_protocol_indices[cpi];
             param_locals[pi].variant_index = fn.params[pi].variant_index;
             param_locals[pi].struct_index = fn.params[pi].struct_index;
             param_locals[pi].shape_index = fn.params[pi].shape_index;
             param_locals[pi].tuple_len = fn.params[pi].tuple_len;
             for (u32 ti = 0; ti < fn.params[pi].tuple_len; ti++) {
                 param_locals[pi].tuple_types[ti] = fn.params[pi].tuple_types[ti];
-                param_locals[pi].tuple_variant_indices[ti] = fn.params[pi].tuple_variant_indices[ti];
+                param_locals[pi].tuple_variant_indices[ti] =
+                    fn.params[pi].tuple_variant_indices[ti];
                 param_locals[pi].tuple_struct_indices[ti] = fn.params[pi].tuple_struct_indices[ti];
             }
             param_locals[pi].init.kind = HirExprKind::LocalRef;
             param_locals[pi].init.type = fn.params[pi].type;
             param_locals[pi].init.generic_index = fn.params[pi].generic_index;
-            param_locals[pi].init.generic_has_error_constraint = fn.params[pi].generic_has_error_constraint;
-            param_locals[pi].init.generic_has_eq_constraint = fn.params[pi].generic_has_eq_constraint;
-            param_locals[pi].init.generic_has_ord_constraint = fn.params[pi].generic_has_ord_constraint;
+            param_locals[pi].init.generic_has_error_constraint =
+                fn.params[pi].generic_has_error_constraint;
+            param_locals[pi].init.generic_has_eq_constraint =
+                fn.params[pi].generic_has_eq_constraint;
+            param_locals[pi].init.generic_has_ord_constraint =
+                fn.params[pi].generic_has_ord_constraint;
             param_locals[pi].init.generic_protocol_index = fn.params[pi].generic_protocol_index;
             param_locals[pi].init.generic_protocol_count = fn.params[pi].generic_protocol_count;
             for (u32 cpi = 0; cpi < param_locals[pi].init.generic_protocol_count; cpi++)
-                param_locals[pi].init.generic_protocol_indices[cpi] = fn.params[pi].generic_protocol_indices[cpi];
+                param_locals[pi].init.generic_protocol_indices[cpi] =
+                    fn.params[pi].generic_protocol_indices[cpi];
             param_locals[pi].init.local_index = pi;
             param_locals[pi].init.variant_index = fn.params[pi].variant_index;
             param_locals[pi].init.struct_index = fn.params[pi].struct_index;
@@ -7663,11 +8109,14 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             param_locals[pi].init.tuple_len = fn.params[pi].tuple_len;
             for (u32 ti = 0; ti < fn.params[pi].tuple_len; ti++) {
                 param_locals[pi].init.tuple_types[ti] = fn.params[pi].tuple_types[ti];
-                param_locals[pi].init.tuple_variant_indices[ti] = fn.params[pi].tuple_variant_indices[ti];
-                param_locals[pi].init.tuple_struct_indices[ti] = fn.params[pi].tuple_struct_indices[ti];
+                param_locals[pi].init.tuple_variant_indices[ti] =
+                    fn.params[pi].tuple_variant_indices[ti];
+                param_locals[pi].init.tuple_struct_indices[ti] =
+                    fn.params[pi].tuple_struct_indices[ti];
             }
         }
-        auto body = analyze_function_body_stmt(*ast_func.body, &scratch, mod, param_locals, fn.params.len, nullptr);
+        auto body = analyze_function_body_stmt(
+            *ast_func.body, &scratch, mod, param_locals, fn.params.len, nullptr);
         if (!body) return core::make_unexpected(body.error());
         FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> named_error_cases;
         for (u32 li = 0; li < scratch.locals.len; li++) {
@@ -7693,9 +8142,11 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         if (named_error_cases.len != 0 && scratch.error_variant_index != 0xffffffffu) {
             const u32 error_variant_index = scratch.error_variant_index;
             for (u32 li = 0; li < scratch.locals.len; li++) {
-                patch_named_error_variant(&scratch.locals[li].init, error_variant_index, named_error_cases);
+                patch_named_error_variant(
+                    &scratch.locals[li].init, error_variant_index, named_error_cases);
                 patch_error_variant_refs(&scratch.locals[li].init, error_variant_index);
-                if (scratch.locals[li].may_error && scratch.locals[li].error_variant_index == 0xffffffffu)
+                if (scratch.locals[li].may_error &&
+                    scratch.locals[li].error_variant_index == 0xffffffffu)
                     scratch.locals[li].error_variant_index = error_variant_index;
             }
             patch_named_error_variant(&body.value(), error_variant_index, named_error_cases);
@@ -7722,20 +8173,26 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 body->generic_index = fn.return_generic_index;
                 body->shape_index = fn.return_shape_index;
                 if (fn.return_generic_index < fn.type_params.len) {
-                    body->generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
-                    body->generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
-                    body->generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+                    body->generic_has_error_constraint =
+                        fn.type_params[fn.return_generic_index].has_error_constraint;
+                    body->generic_has_eq_constraint =
+                        fn.type_params[fn.return_generic_index].has_eq_constraint;
+                    body->generic_has_ord_constraint =
+                        fn.type_params[fn.return_generic_index].has_ord_constraint;
                     body->generic_protocol_index =
                         fn.type_params[fn.return_generic_index].custom_protocol_count != 0
                             ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
                             : 0xffffffffu;
-                    body->generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+                    body->generic_protocol_count =
+                        fn.type_params[fn.return_generic_index].custom_protocol_count;
                     for (u32 cpi = 0; cpi < body->generic_protocol_count; cpi++)
                         body->generic_protocol_indices[cpi] =
                             fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
                 }
-                if (fn.return_type == HirTypeKind::Variant) body->variant_index = fn.return_variant_index;
-                if (fn.return_type == HirTypeKind::Struct) body->struct_index = fn.return_struct_index;
+                if (fn.return_type == HirTypeKind::Variant)
+                    body->variant_index = fn.return_variant_index;
+                if (fn.return_type == HirTypeKind::Struct)
+                    body->struct_index = fn.return_struct_index;
                 if (fn.return_type == HirTypeKind::Tuple) {
                     body->tuple_len = fn.return_tuple_len;
                     for (u32 ti = 0; ti < fn.return_tuple_len; ti++) {
@@ -7755,21 +8212,26 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                                                     fn.return_shape_index);
             expected.generic_index = fn.return_generic_index;
             if (fn.return_generic_index < fn.type_params.len) {
-                expected.generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
-                expected.generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
-                expected.generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+                expected.generic_has_error_constraint =
+                    fn.type_params[fn.return_generic_index].has_error_constraint;
+                expected.generic_has_eq_constraint =
+                    fn.type_params[fn.return_generic_index].has_eq_constraint;
+                expected.generic_has_ord_constraint =
+                    fn.type_params[fn.return_generic_index].has_ord_constraint;
                 expected.generic_protocol_index =
                     fn.type_params[fn.return_generic_index].custom_protocol_count != 0
                         ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
                         : 0xffffffffu;
-                expected.generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+                expected.generic_protocol_count =
+                    fn.type_params[fn.return_generic_index].custom_protocol_count;
                 for (u32 cpi = 0; cpi < expected.generic_protocol_count; cpi++)
                     expected.generic_protocol_indices[cpi] =
                         fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
             }
             if (!same_hir_type_shape(mod, body.value(), expected))
                 return frontend_error(FrontendError::UnsupportedSyntax, ast_func.body->span);
-            if (body->type == HirTypeKind::Variant && body->variant_index != fn.return_variant_index)
+            if (body->type == HirTypeKind::Variant &&
+                body->variant_index != fn.return_variant_index)
                 return frontend_error(FrontendError::UnsupportedSyntax, ast_func.body->span);
         }
         if (fn.return_type != HirTypeKind::Unknown) {
@@ -7789,9 +8251,11 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         HirLocal all_locals[AstFunctionDecl::kMaxParams + HirRoute::kMaxLocals]{};
         u32 all_local_count = 0;
         for (u32 pi = 0; pi < fn.params.len; pi++) all_locals[all_local_count++] = param_locals[pi];
-        for (u32 li = 0; li < scratch.locals.len; li++) all_locals[all_local_count++] = scratch.locals[li];
+        for (u32 li = 0; li < scratch.locals.len; li++)
+            all_locals[all_local_count++] = scratch.locals[li];
         fn.exprs.len = 0;
-        auto normalized = normalize_function_expr(body.value(), &fn, all_locals, all_local_count, fn.params.len);
+        auto normalized =
+            normalize_function_expr(body.value(), &fn, all_locals, all_local_count, fn.params.len);
         if (!normalized) return core::make_unexpected(normalized.error());
         fn.body = normalized.value();
         return {};
@@ -7808,8 +8272,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         for (u32 ti = 0; ti < item.func.type_params.len; ti++) {
             for (u32 seen = 0; seen < fn.type_params.len; seen++) {
                 if (fn.type_params[seen].name.eq(item.func.type_params[ti].name))
-                    return frontend_error(
-                        FrontendError::UnsupportedSyntax, item.func.span, item.func.type_params[ti].name);
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          item.func.span,
+                                          item.func.type_params[ti].name);
             }
             HirFunction::TypeParamDecl type_param{};
             type_param.name = item.func.type_params[ti].name;
@@ -7819,11 +8284,13 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 for (u32 ci = 0; ci < item.func.type_params[ti].constraints.len; ci++) {
                     const auto constraint = item.func.type_params[ti].constraints[ci];
                     Str resolved_constraint = constraint;
-                    if (ci < item.func.type_params[ti].constraint_namespaces.len && item.func.type_params[ti].constraint_namespaces[ci].len != 0) {
-                        if (!resolve_import_namespace_type_name(mod,
-                                                                item.func.type_params[ti].constraint_namespaces[ci],
-                                                                constraint,
-                                                                resolved_constraint)) {
+                    if (ci < item.func.type_params[ti].constraint_namespaces.len &&
+                        item.func.type_params[ti].constraint_namespaces[ci].len != 0) {
+                        if (!resolve_import_namespace_type_name(
+                                mod,
+                                item.func.type_params[ti].constraint_namespaces[ci],
+                                constraint,
+                                resolved_constraint)) {
                             return frontend_error(
                                 FrontendError::UnsupportedSyntax, item.func.span, constraint);
                         }
@@ -7841,11 +8308,14 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     if (kind == HirProtocolKind::Custom) {
                         const u32 pi = find_protocol_index(mod, resolved_constraint);
                         if (pi >= mod.protocols.len)
-                            return frontend_error(FrontendError::UnsupportedSyntax, item.func.span, constraint);
+                            return frontend_error(
+                                FrontendError::UnsupportedSyntax, item.func.span, constraint);
                         type_param.custom_protocol_indices[type_param.custom_protocol_count++] = pi;
                     }
                 }
-                type_param.constraint_kind = item.func.type_params[ti].constraints.len != 0 ? type_param.constraint_kinds[0] : HirProtocolKind::Custom;
+                type_param.constraint_kind = item.func.type_params[ti].constraints.len != 0
+                                                 ? type_param.constraint_kinds[0]
+                                                 : HirProtocolKind::Custom;
             }
             if (!fn.type_params.push(type_param))
                 return frontend_error(FrontendError::TooManyItems, item.func.span);
@@ -7855,13 +8325,16 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             if (!ret_ref.is_tuple && ret_ref.type_arg_names.len != 0) {
                 u32 template_variant_index = 0xffffffffu;
                 u32 template_struct_index = 0xffffffffu;
-                const auto named_kind =
-                    resolve_named_type(mod, ret_ref.name, template_variant_index, template_struct_index);
+                const auto named_kind = resolve_named_type(
+                    mod, ret_ref.name, template_variant_index, template_struct_index);
                 const bool is_generic_named =
-                    (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
-                     mod.variants[template_variant_index].type_params.len == ret_ref.type_arg_names.len) ||
+                    (named_kind == HirTypeKind::Variant &&
+                     template_variant_index < mod.variants.len &&
+                     mod.variants[template_variant_index].type_params.len ==
+                         ret_ref.type_arg_names.len) ||
                     (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
-                     mod.structs[template_struct_index].type_params.len == ret_ref.type_arg_names.len);
+                     mod.structs[template_struct_index].type_params.len ==
+                         ret_ref.type_arg_names.len);
                 if (is_generic_named) {
                     bool has_generic_arg = false;
                     GenericBinding bindings[HirFunction::kMaxTypeParams]{};
@@ -7871,43 +8344,46 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     fn.return_type_arg_count = ret_ref.type_arg_names.len;
                     for (u32 ai = 0; ai < ret_ref.type_arg_names.len; ai++) {
                         AstTypeRef arg_ref = get_ast_type_arg_ref(ret_ref, ai);
-                        auto arg_type = resolve_func_type_ref(mod,
-                                                              arg_ref,
-                                                              &fn.type_params,
-                                                              &fn.return_type_args[ai].generic_index,
-                                                              fn.return_type_args[ai].variant_index,
-                                                              fn.return_type_args[ai].struct_index,
-                                                              fn.return_type_args[ai].tuple_len,
-                                                              fn.return_type_args[ai].tuple_types,
-                                                              fn.return_type_args[ai].tuple_variant_indices,
-                                                              fn.return_type_args[ai].tuple_struct_indices,
-                                                              item.func.span);
+                        auto arg_type =
+                            resolve_func_type_ref(mod,
+                                                  arg_ref,
+                                                  &fn.type_params,
+                                                  &fn.return_type_args[ai].generic_index,
+                                                  fn.return_type_args[ai].variant_index,
+                                                  fn.return_type_args[ai].struct_index,
+                                                  fn.return_type_args[ai].tuple_len,
+                                                  fn.return_type_args[ai].tuple_types,
+                                                  fn.return_type_args[ai].tuple_variant_indices,
+                                                  fn.return_type_args[ai].tuple_struct_indices,
+                                                  item.func.span);
                         if (!arg_type) return core::make_unexpected(arg_type.error());
                         fn.return_type_args[ai].type = arg_type.value();
-                        auto arg_shape = intern_hir_type_shape(&mod,
-                                                               fn.return_type_args[ai].type,
-                                                               fn.return_type_args[ai].generic_index,
-                                                               fn.return_type_args[ai].variant_index,
-                                                               fn.return_type_args[ai].struct_index,
-                                                               fn.return_type_args[ai].tuple_len,
-                                                               fn.return_type_args[ai].tuple_types,
-                                                               fn.return_type_args[ai].tuple_variant_indices,
-                                                               fn.return_type_args[ai].tuple_struct_indices,
-                                                               item.func.span);
+                        auto arg_shape =
+                            intern_hir_type_shape(&mod,
+                                                  fn.return_type_args[ai].type,
+                                                  fn.return_type_args[ai].generic_index,
+                                                  fn.return_type_args[ai].variant_index,
+                                                  fn.return_type_args[ai].struct_index,
+                                                  fn.return_type_args[ai].tuple_len,
+                                                  fn.return_type_args[ai].tuple_types,
+                                                  fn.return_type_args[ai].tuple_variant_indices,
+                                                  fn.return_type_args[ai].tuple_struct_indices,
+                                                  item.func.span);
                         if (!arg_shape) return core::make_unexpected(arg_shape.error());
                         fn.return_type_args[ai].shape_index = arg_shape.value();
-                        auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
-                                                                            &mod,
-                                                                            fn.return_type_args[ai].type,
-                                                                            fn.return_type_args[ai].generic_index,
-                                                                            fn.return_type_args[ai].variant_index,
-                                                                            fn.return_type_args[ai].struct_index,
-                                                                            fn.return_type_args[ai].tuple_len,
-                                                                            fn.return_type_args[ai].tuple_types,
-                                                                            fn.return_type_args[ai].tuple_variant_indices,
-                                                                            fn.return_type_args[ai].tuple_struct_indices,
-                                                                            fn.return_type_args[ai].shape_index,
-                                                                            item.func.span);
+                        auto filled = fill_bound_binding_from_type_metadata(
+                            &bindings[ai],
+                            &mod,
+                            fn.return_type_args[ai].type,
+                            fn.return_type_args[ai].generic_index,
+                            fn.return_type_args[ai].variant_index,
+                            fn.return_type_args[ai].struct_index,
+                            fn.return_type_args[ai].tuple_len,
+                            fn.return_type_args[ai].tuple_types,
+                            fn.return_type_args[ai].tuple_variant_indices,
+                            fn.return_type_args[ai].tuple_struct_indices,
+                            fn.return_type_args[ai].shape_index,
+                            item.func.span);
                         if (!filled) return core::make_unexpected(filled.error());
                         copy_binding_constraints_from_type_params(&bindings[ai], fn.type_params);
                         if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
@@ -7979,7 +8455,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         for (u32 pi = 0; pi < item.func.params.len; pi++) {
             for (u32 seen = 0; seen < fn.params.len; seen++) {
                 if (fn.params[seen].name.eq(item.func.params[pi].name))
-                    return frontend_error(FrontendError::UnsupportedSyntax, item.func.span, item.func.params[pi].name);
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          item.func.span,
+                                          item.func.params[pi].name);
             }
             HirFunction::ParamDecl param{};
             param.name = item.func.params[pi].name;
@@ -7988,13 +8466,16 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             if (!param_ref.is_tuple && param_ref.type_arg_names.len != 0) {
                 u32 template_variant_index = 0xffffffffu;
                 u32 template_struct_index = 0xffffffffu;
-                const auto named_kind =
-                    resolve_named_type(mod, param_ref.name, template_variant_index, template_struct_index);
+                const auto named_kind = resolve_named_type(
+                    mod, param_ref.name, template_variant_index, template_struct_index);
                 const bool is_generic_named =
-                    (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
-                     mod.variants[template_variant_index].type_params.len == param_ref.type_arg_names.len) ||
+                    (named_kind == HirTypeKind::Variant &&
+                     template_variant_index < mod.variants.len &&
+                     mod.variants[template_variant_index].type_params.len ==
+                         param_ref.type_arg_names.len) ||
                     (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
-                     mod.structs[template_struct_index].type_params.len == param_ref.type_arg_names.len);
+                     mod.structs[template_struct_index].type_params.len ==
+                         param_ref.type_arg_names.len);
                 if (is_generic_named) {
                     bool has_generic_arg = false;
                     GenericBinding bindings[HirFunction::kMaxTypeParams]{};
@@ -8004,43 +8485,46 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     param.type_arg_count = param_ref.type_arg_names.len;
                     for (u32 ai = 0; ai < param_ref.type_arg_names.len; ai++) {
                         AstTypeRef arg_ref = get_ast_type_arg_ref(param_ref, ai);
-                        auto arg_type = resolve_func_type_ref(mod,
-                                                              arg_ref,
-                                                              &fn.type_params,
-                                                              &param.type_args[ai].generic_index,
-                                                              param.type_args[ai].variant_index,
-                                                              param.type_args[ai].struct_index,
-                                                              param.type_args[ai].tuple_len,
-                                                              param.type_args[ai].tuple_types,
-                                                              param.type_args[ai].tuple_variant_indices,
-                                                              param.type_args[ai].tuple_struct_indices,
-                                                              item.func.span);
+                        auto arg_type =
+                            resolve_func_type_ref(mod,
+                                                  arg_ref,
+                                                  &fn.type_params,
+                                                  &param.type_args[ai].generic_index,
+                                                  param.type_args[ai].variant_index,
+                                                  param.type_args[ai].struct_index,
+                                                  param.type_args[ai].tuple_len,
+                                                  param.type_args[ai].tuple_types,
+                                                  param.type_args[ai].tuple_variant_indices,
+                                                  param.type_args[ai].tuple_struct_indices,
+                                                  item.func.span);
                         if (!arg_type) return core::make_unexpected(arg_type.error());
                         param.type_args[ai].type = arg_type.value();
-                        auto arg_shape = intern_hir_type_shape(&mod,
-                                                               param.type_args[ai].type,
-                                                               param.type_args[ai].generic_index,
-                                                               param.type_args[ai].variant_index,
-                                                               param.type_args[ai].struct_index,
-                                                               param.type_args[ai].tuple_len,
-                                                               param.type_args[ai].tuple_types,
-                                                               param.type_args[ai].tuple_variant_indices,
-                                                               param.type_args[ai].tuple_struct_indices,
-                                                               item.func.span);
+                        auto arg_shape =
+                            intern_hir_type_shape(&mod,
+                                                  param.type_args[ai].type,
+                                                  param.type_args[ai].generic_index,
+                                                  param.type_args[ai].variant_index,
+                                                  param.type_args[ai].struct_index,
+                                                  param.type_args[ai].tuple_len,
+                                                  param.type_args[ai].tuple_types,
+                                                  param.type_args[ai].tuple_variant_indices,
+                                                  param.type_args[ai].tuple_struct_indices,
+                                                  item.func.span);
                         if (!arg_shape) return core::make_unexpected(arg_shape.error());
                         param.type_args[ai].shape_index = arg_shape.value();
-                        auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
-                                                                            &mod,
-                                                                            param.type_args[ai].type,
-                                                                            param.type_args[ai].generic_index,
-                                                                            param.type_args[ai].variant_index,
-                                                                            param.type_args[ai].struct_index,
-                                                                            param.type_args[ai].tuple_len,
-                                                                            param.type_args[ai].tuple_types,
-                                                                            param.type_args[ai].tuple_variant_indices,
-                                                                            param.type_args[ai].tuple_struct_indices,
-                                                                            param.type_args[ai].shape_index,
-                                                                            item.func.span);
+                        auto filled = fill_bound_binding_from_type_metadata(
+                            &bindings[ai],
+                            &mod,
+                            param.type_args[ai].type,
+                            param.type_args[ai].generic_index,
+                            param.type_args[ai].variant_index,
+                            param.type_args[ai].struct_index,
+                            param.type_args[ai].tuple_len,
+                            param.type_args[ai].tuple_types,
+                            param.type_args[ai].tuple_variant_indices,
+                            param.type_args[ai].tuple_struct_indices,
+                            param.type_args[ai].shape_index,
+                            item.func.span);
                         if (!filled) return core::make_unexpected(filled.error());
                         copy_binding_constraints_from_type_params(&bindings[ai], fn.type_params);
                         if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
@@ -8109,15 +8593,22 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 param.type = param_type.value();
             }
             if (param.type == HirTypeKind::Generic && param.generic_index < fn.type_params.len)
-                param.generic_has_error_constraint = fn.type_params[param.generic_index].has_error_constraint;
+                param.generic_has_error_constraint =
+                    fn.type_params[param.generic_index].has_error_constraint;
             if (param.type == HirTypeKind::Generic && param.generic_index < fn.type_params.len) {
-                param.generic_has_eq_constraint = fn.type_params[param.generic_index].has_eq_constraint;
-                param.generic_has_ord_constraint = fn.type_params[param.generic_index].has_ord_constraint;
-            param.generic_protocol_index = fn.type_params[param.generic_index].custom_protocol_count != 0 ?
-                fn.type_params[param.generic_index].custom_protocol_indices[0] : 0xffffffffu;
-            param.generic_protocol_count = fn.type_params[param.generic_index].custom_protocol_count;
-            for (u32 cpi = 0; cpi < param.generic_protocol_count; cpi++)
-                param.generic_protocol_indices[cpi] = fn.type_params[param.generic_index].custom_protocol_indices[cpi];
+                param.generic_has_eq_constraint =
+                    fn.type_params[param.generic_index].has_eq_constraint;
+                param.generic_has_ord_constraint =
+                    fn.type_params[param.generic_index].has_ord_constraint;
+                param.generic_protocol_index =
+                    fn.type_params[param.generic_index].custom_protocol_count != 0
+                        ? fn.type_params[param.generic_index].custom_protocol_indices[0]
+                        : 0xffffffffu;
+                param.generic_protocol_count =
+                    fn.type_params[param.generic_index].custom_protocol_count;
+                for (u32 cpi = 0; cpi < param.generic_protocol_count; cpi++)
+                    param.generic_protocol_indices[cpi] =
+                        fn.type_params[param.generic_index].custom_protocol_indices[cpi];
             }
             auto param_shape = intern_hir_type_shape(&mod,
                                                      param.type,
@@ -8161,11 +8652,14 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             const auto& method_ast = item.protocol.methods[mi];
             if (method_ast.default_body == nullptr) continue;
             auto* method = find_protocol_method_mut(mod.protocols[protocol_index], method_ast.name);
-            if (method == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, method_ast.name);
+            if (method == nullptr)
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.protocol.span, method_ast.name);
             auto mangled = make_protocol_default_function_name(item.protocol.name, method_ast.name);
             if (!mangled) return core::make_unexpected(mangled.error());
             if (find_function_index(mod, mangled.value()) != mod.functions.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, mangled.value());
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.protocol.span, mangled.value());
 
             AstFunctionDecl synthetic{};
             synthetic.span = item.protocol.span;
@@ -8195,7 +8689,8 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
             if (!extra_type_params.push(self_tp))
                 return frontend_error(FrontendError::TooManyItems, item.protocol.span);
 
-            auto fn = declare_function_like(synthetic, synthetic.span, mangled.value(), &extra_type_params);
+            auto fn = declare_function_like(
+                synthetic, synthetic.span, mangled.value(), &extra_type_params);
             if (!fn) return core::make_unexpected(fn.error());
             if (!mod.functions.push(fn.value()))
                 return frontend_error(FrontendError::TooManyItems, item.protocol.span);
@@ -8203,11 +8698,12 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         }
     }
 
-    auto resolve_impl_target = [&](const AstImplDecl& decl,
-                                  HirTypeKind& out_type,
-                                  u32& out_struct_index,
-                                  bool& out_is_generic_template,
-                                  FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>& out_type_params)
+    auto resolve_impl_target =
+        [&](const AstImplDecl& decl,
+            HirTypeKind& out_type,
+            u32& out_struct_index,
+            bool& out_is_generic_template,
+            FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>& out_type_params)
         -> FrontendResult<void> {
         out_type = HirTypeKind::Unknown;
         out_struct_index = 0xffffffffu;
@@ -8215,12 +8711,14 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
         out_type_params.len = 0;
         if (!decl.target.is_tuple) {
             const u32 templ_struct_index = find_struct_index(mod, decl.target.name);
-            if (templ_struct_index < mod.structs.len && mod.structs[templ_struct_index].type_params.len != 0 &&
+            if (templ_struct_index < mod.structs.len &&
+                mod.structs[templ_struct_index].type_params.len != 0 &&
                 decl.target.type_arg_names.len == mod.structs[templ_struct_index].type_params.len) {
                 bool all_are_placeholders = true;
                 for (u32 i = 0; i < decl.target.type_arg_names.len; i++) {
                     if (decl.target.type_arg_names[i].len == 0)
-                        return frontend_error(FrontendError::UnsupportedSyntax, decl.span, decl.target.name);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, decl.span, decl.target.name);
                     u32 concrete_variant_index = 0xffffffffu;
                     u32 concrete_struct_index = 0xffffffffu;
                     if (resolve_named_type(mod,
@@ -8232,7 +8730,9 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                     }
                     for (u32 j = i + 1; j < decl.target.type_arg_names.len; j++) {
                         if (decl.target.type_arg_names[i].eq(decl.target.type_arg_names[j]))
-                            return frontend_error(FrontendError::UnsupportedSyntax, decl.span, decl.target.type_arg_names[i]);
+                            return frontend_error(FrontendError::UnsupportedSyntax,
+                                                  decl.span,
+                                                  decl.target.type_arg_names[i]);
                     }
                 }
                 if (!all_are_placeholders) goto resolve_concrete_impl_target;
@@ -8248,7 +8748,7 @@ static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
                 return {};
             }
         }
-resolve_concrete_impl_target:
+    resolve_concrete_impl_target:
         u32 target_variant_index = 0xffffffffu;
         u32 target_tuple_len = 0;
         HirTypeKind target_tuple_types[kMaxTupleSlots]{};
@@ -8279,8 +8779,11 @@ resolve_concrete_impl_target:
         u32 target_struct_index = 0xffffffffu;
         bool target_is_generic_template = false;
         FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> impl_target_type_params;
-        auto resolved_target = resolve_impl_target(
-            item.impl_decl, target_type, target_struct_index, target_is_generic_template, impl_target_type_params);
+        auto resolved_target = resolve_impl_target(item.impl_decl,
+                                                   target_type,
+                                                   target_struct_index,
+                                                   target_is_generic_template,
+                                                   impl_target_type_params);
         if (!resolved_target) return core::make_unexpected(resolved_target.error());
         if (!(target_type == HirTypeKind::Bool || target_type == HirTypeKind::I32 ||
               target_type == HirTypeKind::Str || target_type == HirTypeKind::Struct))
@@ -8291,25 +8794,34 @@ resolve_concrete_impl_target:
         for (u32 pi = 0; pi < item.impl_decl.protocols.len; pi++) {
             const Str proto_name = item.impl_decl.protocols[pi];
             Str resolved_proto_name = proto_name;
-            if (pi < item.impl_decl.protocol_namespaces.len && item.impl_decl.protocol_namespaces[pi].len != 0) {
+            if (pi < item.impl_decl.protocol_namespaces.len &&
+                item.impl_decl.protocol_namespaces[pi].len != 0) {
                 if (!resolve_import_namespace_type_name(mod,
                                                         item.impl_decl.protocol_namespaces[pi],
                                                         proto_name,
                                                         resolved_proto_name))
-                    return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
             }
             const u32 protocol_index = find_protocol_index(mod, resolved_proto_name);
             if (protocol_index >= mod.protocols.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
             if (mod.protocols[protocol_index].kind != HirProtocolKind::Custom)
-                return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
             for (u32 seen = 0; seen < protocol_indices.len; seen++) {
                 if (protocol_indices[seen] == protocol_index)
-                    return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
             }
             for (u32 ii = 0; ii < mod.impls.len; ii++) {
                 if (mod.impls[ii].protocol_index == protocol_index &&
-                    impl_targets_overlap(mod, mod.impls[ii], target_type, target_struct_index, target_is_generic_template))
+                    impl_targets_overlap(mod,
+                                         mod.impls[ii],
+                                         target_type,
+                                         target_struct_index,
+                                         target_is_generic_template))
                     return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span);
             }
             if (!protocol_indices.push(protocol_index))
@@ -8324,11 +8836,11 @@ resolve_concrete_impl_target:
                 return frontend_error(FrontendError::TooManyItems, item.impl_decl.span);
             for (u32 ci = 0; ci < mod.conformances.len; ci++) {
                 const auto& existing = mod.conformances[ci];
-                if (existing.protocol_index == protocol_index &&
-                    existing.type == target_type &&
+                if (existing.protocol_index == protocol_index && existing.type == target_type &&
                     existing.struct_index == target_struct_index &&
                     existing.is_generic_template == target_is_generic_template)
-                    return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
             }
             HirConformance conf{};
             conf.span = item.impl_decl.span;
@@ -8347,7 +8859,9 @@ resolve_concrete_impl_target:
                 for (u32 li = 0; li < lhs.methods.len; li++) {
                     for (u32 ri = 0; ri < rhs.methods.len; ri++) {
                         if (lhs.methods[li].name.eq(rhs.methods[ri].name))
-                            return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, lhs.methods[li].name);
+                            return frontend_error(FrontendError::UnsupportedSyntax,
+                                                  item.impl_decl.span,
+                                                  lhs.methods[li].name);
                     }
                 }
             }
@@ -8358,29 +8872,35 @@ resolve_concrete_impl_target:
             if (method_ast.type_params.len != 0)
                 return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span);
             if (method_ast.params.len == 0)
-                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
 
             u32 matched_protocol_slot = 0xffffffffu;
             const HirProtocol::MethodDecl* req = nullptr;
             for (u32 pi = 0; pi < protocol_indices.len; pi++) {
-                const auto* candidate = find_protocol_method(mod.protocols[protocol_indices[pi]], method_ast.name);
+                const auto* candidate =
+                    find_protocol_method(mod.protocols[protocol_indices[pi]], method_ast.name);
                 if (candidate == nullptr) continue;
                 if (matched_protocol_slot != 0xffffffffu)
-                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
                 matched_protocol_slot = pi;
                 req = candidate;
             }
             if (matched_protocol_slot == 0xffffffffu || req == nullptr)
-                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
 
             auto& impl = pending_impls[matched_protocol_slot];
             for (u32 seen = 0; seen < impl.methods.len; seen++) {
                 if (impl.methods[seen].name.eq(method_ast.name))
-                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
             }
 
             if (method_ast.params.len != req->params.len + 1)
-                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
             for (u32 pi = 0; pi < req->params.len; pi++) {
                 u32 method_variant_index = 0xffffffffu;
                 u32 method_struct_index = 0xffffffffu;
@@ -8435,10 +8955,12 @@ resolve_concrete_impl_target:
                     expected.tuple_struct_indices[ti] = req->params[pi].tuple_struct_indices[ti];
                 }
                 if (!same_hir_type_shape(mod, actual, expected))
-                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
             }
             if (req->has_return_type != method_ast.has_return_type)
-                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
             if (req->has_return_type) {
                 u32 method_variant_index = 0xffffffffu;
                 u32 method_struct_index = 0xffffffffu;
@@ -8493,29 +9015,37 @@ resolve_concrete_impl_target:
                     expected.tuple_struct_indices[ti] = req->return_tuple_struct_indices[ti];
                 }
                 if (!same_hir_type_shape(mod, actual, expected))
-                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
             }
             auto type_name = make_impl_target_name(item.impl_decl.target);
             if (!type_name) return core::make_unexpected(type_name.error());
-            auto mangled =
-                make_impl_function_name(mod.protocols[impl.protocol_index].name, type_name.value(), method_ast.name);
+            auto mangled = make_impl_function_name(
+                mod.protocols[impl.protocol_index].name, type_name.value(), method_ast.name);
             if (!mangled) return core::make_unexpected(mangled.error());
             if (find_function_index(mod, mangled.value()) != mod.functions.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, mangled.value());
-            auto fn = declare_function_like(method_ast, method_ast.span, mangled.value(), &impl_target_type_params);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, method_ast.span, mangled.value());
+            auto fn = declare_function_like(
+                method_ast, method_ast.span, mangled.value(), &impl_target_type_params);
             if (!fn) return core::make_unexpected(fn.error());
             if (fn->params.len == 0 || fn->params[0].type != impl.type)
-                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
             if (fn->params[0].type == HirTypeKind::Struct) {
                 const auto& recv_param = fn->params[0];
                 if (!impl.is_generic_template && recv_param.struct_index != impl.struct_index)
-                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
                 if (impl.is_generic_template) {
-                    const bool matches_template = recv_param.template_struct_index == impl.struct_index ||
+                    const bool matches_template =
+                        recv_param.template_struct_index == impl.struct_index ||
                         (recv_param.struct_index < mod.structs.len &&
-                         mod.structs[recv_param.struct_index].template_struct_index == impl.struct_index);
+                         mod.structs[recv_param.struct_index].template_struct_index ==
+                             impl.struct_index);
                     if (!matches_template)
-                        return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
                 }
             }
             if (!mod.functions.push(fn.value()))
@@ -8532,7 +9062,8 @@ resolve_concrete_impl_target:
                 const auto& req = proto.methods[mi];
                 if (req.function_index != 0xffffffffu) continue;
                 if (find_impl_method(pending_impls[pi], req.name) != nullptr) continue;
-                return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, req.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.impl_decl.span, req.name);
             }
             if (!mod.impls.push(pending_impls[pi]))
                 return frontend_error(FrontendError::TooManyItems, item.impl_decl.span);
@@ -8571,32 +9102,39 @@ resolve_concrete_impl_target:
             param_locals[pi].ref_index = pi;
             param_locals[pi].type = fn.params[pi].type;
             param_locals[pi].generic_index = fn.params[pi].generic_index;
-            param_locals[pi].generic_has_error_constraint = fn.params[pi].generic_has_error_constraint;
+            param_locals[pi].generic_has_error_constraint =
+                fn.params[pi].generic_has_error_constraint;
             param_locals[pi].generic_has_eq_constraint = fn.params[pi].generic_has_eq_constraint;
             param_locals[pi].generic_has_ord_constraint = fn.params[pi].generic_has_ord_constraint;
             param_locals[pi].generic_protocol_index = fn.params[pi].generic_protocol_index;
             param_locals[pi].generic_protocol_count = fn.params[pi].generic_protocol_count;
             for (u32 cpi = 0; cpi < param_locals[pi].generic_protocol_count; cpi++)
-                param_locals[pi].generic_protocol_indices[cpi] = fn.params[pi].generic_protocol_indices[cpi];
+                param_locals[pi].generic_protocol_indices[cpi] =
+                    fn.params[pi].generic_protocol_indices[cpi];
             param_locals[pi].variant_index = fn.params[pi].variant_index;
             param_locals[pi].struct_index = fn.params[pi].struct_index;
             param_locals[pi].shape_index = fn.params[pi].shape_index;
             param_locals[pi].tuple_len = fn.params[pi].tuple_len;
             for (u32 ti = 0; ti < fn.params[pi].tuple_len; ti++) {
                 param_locals[pi].tuple_types[ti] = fn.params[pi].tuple_types[ti];
-                param_locals[pi].tuple_variant_indices[ti] = fn.params[pi].tuple_variant_indices[ti];
+                param_locals[pi].tuple_variant_indices[ti] =
+                    fn.params[pi].tuple_variant_indices[ti];
                 param_locals[pi].tuple_struct_indices[ti] = fn.params[pi].tuple_struct_indices[ti];
             }
             param_locals[pi].init.kind = HirExprKind::LocalRef;
             param_locals[pi].init.type = fn.params[pi].type;
             param_locals[pi].init.generic_index = fn.params[pi].generic_index;
-            param_locals[pi].init.generic_has_error_constraint = fn.params[pi].generic_has_error_constraint;
-            param_locals[pi].init.generic_has_eq_constraint = fn.params[pi].generic_has_eq_constraint;
-            param_locals[pi].init.generic_has_ord_constraint = fn.params[pi].generic_has_ord_constraint;
+            param_locals[pi].init.generic_has_error_constraint =
+                fn.params[pi].generic_has_error_constraint;
+            param_locals[pi].init.generic_has_eq_constraint =
+                fn.params[pi].generic_has_eq_constraint;
+            param_locals[pi].init.generic_has_ord_constraint =
+                fn.params[pi].generic_has_ord_constraint;
             param_locals[pi].init.generic_protocol_index = fn.params[pi].generic_protocol_index;
             param_locals[pi].init.generic_protocol_count = fn.params[pi].generic_protocol_count;
             for (u32 cpi = 0; cpi < param_locals[pi].init.generic_protocol_count; cpi++)
-                param_locals[pi].init.generic_protocol_indices[cpi] = fn.params[pi].generic_protocol_indices[cpi];
+                param_locals[pi].init.generic_protocol_indices[cpi] =
+                    fn.params[pi].generic_protocol_indices[cpi];
             param_locals[pi].init.local_index = pi;
             param_locals[pi].init.variant_index = fn.params[pi].variant_index;
             param_locals[pi].init.struct_index = fn.params[pi].struct_index;
@@ -8604,11 +9142,14 @@ resolve_concrete_impl_target:
             param_locals[pi].init.tuple_len = fn.params[pi].tuple_len;
             for (u32 ti = 0; ti < fn.params[pi].tuple_len; ti++) {
                 param_locals[pi].init.tuple_types[ti] = fn.params[pi].tuple_types[ti];
-                param_locals[pi].init.tuple_variant_indices[ti] = fn.params[pi].tuple_variant_indices[ti];
-                param_locals[pi].init.tuple_struct_indices[ti] = fn.params[pi].tuple_struct_indices[ti];
+                param_locals[pi].init.tuple_variant_indices[ti] =
+                    fn.params[pi].tuple_variant_indices[ti];
+                param_locals[pi].init.tuple_struct_indices[ti] =
+                    fn.params[pi].tuple_struct_indices[ti];
             }
         }
-        auto body = analyze_function_body_stmt(*item.func.body, &scratch, mod, param_locals, fn.params.len, nullptr);
+        auto body = analyze_function_body_stmt(
+            *item.func.body, &scratch, mod, param_locals, fn.params.len, nullptr);
         if (!body) return core::make_unexpected(body.error());
         FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> named_error_cases;
         for (u32 li = 0; li < scratch.locals.len; li++) {
@@ -8634,9 +9175,11 @@ resolve_concrete_impl_target:
         if (named_error_cases.len != 0 && scratch.error_variant_index != 0xffffffffu) {
             const u32 error_variant_index = scratch.error_variant_index;
             for (u32 li = 0; li < scratch.locals.len; li++) {
-                patch_named_error_variant(&scratch.locals[li].init, error_variant_index, named_error_cases);
+                patch_named_error_variant(
+                    &scratch.locals[li].init, error_variant_index, named_error_cases);
                 patch_error_variant_refs(&scratch.locals[li].init, error_variant_index);
-                if (scratch.locals[li].may_error && scratch.locals[li].error_variant_index == 0xffffffffu)
+                if (scratch.locals[li].may_error &&
+                    scratch.locals[li].error_variant_index == 0xffffffffu)
                     scratch.locals[li].error_variant_index = error_variant_index;
             }
             patch_named_error_variant(&body.value(), error_variant_index, named_error_cases);
@@ -8663,14 +9206,18 @@ resolve_concrete_impl_target:
                 body->generic_index = fn.return_generic_index;
                 body->shape_index = fn.return_shape_index;
                 if (fn.return_generic_index < fn.type_params.len) {
-                    body->generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
-                    body->generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
-                    body->generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+                    body->generic_has_error_constraint =
+                        fn.type_params[fn.return_generic_index].has_error_constraint;
+                    body->generic_has_eq_constraint =
+                        fn.type_params[fn.return_generic_index].has_eq_constraint;
+                    body->generic_has_ord_constraint =
+                        fn.type_params[fn.return_generic_index].has_ord_constraint;
                     body->generic_protocol_index =
                         fn.type_params[fn.return_generic_index].custom_protocol_count != 0
                             ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
                             : 0xffffffffu;
-                    body->generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+                    body->generic_protocol_count =
+                        fn.type_params[fn.return_generic_index].custom_protocol_count;
                     for (u32 cpi = 0; cpi < body->generic_protocol_count; cpi++)
                         body->generic_protocol_indices[cpi] =
                             fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
@@ -8698,27 +9245,33 @@ resolve_concrete_impl_target:
                                                     fn.return_shape_index);
             expected.generic_index = fn.return_generic_index;
             if (fn.return_generic_index < fn.type_params.len) {
-                expected.generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
-                expected.generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
-                expected.generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+                expected.generic_has_error_constraint =
+                    fn.type_params[fn.return_generic_index].has_error_constraint;
+                expected.generic_has_eq_constraint =
+                    fn.type_params[fn.return_generic_index].has_eq_constraint;
+                expected.generic_has_ord_constraint =
+                    fn.type_params[fn.return_generic_index].has_ord_constraint;
                 expected.generic_protocol_index =
                     fn.type_params[fn.return_generic_index].custom_protocol_count != 0
                         ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
                         : 0xffffffffu;
-                expected.generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+                expected.generic_protocol_count =
+                    fn.type_params[fn.return_generic_index].custom_protocol_count;
                 for (u32 cpi = 0; cpi < expected.generic_protocol_count; cpi++)
                     expected.generic_protocol_indices[cpi] =
                         fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
             }
             if (!same_hir_type_shape(mod, body.value(), expected))
                 return frontend_error(FrontendError::UnsupportedSyntax, item.func.body->span);
-            if (body->type == HirTypeKind::Variant && body->variant_index != fn.return_variant_index)
+            if (body->type == HirTypeKind::Variant &&
+                body->variant_index != fn.return_variant_index)
                 return frontend_error(FrontendError::UnsupportedSyntax, item.func.body->span);
         }
         HirLocal all_locals[AstFunctionDecl::kMaxParams + HirRoute::kMaxLocals]{};
         u32 all_local_count = 0;
         for (u32 pi = 0; pi < fn.params.len; pi++) all_locals[all_local_count++] = param_locals[pi];
-        for (u32 li = 0; li < scratch.locals.len; li++) all_locals[all_local_count++] = scratch.locals[li];
+        for (u32 li = 0; li < scratch.locals.len; li++)
+            all_locals[all_local_count++] = scratch.locals[li];
         fn.exprs.len = 0;
         auto normalized =
             normalize_function_expr(body.value(), &fn, all_locals, all_local_count, fn.params.len);
@@ -8736,7 +9289,8 @@ resolve_concrete_impl_target:
             if (method_ast.default_body == nullptr) continue;
             auto* method = find_protocol_method_mut(mod.protocols[protocol_index], method_ast.name);
             if (method == nullptr || method->function_index >= mod.functions.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, method_ast.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.protocol.span, method_ast.name);
 
             AstFunctionDecl synthetic{};
             synthetic.span = item.protocol.span;
@@ -8756,12 +9310,15 @@ resolve_concrete_impl_target:
                     return frontend_error(FrontendError::TooManyItems, item.protocol.span);
             }
             synthetic.body = method_ast.default_body;
-            auto body_ok = analyze_function_body_like(mod.functions[method->function_index], synthetic, synthetic.span);
+            auto body_ok = analyze_function_body_like(
+                mod.functions[method->function_index], synthetic, synthetic.span);
             if (!body_ok) return core::make_unexpected(body_ok.error());
             method->return_may_nil = mod.functions[method->function_index].body.may_nil;
             method->return_may_error = mod.functions[method->function_index].body.may_error;
-            method->return_error_struct_index = mod.functions[method->function_index].body.error_struct_index;
-            method->return_error_variant_index = mod.functions[method->function_index].body.error_variant_index;
+            method->return_error_struct_index =
+                mod.functions[method->function_index].body.error_struct_index;
+            method->return_error_variant_index =
+                mod.functions[method->function_index].body.error_variant_index;
         }
     }
 
@@ -8772,43 +9329,58 @@ resolve_concrete_impl_target:
         u32 target_struct_index = 0xffffffffu;
         bool target_is_generic_template = false;
         FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> impl_target_type_params;
-        auto resolved_target = resolve_impl_target(
-            item.impl_decl, target_type, target_struct_index, target_is_generic_template, impl_target_type_params);
+        auto resolved_target = resolve_impl_target(item.impl_decl,
+                                                   target_type,
+                                                   target_struct_index,
+                                                   target_is_generic_template,
+                                                   impl_target_type_params);
         if (!resolved_target) return core::make_unexpected(resolved_target.error());
         for (u32 mi = 0; mi < item.impl_decl.methods.len; mi++) {
             const auto& method_ast = item.impl_decl.methods[mi];
             u32 matched_protocol_index = 0xffffffffu;
             for (u32 pi = 0; pi < item.impl_decl.protocols.len; pi++) {
                 Str resolved_proto_name = item.impl_decl.protocols[pi];
-                if (pi < item.impl_decl.protocol_namespaces.len && item.impl_decl.protocol_namespaces[pi].len != 0) {
+                if (pi < item.impl_decl.protocol_namespaces.len &&
+                    item.impl_decl.protocol_namespaces[pi].len != 0) {
                     if (!resolve_import_namespace_type_name(mod,
                                                             item.impl_decl.protocol_namespaces[pi],
                                                             item.impl_decl.protocols[pi],
                                                             resolved_proto_name))
-                        return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, item.impl_decl.protocols[pi]);
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              method_ast.span,
+                                              item.impl_decl.protocols[pi]);
                 }
                 const u32 protocol_index = find_protocol_index(mod, resolved_proto_name);
                 if (protocol_index >= mod.protocols.len) continue;
-                if (find_protocol_method(mod.protocols[protocol_index], method_ast.name) == nullptr) continue;
+                if (find_protocol_method(mod.protocols[protocol_index], method_ast.name) == nullptr)
+                    continue;
                 if (matched_protocol_index != 0xffffffffu)
-                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
                 matched_protocol_index = protocol_index;
             }
             if (matched_protocol_index == 0xffffffffu)
-                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
             const HirImpl* impl_ptr = nullptr;
             for (u32 ii = 0; ii < mod.impls.len; ii++) {
                 if (mod.impls[ii].protocol_index == matched_protocol_index &&
-                    impl_matches_exact_target(mod.impls[ii], target_type, target_struct_index, target_is_generic_template)) {
+                    impl_matches_exact_target(mod.impls[ii],
+                                              target_type,
+                                              target_struct_index,
+                                              target_is_generic_template)) {
                     impl_ptr = &mod.impls[ii];
                     break;
                 }
             }
-            if (impl_ptr == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span);
+            if (impl_ptr == nullptr)
+                return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span);
             const auto* method = find_impl_method(*impl_ptr, method_ast.name);
             if (method == nullptr || method->function_index >= mod.functions.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
-            auto body_ok = analyze_function_body_like(mod.functions[method->function_index], method_ast, method_ast.span);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+            auto body_ok = analyze_function_body_like(
+                mod.functions[method->function_index], method_ast, method_ast.span);
             if (!body_ok) return core::make_unexpected(body_ok.error());
         }
     }
@@ -8831,7 +9403,8 @@ resolve_concrete_impl_target:
                 local.span = stmt.span;
                 local.name = stmt.name;
                 local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
-                auto init = analyze_expr(stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
+                auto init = analyze_expr(
+                    stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!init) return core::make_unexpected(init.error());
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, stmt);
                 if (!typed) return core::make_unexpected(typed.error());
@@ -8867,9 +9440,11 @@ resolve_concrete_impl_target:
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 HirGuard guard{};
                 guard.span = stmt.span;
-                auto bound = analyze_expr(stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
+                auto bound = analyze_expr(
+                    stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!bound) return core::make_unexpected(bound.error());
-                auto cond = analyze_guard_cond(stmt.expr, &route, mod, route.locals.data, route.locals.len);
+                auto cond =
+                    analyze_guard_cond(stmt.expr, &route, mod, route.locals.data, route.locals.len);
                 if (!cond) return core::make_unexpected(cond.error());
                 guard.cond = cond.value();
                 if (stmt.match_arms.len != 0) {
@@ -8922,7 +9497,8 @@ resolve_concrete_impl_target:
                     HirLocal local{};
                     local.span = stmt.span;
                     local.name = stmt.name;
-                    local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
+                    local.ref_index =
+                        next_local_ref_index(&route, route.locals.data, route.locals.len);
                     local.type = bound->type;
                     local.generic_index = bound->generic_index;
                     local.generic_has_error_constraint = bound->generic_has_error_constraint;
@@ -8958,12 +9534,13 @@ resolve_concrete_impl_target:
             auto control = analyze_control_stmt(stmt, &route, mod, nullptr);
             if (!control) return core::make_unexpected(control.error());
             if (si + 1 != item.route.statements.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, item.route.statements[si + 1].span);
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      item.route.statements[si + 1].span);
             break;
         }
 
-        if (route.control.kind == HirControlKind::Direct && route.control.direct_term.span.end == 0 &&
-            route.control.direct_term.span.start == 0)
+        if (route.control.kind == HirControlKind::Direct &&
+            route.control.direct_term.span.end == 0 && route.control.direct_term.span.start == 0)
             return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
 
         FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> named_error_cases;
@@ -8974,11 +9551,13 @@ resolve_concrete_impl_target:
         for (u32 gi = 0; gi < route.guards.len; gi++) {
             auto collected = collect_named_error_cases(route.guards[gi].cond, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
-            collected = collect_named_error_cases(route.guards[gi].fail_match_expr, named_error_cases);
+            collected =
+                collect_named_error_cases(route.guards[gi].fail_match_expr, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
             for (u32 ai = 0; ai < route.guards[gi].fail_match_count; ai++) {
                 collected = collect_named_error_cases(
-                    mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern, named_error_cases);
+                    mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern,
+                    named_error_cases);
                 if (!collected) return core::make_unexpected(collected.error());
             }
         }
@@ -8989,24 +9568,29 @@ resolve_concrete_impl_target:
             auto collected = collect_named_error_cases(route.control.match_expr, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
             for (u32 ai = 0; ai < route.control.match_arms.len; ai++) {
-                collected = collect_named_error_cases(route.control.match_arms[ai].pattern, named_error_cases);
+                collected = collect_named_error_cases(route.control.match_arms[ai].pattern,
+                                                      named_error_cases);
                 if (!collected) return core::make_unexpected(collected.error());
                 for (u32 gi = 0; gi < route.control.match_arms[ai].guards.len; gi++) {
-                    collected =
-                        collect_named_error_cases(route.control.match_arms[ai].guards[gi].cond, named_error_cases);
+                    collected = collect_named_error_cases(
+                        route.control.match_arms[ai].guards[gi].cond, named_error_cases);
                     if (!collected) return core::make_unexpected(collected.error());
                     collected = collect_named_error_cases(
                         route.control.match_arms[ai].guards[gi].fail_match_expr, named_error_cases);
                     if (!collected) return core::make_unexpected(collected.error());
-                    for (u32 fai = 0; fai < route.control.match_arms[ai].guards[gi].fail_match_count; fai++) {
+                    for (u32 fai = 0;
+                         fai < route.control.match_arms[ai].guards[gi].fail_match_count;
+                         fai++) {
                         collected = collect_named_error_cases(
-                            mod.guard_match_arms[route.control.match_arms[ai].guards[gi].fail_match_start + fai]
-                                .pattern,
+                            mod.guard_match_arms
+                                [route.control.match_arms[ai].guards[gi].fail_match_start + fai]
+                                    .pattern,
                             named_error_cases);
                         if (!collected) return core::make_unexpected(collected.error());
                     }
                 }
-                collected = collect_named_error_cases(route.control.match_arms[ai].cond, named_error_cases);
+                collected =
+                    collect_named_error_cases(route.control.match_arms[ai].cond, named_error_cases);
                 if (!collected) return core::make_unexpected(collected.error());
             }
         }
@@ -9024,17 +9608,22 @@ resolve_concrete_impl_target:
                 return frontend_error(FrontendError::TooManyItems, item.route.span);
             route.error_variant_index = mod.variants.len - 1;
             for (u32 li = 0; li < route.locals.len; li++) {
-                patch_named_error_variant(&route.locals[li].init, route.error_variant_index, named_error_cases);
+                patch_named_error_variant(
+                    &route.locals[li].init, route.error_variant_index, named_error_cases);
                 patch_error_variant_refs(&route.locals[li].init, route.error_variant_index);
-                if (route.locals[li].may_error && route.locals[li].error_variant_index == 0xffffffffu)
+                if (route.locals[li].may_error &&
+                    route.locals[li].error_variant_index == 0xffffffffu)
                     route.locals[li].error_variant_index = route.error_variant_index;
             }
             for (u32 gi = 0; gi < route.guards.len; gi++) {
-                patch_named_error_variant(&route.guards[gi].cond, route.error_variant_index, named_error_cases);
-                patch_error_variant_refs(&route.guards[gi].cond, route.error_variant_index);
                 patch_named_error_variant(
-                    &route.guards[gi].fail_match_expr, route.error_variant_index, named_error_cases);
-                patch_error_variant_refs(&route.guards[gi].fail_match_expr, route.error_variant_index);
+                    &route.guards[gi].cond, route.error_variant_index, named_error_cases);
+                patch_error_variant_refs(&route.guards[gi].cond, route.error_variant_index);
+                patch_named_error_variant(&route.guards[gi].fail_match_expr,
+                                          route.error_variant_index,
+                                          named_error_cases);
+                patch_error_variant_refs(&route.guards[gi].fail_match_expr,
+                                         route.error_variant_index);
                 for (u32 ai = 0; ai < route.guards[gi].fail_match_count; ai++) {
                     patch_named_error_variant(
                         &mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern,
@@ -9046,23 +9635,25 @@ resolve_concrete_impl_target:
                 }
             }
             if (route.control.kind == HirControlKind::If) {
-                patch_named_error_variant(&route.control.cond, route.error_variant_index, named_error_cases);
+                patch_named_error_variant(
+                    &route.control.cond, route.error_variant_index, named_error_cases);
                 patch_error_variant_refs(&route.control.cond, route.error_variant_index);
             } else if (route.control.kind == HirControlKind::Match) {
-                patch_named_error_variant(&route.control.match_expr, route.error_variant_index, named_error_cases);
+                patch_named_error_variant(
+                    &route.control.match_expr, route.error_variant_index, named_error_cases);
                 patch_error_variant_refs(&route.control.match_expr, route.error_variant_index);
                 for (u32 ai = 0; ai < route.control.match_arms.len; ai++) {
-                    patch_named_error_variant(
-                        &route.control.match_arms[ai].pattern, route.error_variant_index, named_error_cases);
-                    patch_error_variant_refs(
-                        &route.control.match_arms[ai].pattern, route.error_variant_index);
+                    patch_named_error_variant(&route.control.match_arms[ai].pattern,
+                                              route.error_variant_index,
+                                              named_error_cases);
+                    patch_error_variant_refs(&route.control.match_arms[ai].pattern,
+                                             route.error_variant_index);
                     for (u32 gi = 0; gi < route.control.match_arms[ai].guards.len; gi++) {
-                        patch_named_error_variant(
-                            &route.control.match_arms[ai].guards[gi].cond,
-                            route.error_variant_index,
-                            named_error_cases);
-                        patch_error_variant_refs(
-                            &route.control.match_arms[ai].guards[gi].cond, route.error_variant_index);
+                        patch_named_error_variant(&route.control.match_arms[ai].guards[gi].cond,
+                                                  route.error_variant_index,
+                                                  named_error_cases);
+                        patch_error_variant_refs(&route.control.match_arms[ai].guards[gi].cond,
+                                                 route.error_variant_index);
                         patch_named_error_variant(
                             &route.control.match_arms[ai].guards[gi].fail_match_expr,
                             route.error_variant_index,
@@ -9070,24 +9661,29 @@ resolve_concrete_impl_target:
                         patch_error_variant_refs(
                             &route.control.match_arms[ai].guards[gi].fail_match_expr,
                             route.error_variant_index);
-                        for (u32 fai = 0; fai < route.control.match_arms[ai].guards[gi].fail_match_count; fai++) {
+                        for (u32 fai = 0;
+                             fai < route.control.match_arms[ai].guards[gi].fail_match_count;
+                             fai++) {
                             patch_named_error_variant(
-                                &mod.guard_match_arms[route.control.match_arms[ai].guards[gi].fail_match_start +
-                                                      fai]
-                                     .pattern,
+                                &mod.guard_match_arms
+                                     [route.control.match_arms[ai].guards[gi].fail_match_start +
+                                      fai]
+                                         .pattern,
                                 route.error_variant_index,
                                 named_error_cases);
                             patch_error_variant_refs(
-                                &mod.guard_match_arms[route.control.match_arms[ai].guards[gi].fail_match_start +
-                                                      fai]
-                                     .pattern,
+                                &mod.guard_match_arms
+                                     [route.control.match_arms[ai].guards[gi].fail_match_start +
+                                      fai]
+                                         .pattern,
                                 route.error_variant_index);
                         }
                     }
-                    patch_named_error_variant(
-                        &route.control.match_arms[ai].cond, route.error_variant_index, named_error_cases);
-                    patch_error_variant_refs(
-                        &route.control.match_arms[ai].cond, route.error_variant_index);
+                    patch_named_error_variant(&route.control.match_arms[ai].cond,
+                                              route.error_variant_index,
+                                              named_error_cases);
+                    patch_error_variant_refs(&route.control.match_arms[ai].cond,
+                                             route.error_variant_index);
                 }
             }
         }
@@ -9102,7 +9698,8 @@ resolve_concrete_impl_target:
             const auto& ast_deco = item.route.decorators[di];
             const u32 fn_index = find_function_index(mod, ast_deco.name);
             if (fn_index == mod.functions.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, ast_deco.span, ast_deco.name);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, ast_deco.span, ast_deco.name);
             auto sig_check = validate_decorator_signature(mod.functions[fn_index], ast_deco.span);
             if (!sig_check) return core::make_unexpected(sig_check.error());
 
@@ -9124,9 +9721,11 @@ resolve_concrete_impl_target:
 
             HirLocal deco_local{};
             deco_local.span = ast_deco.span;
-            deco_local.name = intern_generated_name(
-                std::string("_deco_") + std::to_string(di) + "_" + std::string(ast_deco.name.ptr, ast_deco.name.len));
-            deco_local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
+            deco_local.name =
+                intern_generated_name(std::string("_deco_") + std::to_string(di) + "_" +
+                                      std::string(ast_deco.name.ptr, ast_deco.name.len));
+            deco_local.ref_index =
+                next_local_ref_index(&route, route.locals.data, route.locals.len);
             deco_local.type = HirTypeKind::I32;
             deco_local.init = inlined.value();
             const u32 deco_ref = deco_local.ref_index;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -1,0 +1,8375 @@
+#include "rut/compiler/analyze.h"
+#include "rut/compiler/lexer.h"
+#include "rut/compiler/parser.h"
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+#include <deque>
+
+namespace rut {
+
+static u32 g_import_analysis_counter = 0;
+static std::deque<std::string> g_stable_generated_names;
+
+namespace {
+
+static Str intern_generated_name(const std::string& value) {
+    g_stable_generated_names.push_back(value);
+    const auto& kept = g_stable_generated_names.back();
+    return {kept.c_str(), static_cast<u32>(kept.size())};
+}
+
+static std::string str_to_std_string(Str s) {
+    return std::string(s.ptr, s.len);
+}
+
+static Str stash_owned_string(std::deque<std::string>* store, const std::string& value) {
+    store->push_back(value);
+    const auto& kept = store->back();
+    return {kept.c_str(), static_cast<u32>(kept.size())};
+}
+
+static bool type_shape_is_simple_importable(const HirTypeKind type,
+                                            u32 /*variant_index*/,
+                                            u32 /*struct_index*/,
+                                            u32 tuple_len,
+                                            const HirTypeKind* tuple_types,
+                                            const u32* tuple_variant_indices,
+                                            const u32* tuple_struct_indices) {
+    switch (type) {
+        case HirTypeKind::Bool:
+        case HirTypeKind::I32:
+        case HirTypeKind::Str:
+        case HirTypeKind::Generic:
+        case HirTypeKind::Unknown:
+            return true;
+        case HirTypeKind::Tuple:
+            for (u32 i = 0; i < tuple_len; i++) {
+                if (tuple_types[i] == HirTypeKind::Struct && tuple_struct_indices != nullptr &&
+                    tuple_struct_indices[i] != 0xffffffffu)
+                    continue;
+                if (tuple_types[i] == HirTypeKind::Variant &&
+                    tuple_variant_indices != nullptr &&
+                    tuple_variant_indices[i] != 0xffffffffu)
+                    continue;
+                if (!type_shape_is_simple_importable(tuple_types[i],
+                                                    tuple_variant_indices[i],
+                                                    tuple_struct_indices != nullptr ? tuple_struct_indices[i]
+                                                                                    : 0xffffffffu,
+                                                    0,
+                                                    nullptr,
+                                                    nullptr,
+                                                    nullptr))
+                    return false;
+            }
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool read_text_file(const std::filesystem::path& path, std::string* out) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return false;
+    *out = std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    return true;
+}
+
+static bool same_type_shape_node(const HirTypeShape& lhs, const HirTypeShape& rhs) {
+    if (lhs.type != rhs.type) return false;
+    if (lhs.generic_index != rhs.generic_index) return false;
+    if (lhs.variant_index != rhs.variant_index) return false;
+    if (lhs.struct_index != rhs.struct_index) return false;
+    if (lhs.tuple_len != rhs.tuple_len) return false;
+    for (u32 i = 0; i < lhs.tuple_len; i++) {
+        if (lhs.tuple_elem_shape_indices[i] != rhs.tuple_elem_shape_indices[i]) return false;
+    }
+    return true;
+}
+
+static FrontendResult<u32> intern_hir_type_shape(HirModule* mod,
+                                                 HirTypeKind type,
+                                                 u32 generic_index,
+                                                 u32 variant_index,
+                                                 u32 struct_index,
+                                                 u32 tuple_len,
+                                                 const HirTypeKind* tuple_types,
+                                                 const u32* tuple_variant_indices,
+                                                 const u32* tuple_struct_indices,
+                                                 Span span) {
+    HirTypeShape shape{};
+    shape.type = type;
+    shape.generic_index = generic_index;
+    shape.variant_index = variant_index;
+    shape.struct_index = struct_index;
+    shape.tuple_len = tuple_len;
+    shape.is_concrete = type == HirTypeKind::Bool || type == HirTypeKind::I32 || type == HirTypeKind::Str;
+    if (type == HirTypeKind::Variant) shape.is_concrete = variant_index != 0xffffffffu;
+    if (type == HirTypeKind::Struct) shape.is_concrete = struct_index != 0xffffffffu;
+    if (type == HirTypeKind::Tuple) {
+        shape.is_concrete = true;
+        for (u32 i = 0; i < tuple_len; i++) {
+            const auto elem_type = tuple_types[i];
+            const u32 elem_variant_index =
+                elem_type == HirTypeKind::Variant ? tuple_variant_indices[i] : 0xffffffffu;
+            const u32 elem_struct_index =
+                elem_type == HirTypeKind::Struct ? tuple_struct_indices[i] : 0xffffffffu;
+            auto elem_shape = intern_hir_type_shape(mod,
+                                                    elem_type,
+                                                    0xffffffffu,
+                                                    elem_variant_index,
+                                                    elem_struct_index,
+                                                    0,
+                                                    nullptr,
+                                                    nullptr,
+                                                    nullptr,
+                                                    span);
+            if (!elem_shape) return core::make_unexpected(elem_shape.error());
+            shape.tuple_elem_shape_indices[i] = elem_shape.value();
+            if (!mod->type_shapes[elem_shape.value()].is_concrete) shape.is_concrete = false;
+        }
+    }
+    for (u32 i = 0; i < mod->type_shapes.len; i++) {
+        if (same_type_shape_node(mod->type_shapes[i], shape)) return i;
+    }
+    if (!mod->type_shapes.push(shape))
+        return frontend_error(FrontendError::TooManyItems, span);
+    return mod->type_shapes.len - 1;
+}
+
+struct ImportedModuleInfo {
+    static constexpr u32 kMaxSelectedNames = AstImportDecl::kMaxSelectedNames;
+    Span span{};
+    Str path{};
+    HirModule* module = nullptr;
+    bool selective = false;
+    bool has_namespace_alias = false;
+    Str namespace_alias{};
+    FixedVec<AstImportDecl::SelectedName, kMaxSelectedNames> selected_names;
+};
+
+enum class KnownValueState : u8 {
+    Available,
+    Nil,
+    Error,
+    Unknown,
+};
+
+struct MatchPayloadBinding {
+    Str name{};
+    HirTypeKind type = HirTypeKind::Unknown;
+    u32 variant_index = 0xffffffffu;
+    u32 struct_index = 0xffffffffu;
+    u32 shape_index = 0xffffffffu;
+    u32 case_index = 0;
+    u32 tuple_len = 0;
+    HirTypeKind tuple_types[kMaxTupleSlots]{};
+    u32 tuple_variant_indices[kMaxTupleSlots]{};
+    u32 tuple_struct_indices[kMaxTupleSlots]{};
+    const HirExpr* subject = nullptr;
+};
+
+struct RouteNamedErrorCase {
+    Str name{};
+};
+
+struct ConstValue {
+    HirTypeKind type = HirTypeKind::Unknown;
+    bool bool_value = false;
+    i32 int_value = 0;
+    u32 variant_index = 0;
+    u32 case_index = 0;
+};
+
+struct KnownErrorCase {
+    bool known = false;
+    u32 variant_index = 0xffffffffu;
+    u32 case_index = 0xffffffffu;
+};
+
+struct GenericBinding {
+    bool bound = false;
+    HirTypeKind type = HirTypeKind::Unknown;
+    u32 generic_index = 0xffffffffu;
+    u32 variant_index = 0xffffffffu;
+    u32 struct_index = 0xffffffffu;
+    u32 shape_index = 0xffffffffu;
+    u32 tuple_len = 0;
+    HirTypeKind tuple_types[kMaxTupleSlots]{};
+    u32 tuple_variant_indices[kMaxTupleSlots]{};
+    u32 tuple_struct_indices[kMaxTupleSlots]{};
+};
+
+static FrontendResult<u32> instantiate_struct(HirModule* mod,
+                                              u32 template_struct_index,
+                                              const GenericBinding* bindings,
+                                              u32 binding_count,
+                                              Span span);
+
+static FrontendResult<HirTypeKind> instantiate_deferred_named_type(const HirModule& mod,
+                                                                   HirTypeKind declared_kind,
+                                                                   u32 template_variant_index,
+                                                                   u32 template_struct_index,
+                                                                   const HirVariant::TypeArgRef* type_args,
+                                                                   u32 type_arg_count,
+                                                                   const GenericBinding* bindings,
+                                                                   u32 binding_count,
+                                                                   u32* out_variant_index,
+                                                                   u32* out_struct_index,
+                                                                   Span span);
+
+static FrontendResult<void> fill_bound_binding_from_type_metadata(GenericBinding* binding,
+                                                                  HirModule* mod,
+                                                                  HirTypeKind type,
+                                                                  u32 generic_index,
+                                                                  u32 variant_index,
+                                                                  u32 struct_index,
+                                                                  u32 tuple_len,
+                                                                  const HirTypeKind* tuple_types,
+                                                                  const u32* tuple_variant_indices,
+                                                                  const u32* tuple_struct_indices,
+                                                                  u32 shape_index,
+                                                                  Span span);
+
+static bool conformance_matches_binding(const HirModule& mod,
+                                        const HirConformance& c,
+                                        const GenericBinding& binding) {
+    if (c.protocol_index == 0xffffffffu) return false;
+    if (c.type != binding.type) return false;
+    if (c.type == HirTypeKind::Struct) {
+        if (!c.is_generic_template) return c.struct_index == binding.struct_index;
+        if (binding.struct_index >= mod.structs.len) return false;
+        return mod.structs[binding.struct_index].template_struct_index == c.struct_index;
+    }
+    return c.struct_index == 0xffffffffu;
+}
+
+static bool generic_binding_satisfies_custom_protocol(const HirModule& mod,
+                                                    const GenericBinding& binding,
+                                                    u32 protocol_index) {
+    for (u32 i = 0; i < mod.conformances.len; i++) {
+        const auto& c = mod.conformances[i];
+        if (c.protocol_index != protocol_index) continue;
+        if (conformance_matches_binding(mod, c, binding)) return true;
+    }
+    return false;
+}
+
+static bool generic_binding_satisfies_error_constraint(const HirModule& mod, const GenericBinding& binding) {
+    if (binding.type == HirTypeKind::Struct && binding.struct_index < mod.structs.len)
+        return mod.structs[binding.struct_index].conforms_error;
+    return false;
+}
+
+static bool hir_type_shape_satisfies_eq_constraint(const HirModule& mod,
+                                                   HirTypeKind type,
+                                                   u32 variant_index,
+                                                   u32 struct_index,
+                                                   u32 tuple_len,
+                                                   const HirTypeKind* tuple_types,
+                                                   const u32* tuple_variant_indices,
+                                                   const u32* tuple_struct_indices,
+                                                   bool* struct_visiting,
+                                                   bool* variant_visiting) {
+    switch (type) {
+        case HirTypeKind::Bool:
+        case HirTypeKind::I32:
+        case HirTypeKind::Str:
+            return true;
+        case HirTypeKind::Tuple:
+            for (u32 i = 0; i < tuple_len; i++) {
+                if (!hir_type_shape_satisfies_eq_constraint(mod,
+                                                            tuple_types[i],
+                                                            tuple_variant_indices[i],
+                                                            tuple_struct_indices != nullptr
+                                                                ? tuple_struct_indices[i]
+                                                                : 0xffffffffu,
+                                                            0,
+                                                            nullptr,
+                                                            nullptr,
+                                                            nullptr,
+                                                            struct_visiting,
+                                                            variant_visiting))
+                    return false;
+            }
+            return true;
+        case HirTypeKind::Struct: {
+            if (struct_index >= mod.structs.len) return false;
+            if (struct_visiting[struct_index]) return true;
+            struct_visiting[struct_index] = true;
+            const auto& st = mod.structs[struct_index];
+            for (u32 i = 0; i < st.fields.len; i++) {
+                const auto& field = st.fields[i];
+                const bool ok = field.is_error_type ||
+                                hir_type_shape_satisfies_eq_constraint(mod,
+                                                                       field.type,
+                                                                       field.variant_index,
+                                                                       field.struct_index,
+                                                                       field.tuple_len,
+                                                                       field.tuple_types,
+                                                                       field.tuple_variant_indices,
+                                                                       field.tuple_struct_indices,
+                                                                       struct_visiting,
+                                                                       variant_visiting);
+                if (!ok) {
+                    struct_visiting[struct_index] = false;
+                    return false;
+                }
+            }
+            struct_visiting[struct_index] = false;
+            return true;
+        }
+        case HirTypeKind::Variant: {
+            if (variant_index >= mod.variants.len) return false;
+            if (variant_visiting[variant_index]) return true;
+            variant_visiting[variant_index] = true;
+            const auto& variant = mod.variants[variant_index];
+            for (u32 i = 0; i < variant.cases.len; i++) {
+                const auto& c = variant.cases[i];
+                if (!c.has_payload) continue;
+                if (!hir_type_shape_satisfies_eq_constraint(mod,
+                                                            c.payload_type,
+                                                            c.payload_variant_index,
+                                                            c.payload_struct_index,
+                                                            c.payload_tuple_len,
+                                                            c.payload_tuple_types,
+                                                            c.payload_tuple_variant_indices,
+                                                            c.payload_tuple_struct_indices,
+                                                            struct_visiting,
+                                                            variant_visiting)) {
+                    variant_visiting[variant_index] = false;
+                    return false;
+                }
+            }
+            variant_visiting[variant_index] = false;
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+static bool generic_binding_satisfies_eq_constraint(const HirModule& mod, const GenericBinding& binding) {
+    bool struct_visiting[HirModule::kMaxStructs]{};
+    bool variant_visiting[HirModule::kMaxVariants]{};
+    return hir_type_shape_satisfies_eq_constraint(mod,
+                                                  binding.type,
+                                                  binding.variant_index,
+                                                  binding.struct_index,
+                                                  binding.tuple_len,
+                                                  binding.tuple_types,
+                                                  binding.tuple_variant_indices,
+                                                  binding.tuple_struct_indices,
+                                                  struct_visiting,
+                                                  variant_visiting);
+}
+
+static bool hir_type_shape_satisfies_ord_constraint(const HirModule& mod,
+                                                    HirTypeKind type,
+                                                    u32 variant_index,
+                                                    u32 struct_index,
+                                                    u32 tuple_len,
+                                                    const HirTypeKind* tuple_types,
+                                                    const u32* tuple_variant_indices,
+                                                    const u32* tuple_struct_indices,
+                                                    bool* struct_visiting,
+                                                    bool* variant_visiting) {
+    switch (type) {
+        case HirTypeKind::I32:
+        case HirTypeKind::Str:
+            return true;
+        case HirTypeKind::Tuple:
+            for (u32 i = 0; i < tuple_len; i++) {
+                if (!hir_type_shape_satisfies_ord_constraint(mod,
+                                                             tuple_types[i],
+                                                             tuple_variant_indices[i],
+                                                             tuple_struct_indices != nullptr
+                                                                 ? tuple_struct_indices[i]
+                                                                 : 0xffffffffu,
+                                                             0,
+                                                             nullptr,
+                                                             nullptr,
+                                                             nullptr,
+                                                             struct_visiting,
+                                                             variant_visiting))
+                    return false;
+            }
+            return true;
+        case HirTypeKind::Struct: {
+            if (struct_index >= mod.structs.len) return false;
+            if (struct_visiting[struct_index]) return true;
+            struct_visiting[struct_index] = true;
+            const auto& st = mod.structs[struct_index];
+            for (u32 i = 0; i < st.fields.len; i++) {
+                const auto& field = st.fields[i];
+                if (field.is_error_type) {
+                    struct_visiting[struct_index] = false;
+                    return false;
+                }
+                if (!hir_type_shape_satisfies_ord_constraint(mod,
+                                                             field.type,
+                                                             field.variant_index,
+                                                             field.struct_index,
+                                                             field.tuple_len,
+                                                             field.tuple_types,
+                                                             field.tuple_variant_indices,
+                                                             field.tuple_struct_indices,
+                                                             struct_visiting,
+                                                             variant_visiting)) {
+                    struct_visiting[struct_index] = false;
+                    return false;
+                }
+            }
+            struct_visiting[struct_index] = false;
+            return true;
+        }
+        case HirTypeKind::Variant: {
+            if (variant_index >= mod.variants.len) return false;
+            if (variant_visiting[variant_index]) return true;
+            variant_visiting[variant_index] = true;
+            const auto& variant = mod.variants[variant_index];
+            for (u32 i = 0; i < variant.cases.len; i++) {
+                const auto& c = variant.cases[i];
+                if (!c.has_payload) continue;
+                if (!hir_type_shape_satisfies_ord_constraint(mod,
+                                                             c.payload_type,
+                                                             c.payload_variant_index,
+                                                             c.payload_struct_index,
+                                                             c.payload_tuple_len,
+                                                             c.payload_tuple_types,
+                                                             c.payload_tuple_variant_indices,
+                                                             c.payload_tuple_struct_indices,
+                                                             struct_visiting,
+                                                             variant_visiting)) {
+                    variant_visiting[variant_index] = false;
+                    return false;
+                }
+            }
+            variant_visiting[variant_index] = false;
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+static bool generic_binding_satisfies_ord_constraint(const HirModule& mod, const GenericBinding& binding) {
+    bool struct_visiting[HirModule::kMaxStructs]{};
+    bool variant_visiting[HirModule::kMaxVariants]{};
+    return hir_type_shape_satisfies_ord_constraint(mod,
+                                                   binding.type,
+                                                   binding.variant_index,
+                                                   binding.struct_index,
+                                                   binding.tuple_len,
+                                                   binding.tuple_types,
+                                                   binding.tuple_variant_indices,
+                                                   binding.tuple_struct_indices,
+                                                   struct_visiting,
+                                                   variant_visiting);
+}
+
+static bool same_variant_instance_shape(const HirVariant& variant,
+                                        u32 template_variant_index,
+                                        const GenericBinding* bindings,
+                                        u32 binding_count) {
+    if (variant.template_variant_index != template_variant_index) return false;
+    if (variant.instance_type_arg_count != binding_count) return false;
+    for (u32 i = 0; i < binding_count; i++) {
+        if (variant.instance_type_args[i] != bindings[i].type) return false;
+        if (variant.instance_generic_indices[i] != bindings[i].generic_index) return false;
+        if (variant.instance_variant_indices[i] != bindings[i].variant_index) return false;
+        if (variant.instance_struct_indices[i] != bindings[i].struct_index) return false;
+        if (variant.instance_shape_indices[i] != 0xffffffffu && bindings[i].shape_index != 0xffffffffu &&
+            variant.instance_shape_indices[i] != bindings[i].shape_index)
+            return false;
+        if (variant.instance_tuple_lens[i] != bindings[i].tuple_len) return false;
+        for (u32 ti = 0; ti < bindings[i].tuple_len; ti++) {
+            if (variant.instance_tuple_types[i][ti] != bindings[i].tuple_types[ti]) return false;
+            if (variant.instance_tuple_variant_indices[i][ti] != bindings[i].tuple_variant_indices[ti]) return false;
+            if (variant.instance_tuple_struct_indices[i][ti] != bindings[i].tuple_struct_indices[ti]) return false;
+        }
+    }
+    return true;
+}
+
+static FrontendResult<u32> instantiate_variant(HirModule* mod,
+                                               u32 template_variant_index,
+                                               const GenericBinding* bindings,
+                                               u32 binding_count,
+                                               Span span) {
+    for (u32 i = 0; i < mod->variants.len; i++) {
+        if (same_variant_instance_shape(mod->variants[i], template_variant_index, bindings, binding_count))
+            return i;
+    }
+    if (template_variant_index >= mod->variants.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, span);
+    const auto& templ = mod->variants[template_variant_index];
+    HirVariant concrete{};
+    concrete.span = templ.span;
+    concrete.name = templ.name;
+    concrete.template_variant_index = template_variant_index;
+    concrete.instance_type_arg_count = binding_count;
+    for (u32 i = 0; i < binding_count; i++) {
+        concrete.instance_type_args[i] = bindings[i].type;
+        concrete.instance_generic_indices[i] = bindings[i].generic_index;
+        concrete.instance_variant_indices[i] = bindings[i].variant_index;
+        concrete.instance_struct_indices[i] = bindings[i].struct_index;
+        concrete.instance_shape_indices[i] = bindings[i].shape_index;
+        concrete.instance_tuple_lens[i] = bindings[i].tuple_len;
+        for (u32 ti = 0; ti < bindings[i].tuple_len; ti++) {
+            concrete.instance_tuple_types[i][ti] = bindings[i].tuple_types[ti];
+            concrete.instance_tuple_variant_indices[i][ti] = bindings[i].tuple_variant_indices[ti];
+            concrete.instance_tuple_struct_indices[i][ti] = bindings[i].tuple_struct_indices[ti];
+        }
+    }
+    for (u32 ci = 0; ci < templ.cases.len; ci++) {
+        HirVariant::CaseDecl case_decl = templ.cases[ci];
+        if (case_decl.payload_template_variant_index != 0xffffffffu ||
+            case_decl.payload_template_struct_index != 0xffffffffu) {
+            u32 concrete_variant_index = 0xffffffffu;
+            u32 concrete_struct_index = 0xffffffffu;
+            auto concrete_kind = instantiate_deferred_named_type(*mod,
+                                                                 case_decl.payload_type,
+                                                                 case_decl.payload_template_variant_index,
+                                                                 case_decl.payload_template_struct_index,
+                                                                 case_decl.payload_type_args,
+                                                                 case_decl.payload_type_arg_count,
+                                                                 bindings,
+                                                                 binding_count,
+                                                                 &concrete_variant_index,
+                                                                 &concrete_struct_index,
+                                                                 span);
+            if (!concrete_kind) return core::make_unexpected(concrete_kind.error());
+            case_decl.payload_type = concrete_kind.value();
+            case_decl.payload_variant_index = concrete_variant_index;
+            case_decl.payload_struct_index = concrete_struct_index;
+            case_decl.payload_template_variant_index = 0xffffffffu;
+            case_decl.payload_template_struct_index = 0xffffffffu;
+            case_decl.payload_type_arg_count = 0;
+        }
+        if (case_decl.payload_type == HirTypeKind::Generic) {
+            if (case_decl.payload_generic_index >= binding_count)
+                return frontend_error(FrontendError::UnsupportedSyntax, span);
+            const u32 source_generic_index = case_decl.payload_generic_index;
+            case_decl.payload_type = bindings[source_generic_index].type;
+            case_decl.payload_generic_index =
+                bindings[source_generic_index].type == HirTypeKind::Generic ? bindings[source_generic_index].generic_index
+                                                                          : 0xffffffffu;
+            case_decl.payload_variant_index = bindings[source_generic_index].variant_index;
+            case_decl.payload_struct_index = bindings[source_generic_index].struct_index;
+            case_decl.payload_tuple_len = bindings[source_generic_index].tuple_len;
+            for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
+                case_decl.payload_tuple_types[ti] = bindings[source_generic_index].tuple_types[ti];
+                case_decl.payload_tuple_variant_indices[ti] =
+                    bindings[source_generic_index].tuple_variant_indices[ti];
+                case_decl.payload_tuple_struct_indices[ti] =
+                    bindings[source_generic_index].tuple_struct_indices[ti];
+            }
+        }
+        if (case_decl.has_payload) {
+            auto payload_shape = intern_hir_type_shape(mod,
+                                                       case_decl.payload_type,
+                                                       case_decl.payload_generic_index,
+                                                       case_decl.payload_variant_index,
+                                                       case_decl.payload_struct_index,
+                                                       case_decl.payload_tuple_len,
+                                                       case_decl.payload_tuple_types,
+                                                       case_decl.payload_tuple_variant_indices,
+                                                       case_decl.payload_tuple_struct_indices,
+                                                       span);
+            if (!payload_shape) return core::make_unexpected(payload_shape.error());
+            case_decl.payload_shape_index = payload_shape.value();
+        }
+        if (!concrete.cases.push(case_decl))
+            return frontend_error(FrontendError::TooManyItems, span);
+    }
+    if (!mod->variants.push(concrete))
+        return frontend_error(FrontendError::TooManyItems, span);
+    return mod->variants.len - 1;
+}
+
+static FrontendResult<HirTypeKind> instantiate_deferred_named_type(const HirModule& mod,
+                                                                   HirTypeKind declared_kind,
+                                                                   u32 template_variant_index,
+                                                                   u32 template_struct_index,
+                                                                   const HirVariant::TypeArgRef* type_args,
+                                                                   u32 type_arg_count,
+                                                                   const GenericBinding* bindings,
+                                                                   u32 binding_count,
+                                                                   u32* out_variant_index,
+                                                                   u32* out_struct_index,
+                                                                   Span span) {
+    if (out_variant_index) *out_variant_index = 0xffffffffu;
+    if (out_struct_index) *out_struct_index = 0xffffffffu;
+    GenericBinding concrete_args[HirFunction::kMaxTypeParams]{};
+    for (u32 i = 0; i < type_arg_count; i++) {
+        if (type_args[i].generic_index != 0xffffffffu) {
+            if (type_args[i].generic_index >= binding_count)
+                return frontend_error(FrontendError::UnsupportedSyntax, span);
+            concrete_args[i] = bindings[type_args[i].generic_index];
+            continue;
+        }
+        auto filled = fill_bound_binding_from_type_metadata(&concrete_args[i],
+                                                            const_cast<HirModule*>(&mod),
+                                                            type_args[i].type,
+                                                            0xffffffffu,
+                                                            type_args[i].variant_index,
+                                                            type_args[i].struct_index,
+                                                            type_args[i].tuple_len,
+                                                            type_args[i].tuple_types,
+                                                            type_args[i].tuple_variant_indices,
+                                                            type_args[i].tuple_struct_indices,
+                                                            type_args[i].shape_index,
+                                                            span);
+        if (!filled) return core::make_unexpected(filled.error());
+    }
+    if (declared_kind == HirTypeKind::Variant) {
+        auto concrete_index = instantiate_variant(const_cast<HirModule*>(&mod),
+                                                  template_variant_index,
+                                                  concrete_args,
+                                                  type_arg_count,
+                                                  span);
+        if (!concrete_index) return core::make_unexpected(concrete_index.error());
+        if (out_variant_index) *out_variant_index = concrete_index.value();
+        return HirTypeKind::Variant;
+    }
+    if (declared_kind == HirTypeKind::Struct) {
+        auto concrete_index = instantiate_struct(const_cast<HirModule*>(&mod),
+                                                 template_struct_index,
+                                                 concrete_args,
+                                                 type_arg_count,
+                                                 span);
+        if (!concrete_index) return core::make_unexpected(concrete_index.error());
+        if (out_struct_index) *out_struct_index = concrete_index.value();
+        return HirTypeKind::Struct;
+    }
+    return frontend_error(FrontendError::UnsupportedSyntax, span);
+}
+
+static bool same_struct_instance_shape(const HirStruct& st,
+                                       u32 template_struct_index,
+                                       const GenericBinding* bindings,
+                                       u32 binding_count) {
+    if (st.template_struct_index != template_struct_index) return false;
+    if (st.instance_type_arg_count != binding_count) return false;
+    for (u32 i = 0; i < binding_count; i++) {
+        if (st.instance_type_args[i] != bindings[i].type) return false;
+        if (st.instance_generic_indices[i] != bindings[i].generic_index) return false;
+        if (st.instance_variant_indices[i] != bindings[i].variant_index) return false;
+        if (st.instance_struct_indices[i] != bindings[i].struct_index) return false;
+        if (st.instance_shape_indices[i] != 0xffffffffu && bindings[i].shape_index != 0xffffffffu &&
+            st.instance_shape_indices[i] != bindings[i].shape_index)
+            return false;
+        if (st.instance_tuple_lens[i] != bindings[i].tuple_len) return false;
+        for (u32 ti = 0; ti < bindings[i].tuple_len; ti++) {
+            if (st.instance_tuple_types[i][ti] != bindings[i].tuple_types[ti]) return false;
+            if (st.instance_tuple_variant_indices[i][ti] != bindings[i].tuple_variant_indices[ti]) return false;
+            if (st.instance_tuple_struct_indices[i][ti] != bindings[i].tuple_struct_indices[ti]) return false;
+        }
+    }
+    return true;
+}
+
+static FrontendResult<u32> instantiate_struct(HirModule* mod,
+                                              u32 template_struct_index,
+                                              const GenericBinding* bindings,
+                                              u32 binding_count,
+                                              Span span) {
+    for (u32 i = 0; i < mod->structs.len; i++) {
+        if (same_struct_instance_shape(mod->structs[i], template_struct_index, bindings, binding_count))
+            return i;
+    }
+    if (template_struct_index >= mod->structs.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, span);
+    const auto& templ = mod->structs[template_struct_index];
+    HirStruct concrete{};
+    concrete.span = templ.span;
+    concrete.name = templ.name;
+    concrete.conforms_error = templ.conforms_error;
+    concrete.template_struct_index = template_struct_index;
+    concrete.instance_type_arg_count = binding_count;
+    for (u32 i = 0; i < binding_count; i++) {
+        concrete.instance_type_args[i] = bindings[i].type;
+        concrete.instance_generic_indices[i] = bindings[i].generic_index;
+        concrete.instance_variant_indices[i] = bindings[i].variant_index;
+        concrete.instance_struct_indices[i] = bindings[i].struct_index;
+        concrete.instance_shape_indices[i] = bindings[i].shape_index;
+        concrete.instance_tuple_lens[i] = bindings[i].tuple_len;
+        for (u32 ti = 0; ti < bindings[i].tuple_len; ti++) {
+            concrete.instance_tuple_types[i][ti] = bindings[i].tuple_types[ti];
+            concrete.instance_tuple_variant_indices[i][ti] = bindings[i].tuple_variant_indices[ti];
+            concrete.instance_tuple_struct_indices[i][ti] = bindings[i].tuple_struct_indices[ti];
+        }
+    }
+    for (u32 fi = 0; fi < templ.fields.len; fi++) {
+        HirStruct::FieldDecl field = templ.fields[fi];
+        if (field.template_variant_index != 0xffffffffu || field.template_struct_index != 0xffffffffu) {
+            u32 concrete_variant_index = 0xffffffffu;
+            u32 concrete_struct_index = 0xffffffffu;
+            auto concrete_kind = instantiate_deferred_named_type(*mod,
+                                                                 field.type,
+                                                                 field.template_variant_index,
+                                                                 field.template_struct_index,
+                                                                 field.type_args,
+                                                                 field.type_arg_count,
+                                                                 bindings,
+                                                                 binding_count,
+                                                                 &concrete_variant_index,
+                                                                 &concrete_struct_index,
+                                                                 span);
+            if (!concrete_kind) return core::make_unexpected(concrete_kind.error());
+            field.type = concrete_kind.value();
+            field.variant_index = concrete_variant_index;
+            field.struct_index = concrete_struct_index;
+            field.template_variant_index = 0xffffffffu;
+            field.template_struct_index = 0xffffffffu;
+            field.type_arg_count = 0;
+        }
+        if (field.type == HirTypeKind::Generic) {
+            if (field.generic_index >= binding_count)
+                return frontend_error(FrontendError::UnsupportedSyntax, span);
+            const u32 source_generic_index = field.generic_index;
+            field.type = bindings[source_generic_index].type;
+            field.generic_index =
+                bindings[source_generic_index].type == HirTypeKind::Generic ? bindings[source_generic_index].generic_index
+                                                                           : 0xffffffffu;
+            field.variant_index = bindings[source_generic_index].variant_index;
+            field.struct_index = bindings[source_generic_index].struct_index;
+            field.tuple_len = bindings[source_generic_index].tuple_len;
+            for (u32 ti = 0; ti < field.tuple_len; ti++) {
+                field.tuple_types[ti] = bindings[source_generic_index].tuple_types[ti];
+                field.tuple_variant_indices[ti] = bindings[source_generic_index].tuple_variant_indices[ti];
+                field.tuple_struct_indices[ti] = bindings[source_generic_index].tuple_struct_indices[ti];
+            }
+        }
+        auto field_shape = intern_hir_type_shape(mod,
+                                                 field.type,
+                                                 field.generic_index,
+                                                 field.variant_index,
+                                                 field.struct_index,
+                                                 field.tuple_len,
+                                                 field.tuple_types,
+                                                 field.tuple_variant_indices,
+                                                 field.tuple_struct_indices,
+                                                 span);
+        if (!field_shape) return core::make_unexpected(field_shape.error());
+        field.shape_index = field_shape.value();
+        if (!concrete.fields.push(field))
+            return frontend_error(FrontendError::TooManyItems, span);
+    }
+    if (!mod->structs.push(concrete))
+        return frontend_error(FrontendError::TooManyItems, span);
+    return mod->structs.len - 1;
+}
+
+static FrontendResult<void> refresh_concrete_struct_instances(HirModule* mod) {
+    for (u32 si = 0; si < mod->structs.len; si++) {
+        if (mod->structs[si].template_struct_index == 0xffffffffu) continue;
+        const u32 templ_index = mod->structs[si].template_struct_index;
+        if (templ_index >= mod->structs.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, mod->structs[si].span);
+        const auto& templ = mod->structs[templ_index];
+        HirStruct refreshed = mod->structs[si];
+        refreshed.fields.len = 0;
+        GenericBinding bindings[HirFunction::kMaxTypeParams]{};
+        const u32 binding_count = refreshed.instance_type_arg_count;
+        for (u32 bi = 0; bi < binding_count; bi++) {
+            auto filled = fill_bound_binding_from_type_metadata(&bindings[bi],
+                                                                mod,
+                                                                refreshed.instance_type_args[bi],
+                                                                refreshed.instance_generic_indices[bi],
+                                                                refreshed.instance_variant_indices[bi],
+                                                                refreshed.instance_struct_indices[bi],
+                                                                refreshed.instance_tuple_lens[bi],
+                                                                refreshed.instance_tuple_types[bi],
+                                                                refreshed.instance_tuple_variant_indices[bi],
+                                                                refreshed.instance_tuple_struct_indices[bi],
+                                                                refreshed.instance_shape_indices[bi],
+                                                                refreshed.span);
+            if (!filled) return core::make_unexpected(filled.error());
+            refreshed.instance_shape_indices[bi] = bindings[bi].shape_index;
+        }
+        for (u32 fi = 0; fi < templ.fields.len; fi++) {
+            HirStruct::FieldDecl field = templ.fields[fi];
+            if (field.template_variant_index != 0xffffffffu || field.template_struct_index != 0xffffffffu) {
+                u32 concrete_variant_index = 0xffffffffu;
+                u32 concrete_struct_index = 0xffffffffu;
+                auto concrete_kind = instantiate_deferred_named_type(*mod,
+                                                                     field.type,
+                                                                     field.template_variant_index,
+                                                                     field.template_struct_index,
+                                                                     field.type_args,
+                                                                     field.type_arg_count,
+                                                                     bindings,
+                                                                     binding_count,
+                                                                     &concrete_variant_index,
+                                                                     &concrete_struct_index,
+                                                                     refreshed.span);
+                if (!concrete_kind) return core::make_unexpected(concrete_kind.error());
+                field.type = concrete_kind.value();
+                field.variant_index = concrete_variant_index;
+                field.struct_index = concrete_struct_index;
+                field.template_variant_index = 0xffffffffu;
+                field.template_struct_index = 0xffffffffu;
+                field.type_arg_count = 0;
+            }
+            if (field.type == HirTypeKind::Generic) {
+                if (field.generic_index >= binding_count)
+                    return frontend_error(FrontendError::UnsupportedSyntax, refreshed.span);
+                field.type = bindings[field.generic_index].type;
+                field.variant_index = bindings[field.generic_index].variant_index;
+                field.struct_index = bindings[field.generic_index].struct_index;
+                field.tuple_len = bindings[field.generic_index].tuple_len;
+                for (u32 ti = 0; ti < field.tuple_len; ti++) {
+                    field.tuple_types[ti] = bindings[field.generic_index].tuple_types[ti];
+                    field.tuple_variant_indices[ti] = bindings[field.generic_index].tuple_variant_indices[ti];
+                    field.tuple_struct_indices[ti] = bindings[field.generic_index].tuple_struct_indices[ti];
+                }
+                field.generic_index = 0xffffffffu;
+            }
+            auto field_shape = intern_hir_type_shape(mod,
+                                                     field.type,
+                                                     field.generic_index,
+                                                     field.variant_index,
+                                                     field.struct_index,
+                                                     field.tuple_len,
+                                                     field.tuple_types,
+                                                     field.tuple_variant_indices,
+                                                     field.tuple_struct_indices,
+                                                     refreshed.span);
+            if (!field_shape) return core::make_unexpected(field_shape.error());
+            field.shape_index = field_shape.value();
+            if (!refreshed.fields.push(field))
+                return frontend_error(FrontendError::TooManyItems, refreshed.span);
+        }
+        refreshed.conforms_error = false;
+        for (u32 fi = 0; fi < refreshed.fields.len; fi++) {
+            if (refreshed.fields[fi].name.eq({"err", 3}) && refreshed.fields[fi].is_error_type) {
+                refreshed.conforms_error = true;
+                break;
+            }
+        }
+        mod->structs[si] = refreshed;
+    }
+    return {};
+}
+
+static FrontendResult<void> refresh_concrete_variant_instances(HirModule* mod) {
+    for (u32 vi = 0; vi < mod->variants.len; vi++) {
+        if (mod->variants[vi].template_variant_index == 0xffffffffu) continue;
+        const u32 templ_index = mod->variants[vi].template_variant_index;
+        if (templ_index >= mod->variants.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, mod->variants[vi].span);
+        const auto& templ = mod->variants[templ_index];
+        HirVariant refreshed = mod->variants[vi];
+        refreshed.cases.len = 0;
+        GenericBinding bindings[HirFunction::kMaxTypeParams]{};
+        const u32 binding_count = refreshed.instance_type_arg_count;
+        for (u32 bi = 0; bi < binding_count; bi++) {
+            auto filled = fill_bound_binding_from_type_metadata(&bindings[bi],
+                                                                mod,
+                                                                refreshed.instance_type_args[bi],
+                                                                refreshed.instance_generic_indices[bi],
+                                                                refreshed.instance_variant_indices[bi],
+                                                                refreshed.instance_struct_indices[bi],
+                                                                refreshed.instance_tuple_lens[bi],
+                                                                refreshed.instance_tuple_types[bi],
+                                                                refreshed.instance_tuple_variant_indices[bi],
+                                                                refreshed.instance_tuple_struct_indices[bi],
+                                                                refreshed.instance_shape_indices[bi],
+                                                                refreshed.span);
+            if (!filled) return core::make_unexpected(filled.error());
+            refreshed.instance_shape_indices[bi] = bindings[bi].shape_index;
+        }
+        for (u32 ci = 0; ci < templ.cases.len; ci++) {
+            HirVariant::CaseDecl case_decl = templ.cases[ci];
+            if (case_decl.payload_template_variant_index != 0xffffffffu ||
+                case_decl.payload_template_struct_index != 0xffffffffu) {
+                u32 concrete_variant_index = 0xffffffffu;
+                u32 concrete_struct_index = 0xffffffffu;
+                auto concrete_kind = instantiate_deferred_named_type(*mod,
+                                                                     case_decl.payload_type,
+                                                                     case_decl.payload_template_variant_index,
+                                                                     case_decl.payload_template_struct_index,
+                                                                     case_decl.payload_type_args,
+                                                                     case_decl.payload_type_arg_count,
+                                                                     bindings,
+                                                                     binding_count,
+                                                                     &concrete_variant_index,
+                                                                     &concrete_struct_index,
+                                                                     refreshed.span);
+                if (!concrete_kind) return core::make_unexpected(concrete_kind.error());
+                case_decl.payload_type = concrete_kind.value();
+                case_decl.payload_variant_index = concrete_variant_index;
+                case_decl.payload_struct_index = concrete_struct_index;
+                case_decl.payload_template_variant_index = 0xffffffffu;
+                case_decl.payload_template_struct_index = 0xffffffffu;
+                case_decl.payload_type_arg_count = 0;
+            }
+            if (case_decl.payload_type == HirTypeKind::Generic) {
+                if (case_decl.payload_generic_index >= binding_count)
+                    return frontend_error(FrontendError::UnsupportedSyntax, refreshed.span);
+                const u32 source_generic_index = case_decl.payload_generic_index;
+                case_decl.payload_type = bindings[source_generic_index].type;
+                case_decl.payload_generic_index =
+                    bindings[source_generic_index].type == HirTypeKind::Generic
+                        ? bindings[source_generic_index].generic_index
+                        : 0xffffffffu;
+                case_decl.payload_variant_index = bindings[source_generic_index].variant_index;
+                case_decl.payload_struct_index = bindings[source_generic_index].struct_index;
+                case_decl.payload_tuple_len = bindings[source_generic_index].tuple_len;
+                for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
+                    case_decl.payload_tuple_types[ti] = bindings[source_generic_index].tuple_types[ti];
+                    case_decl.payload_tuple_variant_indices[ti] =
+                        bindings[source_generic_index].tuple_variant_indices[ti];
+                    case_decl.payload_tuple_struct_indices[ti] =
+                        bindings[source_generic_index].tuple_struct_indices[ti];
+                }
+            }
+            if (case_decl.has_payload) {
+                auto payload_shape = intern_hir_type_shape(mod,
+                                                           case_decl.payload_type,
+                                                           case_decl.payload_generic_index,
+                                                           case_decl.payload_variant_index,
+                                                           case_decl.payload_struct_index,
+                                                           case_decl.payload_tuple_len,
+                                                           case_decl.payload_tuple_types,
+                                                           case_decl.payload_tuple_variant_indices,
+                                                           case_decl.payload_tuple_struct_indices,
+                                                           refreshed.span);
+                if (!payload_shape) return core::make_unexpected(payload_shape.error());
+                case_decl.payload_shape_index = payload_shape.value();
+            }
+            if (!refreshed.cases.push(case_decl))
+                return frontend_error(FrontendError::TooManyItems, refreshed.span);
+        }
+        mod->variants[vi] = refreshed;
+    }
+    return {};
+}
+
+static u32 find_variant_index(const HirModule& mod, Str name) {
+    for (u32 i = 0; i < mod.variants.len; i++) {
+        if (mod.variants[i].name.eq(name)) return i;
+    }
+    return mod.variants.len;
+}
+
+static u32 find_struct_index(const HirModule& mod, Str name) {
+    for (u32 i = 0; i < mod.structs.len; i++) {
+        if (mod.structs[i].name.eq(name)) return i;
+    }
+    return mod.structs.len;
+}
+
+static u32 find_function_index(const HirModule& mod, Str name) {
+    for (u32 i = 0; i < mod.functions.len; i++) {
+        if (mod.functions[i].name.eq(name)) return i;
+    }
+    return mod.functions.len;
+}
+
+static const HirAlias* find_alias(const HirModule& mod, Str name) {
+    for (u32 i = 0; i < mod.aliases.len; i++) {
+        if (mod.aliases[i].name.eq(name)) return &mod.aliases[i];
+    }
+    return nullptr;
+}
+
+static Str resolve_alias_target_leaf(const HirModule& mod, Str name) {
+    const auto* alias = find_alias(mod, name);
+    if (alias == nullptr || alias->target_parts.len == 0) return name;
+    return alias->target_parts[alias->target_parts.len - 1];
+}
+
+static Str import_namespace_name(Str path, bool has_alias, Str alias) {
+    if (has_alias) return alias;
+    const char* ptr = path.ptr;
+    u32 len = path.len;
+    u32 start = 0;
+    for (u32 i = 0; i < len; i++) {
+        if (ptr[i] == '/' || ptr[i] == '\\') start = i + 1;
+    }
+    u32 end = len;
+    if (end >= 4 && ptr[end - 4] == '.' && ptr[end - 3] == 'r' && ptr[end - 2] == 'u' && ptr[end - 1] == 't')
+        end -= 4;
+    if (end < start) return {};
+    return {ptr + start, end - start};
+}
+
+static bool import_namespace_matches(Str path, bool has_alias, Str alias, Str ns) {
+    const auto name = import_namespace_name(path, has_alias, alias);
+    return name.eq(ns);
+}
+
+static bool has_import_namespace(const HirModule& mod, Str ns) {
+    for (u32 i = 0; i < mod.imports.len; i++) {
+        if (!mod.imports[i].selective && import_namespace_matches(mod.imports[i].path, mod.imports[i].has_namespace_alias, mod.imports[i].namespace_alias, ns)) return true;
+    }
+    return false;
+}
+
+static FrontendResult<void> validate_import_namespaces(const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    for (u32 i = 0; i < imports.len; i++) {
+        if (imports[i].selective) continue;
+        const auto lhs = import_namespace_name(imports[i].path, imports[i].has_namespace_alias, imports[i].namespace_alias);
+        for (u32 j = i + 1; j < imports.len; j++) {
+            if (imports[j].selective) continue;
+            const auto rhs = import_namespace_name(imports[j].path, imports[j].has_namespace_alias, imports[j].namespace_alias);
+            if (!imports[i].path.eq(imports[j].path) && lhs.eq(rhs))
+                return frontend_error(FrontendError::UnsupportedSyntax, imports[j].span, rhs);
+        }
+    }
+    return {};
+}
+
+static FrontendResult<void> validate_import_namespace_bindings(const AstFile& file,
+                                                               const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    for (u32 ii = 0; ii < imports.len; ii++) {
+        if (imports[ii].selective) continue;
+        const auto ns = import_namespace_name(imports[ii].path, imports[ii].has_namespace_alias, imports[ii].namespace_alias);
+        for (u32 i = 0; i < file.items.len; i++) {
+            const auto& item = file.items[i];
+            switch (item.kind) {
+            case AstItemKind::Func:
+                if (item.func.name.eq(ns))
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.func.span, ns);
+                break;
+            case AstItemKind::Struct:
+                if (item.struct_decl.name.eq(ns))
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.struct_decl.span, ns);
+                break;
+            case AstItemKind::Variant:
+                if (item.variant.name.eq(ns))
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.variant.span, ns);
+                break;
+            case AstItemKind::Protocol:
+                if (item.protocol.name.eq(ns))
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, ns);
+                break;
+            case AstItemKind::Using:
+                if (item.using_decl.name.eq(ns))
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.using_decl.span, ns);
+                break;
+            default:
+                break;
+            }
+        }
+        for (u32 jj = 0; jj < imports.len; jj++) {
+            if (ii == jj) continue;
+            const auto& other = imports[jj];
+            if (!other.selective) {
+                if (other.has_namespace_alias) continue;
+                if (import_namespace_name(other.path, other.has_namespace_alias, other.namespace_alias).eq(ns))
+                    return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
+                for (u32 fi = 0; fi < other.module->functions.len; fi++) {
+                    const auto& fn = other.module->functions[fi];
+                    const bool hidden_runtime_fn =
+                        (fn.name.len >= 7 && __builtin_memcmp(fn.name.ptr, "__impl_", 7) == 0) ||
+                        (fn.name.len >= 8 && __builtin_memcmp(fn.name.ptr, "__proto_", 8) == 0);
+                    if (!hidden_runtime_fn && fn.name.eq(ns))
+                        return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
+                }
+                for (u32 pi = 0; pi < other.module->protocols.len; pi++) {
+                    const auto& proto = other.module->protocols[pi];
+                    if (proto.kind == HirProtocolKind::Custom && proto.name.eq(ns))
+                        return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
+                }
+                for (u32 si = 0; si < other.module->structs.len; si++) {
+                    const auto& st = other.module->structs[si];
+                    if (st.template_struct_index == 0xffffffffu && st.name.eq(ns))
+                        return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
+                }
+                for (u32 vi = 0; vi < other.module->variants.len; vi++) {
+                    const auto& variant = other.module->variants[vi];
+                    if (variant.template_variant_index == 0xffffffffu && variant.name.eq(ns))
+                        return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
+                }
+                continue;
+            }
+            for (u32 si = 0; si < other.selected_names.len; si++) {
+                const auto visible = other.selected_names[si].has_alias ? other.selected_names[si].alias : other.selected_names[si].name;
+                if (visible.eq(ns))
+                    return frontend_error(FrontendError::UnsupportedSyntax, imports[ii].span, ns);
+            }
+        }
+    }
+    return {};
+}
+
+static bool resolve_import_namespace_member(const HirModule& mod, const AstExpr& expr, Str* out_member) {
+    if (expr.kind != AstExprKind::Field || expr.lhs == nullptr) return false;
+    if (expr.lhs->kind != AstExprKind::Ident) return false;
+    for (u32 i = 0; i < mod.imports.len; i++) {
+        const auto& imported = mod.imports[i];
+        if (imported.selective) continue;
+        if (!import_namespace_matches(imported.path, imported.has_namespace_alias, imported.namespace_alias, expr.lhs->name))
+            continue;
+        if (imported.has_namespace_alias)
+            *out_member = intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" + str_to_std_string(expr.name));
+        else
+            *out_member = expr.name;
+        return true;
+    }
+    return false;
+}
+
+static bool resolve_import_namespace_type_name(const HirModule& mod, Str ns, Str member, Str* out_name) {
+    for (u32 i = 0; i < mod.imports.len; i++) {
+        const auto& imported = mod.imports[i];
+        if (imported.selective) continue;
+        if (!import_namespace_matches(imported.path, imported.has_namespace_alias, imported.namespace_alias, ns))
+            continue;
+        if (imported.has_namespace_alias)
+            *out_name = intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" + str_to_std_string(member));
+        else
+            *out_name = member;
+        return true;
+    }
+    return false;
+}
+
+static u32 find_protocol_index(const HirModule& mod, Str name) {
+    for (u32 i = 0; i < mod.protocols.len; i++) {
+        if (mod.protocols[i].name.eq(name)) return i;
+    }
+    return mod.protocols.len;
+}
+
+static const HirProtocol::MethodDecl* find_protocol_method(const HirProtocol& proto, Str name) {
+    for (u32 i = 0; i < proto.methods.len; i++) {
+        if (proto.methods[i].name.eq(name)) return &proto.methods[i];
+    }
+    return nullptr;
+}
+
+static HirProtocol::MethodDecl* find_protocol_method_mut(HirProtocol& proto, Str name) {
+    for (u32 i = 0; i < proto.methods.len; i++) {
+        if (proto.methods[i].name.eq(name)) return &proto.methods[i];
+    }
+    return nullptr;
+}
+
+static bool impl_matches_type(const HirModule& mod,
+                             const HirImpl& impl,
+                             HirTypeKind type,
+                             u32 struct_index) {
+    if (impl.type != type) return false;
+    if (type == HirTypeKind::Struct) {
+        if (!impl.is_generic_template) return impl.struct_index == struct_index;
+        if (struct_index >= mod.structs.len) return false;
+        return mod.structs[struct_index].template_struct_index == impl.struct_index;
+    }
+    return impl.struct_index == 0xffffffffu;
+}
+
+static FrontendResult<bool> fill_impl_generic_bindings(const HirModule& mod,
+                                                       const HirImpl& impl,
+                                                       u32 concrete_struct_index,
+                                                       GenericBinding* out,
+                                                       u32* out_count) {
+    *out_count = 0;
+    if (!impl.is_generic_template) return true;
+    if (concrete_struct_index >= mod.structs.len) return false;
+    const auto& st = mod.structs[concrete_struct_index];
+    if (st.template_struct_index != impl.struct_index) return false;
+    *out_count = st.instance_type_arg_count;
+    for (u32 i = 0; i < st.instance_type_arg_count; i++) {
+        auto filled = fill_bound_binding_from_type_metadata(&out[i],
+                                                            const_cast<HirModule*>(&mod),
+                                                            st.instance_type_args[i],
+                                                            st.instance_generic_indices[i],
+                                                            st.instance_variant_indices[i],
+                                                            st.instance_struct_indices[i],
+                                                            st.instance_tuple_lens[i],
+                                                            st.instance_tuple_types[i],
+                                                            st.instance_tuple_variant_indices[i],
+                                                            st.instance_tuple_struct_indices[i],
+                                                            st.instance_shape_indices[i],
+                                                            impl.span);
+        if (!filled) return core::make_unexpected(filled.error());
+    }
+    return true;
+}
+
+static const HirImpl* find_impl_for_type(const HirModule& mod,
+                                         HirTypeKind type,
+                                         u32 struct_index,
+                                         Str method_name) {
+    const HirImpl* match = nullptr;
+    for (u32 i = 0; i < mod.impls.len; i++) {
+        const auto& impl = mod.impls[i];
+        if (!impl_matches_type(mod, impl, type, struct_index)) continue;
+        bool has_method = false;
+        for (u32 mi = 0; mi < impl.methods.len; mi++) {
+            if (impl.methods[mi].name.eq(method_name)) {
+                has_method = true;
+                break;
+            }
+        }
+        if (!has_method) continue;
+        if (match != nullptr) return nullptr;
+        match = &impl;
+    }
+    return match;
+}
+
+static const HirImplMethod* find_impl_method(const HirImpl& impl, Str name) {
+    for (u32 i = 0; i < impl.methods.len; i++) {
+        if (impl.methods[i].name.eq(name)) return &impl.methods[i];
+    }
+    return nullptr;
+}
+
+static FrontendResult<Str> make_protocol_default_function_name(Str protocol_name, Str method_name) {
+    const char prefix[] = "__proto_";
+    const u32 len = static_cast<u32>(sizeof(prefix) - 1) + protocol_name.len + 1 + method_name.len;
+    auto* buf = new (std::nothrow) char[len];
+    if (buf == nullptr) return frontend_error(FrontendError::OutOfMemory, {});
+    u32 off = 0;
+    for (u32 i = 0; i < sizeof(prefix) - 1; i++) buf[off++] = prefix[i];
+    for (u32 i = 0; i < protocol_name.len; i++) buf[off++] = protocol_name.ptr[i];
+    buf[off++] = '_';
+    for (u32 i = 0; i < method_name.len; i++) buf[off++] = method_name.ptr[i];
+    return Str{buf, len};
+}
+
+static bool impl_targets_overlap(const HirModule& mod,
+                                 const HirImpl& impl,
+                                 HirTypeKind type,
+                                 u32 struct_index,
+                                 bool is_generic_template) {
+    if (impl.type != type) return false;
+    if (type != HirTypeKind::Struct) return impl.struct_index == 0xffffffffu;
+    if (impl.is_generic_template && is_generic_template) return impl.struct_index == struct_index;
+    if (!impl.is_generic_template && !is_generic_template) return impl.struct_index == struct_index;
+    if (impl.is_generic_template) {
+        if (struct_index >= mod.structs.len) return false;
+        return mod.structs[struct_index].template_struct_index == impl.struct_index;
+    }
+    if (impl.struct_index >= mod.structs.len) return false;
+    return mod.structs[impl.struct_index].template_struct_index == struct_index;
+}
+
+static bool impl_matches_exact_target(const HirImpl& impl,
+                               HirTypeKind type,
+                               u32 struct_index,
+                               bool is_generic_template) {
+    return impl.type == type && impl.struct_index == struct_index && impl.is_generic_template == is_generic_template;
+}
+
+static FrontendResult<Str> make_impl_function_name(Str protocol_name,
+                                                   Str type_name,
+                                                   Str method_name) {
+    const char prefix[] = "__impl_";
+    const u32 len = static_cast<u32>(sizeof(prefix) - 1) + protocol_name.len + 1 + type_name.len + 1 + method_name.len;
+    auto* buf = new (std::nothrow) char[len];
+    if (buf == nullptr) return frontend_error(FrontendError::OutOfMemory, {});
+    u32 off = 0;
+    for (u32 i = 0; i < sizeof(prefix) - 1; i++) buf[off++] = prefix[i];
+    for (u32 i = 0; i < protocol_name.len; i++) buf[off++] = protocol_name.ptr[i];
+    buf[off++] = '_';
+    for (u32 i = 0; i < type_name.len; i++) buf[off++] = type_name.ptr[i];
+    buf[off++] = '_';
+    for (u32 i = 0; i < method_name.len; i++) buf[off++] = method_name.ptr[i];
+    return Str{buf, len};
+}
+
+static HirProtocolKind resolve_protocol_kind(const HirModule& mod, Str name) {
+    if (name.eq({"Error", 5})) return HirProtocolKind::Error;
+    if (name.eq({"Eq", 2})) return HirProtocolKind::Eq;
+    if (name.eq({"Ord", 3})) return HirProtocolKind::Ord;
+    if (find_protocol_index(mod, name) < mod.protocols.len) return HirProtocolKind::Custom;
+    return static_cast<HirProtocolKind>(0xff);
+}
+
+static u32 find_generic_param_index(const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>& type_params,
+                                    Str name) {
+    for (u32 i = 0; i < type_params.len; i++) {
+        if (type_params[i].name.eq(name)) return i;
+    }
+    return type_params.len;
+}
+
+static HirTypeKind resolve_named_type(const HirModule& mod,
+                                      Str name,
+                                      u32* variant_index = nullptr,
+                                      u32* struct_index = nullptr) {
+    if (variant_index) *variant_index = 0xffffffffu;
+    if (struct_index) *struct_index = 0xffffffffu;
+    if (name.eq({"bool", 4})) return HirTypeKind::Bool;
+    if (name.eq({"i32", 3})) return HirTypeKind::I32;
+    if (name.eq({"str", 3})) return HirTypeKind::Str;
+    const u32 idx = find_variant_index(mod, name);
+    if (idx < mod.variants.len) {
+        if (variant_index) *variant_index = idx;
+        return HirTypeKind::Variant;
+    }
+    const u32 struct_idx = find_struct_index(mod, name);
+    if (struct_idx < mod.structs.len) {
+        if (struct_index) *struct_index = struct_idx;
+        return HirTypeKind::Struct;
+    }
+    return HirTypeKind::Unknown;
+}
+
+static AstTypeRef get_ast_type_arg_ref(const AstTypeRef& ref, u32 index) {
+    if (index < ref.type_args.len && ref.type_args[index] != nullptr) return *ref.type_args[index];
+    AstTypeRef out{};
+    if (index < ref.type_arg_names.len) out.name = ref.type_arg_names[index];
+    if (index < ref.type_arg_namespaces.len) out.namespace_name = ref.type_arg_namespaces[index];
+    return out;
+}
+
+static AstTypeRef get_ast_tuple_elem_ref(const AstTypeRef& ref, u32 index) {
+    if (index < ref.tuple_elem_types.len && ref.tuple_elem_types[index] != nullptr) return *ref.tuple_elem_types[index];
+    AstTypeRef out{};
+    if (index < ref.tuple_elem_names.len) out.name = ref.tuple_elem_names[index];
+    return out;
+}
+
+static FrontendResult<HirTypeKind> resolve_func_type_ref(const HirModule& mod,
+                                                         const AstTypeRef& ref,
+                                                         const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>* type_params,
+                                                         u32* generic_index,
+                                                         u32* variant_index,
+                                                         u32* struct_index,
+                                                         u32* tuple_len,
+                                                         HirTypeKind* tuple_types,
+                                                         u32* tuple_variant_indices,
+                                                         u32* tuple_struct_indices,
+                                                         Span span) {
+    if (generic_index) *generic_index = 0xffffffffu;
+    if (variant_index) *variant_index = 0xffffffffu;
+    if (struct_index) *struct_index = 0xffffffffu;
+    if (tuple_len) *tuple_len = 0;
+    if (!ref.is_tuple) {
+        Str resolved_name = ref.name;
+        if (ref.namespace_name.len != 0) {
+            if (!resolve_import_namespace_type_name(mod, ref.namespace_name, ref.name, &resolved_name))
+                return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
+        }
+        if (type_params != nullptr && ref.namespace_name.len == 0) {
+            const u32 type_param_index = find_generic_param_index(*type_params, resolved_name);
+            if (type_param_index < type_params->len) {
+                if (ref.type_arg_names.len != 0)
+                    return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
+                if (generic_index) *generic_index = type_param_index;
+                return HirTypeKind::Generic;
+            }
+        }
+        const auto kind = resolve_named_type(mod, resolved_name, variant_index, struct_index);
+        if (kind == HirTypeKind::Unknown)
+            return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
+        if (kind == HirTypeKind::Variant && *variant_index < mod.variants.len &&
+            mod.variants[*variant_index].type_params.len != 0) {
+            if (ref.type_arg_names.len != mod.variants[*variant_index].type_params.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
+            GenericBinding bindings[HirVariant::kMaxTypeParams]{};
+            for (u32 i = 0; i < ref.type_arg_names.len; i++) {
+                u32 type_variant_index = 0xffffffffu;
+                u32 type_struct_index = 0xffffffffu;
+                u32 elem_tuple_len = 0;
+                HirTypeKind elem_tuple_types[kMaxTupleSlots]{};
+                u32 elem_tuple_variant_indices[kMaxTupleSlots]{};
+                u32 elem_tuple_struct_indices[kMaxTupleSlots]{};
+                AstTypeRef type_arg_ref = get_ast_type_arg_ref(ref, i);
+                auto type_arg = resolve_func_type_ref(mod,
+                                                      type_arg_ref,
+                                                      type_params,
+                                                      nullptr,
+                                                      &type_variant_index,
+                                                      &type_struct_index,
+                                                      &elem_tuple_len,
+                                                      elem_tuple_types,
+                                                      elem_tuple_variant_indices,
+                                                      elem_tuple_struct_indices,
+                                                      span);
+                if (!type_arg) return core::make_unexpected(type_arg.error());
+                if (type_arg.value() == HirTypeKind::Generic)
+                    return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
+                auto filled = fill_bound_binding_from_type_metadata(&bindings[i],
+                                                                    const_cast<HirModule*>(&mod),
+                                                                    type_arg.value(),
+                                                                    0xffffffffu,
+                                                                    type_variant_index,
+                                                                    type_struct_index,
+                                                                    elem_tuple_len,
+                                                                    elem_tuple_types,
+                                                                    elem_tuple_variant_indices,
+                                                                    elem_tuple_struct_indices,
+                                                                    0xffffffffu,
+                                                                    span);
+                if (!filled) return core::make_unexpected(filled.error());
+            }
+            auto concrete_index =
+                instantiate_variant(const_cast<HirModule*>(&mod), *variant_index, bindings, ref.type_arg_names.len, span);
+            if (!concrete_index) return core::make_unexpected(concrete_index.error());
+            *variant_index = concrete_index.value();
+            return HirTypeKind::Variant;
+        }
+        if (kind == HirTypeKind::Struct && *struct_index < mod.structs.len &&
+            mod.structs[*struct_index].type_params.len != 0) {
+            if (ref.type_arg_names.len != mod.structs[*struct_index].type_params.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
+            GenericBinding bindings[HirStruct::kMaxTypeParams]{};
+            for (u32 i = 0; i < ref.type_arg_names.len; i++) {
+                u32 type_variant_index = 0xffffffffu;
+                u32 type_struct_index = 0xffffffffu;
+                u32 elem_tuple_len = 0;
+                HirTypeKind elem_tuple_types[kMaxTupleSlots]{};
+                u32 elem_tuple_variant_indices[kMaxTupleSlots]{};
+                u32 elem_tuple_struct_indices[kMaxTupleSlots]{};
+                AstTypeRef type_arg_ref = get_ast_type_arg_ref(ref, i);
+                auto type_arg = resolve_func_type_ref(mod,
+                                                      type_arg_ref,
+                                                      type_params,
+                                                      nullptr,
+                                                      &type_variant_index,
+                                                      &type_struct_index,
+                                                      &elem_tuple_len,
+                                                      elem_tuple_types,
+                                                      elem_tuple_variant_indices,
+                                                      elem_tuple_struct_indices,
+                                                      span);
+                if (!type_arg) return core::make_unexpected(type_arg.error());
+                if (type_arg.value() == HirTypeKind::Generic)
+                    return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
+                auto filled = fill_bound_binding_from_type_metadata(&bindings[i],
+                                                                    const_cast<HirModule*>(&mod),
+                                                                    type_arg.value(),
+                                                                    0xffffffffu,
+                                                                    type_variant_index,
+                                                                    type_struct_index,
+                                                                    elem_tuple_len,
+                                                                    elem_tuple_types,
+                                                                    elem_tuple_variant_indices,
+                                                                    elem_tuple_struct_indices,
+                                                                    0xffffffffu,
+                                                                    span);
+                if (!filled) return core::make_unexpected(filled.error());
+            }
+            auto concrete_index =
+                instantiate_struct(const_cast<HirModule*>(&mod), *struct_index, bindings, ref.type_arg_names.len, span);
+            if (!concrete_index) return core::make_unexpected(concrete_index.error());
+            *struct_index = concrete_index.value();
+            return HirTypeKind::Struct;
+        }
+        if (ref.type_arg_names.len != 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
+        return kind;
+    }
+    if (ref.tuple_elem_names.len < 2 && ref.tuple_elem_types.len < 2)
+        return frontend_error(FrontendError::UnsupportedSyntax, span);
+    const u32 elem_count = ref.tuple_elem_types.len != 0 ? ref.tuple_elem_types.len : ref.tuple_elem_names.len;
+    if (tuple_len) *tuple_len = elem_count;
+    for (u32 i = 0; i < elem_count; i++) {
+        u32 elem_variant_index = 0xffffffffu;
+        u32 elem_struct_index = 0xffffffffu;
+        u32 elem_tuple_len = 0;
+        HirTypeKind elem_tuple_types[kMaxTupleSlots]{};
+        u32 elem_tuple_variant_indices[kMaxTupleSlots]{};
+        u32 elem_tuple_struct_indices[kMaxTupleSlots]{};
+        AstTypeRef elem_ref = get_ast_tuple_elem_ref(ref, i);
+        auto kind = resolve_func_type_ref(mod,
+                                          elem_ref,
+                                          type_params,
+                                          nullptr,
+                                          &elem_variant_index,
+                                          &elem_struct_index,
+                                          &elem_tuple_len,
+                                          elem_tuple_types,
+                                          elem_tuple_variant_indices,
+                                          elem_tuple_struct_indices,
+                                          span);
+        if (!kind) return core::make_unexpected(kind.error());
+        if (kind.value() == HirTypeKind::Generic || kind.value() == HirTypeKind::Tuple)
+            return frontend_error(FrontendError::UnsupportedSyntax, span, elem_ref.name);
+        tuple_types[i] = kind.value();
+        tuple_variant_indices[i] = kind.value() == HirTypeKind::Variant ? elem_variant_index : 0xffffffffu;
+        if (tuple_struct_indices != nullptr)
+            tuple_struct_indices[i] = kind.value() == HirTypeKind::Struct ? elem_struct_index : 0xffffffffu;
+    }
+    return HirTypeKind::Tuple;
+}
+
+static bool same_hir_type_shape(const HirExpr& lhs, const HirExpr& rhs) {
+    if (lhs.type != rhs.type) return false;
+    if (lhs.type == HirTypeKind::Generic) return lhs.generic_index == rhs.generic_index;
+    if (lhs.type == HirTypeKind::Variant) return lhs.variant_index == rhs.variant_index;
+    if (lhs.type == HirTypeKind::Struct) return lhs.struct_index == rhs.struct_index;
+    if (lhs.type == HirTypeKind::Tuple) {
+        if (lhs.tuple_len != rhs.tuple_len) return false;
+        for (u32 i = 0; i < lhs.tuple_len; i++) {
+            if (lhs.tuple_types[i] != rhs.tuple_types[i]) return false;
+            if (lhs.tuple_types[i] == HirTypeKind::Variant && lhs.tuple_variant_indices[i] != rhs.tuple_variant_indices[i])
+                return false;
+            if (lhs.tuple_types[i] == HirTypeKind::Struct && lhs.tuple_struct_indices[i] != rhs.tuple_struct_indices[i])
+                return false;
+        }
+    }
+    return true;
+}
+
+static bool same_hir_shape_index(const HirModule& mod, u32 lhs_shape_index, u32 rhs_shape_index) {
+    if (lhs_shape_index == rhs_shape_index) return true;
+    if (lhs_shape_index == 0xffffffffu || rhs_shape_index == 0xffffffffu) return false;
+    if (lhs_shape_index >= mod.type_shapes.len || rhs_shape_index >= mod.type_shapes.len) return false;
+    const auto& lhs = mod.type_shapes[lhs_shape_index];
+    const auto& rhs = mod.type_shapes[rhs_shape_index];
+    if (lhs.type != rhs.type) return false;
+    if (lhs.generic_index != rhs.generic_index) return false;
+    if (lhs.variant_index != rhs.variant_index) return false;
+    if (lhs.struct_index != rhs.struct_index) return false;
+    if (lhs.tuple_len != rhs.tuple_len) return false;
+    for (u32 i = 0; i < lhs.tuple_len; i++) {
+        if (!same_hir_shape_index(mod, lhs.tuple_elem_shape_indices[i], rhs.tuple_elem_shape_indices[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool same_hir_type_shape(const HirModule& mod, const HirExpr& lhs, const HirExpr& rhs) {
+    if (lhs.shape_index != 0xffffffffu && rhs.shape_index != 0xffffffffu)
+        if (same_hir_shape_index(mod, lhs.shape_index, rhs.shape_index)) return true;
+    return same_hir_type_shape(lhs, rhs);
+}
+
+static HirExpr make_expected_param_expr(const HirFunction::ParamDecl& param) {
+    HirExpr expected{};
+    expected.type = param.type;
+    expected.generic_index = param.generic_index;
+    expected.generic_has_error_constraint = param.generic_has_error_constraint;
+    expected.generic_has_eq_constraint = param.generic_has_eq_constraint;
+    expected.generic_has_ord_constraint = param.generic_has_ord_constraint;
+    expected.generic_protocol_index = param.generic_protocol_index;
+    expected.generic_protocol_count = param.generic_protocol_count;
+    for (u32 cpi = 0; cpi < expected.generic_protocol_count; cpi++)
+        expected.generic_protocol_indices[cpi] = param.generic_protocol_indices[cpi];
+    expected.variant_index = param.variant_index;
+    expected.struct_index = param.struct_index;
+    expected.shape_index = param.shape_index;
+    expected.tuple_len = param.tuple_len;
+    for (u32 i = 0; i < param.tuple_len; i++) {
+        expected.tuple_types[i] = param.tuple_types[i];
+        expected.tuple_variant_indices[i] = param.tuple_variant_indices[i];
+        expected.tuple_struct_indices[i] = param.tuple_struct_indices[i];
+    }
+    return expected;
+}
+
+static FrontendResult<void> fill_bound_binding_from_type_metadata(GenericBinding* binding,
+                                                                  HirModule* mod,
+                                                                  HirTypeKind type,
+                                                                  u32 generic_index,
+                                                                  u32 variant_index,
+                                                                  u32 struct_index,
+                                                                  u32 tuple_len,
+                                                                  const HirTypeKind* tuple_types,
+                                                                  const u32* tuple_variant_indices,
+                                                                  const u32* tuple_struct_indices,
+                                                                  u32 shape_index,
+                                                                  Span span) {
+    binding->bound = true;
+    binding->type = type;
+    binding->generic_index = generic_index;
+    binding->variant_index = variant_index;
+    binding->struct_index = struct_index;
+    binding->tuple_len = tuple_len;
+    for (u32 ti = 0; ti < tuple_len; ti++) {
+        binding->tuple_types[ti] = tuple_types[ti];
+        binding->tuple_variant_indices[ti] = tuple_variant_indices[ti];
+        binding->tuple_struct_indices[ti] = tuple_struct_indices[ti];
+    }
+    binding->shape_index = shape_index;
+    if (binding->shape_index == 0xffffffffu) {
+        auto computed_shape = intern_hir_type_shape(mod,
+                                                    binding->type,
+                                                    binding->generic_index,
+                                                    binding->variant_index,
+                                                    binding->struct_index,
+                                                    binding->tuple_len,
+                                                    binding->tuple_types,
+                                                    binding->tuple_variant_indices,
+                                                    binding->tuple_struct_indices,
+                                                    span);
+        if (!computed_shape) return core::make_unexpected(computed_shape.error());
+        binding->shape_index = computed_shape.value();
+    }
+    return {};
+}
+
+static FrontendResult<void> concretize_named_instance_shape(HirExpr* expr,
+                                                            const HirModule& mod,
+                                                            const GenericBinding* generic_bindings,
+                                                            u32 generic_binding_count) {
+    if (expr->type == HirTypeKind::Variant && expr->variant_index < mod.variants.len) {
+        const auto& variant = mod.variants[expr->variant_index];
+        if (variant.template_variant_index != 0xffffffffu) {
+            GenericBinding bindings[HirVariant::kMaxTypeParams]{};
+            for (u32 i = 0; i < variant.instance_type_arg_count; i++) {
+                if (variant.instance_type_args[i] == HirTypeKind::Generic) {
+                    const u32 gi = variant.instance_generic_indices[i];
+                    if (gi >= generic_binding_count || !generic_bindings[gi].bound)
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr->span);
+                    bindings[i] = generic_bindings[gi];
+                } else {
+                    auto filled = fill_bound_binding_from_type_metadata(&bindings[i],
+                                                                        const_cast<HirModule*>(&mod),
+                                                                        variant.instance_type_args[i],
+                                                                        variant.instance_generic_indices[i],
+                                                                        variant.instance_variant_indices[i],
+                                                                        variant.instance_struct_indices[i],
+                                                                        variant.instance_tuple_lens[i],
+                                                                        variant.instance_tuple_types[i],
+                                                                        variant.instance_tuple_variant_indices[i],
+                                                                        variant.instance_tuple_struct_indices[i],
+                                                                        variant.instance_shape_indices[i],
+                                                                        expr->span);
+                    if (!filled) return core::make_unexpected(filled.error());
+                }
+            }
+            auto concrete = instantiate_variant(const_cast<HirModule*>(&mod),
+                                               variant.template_variant_index,
+                                               bindings,
+                                               variant.instance_type_arg_count,
+                                               expr->span);
+            if (!concrete) return core::make_unexpected(concrete.error());
+            expr->variant_index = concrete.value();
+        }
+    }
+    if (expr->type == HirTypeKind::Struct && expr->struct_index < mod.structs.len) {
+        const auto& st = mod.structs[expr->struct_index];
+        if (st.template_struct_index != 0xffffffffu) {
+            GenericBinding bindings[HirStruct::kMaxTypeParams]{};
+            for (u32 i = 0; i < st.instance_type_arg_count; i++) {
+                if (st.instance_type_args[i] == HirTypeKind::Generic) {
+                    const u32 gi = st.instance_generic_indices[i];
+                    if (gi >= generic_binding_count || !generic_bindings[gi].bound)
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr->span);
+                    bindings[i] = generic_bindings[gi];
+                } else {
+                    auto filled = fill_bound_binding_from_type_metadata(&bindings[i],
+                                                                        const_cast<HirModule*>(&mod),
+                                                                        st.instance_type_args[i],
+                                                                        st.instance_generic_indices[i],
+                                                                        st.instance_variant_indices[i],
+                                                                        st.instance_struct_indices[i],
+                                                                        st.instance_tuple_lens[i],
+                                                                        st.instance_tuple_types[i],
+                                                                        st.instance_tuple_variant_indices[i],
+                                                                        st.instance_tuple_struct_indices[i],
+                                                                        st.instance_shape_indices[i],
+                                                                        expr->span);
+                    if (!filled) return core::make_unexpected(filled.error());
+                }
+            }
+            auto concrete = instantiate_struct(const_cast<HirModule*>(&mod),
+                                              st.template_struct_index,
+                                              bindings,
+                                              st.instance_type_arg_count,
+                                              expr->span);
+            if (!concrete) return core::make_unexpected(concrete.error());
+            expr->struct_index = concrete.value();
+        }
+    }
+    if (expr->type != HirTypeKind::Unknown) {
+        auto shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                           expr->type,
+                                           expr->generic_index,
+                                           expr->variant_index,
+                                           expr->struct_index,
+                                           expr->tuple_len,
+                                           expr->tuple_types,
+                                           expr->tuple_variant_indices,
+                                           expr->tuple_struct_indices,
+                                           expr->span);
+        if (!shape) return core::make_unexpected(shape.error());
+        expr->shape_index = shape.value();
+    }
+    return {};
+}
+
+static HirExpr make_expected_type_expr(HirTypeKind type,
+                                       u32 variant_index,
+                                       u32 struct_index,
+                                       u32 tuple_len,
+                                       const HirTypeKind* tuple_types,
+                                       const u32* tuple_variant_indices,
+                                       const u32* tuple_struct_indices,
+                                       u32 shape_index = 0xffffffffu) {
+    HirExpr expected{};
+    expected.type = type;
+    expected.variant_index = variant_index;
+    expected.struct_index = struct_index;
+    expected.shape_index = shape_index;
+    expected.tuple_len = tuple_len;
+    for (u32 i = 0; i < tuple_len; i++) {
+        expected.tuple_types[i] = tuple_types[i];
+        expected.tuple_variant_indices[i] = tuple_variant_indices[i];
+        expected.tuple_struct_indices[i] = tuple_struct_indices[i];
+    }
+    return expected;
+}
+
+static HirExpr make_instance_arg_expr(HirTypeKind type,
+                                      u32 generic_index,
+                                      u32 variant_index,
+                                      u32 struct_index,
+                                      u32 tuple_len,
+                                      const HirTypeKind* tuple_types,
+                                      const u32* tuple_variant_indices,
+                                      const u32* tuple_struct_indices,
+                                      u32 shape_index = 0xffffffffu) {
+    HirExpr out{};
+    out.type = type;
+    out.generic_index = generic_index;
+    out.variant_index = variant_index;
+    out.struct_index = struct_index;
+    out.shape_index = shape_index;
+    out.tuple_len = tuple_len;
+    for (u32 i = 0; i < tuple_len; i++) {
+        out.tuple_types[i] = tuple_types[i];
+        out.tuple_variant_indices[i] = tuple_variant_indices[i];
+        out.tuple_struct_indices[i] = tuple_struct_indices[i];
+    }
+    return out;
+}
+
+static HirExpr apply_generic_binding_to_expr(const HirExpr& expr,
+                                             const GenericBinding* generic_bindings,
+                                             u32 generic_binding_count) {
+    HirExpr out = expr;
+    if (expr.type == HirTypeKind::Generic && expr.generic_index < generic_binding_count &&
+        generic_bindings[expr.generic_index].bound) {
+        const auto& binding = generic_bindings[expr.generic_index];
+        out.type = binding.type;
+        out.generic_index = 0xffffffffu;
+        out.generic_has_error_constraint = false;
+        out.generic_has_eq_constraint = false;
+        out.generic_has_ord_constraint = false;
+        out.generic_protocol_index = 0xffffffffu;
+        out.generic_protocol_count = 0;
+        out.variant_index = binding.variant_index;
+        out.struct_index = binding.struct_index;
+        out.shape_index = binding.shape_index;
+        out.tuple_len = binding.tuple_len;
+        for (u32 i = 0; i < binding.tuple_len; i++) {
+            out.tuple_types[i] = binding.tuple_types[i];
+            out.tuple_variant_indices[i] = binding.tuple_variant_indices[i];
+            out.tuple_struct_indices[i] = binding.tuple_struct_indices[i];
+        }
+    }
+    return out;
+}
+
+static bool bind_generic_shape(GenericBinding* generic_bindings,
+                               u32 generic_binding_count,
+                               u32 generic_index,
+                               const HirExpr& actual) {
+    if (generic_index >= generic_binding_count) return false;
+    auto& binding = generic_bindings[generic_index];
+    if (!binding.bound) {
+        binding.bound = true;
+        binding.type = actual.type;
+        binding.generic_index = actual.type == HirTypeKind::Generic ? actual.generic_index : 0xffffffffu;
+        binding.variant_index = actual.type == HirTypeKind::Variant ? actual.variant_index : 0xffffffffu;
+        binding.struct_index = actual.type == HirTypeKind::Struct ? actual.struct_index : 0xffffffffu;
+        binding.shape_index = actual.shape_index;
+        binding.tuple_len = actual.type == HirTypeKind::Tuple ? actual.tuple_len : 0;
+        for (u32 i = 0; i < binding.tuple_len; i++) {
+            binding.tuple_types[i] = actual.tuple_types[i];
+            binding.tuple_variant_indices[i] = actual.tuple_variant_indices[i];
+            binding.tuple_struct_indices[i] = actual.tuple_struct_indices[i];
+        }
+        return true;
+    }
+    HirExpr expected{};
+    expected.type = binding.type;
+    expected.generic_index = binding.generic_index;
+    expected.variant_index = binding.variant_index;
+    expected.struct_index = binding.struct_index;
+    expected.shape_index = binding.shape_index;
+    expected.tuple_len = binding.tuple_len;
+    for (u32 i = 0; i < binding.tuple_len; i++) {
+        expected.tuple_types[i] = binding.tuple_types[i];
+        expected.tuple_variant_indices[i] = binding.tuple_variant_indices[i];
+        expected.tuple_struct_indices[i] = binding.tuple_struct_indices[i];
+    }
+    return same_hir_type_shape(actual, expected);
+}
+
+static bool bind_named_generic_shape(const HirModule& mod,
+                                     GenericBinding* generic_bindings,
+                                     u32 generic_binding_count,
+                                     const HirExpr& expected,
+                                     const HirExpr& actual) {
+    if (expected.type == HirTypeKind::Generic)
+        return bind_generic_shape(generic_bindings, generic_binding_count, expected.generic_index, actual);
+    if (expected.type == HirTypeKind::Struct) {
+        if (actual.type != HirTypeKind::Struct || expected.struct_index >= mod.structs.len ||
+            actual.struct_index >= mod.structs.len)
+            return false;
+        const auto& est = mod.structs[expected.struct_index];
+        const auto& act = mod.structs[actual.struct_index];
+        if (est.template_struct_index == 0xffffffffu)
+            return same_hir_type_shape(mod, actual, expected);
+        if (act.template_struct_index != est.template_struct_index ||
+            act.instance_type_arg_count != est.instance_type_arg_count)
+            return false;
+        for (u32 i = 0; i < est.instance_type_arg_count; i++) {
+            const auto actual_arg = make_instance_arg_expr(act.instance_type_args[i],
+                                                           act.instance_generic_indices[i],
+                                                           act.instance_variant_indices[i],
+                                                           act.instance_struct_indices[i],
+                                                           act.instance_tuple_lens[i],
+                                                           act.instance_tuple_types[i],
+                                                           act.instance_tuple_variant_indices[i],
+                                                           act.instance_tuple_struct_indices[i],
+                                                           act.instance_shape_indices[i]);
+            const auto expected_arg = make_instance_arg_expr(est.instance_type_args[i],
+                                                             est.instance_generic_indices[i],
+                                                             est.instance_variant_indices[i],
+                                                             est.instance_struct_indices[i],
+                                                             est.instance_tuple_lens[i],
+                                                             est.instance_tuple_types[i],
+                                                             est.instance_tuple_variant_indices[i],
+                                                             est.instance_tuple_struct_indices[i],
+                                                             est.instance_shape_indices[i]);
+            if (!bind_named_generic_shape(mod, generic_bindings, generic_binding_count, expected_arg, actual_arg))
+                return false;
+        }
+        return true;
+    }
+    if (expected.type == HirTypeKind::Variant) {
+        if (actual.type != HirTypeKind::Variant || expected.variant_index >= mod.variants.len ||
+            actual.variant_index >= mod.variants.len)
+            return false;
+        const auto& est = mod.variants[expected.variant_index];
+        const auto& act = mod.variants[actual.variant_index];
+        if (est.template_variant_index == 0xffffffffu)
+            return same_hir_type_shape(mod, actual, expected);
+        if (act.template_variant_index != est.template_variant_index ||
+            act.instance_type_arg_count != est.instance_type_arg_count)
+            return false;
+        for (u32 i = 0; i < est.instance_type_arg_count; i++) {
+            const auto actual_arg = make_instance_arg_expr(act.instance_type_args[i],
+                                                           act.instance_generic_indices[i],
+                                                           act.instance_variant_indices[i],
+                                                           act.instance_struct_indices[i],
+                                                           act.instance_tuple_lens[i],
+                                                           act.instance_tuple_types[i],
+                                                           act.instance_tuple_variant_indices[i],
+                                                           act.instance_tuple_struct_indices[i],
+                                                           act.instance_shape_indices[i]);
+            const auto expected_arg = make_instance_arg_expr(est.instance_type_args[i],
+                                                             est.instance_generic_indices[i],
+                                                             est.instance_variant_indices[i],
+                                                             est.instance_struct_indices[i],
+                                                             est.instance_tuple_lens[i],
+                                                             est.instance_tuple_types[i],
+                                                             est.instance_tuple_variant_indices[i],
+                                                             est.instance_tuple_struct_indices[i],
+                                                             est.instance_shape_indices[i]);
+            if (!bind_named_generic_shape(mod, generic_bindings, generic_binding_count, expected_arg, actual_arg))
+                return false;
+        }
+        return true;
+    }
+    return same_hir_type_shape(mod, actual, expected);
+}
+
+static FrontendResult<void> apply_declared_type_to_expr(HirExpr* expr,
+                                                        const HirModule& mod,
+                                                        const AstStatement& stmt) {
+    if (!stmt.has_type) return {};
+    u32 variant_index = 0xffffffffu;
+    u32 struct_index = 0xffffffffu;
+    u32 tuple_len = 0;
+    HirTypeKind tuple_types[kMaxTupleSlots]{};
+    u32 tuple_variant_indices[kMaxTupleSlots]{};
+    u32 tuple_struct_indices[kMaxTupleSlots]{};
+    auto declared =
+        resolve_func_type_ref(mod,
+                              stmt.type,
+                              nullptr,
+                              nullptr,
+                              &variant_index,
+                              &struct_index,
+                              &tuple_len,
+                              tuple_types,
+                              tuple_variant_indices,
+                              tuple_struct_indices,
+                              stmt.span);
+    if (!declared) return core::make_unexpected(declared.error());
+    auto declared_shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                                declared.value(),
+                                                0xffffffffu,
+                                                variant_index,
+                                                struct_index,
+                                                tuple_len,
+                                                tuple_types,
+                                                tuple_variant_indices,
+                                                tuple_struct_indices,
+                                                stmt.span);
+    if (!declared_shape) return core::make_unexpected(declared_shape.error());
+    if (expr->type == HirTypeKind::Unknown && (expr->may_nil || expr->may_error)) {
+        expr->type = declared.value();
+        expr->variant_index = variant_index;
+        expr->struct_index = struct_index;
+        expr->shape_index = declared_shape.value();
+        expr->tuple_len = tuple_len;
+        for (u32 i = 0; i < tuple_len; i++) {
+            expr->tuple_types[i] = tuple_types[i];
+            expr->tuple_variant_indices[i] = tuple_variant_indices[i];
+            expr->tuple_struct_indices[i] = tuple_struct_indices[i];
+        }
+    }
+    const auto expected = make_expected_type_expr(
+        declared.value(),
+        variant_index,
+        struct_index,
+        tuple_len,
+        tuple_types,
+        tuple_variant_indices,
+        tuple_struct_indices,
+        declared_shape.value());
+    if (!same_hir_type_shape(mod, *expr, expected))
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+    return {};
+}
+
+static KnownValueState known_value_state(const HirExpr& expr,
+                                         const HirLocal* locals,
+                                         u32 local_count,
+                                         u32 depth = 0);
+static bool const_eval_expr(const HirExpr& expr,
+                            const HirLocal* locals,
+                            u32 local_count,
+                            ConstValue* out,
+                            u32 depth = 0);
+static KnownErrorCase known_error_case(const HirExpr& expr,
+                                       const HirLocal* locals,
+                                       u32 local_count,
+                                       u32 depth = 0);
+static Str known_error_name(const HirExpr& expr,
+                            const HirLocal* locals,
+                            u32 local_count,
+                            u32 depth = 0);
+static const HirExpr* known_error_expr(const HirExpr& expr,
+                                       const HirLocal* locals,
+                                       u32 local_count,
+                                       u32 depth = 0);
+static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
+                                            HirRoute* route,
+                                            const HirModule& mod,
+                                            const HirLocal* locals,
+                                            u32 local_count,
+                                            const MatchPayloadBinding* binding = nullptr);
+static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
+                                                         HirRoute* route,
+                                                         const HirModule& mod,
+                                                         const HirExpr* args,
+                                                         u32 arg_count,
+                                                         const GenericBinding* generic_bindings,
+                                                         u32 generic_binding_count);
+static FrontendResult<HirExpr> normalize_function_expr(const HirExpr& expr,
+                                                       HirFunction* fn,
+                                                       const HirLocal* locals,
+                                                       u32 local_count,
+                                                       u32 param_count);
+static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& stmt,
+                                                          HirRoute* scratch,
+                                                          const HirModule& mod,
+                                                          const HirLocal* locals,
+                                                          u32 local_count,
+                                                          const MatchPayloadBinding* binding);
+static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
+                                                 HirRoute* route,
+                                                 const HirModule& mod,
+                                                 const MatchPayloadBinding* binding = nullptr);
+static FrontendResult<void> collect_named_error_cases(const HirExpr& expr,
+                                                      FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases);
+static FrontendResult<void> collect_named_error_cases_ast(
+    const AstStatement& stmt,
+    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases);
+static void patch_named_error_variant(HirExpr* expr,
+                                      u32 variant_index,
+                                      const FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases);
+static FrontendResult<HirExpr> analyze_known_error_field(const HirExpr& base,
+                                                         Str field_name,
+                                                         Span span,
+                                                         const HirModule& mod,
+                                                         const HirLocal* locals,
+                                                         u32 local_count,
+                                                         u32 depth = 0);
+static FrontendResult<void> analyze_guard_fail_body(const AstStatement& stmt,
+                                                    HirGuardBody* body,
+                                                    HirRoute* route,
+                                                    const HirModule& mod,
+                                                    const HirLocal* locals,
+                                                    u32 local_count,
+                                                    const MatchPayloadBinding* binding);
+static FrontendResult<HirExpr> analyze_guard_cond(const AstExpr& expr,
+                                                  HirRoute* route,
+                                                  const HirModule& mod,
+                                                  const HirLocal* locals,
+                                                  u32 local_count);
+static bool is_standard_error_field(Str field_name);
+static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
+                                                 HirRoute* route,
+                                                 const HirModule& mod,
+                                                 const HirLocal* locals,
+                                                 u32 local_count,
+                                                 const MatchPayloadBinding* binding,
+                                                 const HirExpr* pipe_lhs);
+static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
+                                                        HirRoute* route,
+                                                        const HirModule& mod,
+                                                        const HirLocal* locals,
+                                                        u32 local_count,
+                                                        const MatchPayloadBinding* binding) {
+    if (expr.lhs == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+    if (expr.lhs->kind == AstExprKind::Ident && has_import_namespace(mod, expr.lhs->name)) {
+        Str qualified_member{};
+        AstExpr ns_field{};
+        ns_field.kind = AstExprKind::Field;
+        ns_field.lhs = expr.lhs;
+        ns_field.name = expr.name;
+        ns_field.span = expr.span;
+        if (!resolve_import_namespace_member(mod, ns_field, &qualified_member))
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        AstExpr call_expr{};
+        call_expr.kind = AstExprKind::Call;
+        call_expr.span = expr.span;
+        call_expr.name = qualified_member;
+        call_expr.args = expr.args;
+        return analyze_call_expr(call_expr, route, mod, locals, local_count, binding, nullptr);
+    }
+    Str qualified_type_name{};
+    if (resolve_import_namespace_member(mod, *expr.lhs, &qualified_type_name)) {
+        AstExpr variant_expr{};
+        variant_expr.kind = AstExprKind::VariantCase;
+        variant_expr.span = expr.span;
+        variant_expr.name = qualified_type_name;
+        variant_expr.type_args = expr.lhs->type_args;
+        variant_expr.str_value = expr.name;
+        if (expr.args.len == 1) variant_expr.lhs = expr.args[0];
+        else if (expr.args.len > 1) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        auto variant = analyze_expr(variant_expr, route, mod, locals, local_count, binding);
+        if (variant) return variant;
+    }
+    if (expr.lhs->kind == AstExprKind::Ident) {
+        AstExpr variant_expr{};
+        variant_expr.kind = AstExprKind::VariantCase;
+        variant_expr.span = expr.span;
+        variant_expr.name = expr.lhs->name;
+        variant_expr.type_args = expr.lhs->type_args;
+        variant_expr.str_value = expr.name;
+        if (expr.args.len == 1) variant_expr.lhs = expr.args[0];
+        else if (expr.args.len > 1) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        auto variant = analyze_expr(variant_expr, route, mod, locals, local_count, binding);
+        if (variant) return variant;
+    }
+
+    auto build_cmp = [&](HirExprKind kind, const HirExpr& lhs_expr, const HirExpr& rhs_expr) -> FrontendResult<HirExpr> {
+        HirExpr out{};
+        out.kind = kind;
+        out.type = HirTypeKind::Bool;
+        out.span = expr.span;
+        if (!route->exprs.push(lhs_expr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.lhs = &route->exprs[route->exprs.len - 1];
+        if (!route->exprs.push(rhs_expr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.rhs = &route->exprs[route->exprs.len - 1];
+        return out;
+    };
+
+    AstExpr field_expr{};
+    field_expr.kind = AstExprKind::Field;
+    field_expr.span = expr.span;
+    field_expr.lhs = expr.lhs;
+    field_expr.name = expr.name;
+
+    auto recv = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
+    if (!recv) return core::make_unexpected(recv.error());
+    if (expr.args.len == 0 && is_standard_error_field(expr.name) &&
+        (recv->may_error || (recv->type == HirTypeKind::Generic && recv->generic_has_error_constraint))) {
+        return analyze_expr(field_expr, route, mod, locals, local_count, binding);
+    }
+    if (recv->may_nil || recv->may_error) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+
+    const bool is_eq_family = expr.name.eq({"eq", 2}) || expr.name.eq({"ne", 2});
+    const bool is_ord_family = expr.name.eq({"lt", 2}) || expr.name.eq({"gt", 2}) || expr.name.eq({"le", 2}) || expr.name.eq({"ge", 2});
+    if (is_eq_family || is_ord_family) {
+        if (expr.args.len != 1) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        auto rhs = analyze_expr(*expr.args[0], route, mod, locals, local_count, binding);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        if (rhs->may_nil || rhs->may_error) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (!same_hir_type_shape(mod, *recv, *rhs)) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (is_eq_family) {
+            if (recv->type == HirTypeKind::Generic) {
+                if (!recv->generic_has_eq_constraint)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            } else {
+                bool struct_visiting[HirModule::kMaxStructs]{};
+                bool variant_visiting[HirModule::kMaxVariants]{};
+                if (!hir_type_shape_satisfies_eq_constraint(mod,
+                                                            recv->type,
+                                                            recv->variant_index,
+                                                            recv->struct_index,
+                                                            recv->tuple_len,
+                                                            recv->tuple_types,
+                                                            recv->tuple_variant_indices,
+                                                            recv->tuple_struct_indices,
+                                                            struct_visiting,
+                                                            variant_visiting)) {
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+                }
+            }
+            auto eq_expr = build_cmp(HirExprKind::Eq, recv.value(), rhs.value());
+            if (!eq_expr) return core::make_unexpected(eq_expr.error());
+            if (expr.name.eq({"eq", 2})) return eq_expr;
+            HirExpr false_expr{};
+            false_expr.kind = HirExprKind::BoolLit;
+            false_expr.type = HirTypeKind::Bool;
+            false_expr.bool_value = false;
+            false_expr.span = expr.span;
+            return build_cmp(HirExprKind::Eq, eq_expr.value(), false_expr);
+        } else {
+            if (recv->type == HirTypeKind::Generic) {
+                if (!recv->generic_has_ord_constraint)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            } else {
+                bool struct_visiting[HirModule::kMaxStructs]{};
+                bool variant_visiting[HirModule::kMaxVariants]{};
+                if (!hir_type_shape_satisfies_ord_constraint(mod,
+                                                             recv->type,
+                                                             recv->variant_index,
+                                                             recv->struct_index,
+                                                             recv->tuple_len,
+                                                             recv->tuple_types,
+                                                             recv->tuple_variant_indices,
+                                                             recv->tuple_struct_indices,
+                                                             struct_visiting,
+                                                             variant_visiting)) {
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+                }
+            }
+            if (expr.name.eq({"lt", 2})) return build_cmp(HirExprKind::Lt, recv.value(), rhs.value());
+            if (expr.name.eq({"gt", 2})) return build_cmp(HirExprKind::Gt, recv.value(), rhs.value());
+            auto strict = expr.name.eq({"le", 2}) ? build_cmp(HirExprKind::Gt, recv.value(), rhs.value())
+                                                   : build_cmp(HirExprKind::Lt, recv.value(), rhs.value());
+            if (!strict) return core::make_unexpected(strict.error());
+            HirExpr false_expr{};
+            false_expr.kind = HirExprKind::BoolLit;
+            false_expr.type = HirTypeKind::Bool;
+            false_expr.bool_value = false;
+            false_expr.span = expr.span;
+            return build_cmp(HirExprKind::Eq, strict.value(), false_expr);
+        }
+    }
+    if (recv->type == HirTypeKind::Generic && recv->generic_index != 0xffffffffu) {
+        u32 matched_protocol_index = 0xffffffffu;
+        const HirProtocol::MethodDecl* matched_req = nullptr;
+        for (u32 gi = 0; gi < recv->generic_protocol_count; gi++) {
+            const u32 proto_index = recv->generic_protocol_indices[gi];
+            if (proto_index >= mod.protocols.len) continue;
+            const auto* req = find_protocol_method(mod.protocols[proto_index], expr.name);
+            if (req == nullptr) continue;
+            if (matched_protocol_index != 0xffffffffu)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            matched_protocol_index = proto_index;
+            matched_req = req;
+        }
+        if (matched_protocol_index != 0xffffffffu && matched_req != nullptr) {
+            HirExpr out{};
+            out.kind = HirExprKind::ProtocolCall;
+            out.span = expr.span;
+            out.type = HirTypeKind::Unknown;
+            out.protocol_index = matched_protocol_index;
+            out.str_value = expr.name;
+            if (!route->exprs.push(recv.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.lhs = &route->exprs[route->exprs.len - 1];
+            for (u32 i = 0; i < expr.args.len; i++) {
+                auto arg = analyze_expr(*expr.args[i], route, mod, locals, local_count, binding);
+                if (!arg) return core::make_unexpected(arg.error());
+                if (arg->may_nil || arg->may_error)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+                if (!route->exprs.push(arg.value()))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                if (!out.args.push(&route->exprs[route->exprs.len - 1]))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+            }
+            if (matched_req->has_return_type) {
+                out.type = matched_req->return_type;
+                out.generic_index = matched_req->return_generic_index;
+                out.variant_index = matched_req->return_variant_index;
+                out.struct_index = matched_req->return_struct_index;
+                out.shape_index = matched_req->return_shape_index;
+                out.tuple_len = matched_req->return_tuple_len;
+                for (u32 i = 0; i < matched_req->return_tuple_len; i++) {
+                    out.tuple_types[i] = matched_req->return_tuple_types[i];
+                    out.tuple_variant_indices[i] = matched_req->return_tuple_variant_indices[i];
+                    out.tuple_struct_indices[i] = matched_req->return_tuple_struct_indices[i];
+                }
+            }
+            return out;
+        }
+        for (u32 i = 0; i < mod.protocols.len; i++) {
+            if (find_protocol_method(mod.protocols[i], expr.name) != nullptr)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        }
+    }
+    if (recv->type == HirTypeKind::Bool || recv->type == HirTypeKind::I32 || recv->type == HirTypeKind::Str ||
+        recv->type == HirTypeKind::Struct || recv->type == HirTypeKind::Variant || recv->type == HirTypeKind::Tuple) {
+        const auto* impl = find_impl_for_type(mod, recv->type, recv->struct_index, expr.name);
+        if (impl != nullptr) {
+            const auto* method = find_impl_method(*impl, expr.name);
+            if (method == nullptr || method->function_index >= mod.functions.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            AstExpr call_expr{};
+            call_expr.kind = AstExprKind::Call;
+            call_expr.span = expr.span;
+            call_expr.name = mod.functions[method->function_index].name;
+            if (!call_expr.args.push(expr.lhs))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            for (u32 i = 0; i < expr.args.len; i++) {
+                if (!call_expr.args.push(expr.args[i]))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+            }
+            return analyze_call_expr(call_expr, route, mod, locals, local_count, binding, nullptr);
+        }
+        u32 matched_protocol_index = 0xffffffffu;
+        const HirProtocol::MethodDecl* matched_req = nullptr;
+        for (u32 ci = 0; ci < mod.conformances.len; ci++) {
+            const auto& conf = mod.conformances[ci];
+            if (conf.type != recv->type) continue;
+            if (recv->type == HirTypeKind::Struct && conf.struct_index != recv->struct_index) continue;
+            if (recv->type == HirTypeKind::Variant && conf.variant_index != recv->variant_index) continue;
+            if (recv->type == HirTypeKind::Tuple) {
+                if (conf.tuple_len != recv->tuple_len) continue;
+                bool tuple_match = true;
+                for (u32 ti = 0; ti < recv->tuple_len; ti++) {
+                    if (conf.tuple_types[ti] != recv->tuple_types[ti]) {
+                        tuple_match = false;
+                        break;
+                    }
+                    if (conf.tuple_types[ti] == HirTypeKind::Variant &&
+                        conf.tuple_variant_indices[ti] != recv->tuple_variant_indices[ti]) {
+                        tuple_match = false;
+                        break;
+                    }
+                    if (conf.tuple_types[ti] == HirTypeKind::Struct &&
+                        conf.tuple_struct_indices[ti] != recv->tuple_struct_indices[ti]) {
+                        tuple_match = false;
+                        break;
+                    }
+                }
+                if (!tuple_match) continue;
+            }
+            if (conf.protocol_index >= mod.protocols.len) continue;
+            const auto* req = find_protocol_method(mod.protocols[conf.protocol_index], expr.name);
+            if (req == nullptr || req->function_index == 0xffffffffu) continue;
+            if (matched_protocol_index != 0xffffffffu)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            matched_protocol_index = conf.protocol_index;
+            matched_req = req;
+        }
+        if (matched_protocol_index != 0xffffffffu && matched_req != nullptr) {
+            AstExpr call_expr{};
+            call_expr.kind = AstExprKind::Call;
+            call_expr.span = expr.span;
+            call_expr.name = mod.functions[matched_req->function_index].name;
+            if (!call_expr.args.push(expr.lhs))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            for (u32 i = 0; i < expr.args.len; i++) {
+                if (!call_expr.args.push(expr.args[i]))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+            }
+            return analyze_call_expr(call_expr, route, mod, locals, local_count, binding, nullptr);
+        }
+    }
+    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+}
+
+static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
+                                                 HirRoute* route,
+                                                 const HirModule& mod,
+                                                 const HirLocal* locals,
+                                                 u32 local_count,
+                                                 const MatchPayloadBinding* binding,
+                                                 const HirExpr* pipe_lhs);
+
+static FrontendResult<HirExpr> make_guard_bound_init(HirRoute* route, const HirExpr& bound, Span span) {
+    if (!bound.may_error) return bound;
+    if (!route->exprs.push(bound))
+        return frontend_error(FrontendError::TooManyItems, span);
+    HirExpr init{};
+    init.kind = HirExprKind::ValueOf;
+    init.type = bound.type;
+    init.generic_index = bound.generic_index;
+    init.generic_has_error_constraint = bound.generic_has_error_constraint;
+    init.generic_has_eq_constraint = bound.generic_has_eq_constraint;
+    init.generic_has_ord_constraint = bound.generic_has_ord_constraint;
+    init.generic_protocol_index = bound.generic_protocol_index;
+    init.generic_protocol_count = bound.generic_protocol_count;
+    for (u32 i = 0; i < init.generic_protocol_count; i++)
+        init.generic_protocol_indices[i] = bound.generic_protocol_indices[i];
+    init.shape_index = bound.shape_index;
+    init.may_nil = bound.may_nil;
+    init.may_error = false;
+    init.variant_index = bound.variant_index;
+    init.struct_index = bound.struct_index;
+    init.tuple_len = bound.tuple_len;
+    for (u32 i = 0; i < bound.tuple_len; i++) {
+        init.tuple_types[i] = bound.tuple_types[i];
+        init.tuple_variant_indices[i] = bound.tuple_variant_indices[i];
+        init.tuple_struct_indices[i] = bound.tuple_struct_indices[i];
+    }
+    init.error_struct_index = bound.error_struct_index;
+    init.error_variant_index = 0xffffffffu;
+    init.span = span;
+    init.lhs = &route->exprs[route->exprs.len - 1];
+    return init;
+}
+
+static u32 next_local_ref_index(const HirRoute* route, const HirLocal* locals, u32 local_count) {
+    u32 next = 0;
+    for (u32 i = 0; i < local_count; i++) {
+        if (locals[i].ref_index >= next) next = locals[i].ref_index + 1;
+    }
+    for (u32 i = 0; i < route->locals.len; i++) {
+        if (route->locals[i].ref_index >= next) next = route->locals[i].ref_index + 1;
+    }
+    return next;
+}
+
+static FrontendResult<void> insert_scoped_local(HirLocal* locals,
+                                                u32* local_count,
+                                                u32 capacity,
+                                                const HirLocal& local,
+                                                Span span) {
+    if (local.ref_index >= capacity)
+        return frontend_error(FrontendError::TooManyItems, span);
+    if (*local_count <= local.ref_index) *local_count = local.ref_index + 1;
+    locals[local.ref_index] = local;
+    return {};
+}
+
+static const HirStruct* error_struct_decl(const HirModule& mod, u32 struct_index) {
+    if (struct_index >= mod.structs.len) return nullptr;
+    return &mod.structs[struct_index];
+}
+
+static const HirStruct::FieldDecl* find_struct_field(const HirStruct& st, Str field_name) {
+    for (u32 i = 0; i < st.fields.len; i++) {
+        if (st.fields[i].name.eq(field_name)) return &st.fields[i];
+    }
+    return nullptr;
+}
+
+static const HirExpr* find_error_field_init(const HirExpr& expr, Str field_name) {
+    for (u32 i = 0; i < expr.field_inits.len; i++) {
+        if (expr.field_inits[i].name.eq(field_name)) return expr.field_inits[i].value;
+    }
+    return nullptr;
+}
+
+static FrontendResult<HirExpr> analyze_known_error_field(const HirExpr& base,
+                                                         Str field_name,
+                                                         Span span,
+                                                         const HirModule& mod,
+                                                         const HirLocal* locals,
+                                                         u32 local_count,
+                                                         u32 depth) {
+    if (depth > 8) return frontend_error(FrontendError::UnsupportedSyntax, span);
+    if (base.kind == HirExprKind::LocalRef) {
+        if (base.local_index >= local_count) return frontend_error(FrontendError::UnsupportedSyntax, span);
+        return analyze_known_error_field(locals[base.local_index].init,
+                                         field_name,
+                                         span,
+                                         mod,
+                                         locals,
+                                         local_count,
+                                         depth + 1);
+    }
+    if (base.kind != HirExprKind::Error) return frontend_error(FrontendError::UnsupportedSyntax, span);
+
+    if (field_name.eq({"code", 4})) {
+        HirExpr out{};
+        out.kind = HirExprKind::IntLit;
+        out.type = HirTypeKind::I32;
+        out.int_value = base.int_value;
+        out.span = span;
+        return out;
+    }
+    if (field_name.eq({"msg", 3})) {
+        HirExpr out{};
+        out.kind = HirExprKind::StrLit;
+        out.type = HirTypeKind::Str;
+        out.str_value = base.msg;
+        out.span = span;
+        return out;
+    }
+    if (field_name.eq({"line", 4})) {
+        HirExpr out{};
+        out.kind = HirExprKind::IntLit;
+        out.type = HirTypeKind::I32;
+        out.int_value = static_cast<i32>(base.span.line);
+        out.span = span;
+        return out;
+    }
+    if (field_name.eq({"file", 4}) || field_name.eq({"func", 4}))
+        return frontend_error(FrontendError::UnsupportedSyntax, span);
+
+    const HirStruct* st = error_struct_decl(mod, base.error_struct_index);
+    if (!st) return frontend_error(FrontendError::UnsupportedSyntax, span);
+    const HirExpr* field_init = find_error_field_init(base, field_name);
+    if (!field_init) return frontend_error(FrontendError::UnsupportedSyntax, span, field_name);
+    HirExpr out = *field_init;
+    out.span = span;
+    return out;
+}
+
+static bool is_standard_error_field(Str field_name) {
+    return field_name.eq({"code", 4}) || field_name.eq({"msg", 3}) || field_name.eq({"file", 4}) ||
+           field_name.eq({"func", 4}) || field_name.eq({"line", 4});
+}
+
+static FrontendResult<HirExpr> analyze_match_pattern(const AstExpr& pattern_expr,
+                                                     const HirExpr& subject,
+                                                     HirRoute* route,
+                                                     const HirModule& mod,
+                                                     const HirLocal* locals,
+                                                     u32 local_count) {
+    if (pattern_expr.kind == AstExprKind::VariantCase) {
+        const bool subject_is_error_kind =
+            subject.type != HirTypeKind::Variant && subject.may_error &&
+            subject.error_variant_index != 0xffffffffu;
+        u32 variant_index = subject_is_error_kind ? subject.error_variant_index : subject.variant_index;
+        if (pattern_expr.name.len != 0) {
+            variant_index = mod.variants.len;
+            for (u32 i = 0; i < mod.variants.len; i++) {
+                if (mod.variants[i].name.eq(pattern_expr.name)) {
+                    variant_index = i;
+                    break;
+                }
+            }
+            if (variant_index == mod.variants.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, pattern_expr.span, pattern_expr.name);
+            if ((!subject_is_error_kind && (subject.type != HirTypeKind::Variant || subject.variant_index != variant_index)) ||
+                (subject_is_error_kind && subject.error_variant_index != variant_index))
+                return frontend_error(FrontendError::UnsupportedSyntax, pattern_expr.span);
+        } else if (subject.type != HirTypeKind::Variant && !subject_is_error_kind) {
+            return frontend_error(FrontendError::UnsupportedSyntax, pattern_expr.span);
+        }
+
+        const auto& variant = mod.variants[variant_index];
+        u32 case_index = variant.cases.len;
+        for (u32 i = 0; i < variant.cases.len; i++) {
+            if (variant.cases[i].name.eq(pattern_expr.str_value)) {
+                case_index = i;
+                break;
+            }
+        }
+        if (case_index == variant.cases.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, pattern_expr.span, pattern_expr.str_value);
+
+        const auto& case_decl = variant.cases[case_index];
+        if (case_decl.has_payload) {
+            if (pattern_expr.lhs != nullptr && pattern_expr.lhs->kind != AstExprKind::Ident)
+                return frontend_error(FrontendError::UnsupportedSyntax, pattern_expr.span);
+        } else if (pattern_expr.lhs != nullptr) {
+            return frontend_error(FrontendError::UnsupportedSyntax, pattern_expr.span);
+        }
+
+        HirExpr out{};
+        out.kind = HirExprKind::VariantCase;
+        out.type = HirTypeKind::Variant;
+        out.span = pattern_expr.span;
+        out.variant_index = variant_index;
+        out.case_index = case_index;
+        out.int_value = static_cast<i32>(case_index);
+        out.str_value = pattern_expr.str_value;
+        return out;
+    }
+
+    return analyze_expr(pattern_expr, route, mod, locals, local_count, nullptr);
+}
+
+static u8 method_char(u8 token_type) {
+    switch (static_cast<TokenType>(token_type)) {
+        case TokenType::KwGet:
+            return 'G';
+        case TokenType::KwPost:
+        case TokenType::KwPut:
+        case TokenType::KwPatch:
+            return 'P';
+        case TokenType::KwDelete:
+            return 'D';
+        case TokenType::KwHead:
+            return 'H';
+        case TokenType::KwOptions:
+            return 'O';
+        default:
+            return 0;
+    }
+}
+
+static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
+                                                         HirRoute* route,
+                                                         const HirModule& mod,
+                                                         const HirExpr* args,
+                                                         u32 arg_count,
+                                                         const GenericBinding* generic_bindings,
+                                                         u32 generic_binding_count) {
+    HirExpr out = apply_generic_binding_to_expr(expr, generic_bindings, generic_binding_count);
+    auto concretized = concretize_named_instance_shape(&out, mod, generic_bindings, generic_binding_count);
+    if (!concretized) return core::make_unexpected(concretized.error());
+    out.lhs = nullptr;
+    out.rhs = nullptr;
+    out.field_inits.len = 0;
+    out.args.len = 0;
+
+    if (expr.kind == HirExprKind::LocalRef) {
+        if (expr.local_index >= arg_count)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        HirExpr arg = args[expr.local_index];
+        arg.span = expr.span;
+        auto concretized = concretize_named_instance_shape(&arg, mod, generic_bindings, generic_binding_count);
+        if (!concretized) return core::make_unexpected(concretized.error());
+        return arg;
+    }
+
+    if (expr.kind == HirExprKind::ProtocolCall) {
+        if (expr.lhs == nullptr)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        auto recv = instantiate_function_expr(*expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        if (!recv) return core::make_unexpected(recv.error());
+        if (recv->type == HirTypeKind::Generic)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
+        const HirImpl* impl = find_impl_for_type(mod, recv->type, recv->struct_index, expr.str_value);
+        u32 function_index = 0xffffffffu;
+        if (impl != nullptr) {
+            const auto* method = find_impl_method(*impl, expr.str_value);
+            if (method == nullptr || method->function_index >= mod.functions.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
+            function_index = method->function_index;
+        } else {
+            if (expr.protocol_index >= mod.protocols.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
+            const auto* req = find_protocol_method(mod.protocols[expr.protocol_index], expr.str_value);
+            if (req == nullptr || req->function_index == 0xffffffffu)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
+            function_index = req->function_index;
+        }
+        const auto& fn = mod.functions[function_index];
+        HirExpr call_args[AstExpr::kMaxArgs]{};
+        u32 call_arg_count = 0;
+        call_args[call_arg_count++] = recv.value();
+        for (u32 i = 0; i < expr.args.len; i++) {
+            auto arg = instantiate_function_expr(*expr.args[i], route, mod, args, arg_count, generic_bindings, generic_binding_count);
+            if (!arg) return core::make_unexpected(arg.error());
+            call_args[call_arg_count++] = arg.value();
+        }
+        GenericBinding impl_bindings[HirFunction::kMaxTypeParams]{};
+        u32 impl_binding_count = 0;
+        if (impl != nullptr) {
+            auto impl_filled =
+                fill_impl_generic_bindings(mod, *impl, recv->struct_index, impl_bindings, &impl_binding_count);
+            if (!impl_filled) return core::make_unexpected(impl_filled.error());
+            if (!impl_filled.value())
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
+        } else {
+            if (fn.type_params.len == 0 || !fn.type_params[0].name.eq(Str{"Self", 4}))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
+            impl_binding_count = 1;
+            auto filled = fill_bound_binding_from_type_metadata(&impl_bindings[0],
+                                                                const_cast<HirModule*>(&mod),
+                                                                recv->type,
+                                                                recv->generic_index,
+                                                                recv->variant_index,
+                                                                recv->struct_index,
+                                                                recv->tuple_len,
+                                                                recv->tuple_types,
+                                                                recv->tuple_variant_indices,
+                                                                recv->tuple_struct_indices,
+                                                                recv->shape_index,
+                                                                expr.span);
+            if (!filled) return core::make_unexpected(filled.error());
+        }
+        auto inlined = instantiate_function_expr(fn.body,
+                                                 route,
+                                                 mod,
+                                                 call_args,
+                                                 call_arg_count,
+                                                 impl_bindings,
+                                                 impl_binding_count);
+        if (!inlined) return core::make_unexpected(inlined.error());
+        inlined->span = expr.span;
+        return inlined.value();
+    }
+
+    if (expr.kind == HirExprKind::TupleSlot) {
+        if (expr.lhs == nullptr)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        auto lhs = instantiate_function_expr(
+            *expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (lhs->type != HirTypeKind::Tuple)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        const u32 slot = static_cast<u32>(expr.int_value);
+        if (slot >= lhs->tuple_len)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (lhs->args.len == lhs->tuple_len && lhs->args[slot] != nullptr) {
+            HirExpr out_elem = *lhs->args[slot];
+            out_elem.span = expr.span;
+            return out_elem;
+        }
+        HirExpr out_slot = expr;
+        if (!route->exprs.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        out_slot.lhs = &route->exprs[route->exprs.len - 1];
+        out_slot.span = expr.span;
+        return out_slot;
+    }
+
+    if (expr.lhs != nullptr) {
+        auto lhs =
+            instantiate_function_expr(*expr.lhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!route->exprs.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.lhs = &route->exprs[route->exprs.len - 1];
+    }
+    if (expr.rhs != nullptr) {
+        auto rhs =
+            instantiate_function_expr(*expr.rhs, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        if (!route->exprs.push(rhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.rhs = &route->exprs[route->exprs.len - 1];
+    }
+    for (u32 i = 0; i < expr.field_inits.len; i++) {
+        auto val = instantiate_function_expr(
+            *expr.field_inits[i].value, route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        if (!val) return core::make_unexpected(val.error());
+        if (!route->exprs.push(val.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr::FieldInit init{};
+        init.name = expr.field_inits[i].name;
+        init.value = &route->exprs[route->exprs.len - 1];
+        if (!out.field_inits.push(init))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+    }
+    for (u32 i = 0; i < expr.args.len; i++) {
+        auto arg =
+            instantiate_function_expr(*expr.args[i], route, mod, args, arg_count, generic_bindings, generic_binding_count);
+        if (!arg) return core::make_unexpected(arg.error());
+        if (!route->exprs.push(arg.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!out.args.push(&route->exprs[route->exprs.len - 1]))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+    }
+    out.span = expr.span;
+    return out;
+}
+
+static FrontendResult<HirExpr> normalize_function_expr(const HirExpr& expr,
+                                                       HirFunction* fn,
+                                                       const HirLocal* locals,
+                                                       u32 local_count,
+                                                       u32 param_count) {
+    HirExpr out = expr;
+    out.lhs = nullptr;
+    out.rhs = nullptr;
+    out.field_inits.len = 0;
+    out.args.len = 0;
+
+    if (expr.kind == HirExprKind::LocalRef) {
+        if (expr.local_index >= local_count)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.local_index < param_count) return expr;
+        return normalize_function_expr(locals[expr.local_index].init, fn, locals, local_count, param_count);
+    }
+
+    if (expr.kind == HirExprKind::TupleSlot) {
+        if (expr.lhs == nullptr)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        auto lhs = normalize_function_expr(*expr.lhs, fn, locals, local_count, param_count);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (lhs->type != HirTypeKind::Tuple)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        const u32 slot = static_cast<u32>(expr.int_value);
+        if (slot >= lhs->tuple_len)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (lhs->args.len == lhs->tuple_len && lhs->args[slot] != nullptr) {
+            HirExpr out_elem = *lhs->args[slot];
+            out_elem.span = expr.span;
+            return out_elem;
+        }
+        if (!fn->exprs.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.lhs = &fn->exprs[fn->exprs.len - 1];
+        out.span = expr.span;
+        return out;
+    }
+
+    if (expr.lhs != nullptr) {
+        auto lhs = normalize_function_expr(*expr.lhs, fn, locals, local_count, param_count);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!fn->exprs.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.lhs = &fn->exprs[fn->exprs.len - 1];
+    }
+    if (expr.rhs != nullptr) {
+        auto rhs = normalize_function_expr(*expr.rhs, fn, locals, local_count, param_count);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        if (!fn->exprs.push(rhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.rhs = &fn->exprs[fn->exprs.len - 1];
+    }
+    for (u32 i = 0; i < expr.field_inits.len; i++) {
+        auto val = normalize_function_expr(*expr.field_inits[i].value, fn, locals, local_count, param_count);
+        if (!val) return core::make_unexpected(val.error());
+        if (!fn->exprs.push(val.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr::FieldInit init{};
+        init.name = expr.field_inits[i].name;
+        init.value = &fn->exprs[fn->exprs.len - 1];
+        if (!out.field_inits.push(init))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+    }
+    for (u32 i = 0; i < expr.args.len; i++) {
+        auto arg = normalize_function_expr(*expr.args[i], fn, locals, local_count, param_count);
+        if (!arg) return core::make_unexpected(arg.error());
+        if (!fn->exprs.push(arg.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!out.args.push(&fn->exprs[fn->exprs.len - 1]))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+    }
+    out.span = expr.span;
+    return out;
+}
+
+static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& stmt,
+                                                          HirRoute* scratch,
+                                                          const HirModule& mod,
+                                                          const HirLocal* locals,
+                                                          u32 local_count,
+                                                          const MatchPayloadBinding* binding = nullptr) {
+    auto merge_expr_shape = [&](const HirExpr& lhs, const HirExpr& rhs, HirExpr* out) -> bool {
+        HirTypeKind merged_type = lhs.type;
+        u32 merged_generic_index = lhs.generic_index;
+        u32 merged_shape_index = lhs.shape_index;
+        bool merged_generic_has_error_constraint = lhs.generic_has_error_constraint;
+        bool merged_generic_has_eq_constraint = lhs.generic_has_eq_constraint;
+        bool merged_generic_has_ord_constraint = lhs.generic_has_ord_constraint;
+        u32 merged_variant_index = lhs.variant_index;
+        u32 merged_tuple_len = lhs.tuple_len;
+        HirTypeKind merged_tuple_types[kMaxTupleSlots]{};
+        u32 merged_tuple_variant_indices[kMaxTupleSlots]{};
+        u32 merged_tuple_struct_indices[kMaxTupleSlots]{};
+        for (u32 i = 0; i < lhs.tuple_len; i++) {
+            merged_tuple_types[i] = lhs.tuple_types[i];
+            merged_tuple_variant_indices[i] = lhs.tuple_variant_indices[i];
+            merged_tuple_struct_indices[i] = lhs.tuple_struct_indices[i];
+        }
+        if (lhs.type == HirTypeKind::Unknown) {
+            merged_type = rhs.type;
+            merged_generic_index = rhs.generic_index;
+            merged_shape_index = rhs.shape_index;
+            merged_generic_has_error_constraint = rhs.generic_has_error_constraint;
+            merged_generic_has_eq_constraint = rhs.generic_has_eq_constraint;
+            merged_generic_has_ord_constraint = rhs.generic_has_ord_constraint;
+            merged_variant_index = rhs.variant_index;
+            merged_tuple_len = rhs.tuple_len;
+            for (u32 i = 0; i < rhs.tuple_len; i++) {
+                merged_tuple_types[i] = rhs.tuple_types[i];
+                merged_tuple_variant_indices[i] = rhs.tuple_variant_indices[i];
+                merged_tuple_struct_indices[i] = rhs.tuple_struct_indices[i];
+            }
+        } else if (rhs.type != HirTypeKind::Unknown) {
+            if (!same_hir_type_shape(mod, lhs, rhs)) return false;
+        }
+        u32 merged_error_struct = lhs.error_struct_index;
+        u32 merged_error_variant = lhs.error_variant_index;
+        u32 merged_struct_index = lhs.struct_index;
+        if (lhs.type == HirTypeKind::Unknown) merged_struct_index = rhs.struct_index;
+        if (lhs.error_struct_index == 0xffffffffu) {
+            merged_error_struct = rhs.error_struct_index;
+            merged_error_variant = rhs.error_variant_index;
+        } else if (rhs.error_struct_index != 0xffffffffu) {
+            if (lhs.error_struct_index != rhs.error_struct_index ||
+                lhs.error_variant_index != rhs.error_variant_index)
+                return false;
+        }
+
+        out->type = merged_type;
+        out->generic_index = merged_generic_index;
+        out->shape_index = merged_shape_index;
+        out->generic_has_error_constraint = merged_generic_has_error_constraint;
+        out->generic_has_eq_constraint = merged_generic_has_eq_constraint;
+        out->generic_has_ord_constraint = merged_generic_has_ord_constraint;
+        out->generic_protocol_index =
+            lhs.generic_protocol_index != 0xffffffffu ? lhs.generic_protocol_index : rhs.generic_protocol_index;
+        out->generic_protocol_count =
+            lhs.generic_protocol_count != 0 ? lhs.generic_protocol_count : rhs.generic_protocol_count;
+        for (u32 i = 0; i < out->generic_protocol_count; i++) {
+            out->generic_protocol_indices[i] =
+                lhs.generic_protocol_count != 0 ? lhs.generic_protocol_indices[i] : rhs.generic_protocol_indices[i];
+        }
+        out->variant_index = merged_variant_index;
+        out->struct_index = merged_struct_index;
+        out->tuple_len = merged_tuple_len;
+        for (u32 i = 0; i < merged_tuple_len; i++) {
+            out->tuple_types[i] = merged_tuple_types[i];
+            out->tuple_variant_indices[i] = merged_tuple_variant_indices[i];
+            out->tuple_struct_indices[i] = merged_tuple_struct_indices[i];
+        }
+        out->may_nil = lhs.may_nil || rhs.may_nil;
+        out->may_error = lhs.may_error || rhs.may_error;
+        out->error_struct_index = merged_error_struct;
+        out->error_variant_index = merged_error_variant;
+        return true;
+    };
+
+    auto analyze_function_guard_match_expr =
+        [&](const FixedVec<AstStatement::MatchArm, AstStatement::kMaxMatchArms>& ast_arms,
+            const HirExpr& subject,
+            const HirLocal* cur_locals,
+            u32 cur_local_count) -> FrontendResult<HirExpr> {
+        if (!subject.may_error)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+
+        bool seen_wildcard = false;
+        bool seen_variant_cases[HirVariant::kMaxCases]{};
+        u32 seen_variant_case_count = 0;
+        HirExpr result{};
+        bool have_result = false;
+
+        for (i32 ai = static_cast<i32>(ast_arms.len) - 1; ai >= 0; ai--) {
+            const auto& arm = ast_arms[static_cast<u32>(ai)];
+            if (arm.is_wildcard) {
+                if (seen_wildcard)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                seen_wildcard = true;
+                auto body =
+                    analyze_function_body_stmt(*arm.stmt, scratch, mod, cur_locals, cur_local_count, binding);
+                if (!body) return core::make_unexpected(body.error());
+                result = body.value();
+                have_result = true;
+                continue;
+            }
+
+            auto pattern =
+                analyze_match_pattern(arm.pattern, subject, scratch, mod, cur_locals, cur_local_count);
+            if (!pattern) return core::make_unexpected(pattern.error());
+            if (pattern->kind != HirExprKind::VariantCase)
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            if (!(subject.may_error && subject.error_variant_index != 0xffffffffu) ||
+                pattern->variant_index != subject.error_variant_index)
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            const u32 case_index = static_cast<u32>(pattern->int_value);
+            if (case_index >= HirVariant::kMaxCases)
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            if (seen_variant_cases[case_index])
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            seen_variant_cases[case_index] = true;
+            seen_variant_case_count++;
+
+            auto body =
+                analyze_function_body_stmt(*arm.stmt, scratch, mod, cur_locals, cur_local_count, binding);
+            if (!body) return core::make_unexpected(body.error());
+            if (!have_result) {
+                result = body.value();
+                have_result = true;
+                continue;
+            }
+
+            HirExpr merged_shape{};
+            if (!merge_expr_shape(body.value(), result, &merged_shape))
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+
+            HirExpr code_field{};
+            code_field.kind = HirExprKind::Field;
+            code_field.type = HirTypeKind::I32;
+            code_field.span = arm.span;
+            code_field.str_value = Str{"code", 4};
+            if (!scratch->exprs.push(subject))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            code_field.lhs = &scratch->exprs[scratch->exprs.len - 1];
+
+            HirExpr pattern_code{};
+            pattern_code.kind = HirExprKind::IntLit;
+            pattern_code.type = HirTypeKind::I32;
+            pattern_code.int_value = static_cast<i32>(case_index);
+            pattern_code.span = arm.span;
+
+            HirExpr cond{};
+            cond.kind = HirExprKind::Eq;
+            cond.type = HirTypeKind::Bool;
+            cond.span = arm.span;
+            if (!scratch->exprs.push(code_field))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            cond.lhs = &scratch->exprs[scratch->exprs.len - 1];
+            if (!scratch->exprs.push(pattern_code))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            cond.rhs = &scratch->exprs[scratch->exprs.len - 1];
+
+            HirExpr out{};
+            out.kind = HirExprKind::IfElse;
+            out.type = merged_shape.type;
+            out.generic_index = merged_shape.generic_index;
+            out.generic_has_error_constraint = merged_shape.generic_has_error_constraint;
+            out.generic_has_eq_constraint = merged_shape.generic_has_eq_constraint;
+            out.generic_has_ord_constraint = merged_shape.generic_has_ord_constraint;
+            out.generic_protocol_index = merged_shape.generic_protocol_index;
+            out.generic_protocol_count = merged_shape.generic_protocol_count;
+            for (u32 cpi = 0; cpi < out.generic_protocol_count; cpi++)
+                out.generic_protocol_indices[cpi] = merged_shape.generic_protocol_indices[cpi];
+            out.shape_index = merged_shape.shape_index;
+            out.may_nil = merged_shape.may_nil;
+            out.may_error = merged_shape.may_error;
+            out.variant_index = merged_shape.variant_index;
+            out.struct_index = merged_shape.struct_index;
+            out.tuple_len = merged_shape.tuple_len;
+            for (u32 i = 0; i < merged_shape.tuple_len; i++) {
+                out.tuple_types[i] = merged_shape.tuple_types[i];
+                out.tuple_variant_indices[i] = merged_shape.tuple_variant_indices[i];
+                out.tuple_struct_indices[i] = merged_shape.tuple_struct_indices[i];
+            }
+            out.error_struct_index = merged_shape.error_struct_index;
+            out.error_variant_index = merged_shape.error_variant_index;
+            out.shape_index = merged_shape.shape_index;
+            out.span = stmt.span;
+            if (!scratch->exprs.push(cond))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            out.lhs = &scratch->exprs[scratch->exprs.len - 1];
+            if (!scratch->exprs.push(body.value()))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            out.rhs = &scratch->exprs[scratch->exprs.len - 1];
+            if (!scratch->exprs.push(result))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            if (!out.args.push(&scratch->exprs[scratch->exprs.len - 1]))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            result = out;
+        }
+
+        if (!have_result)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        if (!seen_wildcard)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        if (subject.error_variant_index != 0xffffffffu) {
+            const auto& variant = mod.variants[subject.error_variant_index];
+            if (!seen_wildcard && seen_variant_case_count != variant.cases.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        }
+        return result;
+    };
+
+    if (stmt.kind == AstStmtKind::Expr)
+        return analyze_expr(stmt.expr, scratch, mod, locals, local_count, binding);
+
+    if (stmt.kind == AstStmtKind::If) {
+        auto cond = analyze_expr(stmt.expr, scratch, mod, locals, local_count, binding);
+        if (!cond) return core::make_unexpected(cond.error());
+        if (cond->type != HirTypeKind::Bool || cond->may_nil || cond->may_error)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+        auto then_expr = analyze_function_body_stmt(*stmt.then_stmt, scratch, mod, locals, local_count, binding);
+        if (!then_expr) return core::make_unexpected(then_expr.error());
+        auto else_expr = analyze_function_body_stmt(*stmt.else_stmt, scratch, mod, locals, local_count, binding);
+        if (!else_expr) return core::make_unexpected(else_expr.error());
+        HirExpr merged_shape{};
+        if (!merge_expr_shape(then_expr.value(), else_expr.value(), &merged_shape))
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+
+        HirExpr out{};
+        out.kind = HirExprKind::IfElse;
+        out.type = merged_shape.type;
+        out.generic_index = merged_shape.generic_index;
+        out.generic_has_error_constraint = merged_shape.generic_has_error_constraint;
+        out.generic_has_eq_constraint = merged_shape.generic_has_eq_constraint;
+        out.generic_has_ord_constraint = merged_shape.generic_has_ord_constraint;
+        out.generic_protocol_index = merged_shape.generic_protocol_index;
+        out.generic_protocol_count = merged_shape.generic_protocol_count;
+        for (u32 cpi = 0; cpi < out.generic_protocol_count; cpi++)
+            out.generic_protocol_indices[cpi] = merged_shape.generic_protocol_indices[cpi];
+        out.shape_index = merged_shape.shape_index;
+        out.may_nil = merged_shape.may_nil;
+        out.may_error = merged_shape.may_error;
+        out.variant_index = merged_shape.variant_index;
+        out.struct_index = merged_shape.struct_index;
+        out.tuple_len = merged_shape.tuple_len;
+        for (u32 i = 0; i < merged_shape.tuple_len; i++) {
+            out.tuple_types[i] = merged_shape.tuple_types[i];
+            out.tuple_variant_indices[i] = merged_shape.tuple_variant_indices[i];
+            out.tuple_struct_indices[i] = merged_shape.tuple_struct_indices[i];
+        }
+        out.error_struct_index = merged_shape.error_struct_index;
+        out.error_variant_index = merged_shape.error_variant_index;
+        out.span = stmt.span;
+        if (!scratch->exprs.push(cond.value()))
+            return frontend_error(FrontendError::TooManyItems, stmt.span);
+        out.lhs = &scratch->exprs[scratch->exprs.len - 1];
+        if (!scratch->exprs.push(then_expr.value()))
+            return frontend_error(FrontendError::TooManyItems, stmt.span);
+        out.rhs = &scratch->exprs[scratch->exprs.len - 1];
+        if (!scratch->exprs.push(else_expr.value()))
+            return frontend_error(FrontendError::TooManyItems, stmt.span);
+        if (!out.args.push(&scratch->exprs[scratch->exprs.len - 1]))
+            return frontend_error(FrontendError::TooManyItems, stmt.span);
+        return out;
+    }
+
+    if (stmt.kind == AstStmtKind::Match && stmt.is_const) {
+        auto subject = analyze_expr(stmt.expr, scratch, mod, locals, local_count, nullptr);
+        if (!subject) return core::make_unexpected(subject.error());
+        ConstValue subject_value{};
+        if (!const_eval_expr(subject.value(), locals, local_count, &subject_value))
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+
+        if (!scratch->exprs.push(subject.value()))
+            return frontend_error(FrontendError::TooManyItems, stmt.span);
+        const HirExpr* subject_ptr = &scratch->exprs[scratch->exprs.len - 1];
+
+        const AstStatement::MatchArm* wildcard_arm = nullptr;
+        const AstStatement::MatchArm* selected_arm = nullptr;
+        MatchPayloadBinding selected_binding{};
+        const MatchPayloadBinding* selected_binding_ptr = binding;
+
+        for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+            const auto& arm = stmt.match_arms[ai];
+            if (arm.is_wildcard) {
+                wildcard_arm = &arm;
+                continue;
+            }
+            auto pattern = analyze_match_pattern(arm.pattern, subject.value(), scratch, mod, locals, local_count);
+            if (!pattern) return core::make_unexpected(pattern.error());
+
+            bool matched = false;
+            if (pattern->kind == HirExprKind::BoolLit && subject_value.type == HirTypeKind::Bool) {
+                matched = pattern->bool_value == subject_value.bool_value;
+            } else if (pattern->kind == HirExprKind::IntLit && subject_value.type == HirTypeKind::I32) {
+                matched = pattern->int_value == subject_value.int_value;
+            } else if (pattern->kind == HirExprKind::VariantCase && subject_value.type == HirTypeKind::Variant) {
+                matched = pattern->variant_index == subject_value.variant_index &&
+                          pattern->case_index == subject_value.case_index;
+            }
+            if (!matched) continue;
+            selected_arm = &arm;
+            if (pattern->kind == HirExprKind::VariantCase &&
+                mod.variants[pattern->variant_index].cases[pattern->case_index].has_payload &&
+                arm.pattern.lhs != nullptr) {
+                selected_binding.name = arm.pattern.lhs->name;
+                selected_binding.type = mod.variants[pattern->variant_index].cases[pattern->case_index].payload_type;
+                selected_binding.variant_index =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_variant_index;
+                selected_binding.struct_index =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_struct_index;
+                selected_binding.shape_index =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_shape_index;
+                selected_binding.tuple_len =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_tuple_len;
+                for (u32 ti = 0; ti < selected_binding.tuple_len; ti++) {
+                    selected_binding.tuple_types[ti] =
+                        mod.variants[pattern->variant_index].cases[pattern->case_index].payload_tuple_types[ti];
+                    selected_binding.tuple_variant_indices[ti] =
+                        mod.variants[pattern->variant_index].cases[pattern->case_index]
+                            .payload_tuple_variant_indices[ti];
+                    selected_binding.tuple_struct_indices[ti] =
+                        mod.variants[pattern->variant_index].cases[pattern->case_index]
+                            .payload_tuple_struct_indices[ti];
+                }
+                selected_binding.case_index = pattern->case_index;
+                selected_binding.subject = subject_ptr;
+                selected_binding_ptr = &selected_binding;
+            }
+            break;
+        }
+
+        if (selected_arm == nullptr) selected_arm = wildcard_arm;
+        if (selected_arm == nullptr)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        return analyze_function_body_stmt(
+            *selected_arm->stmt, scratch, mod, locals, local_count, selected_binding_ptr);
+    }
+
+    if (stmt.kind == AstStmtKind::Match) {
+        auto subject = analyze_expr(stmt.expr, scratch, mod, locals, local_count, nullptr);
+        if (!subject) return core::make_unexpected(subject.error());
+        if (subject->may_nil || subject->may_error)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+
+        if (!scratch->exprs.push(subject.value()))
+            return frontend_error(FrontendError::TooManyItems, stmt.span);
+        const HirExpr* subject_ptr = &scratch->exprs[scratch->exprs.len - 1];
+
+        bool seen_wildcard = false;
+        bool seen_variant_cases[HirVariant::kMaxCases]{};
+        u32 seen_variant_case_count = 0;
+        HirExpr result{};
+        bool have_result = false;
+
+        for (i32 ai = static_cast<i32>(stmt.match_arms.len) - 1; ai >= 0; ai--) {
+            const auto& arm = stmt.match_arms[static_cast<u32>(ai)];
+            if (arm.is_wildcard) {
+                if (seen_wildcard)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                seen_wildcard = true;
+                auto body =
+                    analyze_function_body_stmt(*arm.stmt, scratch, mod, locals, local_count, binding);
+                if (!body) return core::make_unexpected(body.error());
+                result = body.value();
+                have_result = true;
+                continue;
+            }
+
+            auto pattern = analyze_match_pattern(arm.pattern, subject.value(), scratch, mod, locals, local_count);
+            if (!pattern) return core::make_unexpected(pattern.error());
+            if (pattern->kind != HirExprKind::BoolLit && pattern->kind != HirExprKind::IntLit &&
+                pattern->kind != HirExprKind::VariantCase)
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            if (pattern->type != subject->type)
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            if (pattern->type == HirTypeKind::Variant) {
+                if (pattern->variant_index != subject->variant_index)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                const u32 case_index = static_cast<u32>(pattern->int_value);
+                if (case_index >= HirVariant::kMaxCases)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (seen_variant_cases[case_index])
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                seen_variant_cases[case_index] = true;
+                seen_variant_case_count++;
+            }
+
+            MatchPayloadBinding arm_binding{};
+            const MatchPayloadBinding* arm_binding_ptr = binding;
+            if (pattern->type == HirTypeKind::Variant) {
+                const u32 case_index = static_cast<u32>(pattern->int_value);
+                const auto& case_decl = mod.variants[pattern->variant_index].cases[case_index];
+                if (case_decl.has_payload && arm.pattern.lhs != nullptr) {
+                    arm_binding.name = arm.pattern.lhs->name;
+                    arm_binding.type = case_decl.payload_type;
+                    arm_binding.variant_index = case_decl.payload_variant_index;
+                    arm_binding.struct_index = case_decl.payload_struct_index;
+                    arm_binding.shape_index = case_decl.payload_shape_index;
+                    arm_binding.tuple_len = case_decl.payload_tuple_len;
+                    for (u32 ti = 0; ti < arm_binding.tuple_len; ti++) {
+                        arm_binding.tuple_types[ti] = case_decl.payload_tuple_types[ti];
+                        arm_binding.tuple_variant_indices[ti] = case_decl.payload_tuple_variant_indices[ti];
+                        arm_binding.tuple_struct_indices[ti] = case_decl.payload_tuple_struct_indices[ti];
+                    }
+                    arm_binding.case_index = case_index;
+                    arm_binding.subject = subject_ptr;
+                    arm_binding_ptr = &arm_binding;
+                }
+            }
+
+            auto body =
+                analyze_function_body_stmt(*arm.stmt, scratch, mod, locals, local_count, arm_binding_ptr);
+            if (!body) return core::make_unexpected(body.error());
+            if (!have_result) {
+                result = body.value();
+                have_result = true;
+                continue;
+            }
+            HirExpr merged_shape{};
+            if (!merge_expr_shape(body.value(), result, &merged_shape))
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+
+            HirExpr cond{};
+            cond.kind = HirExprKind::Eq;
+            cond.type = HirTypeKind::Bool;
+            cond.span = arm.span;
+            if (!scratch->exprs.push(*subject_ptr))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            cond.lhs = &scratch->exprs[scratch->exprs.len - 1];
+            if (!scratch->exprs.push(pattern.value()))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            cond.rhs = &scratch->exprs[scratch->exprs.len - 1];
+
+            HirExpr out{};
+            out.kind = HirExprKind::IfElse;
+            out.type = merged_shape.type;
+            out.generic_index = merged_shape.generic_index;
+            out.generic_has_error_constraint = merged_shape.generic_has_error_constraint;
+            out.generic_has_eq_constraint = merged_shape.generic_has_eq_constraint;
+            out.generic_has_ord_constraint = merged_shape.generic_has_ord_constraint;
+            out.generic_protocol_index = merged_shape.generic_protocol_index;
+            out.generic_protocol_count = merged_shape.generic_protocol_count;
+            for (u32 cpi = 0; cpi < out.generic_protocol_count; cpi++)
+                out.generic_protocol_indices[cpi] = merged_shape.generic_protocol_indices[cpi];
+            out.may_nil = merged_shape.may_nil;
+            out.may_error = merged_shape.may_error;
+            out.variant_index = merged_shape.variant_index;
+            out.struct_index = merged_shape.struct_index;
+            out.tuple_len = merged_shape.tuple_len;
+            for (u32 i = 0; i < merged_shape.tuple_len; i++) {
+                out.tuple_types[i] = merged_shape.tuple_types[i];
+                out.tuple_variant_indices[i] = merged_shape.tuple_variant_indices[i];
+                out.tuple_struct_indices[i] = merged_shape.tuple_struct_indices[i];
+            }
+            out.error_struct_index = merged_shape.error_struct_index;
+            out.error_variant_index = merged_shape.error_variant_index;
+            out.shape_index = merged_shape.shape_index;
+            out.span = stmt.span;
+            if (!scratch->exprs.push(cond))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            out.lhs = &scratch->exprs[scratch->exprs.len - 1];
+            if (!scratch->exprs.push(body.value()))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            out.rhs = &scratch->exprs[scratch->exprs.len - 1];
+            if (!scratch->exprs.push(result))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            if (!out.args.push(&scratch->exprs[scratch->exprs.len - 1]))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+            result = out;
+        }
+
+        if (!have_result)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        if (result.type == HirTypeKind::Unknown && !result.may_nil && !result.may_error)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        if (!seen_wildcard) {
+            if (subject->type != HirTypeKind::Variant)
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+            const auto& variant = mod.variants[subject->variant_index];
+            if (seen_variant_case_count != variant.cases.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        }
+        return result;
+    }
+
+    if (stmt.kind == AstStmtKind::Block) {
+        HirLocal scoped[HirRoute::kMaxLocals]{};
+        for (u32 i = 0; i < local_count; i++) scoped[i] = locals[i];
+        u32 scoped_count = local_count;
+        auto analyze_block_tail =
+            [&](auto&& self, u32 si, const HirLocal* cur_locals, u32 cur_local_count) -> FrontendResult<HirExpr> {
+            if (si >= stmt.block_stmts.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+            const auto& inner = *stmt.block_stmts[si];
+            const bool is_last = si + 1 == stmt.block_stmts.len;
+            if (inner.kind == AstStmtKind::Let && !is_last) {
+                auto init = analyze_expr(inner.expr, scratch, mod, cur_locals, cur_local_count, nullptr);
+                if (!init) return core::make_unexpected(init.error());
+                auto typed = apply_declared_type_to_expr(&init.value(), mod, inner);
+                if (!typed) return core::make_unexpected(typed.error());
+                if (cur_local_count >= HirRoute::kMaxLocals)
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                HirLocal next_locals[HirRoute::kMaxLocals]{};
+                for (u32 i = 0; i < cur_local_count; i++) next_locals[i] = cur_locals[i];
+                u32 next_count = cur_local_count;
+                HirLocal local{};
+                local.span = inner.span;
+                local.name = inner.name;
+                local.ref_index = next_local_ref_index(scratch, cur_locals, cur_local_count);
+                local.type = init->type;
+                local.generic_index = init->generic_index;
+                local.generic_has_error_constraint = init->generic_has_error_constraint;
+                local.generic_has_eq_constraint = init->generic_has_eq_constraint;
+                local.generic_has_ord_constraint = init->generic_has_ord_constraint;
+                local.generic_protocol_index = init->generic_protocol_index;
+                local.generic_protocol_count = init->generic_protocol_count;
+                for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                    local.generic_protocol_indices[cpi] = init->generic_protocol_indices[cpi];
+                local.may_nil = init->may_nil;
+                local.may_error = init->may_error;
+                local.variant_index = init->variant_index;
+                local.struct_index = init->struct_index;
+                local.tuple_len = init->tuple_len;
+                for (u32 ti = 0; ti < init->tuple_len; ti++) {
+                    local.tuple_types[ti] = init->tuple_types[ti];
+                    local.tuple_variant_indices[ti] = init->tuple_variant_indices[ti];
+                    local.tuple_struct_indices[ti] = init->tuple_struct_indices[ti];
+                }
+                local.error_struct_index = init->error_struct_index;
+                local.error_variant_index = init->error_variant_index;
+                local.shape_index = init->shape_index;
+                local.init = init.value();
+                auto inserted =
+                    insert_scoped_local(next_locals, &next_count, HirRoute::kMaxLocals, local, inner.span);
+                if (!inserted) return core::make_unexpected(inserted.error());
+                if (!scratch->locals.push(local))
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                return self(self, si + 1, next_locals, next_count);
+            }
+            if (inner.kind == AstStmtKind::Guard && !is_last) {
+                auto bound = analyze_expr(inner.expr, scratch, mod, cur_locals, cur_local_count, nullptr);
+                if (!bound) return core::make_unexpected(bound.error());
+                auto cond = analyze_guard_cond(inner.expr, scratch, mod, cur_locals, cur_local_count);
+                if (!cond) return core::make_unexpected(cond.error());
+
+                HirLocal succ_locals[HirRoute::kMaxLocals]{};
+                for (u32 i = 0; i < cur_local_count; i++) succ_locals[i] = cur_locals[i];
+                u32 succ_count = cur_local_count;
+                if (inner.bind_value) {
+                    if (known_value_state(bound.value(), cur_locals, cur_local_count) == KnownValueState::Error)
+                        return frontend_error(FrontendError::UnsupportedSyntax, inner.expr.span);
+                    HirLocal local{};
+                    local.span = inner.span;
+                    local.name = inner.name;
+                    local.ref_index = next_local_ref_index(scratch, cur_locals, cur_local_count);
+                    local.type = bound->type;
+                    local.generic_index = bound->generic_index;
+                    local.generic_has_error_constraint = bound->generic_has_error_constraint;
+                    local.generic_has_eq_constraint = bound->generic_has_eq_constraint;
+                    local.generic_has_ord_constraint = bound->generic_has_ord_constraint;
+                    local.generic_protocol_index = bound->generic_protocol_index;
+                    local.generic_protocol_count = bound->generic_protocol_count;
+                    for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                        local.generic_protocol_indices[cpi] = bound->generic_protocol_indices[cpi];
+                    local.may_nil = bound->may_nil;
+                    local.may_error = false;
+                    local.variant_index = bound->variant_index;
+                    local.struct_index = bound->struct_index;
+                    local.tuple_len = bound->tuple_len;
+                    for (u32 ti = 0; ti < bound->tuple_len; ti++) {
+                        local.tuple_types[ti] = bound->tuple_types[ti];
+                        local.tuple_variant_indices[ti] = bound->tuple_variant_indices[ti];
+                        local.tuple_struct_indices[ti] = bound->tuple_struct_indices[ti];
+                    }
+                    local.error_struct_index = bound->error_struct_index;
+                    local.error_variant_index = 0xffffffffu;
+                    local.shape_index = bound->shape_index;
+                    auto init = make_guard_bound_init(scratch, bound.value(), inner.span);
+                    if (!init) return core::make_unexpected(init.error());
+                    local.init = init.value();
+                    auto inserted =
+                        insert_scoped_local(succ_locals, &succ_count, HirRoute::kMaxLocals, local, inner.span);
+                    if (!inserted) return core::make_unexpected(inserted.error());
+                    if (!scratch->locals.push(local))
+                        return frontend_error(FrontendError::TooManyItems, inner.span);
+                }
+
+                auto then_expr = self(self, si + 1, succ_locals, succ_count);
+                if (!then_expr) return core::make_unexpected(then_expr.error());
+                FrontendResult<HirExpr> else_expr = frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                if (inner.match_arms.len != 0) {
+                    else_expr = analyze_function_guard_match_expr(
+                        inner.match_arms, bound.value(), cur_locals, cur_local_count);
+                } else {
+                    else_expr = analyze_function_body_stmt(
+                        *inner.else_stmt, scratch, mod, cur_locals, cur_local_count, binding);
+                }
+                if (!else_expr) return core::make_unexpected(else_expr.error());
+                HirExpr merged_shape{};
+                if (!merge_expr_shape(then_expr.value(), else_expr.value(), &merged_shape))
+                    return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+
+                HirExpr out{};
+                out.kind = HirExprKind::IfElse;
+                out.type = merged_shape.type;
+                out.generic_index = merged_shape.generic_index;
+                out.generic_has_error_constraint = merged_shape.generic_has_error_constraint;
+                out.generic_has_eq_constraint = merged_shape.generic_has_eq_constraint;
+                out.generic_has_ord_constraint = merged_shape.generic_has_ord_constraint;
+                out.generic_protocol_index = merged_shape.generic_protocol_index;
+                out.generic_protocol_count = merged_shape.generic_protocol_count;
+                for (u32 cpi = 0; cpi < out.generic_protocol_count; cpi++)
+                    out.generic_protocol_indices[cpi] = merged_shape.generic_protocol_indices[cpi];
+                out.may_nil = merged_shape.may_nil;
+                out.may_error = merged_shape.may_error;
+                out.variant_index = merged_shape.variant_index;
+                out.struct_index = merged_shape.struct_index;
+                out.tuple_len = merged_shape.tuple_len;
+                for (u32 i = 0; i < merged_shape.tuple_len; i++) {
+                    out.tuple_types[i] = merged_shape.tuple_types[i];
+                    out.tuple_variant_indices[i] = merged_shape.tuple_variant_indices[i];
+                    out.tuple_struct_indices[i] = merged_shape.tuple_struct_indices[i];
+                }
+                out.error_struct_index = merged_shape.error_struct_index;
+                out.error_variant_index = merged_shape.error_variant_index;
+                out.span = inner.span;
+                if (!scratch->exprs.push(cond.value()))
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                out.lhs = &scratch->exprs[scratch->exprs.len - 1];
+                if (!scratch->exprs.push(then_expr.value()))
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                out.rhs = &scratch->exprs[scratch->exprs.len - 1];
+                if (!scratch->exprs.push(else_expr.value()))
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                if (!out.args.push(&scratch->exprs[scratch->exprs.len - 1]))
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                return out;
+            }
+            if (!is_last && inner.kind != AstStmtKind::Let && inner.kind != AstStmtKind::Guard)
+                return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+            return analyze_function_body_stmt(inner, scratch, mod, cur_locals, cur_local_count, binding);
+        };
+        return analyze_block_tail(analyze_block_tail, 0, scoped, scoped_count);
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+    }
+
+    return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+}
+
+static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
+                                            HirRoute* route,
+                                            const HirModule& mod,
+                                            const HirLocal* locals,
+                                            u32 local_count,
+                                            const MatchPayloadBinding* binding) {
+    HirExpr out{};
+    out.span = expr.span;
+    if (expr.kind == AstExprKind::Placeholder)
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+    if (expr.kind == AstExprKind::BoolLit) {
+        out.kind = HirExprKind::BoolLit;
+        out.type = HirTypeKind::Bool;
+        out.bool_value = expr.bool_value;
+        return out;
+    }
+    if (expr.kind == AstExprKind::IntLit) {
+        out.kind = HirExprKind::IntLit;
+        out.type = HirTypeKind::I32;
+        out.int_value = expr.int_value;
+        return out;
+    }
+    if (expr.kind == AstExprKind::StrLit) {
+        out.kind = HirExprKind::StrLit;
+        out.type = HirTypeKind::Str;
+        out.str_value = expr.str_value;
+        return out;
+    }
+    if (expr.kind == AstExprKind::Call)
+        return analyze_call_expr(expr, route, mod, locals, local_count, binding, nullptr);
+    if (expr.kind == AstExprKind::StructInit) {
+        Str resolved_struct_name = expr.name;
+        if (expr.lhs != nullptr) {
+            if (expr.lhs->kind == AstExprKind::Ident) {
+                if (!has_import_namespace(mod, expr.lhs->name) ||
+                    !resolve_import_namespace_type_name(mod, expr.lhs->name, expr.name, &resolved_struct_name))
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            } else {
+                if (!resolve_import_namespace_member(mod, *expr.lhs, &resolved_struct_name))
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            }
+        }
+        const u32 struct_index = find_struct_index(mod, resolved_struct_name);
+        if (struct_index == mod.structs.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        u32 concrete_struct_index = struct_index;
+        if (mod.structs[struct_index].type_params.len != 0) {
+            GenericBinding bindings[HirStruct::kMaxTypeParams]{};
+            if (expr.type_args.len != 0 && expr.type_args.len != mod.structs[struct_index].type_params.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            if (expr.type_args.len != 0) {
+                for (u32 i = 0; i < expr.type_args.len; i++) {
+                    u32 type_variant_index = 0xffffffffu;
+                    u32 type_struct_index = 0xffffffffu;
+                    u32 tuple_len = 0;
+                    HirTypeKind tuple_types[kMaxTupleSlots]{};
+                    u32 tuple_variant_indices[kMaxTupleSlots]{};
+                    u32 tuple_struct_indices[kMaxTupleSlots]{};
+                    auto type_arg = resolve_func_type_ref(mod,
+                                                          expr.type_args[i],
+                                                          nullptr,
+                                                          nullptr,
+                                                          &type_variant_index,
+                                                          &type_struct_index,
+                                                          &tuple_len,
+                                                          tuple_types,
+                                                          tuple_variant_indices,
+                                                          tuple_struct_indices,
+                                                          expr.span);
+                    if (!type_arg) return core::make_unexpected(type_arg.error());
+                    auto filled = fill_bound_binding_from_type_metadata(&bindings[i],
+                                                                        const_cast<HirModule*>(&mod),
+                                                                        type_arg.value(),
+                                                                        0xffffffffu,
+                                                                        type_variant_index,
+                                                                        type_struct_index,
+                                                                        tuple_len,
+                                                                        tuple_types,
+                                                                        tuple_variant_indices,
+                                                                        tuple_struct_indices,
+                                                                        0xffffffffu,
+                                                                        expr.span);
+                    if (!filled) return core::make_unexpected(filled.error());
+                }
+            } else {
+                if (expr.field_inits.len != mod.structs[struct_index].fields.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+                for (u32 fi = 0; fi < expr.field_inits.len; fi++) {
+                    u32 field_index = mod.structs[struct_index].fields.len;
+                    for (u32 decl_i = 0; decl_i < mod.structs[struct_index].fields.len; decl_i++) {
+                        if (mod.structs[struct_index].fields[decl_i].name.eq(expr.field_inits[fi].name)) {
+                            field_index = decl_i;
+                            break;
+                        }
+                    }
+                    if (field_index == mod.structs[struct_index].fields.len)
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
+                    const auto& field_decl = mod.structs[struct_index].fields[field_index];
+                    auto field_value =
+                        analyze_expr(*expr.field_inits[fi].value, route, mod, locals, local_count, binding);
+                    if (!field_value) return core::make_unexpected(field_value.error());
+                    if (field_value->may_nil || field_value->may_error)
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+                    bool bound = false;
+                    if (field_decl.generic_index != 0xffffffffu) {
+                        bound = bind_generic_shape(bindings,
+                                                   mod.structs[struct_index].type_params.len,
+                                                   field_decl.generic_index,
+                                                   field_value.value());
+                    } else if (field_decl.template_variant_index != 0xffffffffu ||
+                               field_decl.template_struct_index != 0xffffffffu) {
+                        const auto expected = make_expected_type_expr(field_decl.type,
+                                                                      field_decl.variant_index,
+                                                                      field_decl.struct_index,
+                                                                      field_decl.tuple_len,
+                                                                      field_decl.tuple_types,
+                                                                      field_decl.tuple_variant_indices,
+                                                                      field_decl.tuple_struct_indices,
+                                                                      field_decl.shape_index);
+                        bound = bind_named_generic_shape(mod,
+                                                         bindings,
+                                                         mod.structs[struct_index].type_params.len,
+                                                         expected,
+                                                         field_value.value());
+                    } else {
+                        bound = true;
+                    }
+                    if (!bound)
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+                }
+            }
+            for (u32 i = 0; i < mod.structs[struct_index].type_params.len; i++) {
+                if (!bindings[i].bound)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            }
+            auto concrete_index =
+                instantiate_struct(const_cast<HirModule*>(&mod),
+                                   struct_index,
+                                   bindings,
+                                   mod.structs[struct_index].type_params.len,
+                                   expr.span);
+            if (!concrete_index) return core::make_unexpected(concrete_index.error());
+            concrete_struct_index = concrete_index.value();
+        } else if (expr.type_args.len != 0) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        }
+        if (expr.field_inits.len != mod.structs[concrete_struct_index].fields.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        out.kind = HirExprKind::StructInit;
+        out.type = HirTypeKind::Struct;
+        out.struct_index = concrete_struct_index;
+        out.str_value = resolved_struct_name;
+        for (u32 fi = 0; fi < expr.field_inits.len; fi++) {
+            for (u32 seen = 0; seen < fi; seen++) {
+                if (expr.field_inits[seen].name.eq(expr.field_inits[fi].name))
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
+            }
+            u32 field_index = mod.structs[concrete_struct_index].fields.len;
+            for (u32 decl_i = 0; decl_i < mod.structs[concrete_struct_index].fields.len; decl_i++) {
+                if (mod.structs[concrete_struct_index].fields[decl_i].name.eq(expr.field_inits[fi].name)) {
+                    field_index = decl_i;
+                    break;
+                }
+            }
+            if (field_index == mod.structs[concrete_struct_index].fields.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
+            const auto& field_decl = mod.structs[concrete_struct_index].fields[field_index];
+            auto field_value =
+                analyze_expr(*expr.field_inits[fi].value, route, mod, locals, local_count, binding);
+            if (!field_value) return core::make_unexpected(field_value.error());
+            if (field_value->may_nil || field_value->may_error)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+            const auto expected = make_expected_type_expr(field_decl.type,
+                                                          field_decl.variant_index,
+                                                          field_decl.struct_index,
+                                                          field_decl.tuple_len,
+                                                          field_decl.tuple_types,
+                                                          field_decl.tuple_variant_indices,
+                                                          field_decl.tuple_struct_indices,
+                                                          field_decl.shape_index);
+            if (!same_hir_type_shape(mod, field_value.value(), expected))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+            if (!route->exprs.push(field_value.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr::FieldInit field_init{};
+            field_init.name = expr.field_inits[fi].name;
+            field_init.value = &route->exprs[route->exprs.len - 1];
+            if (!out.field_inits.push(field_init))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+        }
+        return out;
+    }
+    if (expr.kind == AstExprKind::MethodCall) {
+        return analyze_method_call_expr(expr, route, mod, locals, local_count, binding);
+    }
+    if (expr.kind == AstExprKind::Field) {
+        if (expr.lhs == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.lhs->kind == AstExprKind::Ident) {
+            const u32 variant_index = [&]() {
+                for (u32 i = 0; i < mod.variants.len; i++) {
+                    if (mod.variants[i].name.eq(expr.lhs->name)) return i;
+                }
+                return mod.variants.len;
+            }();
+            if (variant_index < mod.variants.len) {
+                AstExpr variant_expr{};
+                variant_expr.kind = AstExprKind::VariantCase;
+                variant_expr.span = expr.span;
+                variant_expr.name = expr.lhs->name;
+                variant_expr.str_value = expr.name;
+                return analyze_expr(variant_expr, route, mod, locals, local_count, binding);
+            }
+        }
+        Str qualified_type_name{};
+        if (resolve_import_namespace_member(mod, *expr.lhs, &qualified_type_name)) {
+            AstExpr variant_expr{};
+            variant_expr.kind = AstExprKind::VariantCase;
+            variant_expr.span = expr.span;
+            variant_expr.name = qualified_type_name;
+            variant_expr.type_args = expr.type_args;
+            variant_expr.str_value = expr.name;
+            return analyze_expr(variant_expr, route, mod, locals, local_count, binding);
+        }
+        auto base = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
+        if (!base) return core::make_unexpected(base.error());
+        const auto known_state = known_value_state(base.value(), locals, local_count);
+        if (known_state == KnownValueState::Error &&
+            !expr.name.eq({"file", 4}) && !expr.name.eq({"func", 4}))
+            return analyze_known_error_field(base.value(), expr.name, expr.span, mod, locals, local_count);
+        if (base->type == HirTypeKind::Struct && !base->may_error) {
+            if (base->struct_index >= mod.structs.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            const auto* field = find_struct_field(mod.structs[base->struct_index], expr.name);
+            if (!field) return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            out.kind = HirExprKind::Field;
+            out.span = expr.span;
+            out.type = field->type;
+            out.variant_index = field->variant_index;
+            out.struct_index = field->struct_index;
+            out.shape_index = field->shape_index;
+            out.tuple_len = field->tuple_len;
+            for (u32 i = 0; i < field->tuple_len; i++) {
+                out.tuple_types[i] = field->tuple_types[i];
+                out.tuple_variant_indices[i] = field->tuple_variant_indices[i];
+                out.tuple_struct_indices[i] = field->tuple_struct_indices[i];
+            }
+            if (!route->exprs.push(base.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.lhs = &route->exprs[route->exprs.len - 1];
+            out.str_value = expr.name;
+            out.struct_index = base->struct_index;
+            return out;
+        }
+        if (base->type == HirTypeKind::Generic && !base->may_error) {
+            if (!base->generic_has_error_constraint)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            if (!is_standard_error_field(expr.name))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            out.kind = HirExprKind::Field;
+            out.span = expr.span;
+            out.type = expr.name.eq({"code", 4}) || expr.name.eq({"line", 4}) ? HirTypeKind::I32 : HirTypeKind::Str;
+            if (!route->exprs.push(base.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.lhs = &route->exprs[route->exprs.len - 1];
+            out.str_value = expr.name;
+            return out;
+        }
+        if (!base->may_error) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (is_standard_error_field(expr.name)) {
+            out.kind = HirExprKind::Field;
+            out.span = expr.span;
+            out.type = expr.name.eq({"code", 4}) || expr.name.eq({"line", 4}) ? HirTypeKind::I32
+                                                                               : HirTypeKind::Str;
+            if (!route->exprs.push(base.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.lhs = &route->exprs[route->exprs.len - 1];
+            out.str_value = expr.name;
+            return out;
+        }
+        const HirStruct* st = error_struct_decl(mod, base->error_struct_index);
+        if (!st) return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        const auto* field = find_struct_field(*st, expr.name);
+        if (!field) return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        if (field->is_error_type)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        out.kind = HirExprKind::Field;
+        out.span = expr.span;
+        out.type = field->type;
+        out.variant_index = field->variant_index;
+        out.struct_index = field->struct_index;
+        out.shape_index = field->shape_index;
+        out.tuple_len = field->tuple_len;
+        for (u32 i = 0; i < field->tuple_len; i++) {
+            out.tuple_types[i] = field->tuple_types[i];
+            out.tuple_variant_indices[i] = field->tuple_variant_indices[i];
+            out.tuple_struct_indices[i] = field->tuple_struct_indices[i];
+        }
+        if (!route->exprs.push(base.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.lhs = &route->exprs[route->exprs.len - 1];
+        out.str_value = expr.name;
+        out.error_struct_index = base->error_struct_index;
+        return out;
+    }
+    if (expr.kind == AstExprKind::VariantCase) {
+        if (expr.name.len == 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        u32 variant_index = mod.variants.len;
+        for (u32 i = 0; i < mod.variants.len; i++) {
+            if (mod.variants[i].name.eq(expr.name)) {
+                variant_index = i;
+                break;
+            }
+        }
+        if (variant_index == mod.variants.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        if (mod.variants[variant_index].type_params.len != 0) {
+            GenericBinding bindings[HirVariant::kMaxTypeParams]{};
+            if (expr.type_args.len != 0 && expr.type_args.len != mod.variants[variant_index].type_params.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            u32 template_case_index = mod.variants[variant_index].cases.len;
+            for (u32 i = 0; i < mod.variants[variant_index].cases.len; i++) {
+                if (mod.variants[variant_index].cases[i].name.eq(expr.str_value)) {
+                    template_case_index = i;
+                    break;
+                }
+            }
+            if (template_case_index == mod.variants[variant_index].cases.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
+            const auto& template_case_decl = mod.variants[variant_index].cases[template_case_index];
+            if (expr.type_args.len != 0) {
+                for (u32 i = 0; i < expr.type_args.len; i++) {
+                    u32 type_variant_index = 0xffffffffu;
+                    u32 type_struct_index = 0xffffffffu;
+                    u32 tuple_len = 0;
+                    HirTypeKind tuple_types[kMaxTupleSlots]{};
+                    u32 tuple_variant_indices[kMaxTupleSlots]{};
+                    u32 tuple_struct_indices[kMaxTupleSlots]{};
+                    auto type_arg = resolve_func_type_ref(mod,
+                                                          expr.type_args[i],
+                                                          nullptr,
+                                                          nullptr,
+                                                          &type_variant_index,
+                                                          &type_struct_index,
+                                                          &tuple_len,
+                                                          tuple_types,
+                                                          tuple_variant_indices,
+                                                          tuple_struct_indices,
+                                                          expr.span);
+                    if (!type_arg) return core::make_unexpected(type_arg.error());
+                    auto filled = fill_bound_binding_from_type_metadata(&bindings[i],
+                                                                        const_cast<HirModule*>(&mod),
+                                                                        type_arg.value(),
+                                                                        0xffffffffu,
+                                                                        type_variant_index,
+                                                                        type_struct_index,
+                                                                        tuple_len,
+                                                                        tuple_types,
+                                                                        tuple_variant_indices,
+                                                                        tuple_struct_indices,
+                                                                        0xffffffffu,
+                                                                        expr.span);
+                    if (!filled) return core::make_unexpected(filled.error());
+                }
+            } else {
+                if (!template_case_decl.has_payload || expr.lhs == nullptr)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+                auto payload = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
+                if (!payload) return core::make_unexpected(payload.error());
+                if (payload->may_nil || payload->may_error)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+                bool bound = false;
+                if (template_case_decl.payload_generic_index != 0xffffffffu) {
+                    bound = bind_generic_shape(bindings,
+                                               mod.variants[variant_index].type_params.len,
+                                               template_case_decl.payload_generic_index,
+                                               payload.value());
+                } else if (template_case_decl.payload_template_variant_index != 0xffffffffu ||
+                           template_case_decl.payload_template_struct_index != 0xffffffffu) {
+                    const auto expected = make_expected_type_expr(template_case_decl.payload_type,
+                                                                  template_case_decl.payload_variant_index,
+                                                                  template_case_decl.payload_struct_index,
+                                                                  template_case_decl.payload_tuple_len,
+                                                                  template_case_decl.payload_tuple_types,
+                                                                  template_case_decl.payload_tuple_variant_indices,
+                                                                  template_case_decl.payload_tuple_struct_indices,
+                                                                  template_case_decl.payload_shape_index);
+                    bound = bind_named_generic_shape(mod,
+                                                     bindings,
+                                                     mod.variants[variant_index].type_params.len,
+                                                     expected,
+                                                     payload.value());
+                }
+                if (!bound)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+                for (u32 i = 0; i < mod.variants[variant_index].type_params.len; i++) {
+                    if (!bindings[i].bound)
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+                }
+            }
+            auto concrete_index = instantiate_variant(const_cast<HirModule*>(&mod),
+                                                     variant_index,
+                                                     bindings,
+                                                     mod.variants[variant_index].type_params.len,
+                                                     expr.span);
+            if (!concrete_index) return core::make_unexpected(concrete_index.error());
+            variant_index = concrete_index.value();
+        } else if (expr.type_args.len != 0) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        }
+        u32 case_index = mod.variants[variant_index].cases.len;
+        for (u32 i = 0; i < mod.variants[variant_index].cases.len; i++) {
+            if (mod.variants[variant_index].cases[i].name.eq(expr.str_value)) {
+                case_index = i;
+                break;
+            }
+        }
+        if (case_index == mod.variants[variant_index].cases.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.str_value);
+        const auto& case_decl = mod.variants[variant_index].cases[case_index];
+        if (case_decl.has_payload) {
+            if (expr.lhs == nullptr)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            auto payload = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
+            if (!payload) return core::make_unexpected(payload.error());
+            if (payload->may_nil || payload->may_error)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            const auto expected = make_expected_type_expr(case_decl.payload_type,
+                                                          case_decl.payload_variant_index,
+                                                          case_decl.payload_struct_index,
+                                                          case_decl.payload_tuple_len,
+                                                          case_decl.payload_tuple_types,
+                                                          case_decl.payload_tuple_variant_indices,
+                                                          case_decl.payload_tuple_struct_indices,
+                                                          case_decl.payload_shape_index);
+            if (!same_hir_type_shape(mod, payload.value(), expected))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            if (!route->exprs.push(payload.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.lhs = &route->exprs[route->exprs.len - 1];
+        } else if (expr.lhs != nullptr) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        }
+        out.kind = HirExprKind::VariantCase;
+        out.type = HirTypeKind::Variant;
+        out.variant_index = variant_index;
+        out.case_index = case_index;
+        out.int_value = static_cast<i32>(case_index);
+        out.str_value = expr.str_value;
+        return out;
+    }
+    if (expr.kind == AstExprKind::Tuple) {
+        if (expr.args.len < 2)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        out.kind = HirExprKind::Tuple;
+        out.type = HirTypeKind::Tuple;
+        out.tuple_len = expr.args.len;
+        for (u32 i = 0; i < expr.args.len; i++) {
+            auto elem = analyze_expr(*expr.args[i], route, mod, locals, local_count, binding);
+            if (!elem) return core::make_unexpected(elem.error());
+            if (elem->may_nil || elem->may_error || elem->type == HirTypeKind::Unknown ||
+                elem->type == HirTypeKind::Tuple)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+            out.tuple_types[i] = elem->type;
+            out.tuple_variant_indices[i] = elem->variant_index;
+            out.tuple_struct_indices[i] = elem->struct_index;
+            if (!route->exprs.push(elem.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            if (!out.args.push(&route->exprs[route->exprs.len - 1]))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+        }
+        auto tuple_shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                                 out.type,
+                                                 out.generic_index,
+                                                 out.variant_index,
+                                                 out.struct_index,
+                                                 out.tuple_len,
+                                                 out.tuple_types,
+                                                 out.tuple_variant_indices,
+                                                 out.tuple_struct_indices,
+                                                 expr.span);
+        if (!tuple_shape) return core::make_unexpected(tuple_shape.error());
+        out.shape_index = tuple_shape.value();
+        return out;
+    }
+    if (expr.kind == AstExprKind::ReqHeader) {
+        out.kind = HirExprKind::ReqHeader;
+        out.type = HirTypeKind::Str;
+        out.may_nil = true;
+        out.str_value = expr.str_value;
+        return out;
+    }
+    if (expr.kind == AstExprKind::Nil) {
+        out.kind = HirExprKind::Nil;
+        out.type = HirTypeKind::Unknown;
+        out.may_nil = true;
+        return out;
+    }
+    if (expr.kind == AstExprKind::Error) {
+        out.kind = HirExprKind::Error;
+        out.type = HirTypeKind::Unknown;
+        out.may_error = true;
+        out.msg = expr.msg;
+        if (expr.name.len != 0) {
+            const u32 struct_index = find_struct_index(mod, expr.name);
+            if (struct_index == mod.structs.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            if (!mod.structs[struct_index].conforms_error)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            out.error_struct_index = struct_index;
+            u32 required_extra_fields = 0;
+            for (u32 fi = 0; fi < mod.structs[struct_index].fields.len; fi++) {
+                if (mod.structs[struct_index].fields[fi].name.eq({"err", 3}) &&
+                    mod.structs[struct_index].fields[fi].is_error_type)
+                    continue;
+                required_extra_fields++;
+            }
+            if (expr.field_inits.len != required_extra_fields)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            for (u32 fi = 0; fi < expr.field_inits.len; fi++) {
+                for (u32 seen = 0; seen < fi; seen++) {
+                    if (expr.field_inits[seen].name.eq(expr.field_inits[fi].name))
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
+                }
+                u32 field_index = mod.structs[struct_index].fields.len;
+                for (u32 decl_i = 0; decl_i < mod.structs[struct_index].fields.len; decl_i++) {
+                    if (mod.structs[struct_index].fields[decl_i].name.eq(expr.field_inits[fi].name)) {
+                        field_index = decl_i;
+                        break;
+                    }
+                }
+                if (field_index == mod.structs[struct_index].fields.len)
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
+                const auto& field_decl = mod.structs[struct_index].fields[field_index];
+                if (field_decl.name.eq({"err", 3}) && field_decl.is_error_type)
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, expr.span, expr.field_inits[fi].name);
+                auto field_value =
+                    analyze_expr(*expr.field_inits[fi].value, route, mod, locals, local_count, binding);
+                if (!field_value) return core::make_unexpected(field_value.error());
+                if (field_value->may_nil || field_value->may_error)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+                const auto expected = make_expected_type_expr(field_decl.type,
+                                                              field_decl.variant_index,
+                                                              field_decl.struct_index,
+                                                              field_decl.tuple_len,
+                                                              field_decl.tuple_types,
+                                                              field_decl.tuple_variant_indices,
+                                                              field_decl.tuple_struct_indices,
+                                                              field_decl.shape_index);
+                if (!same_hir_type_shape(mod, field_value.value(), expected))
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.field_inits[fi].value->span);
+                if (!route->exprs.push(field_value.value()))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                HirExpr::FieldInit field_init{};
+                field_init.name = expr.field_inits[fi].name;
+                field_init.value = &route->exprs[route->exprs.len - 1];
+                if (!out.field_inits.push(field_init))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+            }
+        }
+        if (expr.lhs == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.lhs->kind == AstExprKind::IntLit) {
+            out.int_value = expr.lhs->int_value;
+            return out;
+        }
+        if (expr.lhs->kind == AstExprKind::VariantCase && expr.lhs->name.len == 0) {
+            out.str_value = expr.lhs->str_value;
+            if (route != nullptr && route->error_variant_index != 0xffffffffu) {
+                out.error_variant_index = route->error_variant_index;
+                const auto& variant = mod.variants[route->error_variant_index];
+                u32 case_index = variant.cases.len;
+                for (u32 i = 0; i < variant.cases.len; i++) {
+                    if (variant.cases[i].name.eq(expr.lhs->str_value)) {
+                        case_index = i;
+                        break;
+                    }
+                }
+                if (case_index == variant.cases.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.lhs->str_value);
+                out.error_case_index = case_index;
+                out.int_value = static_cast<i32>(case_index);
+            }
+            return out;
+        }
+        auto kind = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
+        if (!kind) return core::make_unexpected(kind.error());
+        if (kind->kind == HirExprKind::VariantCase && kind->lhs == nullptr) {
+            out.int_value = kind->int_value;
+            out.str_value = kind->str_value;
+            out.error_variant_index = kind->variant_index;
+            out.error_case_index = kind->case_index;
+            return out;
+        }
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+    }
+    if (expr.kind == AstExprKind::Or) {
+        auto lhs = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto rhs = analyze_expr(*expr.rhs, route, mod, locals, local_count, binding);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        if (rhs->may_nil || rhs->may_error)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.rhs->span);
+        if (lhs->type != HirTypeKind::Unknown && !same_hir_type_shape(mod, lhs.value(), rhs.value()))
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (lhs->kind == HirExprKind::Nil) {
+            HirExpr folded = rhs.value();
+            folded.span = expr.span;
+            folded.may_nil = false;
+            folded.may_error = false;
+            return folded;
+        }
+        if (lhs->kind == HirExprKind::Error) {
+            HirExpr folded = rhs.value();
+            folded.span = expr.span;
+            folded.may_nil = false;
+            folded.may_error = false;
+            return folded;
+        }
+        const auto lhs_state = known_value_state(lhs.value(), locals, local_count);
+        if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
+            HirExpr folded = rhs.value();
+            folded.span = expr.span;
+            folded.may_nil = false;
+            folded.may_error = false;
+            return folded;
+        }
+        if (lhs_state == KnownValueState::Available) {
+            HirExpr folded = lhs.value();
+            folded.span = expr.span;
+            return folded;
+        }
+        if (!route->exprs.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
+        if (!route->exprs.push(rhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
+        out.kind = HirExprKind::Or;
+        out.type = lhs->type == HirTypeKind::Unknown ? rhs->type : lhs->type;
+        out.lhs = lhs_ptr;
+        out.rhs = rhs_ptr;
+        return out;
+    }
+    if (expr.kind == AstExprKind::Pipe) {
+        if (expr.lhs == nullptr || expr.rhs == nullptr)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        auto lhs = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (expr.rhs->kind != AstExprKind::Call)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.rhs->span);
+        return analyze_call_expr(*expr.rhs, route, mod, locals, local_count, binding, &lhs.value());
+    }
+    if (expr.kind == AstExprKind::Eq || expr.kind == AstExprKind::Lt || expr.kind == AstExprKind::Gt) {
+        auto lhs = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto rhs = analyze_expr(*expr.rhs, route, mod, locals, local_count, binding);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        if (lhs->may_nil || lhs->may_error || rhs->may_nil || rhs->may_error)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (lhs->type != rhs->type) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.kind == AstExprKind::Eq) {
+            if (lhs->type == HirTypeKind::Generic && !lhs->generic_has_eq_constraint)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        } else {
+            if (lhs->type == HirTypeKind::Generic) {
+                if (!lhs->generic_has_ord_constraint)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            } else {
+                bool struct_visiting[HirModule::kMaxStructs]{};
+                bool variant_visiting[HirModule::kMaxVariants]{};
+                if (!hir_type_shape_satisfies_ord_constraint(mod,
+                                                             lhs->type,
+                                                             lhs->variant_index,
+                                                             lhs->struct_index,
+                                                             lhs->tuple_len,
+                                                             lhs->tuple_types,
+                                                             lhs->tuple_variant_indices,
+                                                             lhs->tuple_struct_indices,
+                                                             struct_visiting,
+                                                             variant_visiting)) {
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+                }
+            }
+        }
+        if (!route->exprs.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
+        if (!route->exprs.push(rhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
+        out.kind = expr.kind == AstExprKind::Eq ? HirExprKind::Eq : (expr.kind == AstExprKind::Lt ? HirExprKind::Lt : HirExprKind::Gt);
+        out.type = HirTypeKind::Bool;
+        out.lhs = lhs_ptr;
+        out.rhs = rhs_ptr;
+        return out;
+    }
+    for (u32 i = 0; i < local_count; i++) {
+        if (locals[i].name.eq(expr.name)) {
+            if (locals[i].type == HirTypeKind::Tuple) {
+                HirExpr tuple = locals[i].init;
+                tuple.span = expr.span;
+                return tuple;
+            }
+            out.kind = HirExprKind::LocalRef;
+            out.type = locals[i].type;
+            out.generic_index = locals[i].generic_index;
+            out.generic_has_error_constraint = locals[i].generic_has_error_constraint;
+            out.generic_has_eq_constraint = locals[i].generic_has_eq_constraint;
+            out.generic_has_ord_constraint = locals[i].generic_has_ord_constraint;
+            out.generic_protocol_index = locals[i].generic_protocol_index;
+            out.generic_protocol_count = locals[i].generic_protocol_count;
+            for (u32 cpi = 0; cpi < out.generic_protocol_count; cpi++)
+                out.generic_protocol_indices[cpi] = locals[i].generic_protocol_indices[cpi];
+            out.may_nil = locals[i].may_nil;
+            out.may_error = locals[i].may_error;
+            out.local_index = locals[i].ref_index;
+            out.variant_index = locals[i].variant_index;
+            out.error_struct_index = locals[i].error_struct_index;
+            out.struct_index = locals[i].struct_index;
+            out.error_variant_index = locals[i].error_variant_index;
+            out.shape_index = locals[i].shape_index;
+            out.tuple_len = locals[i].tuple_len;
+            for (u32 ti = 0; ti < locals[i].tuple_len; ti++) {
+                out.tuple_types[ti] = locals[i].tuple_types[ti];
+                out.tuple_variant_indices[ti] = locals[i].tuple_variant_indices[ti];
+                out.tuple_struct_indices[ti] = locals[i].tuple_struct_indices[ti];
+            }
+            return out;
+        }
+    }
+    if (binding && binding->subject && expr.name.eq(binding->name)) {
+        out.kind = HirExprKind::MatchPayload;
+        out.type = binding->type;
+        out.variant_index = binding->variant_index;
+        out.struct_index = binding->struct_index;
+        out.shape_index = binding->shape_index;
+        out.case_index = binding->case_index;
+        out.tuple_len = binding->tuple_len;
+        for (u32 ti = 0; ti < binding->tuple_len; ti++) {
+            out.tuple_types[ti] = binding->tuple_types[ti];
+            out.tuple_variant_indices[ti] = binding->tuple_variant_indices[ti];
+            out.tuple_struct_indices[ti] = binding->tuple_struct_indices[ti];
+        }
+        if (!route->exprs.push(*binding->subject))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.lhs = &route->exprs[route->exprs.len - 1];
+        return out;
+    }
+    return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+}
+
+static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
+                                                 HirRoute* route,
+                                                 const HirModule& mod,
+                                                 const HirLocal* locals,
+                                                 u32 local_count,
+                                                 const MatchPayloadBinding* binding,
+                                                 const HirExpr* pipe_lhs) {
+    const Str callee_name = resolve_alias_target_leaf(mod, expr.name);
+    const u32 fn_index = find_function_index(mod, callee_name);
+    if (fn_index == mod.functions.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+    const auto& fn = mod.functions[fn_index];
+    if (expr.args.len != fn.params.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+    if (expr.type_args.len != 0 && expr.type_args.len != fn.type_params.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+    GenericBinding generic_bindings[HirFunction::kMaxTypeParams]{};
+    for (u32 i = 0; i < expr.type_args.len; i++) {
+        u32 variant_index = 0xffffffffu;
+        u32 struct_index = 0xffffffffu;
+        u32 tuple_len = 0;
+        HirTypeKind tuple_types[kMaxTupleSlots]{};
+        u32 tuple_variant_indices[kMaxTupleSlots]{};
+        u32 tuple_struct_indices[kMaxTupleSlots]{};
+        auto type_arg = resolve_func_type_ref(mod,
+                                              expr.type_args[i],
+                                              nullptr,
+                                              nullptr,
+                                              &variant_index,
+                                              &struct_index,
+                                              &tuple_len,
+                                              tuple_types,
+                                              tuple_variant_indices,
+                                              tuple_struct_indices,
+                                              expr.span);
+        if (!type_arg) return core::make_unexpected(type_arg.error());
+        auto filled = fill_bound_binding_from_type_metadata(&generic_bindings[i],
+                                                            const_cast<HirModule*>(&mod),
+                                                            type_arg.value(),
+                                                            0xffffffffu,
+                                                            variant_index,
+                                                            struct_index,
+                                                            tuple_len,
+                                                            tuple_types,
+                                                            tuple_variant_indices,
+                                                            tuple_struct_indices,
+                                                            0xffffffffu,
+                                                            expr.span);
+        if (!filled) return core::make_unexpected(filled.error());
+        if (fn.type_params[i].has_error_constraint &&
+            !generic_binding_satisfies_error_constraint(mod, generic_bindings[i]))
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        if (fn.type_params[i].has_eq_constraint &&
+            !generic_binding_satisfies_eq_constraint(mod, generic_bindings[i]))
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        if (fn.type_params[i].has_ord_constraint &&
+            !generic_binding_satisfies_ord_constraint(mod, generic_bindings[i]))
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+    }
+    auto concrete_return_expr = [&]() -> FrontendResult<HirExpr> {
+        HirExpr expected{};
+        expected.type = fn.return_type;
+        expected.generic_index = fn.return_generic_index;
+        expected.shape_index = fn.return_shape_index;
+        if (fn.return_generic_index < fn.type_params.len)
+            expected.generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
+        if (fn.return_generic_index < fn.type_params.len) {
+            expected.generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
+            expected.generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+            expected.generic_protocol_index =
+                fn.type_params[fn.return_generic_index].custom_protocol_count != 0
+                    ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
+                    : 0xffffffffu;
+            expected.generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+            for (u32 cpi = 0; cpi < expected.generic_protocol_count; cpi++)
+                expected.generic_protocol_indices[cpi] =
+                    fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
+        }
+        expected.variant_index = fn.return_variant_index;
+        expected.struct_index = fn.return_struct_index;
+        expected.tuple_len = fn.return_tuple_len;
+        for (u32 i = 0; i < fn.return_tuple_len; i++) {
+            expected.tuple_types[i] = fn.return_tuple_types[i];
+            expected.tuple_variant_indices[i] = fn.return_tuple_variant_indices[i];
+            expected.tuple_struct_indices[i] = fn.return_tuple_struct_indices[i];
+        }
+        auto out = apply_generic_binding_to_expr(expected, generic_bindings, fn.type_params.len);
+        auto concretized = concretize_named_instance_shape(&out, mod, generic_bindings, fn.type_params.len);
+        if (!concretized) return core::make_unexpected(concretized.error());
+        return out;
+    };
+    auto placeholder_slot_expr = [&](const HirExpr& source, i32 slot, Span span) -> FrontendResult<HirExpr> {
+        if (slot <= 0 || slot > static_cast<i32>(kMaxTupleSlots))
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
+        if (source.type != HirTypeKind::Tuple) {
+            if (slot != 1) return frontend_error(FrontendError::UnsupportedSyntax, span);
+            return source;
+        }
+        if (slot > static_cast<i32>(source.tuple_len))
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
+        const u32 slot_index = static_cast<u32>(slot - 1);
+        if (source.args.len == source.tuple_len && source.args[slot_index] != nullptr)
+            return *source.args[slot_index];
+        HirExpr out{};
+        out.kind = HirExprKind::TupleSlot;
+        out.type = source.tuple_types[slot_index];
+        if (out.type == HirTypeKind::Struct) out.struct_index = source.tuple_struct_indices[slot_index];
+        else out.variant_index = source.tuple_variant_indices[slot_index];
+        if (out.type != HirTypeKind::Tuple) {
+            auto shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                               out.type,
+                                               out.generic_index,
+                                               out.variant_index,
+                                               out.struct_index,
+                                               out.tuple_len,
+                                               out.tuple_types,
+                                               out.tuple_variant_indices,
+                                               out.tuple_struct_indices,
+                                               span);
+            if (!shape) return core::make_unexpected(shape.error());
+            out.shape_index = shape.value();
+        }
+        out.span = span;
+        out.int_value = static_cast<i32>(slot_index);
+        out.lhs = const_cast<HirExpr*>(&source);
+        return out;
+    };
+    auto concrete_param_expr = [&](const HirFunction::ParamDecl& param) -> FrontendResult<HirExpr> {
+        auto expected = make_expected_param_expr(param);
+        auto concretized = concretize_named_instance_shape(&expected, mod, generic_bindings, fn.type_params.len);
+        if (!concretized) return core::make_unexpected(concretized.error());
+        return expected;
+    };
+    if (pipe_lhs != nullptr) {
+        const auto lhs_state = known_value_state(*pipe_lhs, locals, local_count);
+        if (lhs_state == KnownValueState::Nil) {
+            HirExpr folded{};
+            folded.kind = HirExprKind::Nil;
+            auto ret = concrete_return_expr();
+            if (!ret) return core::make_unexpected(ret.error());
+            folded.type = ret->type;
+            folded.generic_index = ret->generic_index;
+            folded.generic_has_error_constraint = ret->generic_has_error_constraint;
+            folded.generic_has_eq_constraint = ret->generic_has_eq_constraint;
+            folded.generic_has_ord_constraint = ret->generic_has_ord_constraint;
+            folded.generic_protocol_index = ret->generic_protocol_index;
+            folded.generic_protocol_count = ret->generic_protocol_count;
+            for (u32 cpi = 0; cpi < folded.generic_protocol_count; cpi++)
+                folded.generic_protocol_indices[cpi] = ret->generic_protocol_indices[cpi];
+            folded.variant_index = ret->variant_index;
+            folded.struct_index = ret->struct_index;
+            folded.shape_index = ret->shape_index;
+            folded.tuple_len = ret->tuple_len;
+            for (u32 i = 0; i < ret->tuple_len; i++) {
+                folded.tuple_types[i] = ret->tuple_types[i];
+                folded.tuple_variant_indices[i] = ret->tuple_variant_indices[i];
+                folded.tuple_struct_indices[i] = ret->tuple_struct_indices[i];
+            }
+            folded.span = expr.span;
+            folded.may_nil = true;
+            return folded;
+        }
+        if (lhs_state == KnownValueState::Error) {
+            const HirExpr* err_expr = known_error_expr(*pipe_lhs, locals, local_count);
+            if (!err_expr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            HirExpr folded = *err_expr;
+            auto ret = concrete_return_expr();
+            if (!ret) return core::make_unexpected(ret.error());
+            folded.type = ret->type;
+            folded.generic_index = ret->generic_index;
+            folded.generic_has_error_constraint = ret->generic_has_error_constraint;
+            folded.generic_has_eq_constraint = ret->generic_has_eq_constraint;
+            folded.generic_has_ord_constraint = ret->generic_has_ord_constraint;
+            folded.generic_protocol_index = ret->generic_protocol_index;
+            folded.generic_protocol_count = ret->generic_protocol_count;
+            for (u32 cpi = 0; cpi < folded.generic_protocol_count; cpi++)
+                folded.generic_protocol_indices[cpi] = ret->generic_protocol_indices[cpi];
+            folded.variant_index = ret->variant_index;
+            folded.struct_index = ret->struct_index;
+            folded.shape_index = ret->shape_index;
+            folded.tuple_len = ret->tuple_len;
+            for (u32 i = 0; i < ret->tuple_len; i++) {
+                folded.tuple_types[i] = ret->tuple_types[i];
+                folded.tuple_variant_indices[i] = ret->tuple_variant_indices[i];
+                folded.tuple_struct_indices[i] = ret->tuple_struct_indices[i];
+            }
+            folded.span = expr.span;
+            folded.may_nil = false;
+            folded.may_error = true;
+            return folded;
+        }
+        if (lhs_state == KnownValueState::Unknown && (pipe_lhs->may_nil || pipe_lhs->may_error)) {
+            u32 placeholder_count = 0;
+            for (u32 i = 0; i < expr.args.len; i++) {
+                const auto& arg_expr = *expr.args[i];
+                if (arg_expr.kind == AstExprKind::Placeholder) {
+                    placeholder_count++;
+                    if (arg_expr.int_value != 1)
+                        return frontend_error(FrontendError::UnsupportedSyntax, arg_expr.span);
+                }
+            }
+            if (!route->exprs.push(*pipe_lhs))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
+
+            HirExpr unwrapped{};
+            unwrapped.kind = HirExprKind::ValueOf;
+            unwrapped.type = pipe_lhs->type;
+            unwrapped.generic_index = pipe_lhs->generic_index;
+            unwrapped.generic_has_error_constraint = pipe_lhs->generic_has_error_constraint;
+            unwrapped.generic_has_eq_constraint = pipe_lhs->generic_has_eq_constraint;
+            unwrapped.generic_has_ord_constraint = pipe_lhs->generic_has_ord_constraint;
+            unwrapped.generic_protocol_index = pipe_lhs->generic_protocol_index;
+            unwrapped.generic_protocol_count = pipe_lhs->generic_protocol_count;
+            for (u32 cpi = 0; cpi < unwrapped.generic_protocol_count; cpi++)
+                unwrapped.generic_protocol_indices[cpi] = pipe_lhs->generic_protocol_indices[cpi];
+            unwrapped.variant_index = pipe_lhs->variant_index;
+            unwrapped.struct_index = pipe_lhs->struct_index;
+            unwrapped.tuple_len = pipe_lhs->tuple_len;
+            for (u32 i = 0; i < pipe_lhs->tuple_len; i++) {
+                unwrapped.tuple_types[i] = pipe_lhs->tuple_types[i];
+                unwrapped.tuple_variant_indices[i] = pipe_lhs->tuple_variant_indices[i];
+                unwrapped.tuple_struct_indices[i] = pipe_lhs->tuple_struct_indices[i];
+            }
+            unwrapped.shape_index = pipe_lhs->shape_index;
+            unwrapped.error_struct_index = pipe_lhs->error_struct_index;
+            unwrapped.error_variant_index = pipe_lhs->error_variant_index;
+            unwrapped.span = expr.span;
+            unwrapped.lhs = lhs_ptr;
+
+            HirExpr analyzed_args[AstExpr::kMaxArgs]{};
+            for (u32 i = 0; i < expr.args.len; i++) {
+                const auto& arg_expr = *expr.args[i];
+                if (arg_expr.kind == AstExprKind::Placeholder) {
+                    analyzed_args[i] = unwrapped;
+                } else {
+                    auto arg = analyze_expr(arg_expr, route, mod, locals, local_count, binding);
+                    if (!arg) return core::make_unexpected(arg.error());
+                    if (arg->may_nil || arg->may_error)
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+                    analyzed_args[i] = arg.value();
+                }
+                if (fn.params[i].type == HirTypeKind::Generic) {
+                    if (!bind_generic_shape(generic_bindings,
+                                            fn.type_params.len,
+                                            fn.params[i].generic_index,
+                                            analyzed_args[i]))
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+                    if (fn.type_params[fn.params[i].generic_index].has_error_constraint &&
+                        !generic_binding_satisfies_error_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+                    if (fn.type_params[fn.params[i].generic_index].has_eq_constraint &&
+                        !generic_binding_satisfies_eq_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+                    if (fn.type_params[fn.params[i].generic_index].has_ord_constraint &&
+                        !generic_binding_satisfies_ord_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+                    if (fn.type_params[fn.params[i].generic_index].has_constraint &&
+                        fn.type_params[fn.params[i].generic_index].constraint_kind == HirProtocolKind::Custom &&
+                        !generic_binding_satisfies_custom_protocol(mod,
+                                                                   generic_bindings[fn.params[i].generic_index],
+                                                                   find_protocol_index(mod, fn.type_params[fn.params[i].generic_index].constraint)))
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              expr.args[i]->span,
+                                              fn.type_params[fn.params[i].generic_index].constraint);
+                } else if (fn.params[i].template_variant_index != 0xffffffffu ||
+                           fn.params[i].template_struct_index != 0xffffffffu) {
+                    const auto expected_shape = make_expected_param_expr(fn.params[i]);
+                    if (!bind_named_generic_shape(
+                            mod, generic_bindings, fn.type_params.len, expected_shape, analyzed_args[i]))
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+                    auto expected = concrete_param_expr(fn.params[i]);
+                    if (!expected) return core::make_unexpected(expected.error());
+                    if (!same_hir_type_shape(mod, analyzed_args[i], expected.value()))
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+                } else {
+                    auto expected = concrete_param_expr(fn.params[i]);
+                    if (!expected) return core::make_unexpected(expected.error());
+                    if (!same_hir_type_shape(mod, analyzed_args[i], expected.value()))
+                        return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+                }
+            }
+            if (placeholder_count != 1)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+
+            auto ret = concrete_return_expr();
+            if (!ret) return core::make_unexpected(ret.error());
+            if (ret->type != HirTypeKind::I32 && ret->type != HirTypeKind::Str && ret->type != HirTypeKind::Variant)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+
+            auto then_expr = instantiate_function_expr(
+                fn.body, route, mod, analyzed_args, expr.args.len, generic_bindings, fn.type_params.len);
+            if (!then_expr) return core::make_unexpected(then_expr.error());
+            if (pipe_lhs->may_error && then_expr->may_error &&
+                (pipe_lhs->error_struct_index != then_expr->error_struct_index ||
+                 pipe_lhs->error_variant_index != then_expr->error_variant_index))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            if (!route->exprs.push(then_expr.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* then_ptr = &route->exprs[route->exprs.len - 1];
+
+            HirExpr cond{};
+            cond.kind = HirExprKind::HasValue;
+            cond.type = HirTypeKind::Bool;
+            cond.span = expr.span;
+            cond.lhs = lhs_ptr;
+            if (!route->exprs.push(cond))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* cond_ptr = &route->exprs[route->exprs.len - 1];
+
+            HirExpr missing{};
+            missing.kind = HirExprKind::MissingOf;
+            missing.type = ret->type;
+            missing.generic_index = ret->generic_index;
+            missing.generic_has_error_constraint = ret->generic_has_error_constraint;
+            missing.generic_has_eq_constraint = ret->generic_has_eq_constraint;
+            missing.generic_has_ord_constraint = ret->generic_has_ord_constraint;
+            missing.generic_protocol_index = ret->generic_protocol_index;
+            missing.generic_protocol_count = ret->generic_protocol_count;
+            for (u32 cpi = 0; cpi < missing.generic_protocol_count; cpi++)
+                missing.generic_protocol_indices[cpi] = ret->generic_protocol_indices[cpi];
+            missing.variant_index = ret->variant_index;
+            missing.struct_index = ret->struct_index;
+            missing.tuple_len = ret->tuple_len;
+            for (u32 i = 0; i < ret->tuple_len; i++) {
+                missing.tuple_types[i] = ret->tuple_types[i];
+                missing.tuple_variant_indices[i] = ret->tuple_variant_indices[i];
+                missing.tuple_struct_indices[i] = ret->tuple_struct_indices[i];
+            }
+            missing.span = expr.span;
+            missing.shape_index = ret->shape_index;
+            missing.may_nil = pipe_lhs->may_nil || then_expr->may_nil;
+            missing.may_error = pipe_lhs->may_error || then_expr->may_error;
+            missing.error_struct_index = then_expr->may_error ? then_expr->error_struct_index
+                                                              : pipe_lhs->error_struct_index;
+            missing.error_variant_index = then_expr->may_error ? then_expr->error_variant_index
+                                                               : pipe_lhs->error_variant_index;
+            missing.lhs = lhs_ptr;
+            if (!route->exprs.push(missing))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* else_ptr = &route->exprs[route->exprs.len - 1];
+
+            HirExpr out{};
+            out.kind = HirExprKind::IfElse;
+            out.type = ret->type;
+            out.generic_index = ret->generic_index;
+            out.generic_has_error_constraint = ret->generic_has_error_constraint;
+            out.generic_has_eq_constraint = ret->generic_has_eq_constraint;
+            out.generic_has_ord_constraint = ret->generic_has_ord_constraint;
+            out.generic_protocol_index = ret->generic_protocol_index;
+            out.generic_protocol_count = ret->generic_protocol_count;
+            for (u32 cpi = 0; cpi < out.generic_protocol_count; cpi++)
+                out.generic_protocol_indices[cpi] = ret->generic_protocol_indices[cpi];
+            out.variant_index = ret->variant_index;
+            out.struct_index = ret->struct_index;
+            out.tuple_len = ret->tuple_len;
+            for (u32 i = 0; i < ret->tuple_len; i++) {
+                out.tuple_types[i] = ret->tuple_types[i];
+                out.tuple_variant_indices[i] = ret->tuple_variant_indices[i];
+                out.tuple_struct_indices[i] = ret->tuple_struct_indices[i];
+            }
+            out.span = expr.span;
+            out.shape_index = ret->shape_index;
+            out.may_nil = pipe_lhs->may_nil || then_expr->may_nil;
+            out.may_error = pipe_lhs->may_error || then_expr->may_error;
+            out.error_struct_index = then_expr->may_error ? then_expr->error_struct_index
+                                                          : pipe_lhs->error_struct_index;
+            out.error_variant_index = then_expr->may_error ? then_expr->error_variant_index
+                                                           : pipe_lhs->error_variant_index;
+            out.lhs = cond_ptr;
+            out.rhs = then_ptr;
+            if (!out.args.push(else_ptr))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            return out;
+        }
+    }
+    HirExpr analyzed_args[AstExpr::kMaxArgs]{};
+    u32 placeholder_count = 0;
+    for (u32 i = 0; i < expr.args.len; i++) {
+        const auto& arg_expr = *expr.args[i];
+        if (arg_expr.kind == AstExprKind::Placeholder) {
+            if (pipe_lhs == nullptr)
+                return frontend_error(FrontendError::UnsupportedSyntax, arg_expr.span);
+            placeholder_count++;
+            auto slot_expr = placeholder_slot_expr(*pipe_lhs, arg_expr.int_value, arg_expr.span);
+            if (!slot_expr) return core::make_unexpected(slot_expr.error());
+            analyzed_args[i] = slot_expr.value();
+        } else {
+            auto arg = analyze_expr(arg_expr, route, mod, locals, local_count, binding);
+            if (!arg) return core::make_unexpected(arg.error());
+            if (arg->may_nil || arg->may_error)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+            analyzed_args[i] = arg.value();
+        }
+        if (fn.params[i].type == HirTypeKind::Generic) {
+            if (!bind_generic_shape(generic_bindings, fn.type_params.len, fn.params[i].generic_index, analyzed_args[i]))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+            if (fn.type_params[fn.params[i].generic_index].has_error_constraint &&
+                !generic_binding_satisfies_error_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+            if (fn.type_params[fn.params[i].generic_index].has_eq_constraint &&
+                !generic_binding_satisfies_eq_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+            if (fn.type_params[fn.params[i].generic_index].has_ord_constraint &&
+                !generic_binding_satisfies_ord_constraint(mod, generic_bindings[fn.params[i].generic_index]))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+            for (u32 cpi = 0; cpi < fn.type_params[fn.params[i].generic_index].custom_protocol_count; cpi++) {
+                const u32 proto_index = fn.type_params[fn.params[i].generic_index].custom_protocol_indices[cpi];
+                if (!generic_binding_satisfies_custom_protocol(mod,
+                                                               generic_bindings[fn.params[i].generic_index],
+                                                               proto_index))
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          expr.args[i]->span,
+                                          mod.protocols[proto_index].name);
+            }
+        } else if (fn.params[i].template_variant_index != 0xffffffffu ||
+                   fn.params[i].template_struct_index != 0xffffffffu) {
+            const auto expected_shape = make_expected_param_expr(fn.params[i]);
+            if (!bind_named_generic_shape(mod, generic_bindings, fn.type_params.len, expected_shape, analyzed_args[i]))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+            auto expected = concrete_param_expr(fn.params[i]);
+            if (!expected) return core::make_unexpected(expected.error());
+            if (!same_hir_type_shape(mod, analyzed_args[i], expected.value()))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+        } else {
+            auto expected = concrete_param_expr(fn.params[i]);
+            if (!expected) return core::make_unexpected(expected.error());
+            if (!same_hir_type_shape(mod, analyzed_args[i], expected.value()))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+        }
+    }
+    if (pipe_lhs != nullptr && placeholder_count == 0)
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+    auto inlined =
+        instantiate_function_expr(fn.body, route, mod, analyzed_args, expr.args.len, generic_bindings, fn.type_params.len);
+    if (!inlined) return core::make_unexpected(inlined.error());
+    inlined->span = expr.span;
+    return inlined.value();
+}
+
+static bool push_named_error_case(FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases, Str name) {
+    for (u32 i = 0; i < cases->len; i++) {
+        if ((*cases)[i].name.eq(name)) return true;
+    }
+    RouteNamedErrorCase entry{};
+    entry.name = name;
+    return cases->push(entry);
+}
+
+static FrontendResult<void> collect_named_error_cases_ast_expr(
+    const AstExpr& expr,
+    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases) {
+    if (expr.kind == AstExprKind::Error && expr.lhs != nullptr && expr.lhs->kind == AstExprKind::VariantCase &&
+        expr.lhs->name.len == 0 && expr.lhs->str_value.len != 0) {
+        if (!push_named_error_case(cases, expr.lhs->str_value))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+    }
+    if (expr.lhs != nullptr) {
+        auto lhs = collect_named_error_cases_ast_expr(*expr.lhs, cases);
+        if (!lhs) return lhs;
+    }
+    if (expr.rhs != nullptr) {
+        auto rhs = collect_named_error_cases_ast_expr(*expr.rhs, cases);
+        if (!rhs) return rhs;
+    }
+    for (u32 i = 0; i < expr.field_inits.len; i++) {
+        auto value = collect_named_error_cases_ast_expr(*expr.field_inits[i].value, cases);
+        if (!value) return value;
+    }
+    for (u32 i = 0; i < expr.args.len; i++) {
+        auto arg = collect_named_error_cases_ast_expr(*expr.args[i], cases);
+        if (!arg) return arg;
+    }
+    return {};
+}
+
+static FrontendResult<void> collect_named_error_cases_ast(
+    const AstStatement& stmt,
+    FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases) {
+    auto expr_cases = collect_named_error_cases_ast_expr(stmt.expr, cases);
+    if (!expr_cases) return expr_cases;
+    if (stmt.then_stmt != nullptr) {
+        auto then_cases = collect_named_error_cases_ast(*stmt.then_stmt, cases);
+        if (!then_cases) return then_cases;
+    }
+    if (stmt.else_stmt != nullptr) {
+        auto else_cases = collect_named_error_cases_ast(*stmt.else_stmt, cases);
+        if (!else_cases) return else_cases;
+    }
+    for (u32 i = 0; i < stmt.block_stmts.len; i++) {
+        auto block_cases = collect_named_error_cases_ast(*stmt.block_stmts[i], cases);
+        if (!block_cases) return block_cases;
+    }
+    for (u32 i = 0; i < stmt.match_arms.len; i++) {
+        auto pattern_cases = collect_named_error_cases_ast_expr(stmt.match_arms[i].pattern, cases);
+        if (!pattern_cases) return pattern_cases;
+        if (stmt.match_arms[i].stmt != nullptr) {
+            auto body_cases = collect_named_error_cases_ast(*stmt.match_arms[i].stmt, cases);
+            if (!body_cases) return body_cases;
+        }
+    }
+    return {};
+}
+
+static FrontendResult<void> collect_named_error_cases(const HirExpr& expr,
+                                                      FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>* cases) {
+    if (expr.kind == HirExprKind::Error && expr.error_variant_index == 0xffffffffu && expr.str_value.len != 0) {
+        if (!push_named_error_case(cases, expr.str_value))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+    }
+    if (expr.lhs != nullptr) {
+        auto lhs = collect_named_error_cases(*expr.lhs, cases);
+        if (!lhs) return lhs;
+    }
+    if (expr.rhs != nullptr) {
+        auto rhs = collect_named_error_cases(*expr.rhs, cases);
+        if (!rhs) return rhs;
+    }
+    return {};
+}
+
+static void patch_named_error_variant(HirExpr* expr,
+                                      u32 variant_index,
+                                      const FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases>& cases) {
+    if (expr->kind == HirExprKind::VariantCase && expr->variant_index == 0xffffffffu &&
+        expr->str_value.len != 0) {
+        expr->variant_index = variant_index;
+        for (u32 i = 0; i < cases.len; i++) {
+            if (cases[i].name.eq(expr->str_value)) {
+                expr->case_index = i;
+                expr->int_value = static_cast<i32>(i);
+                break;
+            }
+        }
+    }
+    if (expr->kind == HirExprKind::Error && expr->error_variant_index == 0xffffffffu && expr->str_value.len != 0) {
+        expr->error_variant_index = variant_index;
+        for (u32 i = 0; i < cases.len; i++) {
+            if (cases[i].name.eq(expr->str_value)) {
+                expr->error_case_index = i;
+                expr->int_value = static_cast<i32>(i);
+                break;
+            }
+        }
+    }
+    if (expr->lhs != nullptr) patch_named_error_variant(expr->lhs, variant_index, cases);
+    if (expr->rhs != nullptr) patch_named_error_variant(expr->rhs, variant_index, cases);
+}
+
+static void patch_error_variant_refs(HirExpr* expr, u32 variant_index) {
+    if (expr->may_error && expr->error_variant_index == 0xffffffffu && expr->type != HirTypeKind::Variant)
+        expr->error_variant_index = variant_index;
+    if (expr->lhs != nullptr) patch_error_variant_refs(expr->lhs, variant_index);
+    if (expr->rhs != nullptr) patch_error_variant_refs(expr->rhs, variant_index);
+}
+
+static FrontendResult<HirTerminator> analyze_term(const AstStatement& stmt,
+                                                  const HirModule& mod) {
+    HirTerminator term{};
+    term.span = stmt.span;
+    if (stmt.kind == AstStmtKind::ReturnStatus) {
+        if (stmt.status_code < 100 || stmt.status_code > 999)
+            return frontend_error(FrontendError::InvalidStatusCode, stmt.span);
+        term.kind = HirTerminatorKind::ReturnStatus;
+        term.status_code = stmt.status_code;
+        return term;
+    }
+
+    u32 upstream_index = mod.upstreams.len;
+    for (u32 j = 0; j < mod.upstreams.len; j++) {
+        if (mod.upstreams[j].name.eq(stmt.name)) {
+            upstream_index = j;
+            break;
+        }
+    }
+    if (upstream_index == mod.upstreams.len)
+        return frontend_error(FrontendError::UnknownUpstream, stmt.span, stmt.name);
+    term.kind = HirTerminatorKind::ForwardUpstream;
+    term.upstream_index = upstream_index;
+    return term;
+}
+
+static FrontendResult<void> analyze_guard_match_arms(
+    const FixedVec<AstStatement::MatchArm, AstStatement::kMaxMatchArms>& ast_arms,
+    const HirExpr& subject,
+    HirRoute* route,
+    const HirModule& mod,
+    const HirLocal* locals,
+    u32 local_count,
+    FixedVec<HirGuardMatchArm, HirModule::kMaxGuardMatchArms>* guard_match_arms,
+    HirGuard* guard) {
+    bool seen_wildcard = false;
+    guard->fail_match_start = guard_match_arms->len;
+    guard->fail_match_count = 0;
+    for (u32 ai = 0; ai < ast_arms.len; ai++) {
+        const auto& arm = ast_arms[ai];
+        HirGuardMatchArm hir_arm{};
+        hir_arm.span = arm.span;
+        hir_arm.is_wildcard = arm.is_wildcard;
+        if (seen_wildcard) return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+        if (!arm.is_wildcard) {
+            HirExpr pattern{};
+            if (subject.may_error && subject.error_variant_index == 0xffffffffu &&
+                arm.pattern.kind == AstExprKind::VariantCase && arm.pattern.name.len == 0) {
+                pattern.kind = HirExprKind::VariantCase;
+                pattern.type = HirTypeKind::Variant;
+                pattern.span = arm.pattern.span;
+                pattern.variant_index = 0xffffffffu;
+                pattern.case_index = 0xffffffffu;
+                pattern.int_value = -1;
+                pattern.str_value = arm.pattern.str_value;
+            } else {
+                auto analyzed_pattern =
+                    analyze_match_pattern(arm.pattern, subject, route, mod, locals, local_count);
+                if (!analyzed_pattern) return core::make_unexpected(analyzed_pattern.error());
+                pattern = analyzed_pattern.value();
+                if (pattern.kind != HirExprKind::VariantCase)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (!(subject.may_error && subject.error_variant_index != 0xffffffffu) ||
+                    pattern.variant_index != subject.error_variant_index)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            }
+            const u32 case_index = static_cast<u32>(pattern.int_value);
+            if (pattern.variant_index != 0xffffffffu && case_index >= HirVariant::kMaxCases)
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            bool duplicate = false;
+            for (u32 i = 0; i < guard->fail_match_count; i++) {
+                const auto& seen = (*guard_match_arms)[guard->fail_match_start + i];
+                if (!seen.is_wildcard &&
+                    ((pattern.variant_index == 0xffffffffu && seen.pattern.str_value.eq(pattern.str_value)) ||
+                     (pattern.variant_index != 0xffffffffu &&
+                      static_cast<u32>(seen.pattern.int_value) == case_index))) {
+                    duplicate = true;
+                    break;
+                }
+            }
+            if (duplicate)
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            hir_arm.pattern = pattern;
+        } else {
+            seen_wildcard = true;
+        }
+        auto term = analyze_term(*arm.stmt, mod);
+        if (!term) return core::make_unexpected(term.error());
+        hir_arm.direct_term = term.value();
+        if (!guard_match_arms->push(hir_arm))
+            return frontend_error(FrontendError::TooManyItems, arm.span);
+        guard->fail_match_count++;
+    }
+    if (!seen_wildcard) return frontend_error(FrontendError::UnsupportedSyntax, subject.span);
+    return {};
+}
+
+static KnownValueState known_value_state(const HirExpr& expr,
+                                         const HirLocal* locals,
+                                         u32 local_count,
+                                         u32 depth) {
+    if (depth > local_count) return KnownValueState::Unknown;
+    if (expr.kind == HirExprKind::Nil) return KnownValueState::Nil;
+    if (expr.kind == HirExprKind::Error) return KnownValueState::Error;
+    if (!expr.may_nil && !expr.may_error) return KnownValueState::Available;
+    if (expr.kind == HirExprKind::LocalRef && expr.local_index < local_count) {
+        return known_value_state(locals[expr.local_index].init, locals, local_count, depth + 1);
+    }
+    return KnownValueState::Unknown;
+}
+
+static KnownErrorCase known_error_case(const HirExpr& expr,
+                                       const HirLocal* locals,
+                                       u32 local_count,
+                                       u32 depth) {
+    if (depth > local_count) return {};
+    if (expr.kind == HirExprKind::Error && expr.error_variant_index != 0xffffffffu &&
+        expr.error_case_index != 0xffffffffu) {
+        KnownErrorCase out{};
+        out.known = true;
+        out.variant_index = expr.error_variant_index;
+        out.case_index = expr.error_case_index;
+        return out;
+    }
+    if (expr.kind == HirExprKind::LocalRef && expr.local_index < local_count) {
+        return known_error_case(locals[expr.local_index].init, locals, local_count, depth + 1);
+    }
+    return {};
+}
+
+static Str known_error_name(const HirExpr& expr,
+                            const HirLocal* locals,
+                            u32 local_count,
+                            u32 depth) {
+    if (depth > local_count) return {};
+    if (expr.kind == HirExprKind::Error && expr.str_value.len != 0) return expr.str_value;
+    if (expr.kind == HirExprKind::LocalRef && expr.local_index < local_count) {
+        return known_error_name(locals[expr.local_index].init, locals, local_count, depth + 1);
+    }
+    return {};
+}
+
+static const HirExpr* known_error_expr(const HirExpr& expr,
+                                       const HirLocal* locals,
+                                       u32 local_count,
+                                       u32 depth) {
+    if (depth > local_count) return nullptr;
+    if (expr.kind == HirExprKind::Error) return &expr;
+    if (expr.kind == HirExprKind::LocalRef && expr.local_index < local_count) {
+        return known_error_expr(locals[expr.local_index].init, locals, local_count, depth + 1);
+    }
+    return nullptr;
+}
+
+static bool const_eval_expr(const HirExpr& expr,
+                            const HirLocal* locals,
+                            u32 local_count,
+                            ConstValue* out,
+                            u32 depth) {
+    if (depth > local_count) return false;
+    if (expr.kind == HirExprKind::BoolLit) {
+        out->type = HirTypeKind::Bool;
+        out->bool_value = expr.bool_value;
+        return true;
+    }
+    if (expr.kind == HirExprKind::IntLit) {
+        out->type = HirTypeKind::I32;
+        out->int_value = expr.int_value;
+        return true;
+    }
+    if (expr.kind == HirExprKind::VariantCase) {
+        out->type = HirTypeKind::Variant;
+        out->variant_index = expr.variant_index;
+        out->case_index = expr.case_index;
+        return true;
+    }
+    if (expr.kind == HirExprKind::LocalRef && expr.local_index < local_count) {
+        return const_eval_expr(locals[expr.local_index].init, locals, local_count, out, depth + 1);
+    }
+    if ((expr.kind == HirExprKind::Eq || expr.kind == HirExprKind::Lt || expr.kind == HirExprKind::Gt) &&
+        expr.lhs != nullptr && expr.rhs != nullptr) {
+        ConstValue lhs{};
+        ConstValue rhs{};
+        if (!const_eval_expr(*expr.lhs, locals, local_count, &lhs, depth + 1)) return false;
+        if (!const_eval_expr(*expr.rhs, locals, local_count, &rhs, depth + 1)) return false;
+        if (lhs.type != rhs.type) return false;
+        out->type = HirTypeKind::Bool;
+        if (expr.kind == HirExprKind::Eq) {
+            if (lhs.type == HirTypeKind::Bool) {
+                out->bool_value = lhs.bool_value == rhs.bool_value;
+                return true;
+            }
+            if (lhs.type == HirTypeKind::I32) {
+                out->bool_value = lhs.int_value == rhs.int_value;
+                return true;
+            }
+            if (lhs.type == HirTypeKind::Variant) {
+                out->bool_value =
+                    lhs.variant_index == rhs.variant_index && lhs.case_index == rhs.case_index;
+                return true;
+            }
+            return false;
+        }
+        if (lhs.type == HirTypeKind::I32) {
+            out->bool_value = expr.kind == HirExprKind::Lt ? (lhs.int_value < rhs.int_value)
+                                                           : (lhs.int_value > rhs.int_value);
+            return true;
+        }
+    }
+    return false;
+}
+
+static FrontendResult<HirExpr> analyze_guard_cond(const AstExpr& expr,
+                                                  HirRoute* route,
+                                                  const HirModule& mod,
+                                                  const HirLocal* locals,
+                                                  u32 local_count) {
+    auto analyzed = analyze_expr(expr, route, mod, locals, local_count);
+    if (!analyzed) return core::make_unexpected(analyzed.error());
+
+    HirExpr cond{};
+    cond.span = expr.span;
+    cond.kind = HirExprKind::BoolLit;
+    cond.type = HirTypeKind::Bool;
+
+    if (!analyzed->may_error) {
+        cond.bool_value = true;
+        return cond;
+    }
+
+    const auto state = known_value_state(analyzed.value(), locals, local_count);
+    if (state == KnownValueState::Error) {
+        cond.bool_value = false;
+        return cond;
+    }
+    if (state == KnownValueState::Available || state == KnownValueState::Nil) {
+        cond.bool_value = true;
+        return cond;
+    }
+
+    if (!route->exprs.push(analyzed.value()))
+        return frontend_error(FrontendError::TooManyItems, expr.span);
+    cond.kind = HirExprKind::NoError;
+    cond.lhs = &route->exprs[route->exprs.len - 1];
+    return cond;
+}
+
+static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
+                                                   HirMatchArm* arm,
+                                                   HirRoute* route,
+                                                   const HirModule& mod,
+                                                   const HirLocal* locals,
+                                                   u32 local_count,
+                                                   const MatchPayloadBinding* binding) {
+    if (stmt.kind == AstStmtKind::Block) {
+        FixedVec<HirLocal, HirRoute::kMaxLocals> scoped_locals;
+        for (u32 i = 0; i < local_count; i++) {
+            if (!scoped_locals.push(locals[i]))
+                return frontend_error(FrontendError::TooManyItems, stmt.span);
+        }
+        for (u32 si = 0; si < stmt.block_stmts.len; si++) {
+            const auto& inner = *stmt.block_stmts[si];
+            const bool is_last = si + 1 == stmt.block_stmts.len;
+            if (inner.kind == AstStmtKind::Let) {
+                if (is_last)
+                    return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                HirLocal local{};
+                local.span = inner.span;
+                local.name = inner.name;
+                local.ref_index = next_local_ref_index(route, scoped_locals.data, scoped_locals.len);
+                auto init = analyze_expr(inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
+                if (!init) return core::make_unexpected(init.error());
+                auto typed = apply_declared_type_to_expr(&init.value(), mod, inner);
+                if (!typed) return core::make_unexpected(typed.error());
+                local.type = init->type;
+                local.generic_index = init->generic_index;
+                local.generic_has_error_constraint = init->generic_has_error_constraint;
+                local.generic_has_eq_constraint = init->generic_has_eq_constraint;
+                local.generic_has_ord_constraint = init->generic_has_ord_constraint;
+                local.generic_protocol_index = init->generic_protocol_index;
+                local.generic_protocol_count = init->generic_protocol_count;
+                for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                    local.generic_protocol_indices[cpi] = init->generic_protocol_indices[cpi];
+                local.may_nil = init->may_nil;
+                local.may_error = init->may_error;
+                local.variant_index = init->variant_index;
+                local.struct_index = init->struct_index;
+                local.tuple_len = init->tuple_len;
+                for (u32 ti = 0; ti < init->tuple_len; ti++) {
+                    local.tuple_types[ti] = init->tuple_types[ti];
+                    local.tuple_variant_indices[ti] = init->tuple_variant_indices[ti];
+                    local.tuple_struct_indices[ti] = init->tuple_struct_indices[ti];
+                }
+                local.error_struct_index = init->error_struct_index;
+                local.error_variant_index = init->error_variant_index;
+                local.shape_index = init->shape_index;
+                local.init = init.value();
+                if (!route->locals.push(local))
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                if (local.ref_index >= HirRoute::kMaxLocals)
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                if (scoped_locals.len <= local.ref_index) scoped_locals.len = local.ref_index + 1;
+                scoped_locals[local.ref_index] = local;
+                continue;
+            }
+            if (inner.kind == AstStmtKind::Guard) {
+                if (is_last)
+                    return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                HirGuard guard{};
+                guard.span = inner.span;
+                auto bound = analyze_expr(inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
+                if (!bound) return core::make_unexpected(bound.error());
+                auto cond =
+                    analyze_guard_cond(inner.expr, route, mod, scoped_locals.data, scoped_locals.len);
+                if (!cond) return core::make_unexpected(cond.error());
+                guard.cond = cond.value();
+                if (inner.match_arms.len != 0) {
+                    if (!bound->may_error) {
+                        u32 fallback_arm = 0;
+                        for (u32 ai = 0; ai < inner.match_arms.len; ai++) {
+                            if (inner.match_arms[ai].is_wildcard) {
+                                fallback_arm = ai;
+                                break;
+                            }
+                        }
+                        auto fail_term = analyze_term(*inner.match_arms[fallback_arm].stmt, mod);
+                        if (!fail_term) return core::make_unexpected(fail_term.error());
+                        guard.fail_term = fail_term.value();
+                    } else {
+                        guard.fail_kind = HirGuard::FailKind::Match;
+                        guard.fail_match_expr = bound.value();
+                        auto* guard_match_arms =
+                            const_cast<FixedVec<HirGuardMatchArm, HirModule::kMaxGuardMatchArms>*>(
+                                &mod.guard_match_arms);
+                        auto fail_match = analyze_guard_match_arms(inner.match_arms,
+                                                                   bound.value(),
+                                                                   route,
+                                                                   mod,
+                                                                   scoped_locals.data,
+                                                                   scoped_locals.len,
+                                                                   guard_match_arms,
+                                                                   &guard);
+                        if (!fail_match) return core::make_unexpected(fail_match.error());
+                    }
+                } else {
+                    if (inner.else_stmt->kind == AstStmtKind::ReturnStatus ||
+                        inner.else_stmt->kind == AstStmtKind::ForwardUpstream) {
+                        auto fail_term = analyze_term(*inner.else_stmt, mod);
+                        if (!fail_term) return core::make_unexpected(fail_term.error());
+                        guard.fail_term = fail_term.value();
+                    } else {
+                        guard.fail_kind = HirGuard::FailKind::Body;
+                        auto fail_body = analyze_guard_fail_body(*inner.else_stmt,
+                                                                 &guard.fail_body,
+                                                                 route,
+                                                                 mod,
+                                                                 scoped_locals.data,
+                                                                 scoped_locals.len,
+                                                                 binding);
+                        if (!fail_body) return core::make_unexpected(fail_body.error());
+                    }
+                }
+                if (!arm->guards.push(guard))
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                if (inner.bind_value) {
+                    if (known_value_state(bound.value(), scoped_locals.data, scoped_locals.len) ==
+                        KnownValueState::Error)
+                        return frontend_error(FrontendError::UnsupportedSyntax, inner.expr.span);
+                    HirLocal local{};
+                    local.span = inner.span;
+                    local.name = inner.name;
+                    local.ref_index = next_local_ref_index(route, scoped_locals.data, scoped_locals.len);
+                    local.type = bound->type;
+                    local.generic_index = bound->generic_index;
+                    local.generic_has_error_constraint = bound->generic_has_error_constraint;
+                    local.generic_has_eq_constraint = bound->generic_has_eq_constraint;
+                    local.generic_has_ord_constraint = bound->generic_has_ord_constraint;
+                    local.generic_protocol_index = bound->generic_protocol_index;
+                    local.generic_protocol_count = bound->generic_protocol_count;
+                    for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                        local.generic_protocol_indices[cpi] = bound->generic_protocol_indices[cpi];
+                    local.may_nil = bound->may_nil;
+                    local.may_error = false;
+                    local.variant_index = bound->variant_index;
+                    local.struct_index = bound->struct_index;
+                    local.tuple_len = bound->tuple_len;
+                    for (u32 ti = 0; ti < bound->tuple_len; ti++) {
+                        local.tuple_types[ti] = bound->tuple_types[ti];
+                        local.tuple_variant_indices[ti] = bound->tuple_variant_indices[ti];
+                        local.tuple_struct_indices[ti] = bound->tuple_struct_indices[ti];
+                    }
+                    local.error_struct_index = bound->error_struct_index;
+                    local.error_variant_index = 0xffffffffu;
+                    local.shape_index = bound->shape_index;
+                    auto init = make_guard_bound_init(route, bound.value(), inner.span);
+                    if (!init) return core::make_unexpected(init.error());
+                    local.init = init.value();
+                    if (!route->locals.push(local))
+                        return frontend_error(FrontendError::TooManyItems, inner.span);
+                    if (local.ref_index >= HirRoute::kMaxLocals)
+                        return frontend_error(FrontendError::TooManyItems, inner.span);
+                    if (scoped_locals.len <= local.ref_index) scoped_locals.len = local.ref_index + 1;
+                    scoped_locals[local.ref_index] = local;
+                }
+                continue;
+            }
+            if (!is_last)
+                return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+            return analyze_match_arm_body(inner, arm, route, mod, scoped_locals.data, scoped_locals.len, binding);
+        }
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+    }
+    if (stmt.kind == AstStmtKind::If) {
+        arm->body_kind = HirMatchArm::BodyKind::If;
+        auto cond = analyze_expr(stmt.expr, route, mod, locals, local_count, binding);
+        if (!cond) return core::make_unexpected(cond.error());
+        if (cond->type != HirTypeKind::Bool)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+        arm->cond = cond.value();
+        auto then_term = analyze_term(*stmt.then_stmt, mod);
+        if (!then_term) return core::make_unexpected(then_term.error());
+        auto else_term = analyze_term(*stmt.else_stmt, mod);
+        if (!else_term) return core::make_unexpected(else_term.error());
+        arm->then_term = then_term.value();
+        arm->else_term = else_term.value();
+        return {};
+    }
+
+    arm->body_kind = HirMatchArm::BodyKind::Direct;
+    auto term = analyze_term(stmt, mod);
+    if (!term) return core::make_unexpected(term.error());
+    arm->direct_term = term.value();
+    return {};
+}
+
+static FrontendResult<void> analyze_guard_fail_body(const AstStatement& stmt,
+                                                    HirGuardBody* body,
+                                                    HirRoute* route,
+                                                    const HirModule& mod,
+                                                    const HirLocal* locals,
+                                                    u32 local_count,
+                                                    const MatchPayloadBinding* binding) {
+    if (stmt.kind == AstStmtKind::Block) {
+        FixedVec<HirLocal, HirRoute::kMaxLocals> scoped_locals;
+        for (u32 i = 0; i < local_count; i++) {
+            if (!scoped_locals.push(locals[i]))
+                return frontend_error(FrontendError::TooManyItems, stmt.span);
+        }
+        for (u32 si = 0; si < stmt.block_stmts.len; si++) {
+            const auto& inner = *stmt.block_stmts[si];
+            const bool is_last = si + 1 == stmt.block_stmts.len;
+            if (inner.kind == AstStmtKind::Let) {
+                if (is_last)
+                    return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                HirLocal local{};
+                local.span = inner.span;
+                local.name = inner.name;
+                local.ref_index = next_local_ref_index(route, scoped_locals.data, scoped_locals.len);
+                auto init = analyze_expr(inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
+                if (!init) return core::make_unexpected(init.error());
+                auto typed = apply_declared_type_to_expr(&init.value(), mod, inner);
+                if (!typed) return core::make_unexpected(typed.error());
+                local.type = init->type;
+                local.generic_index = init->generic_index;
+                local.generic_has_error_constraint = init->generic_has_error_constraint;
+                local.generic_has_eq_constraint = init->generic_has_eq_constraint;
+                local.generic_has_ord_constraint = init->generic_has_ord_constraint;
+                local.generic_protocol_index = init->generic_protocol_index;
+                local.generic_protocol_count = init->generic_protocol_count;
+                for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                    local.generic_protocol_indices[cpi] = init->generic_protocol_indices[cpi];
+                local.may_nil = init->may_nil;
+                local.may_error = init->may_error;
+                local.variant_index = init->variant_index;
+                local.struct_index = init->struct_index;
+                local.tuple_len = init->tuple_len;
+                for (u32 ti = 0; ti < init->tuple_len; ti++) {
+                    local.tuple_types[ti] = init->tuple_types[ti];
+                    local.tuple_variant_indices[ti] = init->tuple_variant_indices[ti];
+                    local.tuple_struct_indices[ti] = init->tuple_struct_indices[ti];
+                }
+                local.error_struct_index = init->error_struct_index;
+                local.error_variant_index = init->error_variant_index;
+                local.shape_index = init->shape_index;
+                local.init = init.value();
+                if (!route->locals.push(local))
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                if (local.ref_index >= HirRoute::kMaxLocals)
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                if (scoped_locals.len <= local.ref_index) scoped_locals.len = local.ref_index + 1;
+                scoped_locals[local.ref_index] = local;
+                continue;
+            }
+            if (!is_last)
+                return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+            return analyze_guard_fail_body(inner, body, route, mod, scoped_locals.data, scoped_locals.len, binding);
+        }
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+    }
+    if (stmt.kind == AstStmtKind::If) {
+        body->body_kind = HirGuardBody::BodyKind::If;
+        auto cond = analyze_expr(stmt.expr, route, mod, locals, local_count, binding);
+        if (!cond) return core::make_unexpected(cond.error());
+        if (cond->type != HirTypeKind::Bool)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+        body->cond = cond.value();
+        auto then_term = analyze_term(*stmt.then_stmt, mod);
+        if (!then_term) return core::make_unexpected(then_term.error());
+        auto else_term = analyze_term(*stmt.else_stmt, mod);
+        if (!else_term) return core::make_unexpected(else_term.error());
+        body->then_term = then_term.value();
+        body->else_term = else_term.value();
+        return {};
+    }
+    body->body_kind = HirGuardBody::BodyKind::Direct;
+    auto term = analyze_term(stmt, mod);
+    if (!term) return core::make_unexpected(term.error());
+    body->direct_term = term.value();
+    return {};
+}
+
+static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
+                                                 HirRoute* route,
+                                                 const HirModule& mod,
+                                                 const MatchPayloadBinding* binding) {
+    const HirLocal* locals = route->locals.data;
+    const u32 local_count = route->locals.len;
+
+    if (stmt.kind == AstStmtKind::If && stmt.is_const) {
+        auto cond = analyze_expr(stmt.expr, route, mod, locals, local_count, binding);
+        if (!cond) return core::make_unexpected(cond.error());
+        ConstValue value{};
+        if (!const_eval_expr(cond.value(), locals, local_count, &value) || value.type != HirTypeKind::Bool)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+        return analyze_control_stmt(value.bool_value ? *stmt.then_stmt : *stmt.else_stmt, route, mod, binding);
+    }
+
+    if (stmt.kind == AstStmtKind::Match && stmt.is_const) {
+        auto subject = analyze_expr(stmt.expr, route, mod, locals, local_count, binding);
+        if (!subject) return core::make_unexpected(subject.error());
+        ConstValue subject_value{};
+        if (!const_eval_expr(subject.value(), locals, local_count, &subject_value))
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+        if (!route->exprs.push(subject.value()))
+            return frontend_error(FrontendError::TooManyItems, stmt.span);
+        const HirExpr* subject_ptr = &route->exprs[route->exprs.len - 1];
+
+        const AstStatement::MatchArm* wildcard_arm = nullptr;
+        const AstStatement::MatchArm* selected_arm = nullptr;
+        MatchPayloadBinding selected_binding{};
+        const MatchPayloadBinding* selected_binding_ptr = binding;
+
+        for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+            const auto& arm = stmt.match_arms[ai];
+            if (arm.is_wildcard) {
+                wildcard_arm = &arm;
+                continue;
+            }
+            auto pattern = analyze_match_pattern(arm.pattern, subject.value(), route, mod, locals, local_count);
+            if (!pattern) return core::make_unexpected(pattern.error());
+
+            bool matched = false;
+            if (pattern->kind == HirExprKind::BoolLit && subject_value.type == HirTypeKind::Bool) {
+                matched = pattern->bool_value == subject_value.bool_value;
+            } else if (pattern->kind == HirExprKind::IntLit && subject_value.type == HirTypeKind::I32) {
+                matched = pattern->int_value == subject_value.int_value;
+            } else if (pattern->kind == HirExprKind::VariantCase && subject_value.type == HirTypeKind::Variant) {
+                matched = pattern->variant_index == subject_value.variant_index &&
+                          pattern->case_index == subject_value.case_index;
+            }
+
+            if (!matched) continue;
+            selected_arm = &arm;
+            if (pattern->kind == HirExprKind::VariantCase &&
+                mod.variants[pattern->variant_index].cases[pattern->case_index].has_payload &&
+                arm.pattern.lhs != nullptr) {
+                selected_binding = {};
+                selected_binding.name = arm.pattern.lhs->name;
+                selected_binding.type = mod.variants[pattern->variant_index].cases[pattern->case_index].payload_type;
+                selected_binding.variant_index =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_variant_index;
+                selected_binding.struct_index =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_struct_index;
+                selected_binding.shape_index =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_shape_index;
+                selected_binding.tuple_len =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_tuple_len;
+                for (u32 ti = 0; ti < selected_binding.tuple_len; ti++) {
+                    selected_binding.tuple_types[ti] =
+                        mod.variants[pattern->variant_index].cases[pattern->case_index].payload_tuple_types[ti];
+                    selected_binding.tuple_variant_indices[ti] =
+                        mod.variants[pattern->variant_index].cases[pattern->case_index]
+                            .payload_tuple_variant_indices[ti];
+                    selected_binding.tuple_struct_indices[ti] =
+                        mod.variants[pattern->variant_index].cases[pattern->case_index]
+                            .payload_tuple_struct_indices[ti];
+                }
+                selected_binding.case_index = pattern->case_index;
+                selected_binding.subject = subject_ptr;
+                selected_binding_ptr = &selected_binding;
+            }
+            break;
+        }
+
+        if (selected_arm == nullptr) selected_arm = wildcard_arm;
+        if (selected_arm == nullptr)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        route->control.match_expr = subject.value();
+        return analyze_control_stmt(*selected_arm->stmt, route, mod, selected_binding_ptr);
+    }
+
+    if (stmt.kind == AstStmtKind::If) {
+        auto cond = analyze_expr(stmt.expr, route, mod, locals, local_count, binding);
+        if (!cond) return core::make_unexpected(cond.error());
+        if (cond->type != HirTypeKind::Bool)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+        const auto simple_branch = [](const AstStatement& branch) {
+            return branch.kind == AstStmtKind::ReturnStatus || branch.kind == AstStmtKind::ForwardUpstream;
+        };
+        if (simple_branch(*stmt.then_stmt) && simple_branch(*stmt.else_stmt)) {
+            route->control.kind = HirControlKind::If;
+            route->control.cond = cond.value();
+            auto then_term = analyze_term(*stmt.then_stmt, mod);
+            if (!then_term) return core::make_unexpected(then_term.error());
+            auto else_term = analyze_term(*stmt.else_stmt, mod);
+            if (!else_term) return core::make_unexpected(else_term.error());
+            route->control.then_term = then_term.value();
+            route->control.else_term = else_term.value();
+            return {};
+        }
+
+        const auto supported_branch = [](const AstStatement& branch) {
+            return branch.kind == AstStmtKind::ReturnStatus || branch.kind == AstStmtKind::ForwardUpstream ||
+                   branch.kind == AstStmtKind::If || branch.kind == AstStmtKind::Block;
+        };
+        if (!supported_branch(*stmt.then_stmt) || !supported_branch(*stmt.else_stmt))
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+
+        route->control.kind = HirControlKind::Match;
+        route->control.match_expr = cond.value();
+        route->control.match_arms.len = 0;
+
+        auto make_bool_pattern = [&](bool value, Span span) {
+            HirExpr pattern{};
+            pattern.kind = HirExprKind::BoolLit;
+            pattern.type = HirTypeKind::Bool;
+            pattern.bool_value = value;
+            pattern.span = span;
+            return pattern;
+        };
+
+        HirMatchArm then_arm{};
+        then_arm.span = stmt.then_stmt->span;
+        then_arm.pattern = make_bool_pattern(true, stmt.then_stmt->span);
+        auto then_body = analyze_match_arm_body(*stmt.then_stmt, &then_arm, route, mod, locals, local_count, binding);
+        if (!then_body) return core::make_unexpected(then_body.error());
+        if (!route->control.match_arms.push(then_arm))
+            return frontend_error(FrontendError::TooManyItems, stmt.then_stmt->span);
+
+        HirMatchArm else_arm{};
+        else_arm.span = stmt.else_stmt->span;
+        else_arm.pattern = make_bool_pattern(false, stmt.else_stmt->span);
+        auto else_body = analyze_match_arm_body(*stmt.else_stmt, &else_arm, route, mod, locals, local_count, binding);
+        if (!else_body) return core::make_unexpected(else_body.error());
+        if (!route->control.match_arms.push(else_arm))
+            return frontend_error(FrontendError::TooManyItems, stmt.else_stmt->span);
+        return {};
+    }
+
+    if (stmt.kind == AstStmtKind::Match) {
+        auto subject = analyze_expr(stmt.expr, route, mod, locals, local_count, binding);
+        if (!subject) return core::make_unexpected(subject.error());
+        const auto state = known_value_state(subject.value(), locals, local_count);
+        const auto err_name = known_error_name(subject.value(), locals, local_count);
+        const bool subject_is_error_kind =
+            subject->type != HirTypeKind::Variant && subject->may_error &&
+            (subject->error_variant_index != 0xffffffffu ||
+             (state == KnownValueState::Error && err_name.len != 0));
+        if (subject->type != HirTypeKind::Variant && subject->may_error &&
+            (subject->error_variant_index != 0xffffffffu ||
+             (state == KnownValueState::Error && err_name.len != 0))) {
+            if (state != KnownValueState::Unknown) {
+                const AstStatement::MatchArm* wildcard_arm = nullptr;
+                const AstStatement::MatchArm* selected_arm = nullptr;
+                if (state == KnownValueState::Error) {
+                    const auto err_case = known_error_case(subject.value(), locals, local_count);
+                    if (!err_case.known)
+                        if (err_name.len == 0)
+                            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                    for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+                        const auto& arm = stmt.match_arms[ai];
+                        if (arm.is_wildcard) {
+                            wildcard_arm = &arm;
+                            continue;
+                        }
+                        if (arm.pattern.kind != AstExprKind::VariantCase)
+                            return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                        bool matched = false;
+                        if (err_case.known && arm.pattern.name.len != 0) {
+                            auto pattern = analyze_match_pattern(
+                                arm.pattern, subject.value(), route, mod, locals, local_count);
+                            if (!pattern) return core::make_unexpected(pattern.error());
+                            matched = pattern->kind == HirExprKind::VariantCase &&
+                                      pattern->variant_index == err_case.variant_index &&
+                                      pattern->case_index == err_case.case_index;
+                        } else {
+                            matched = arm.pattern.str_value.eq(err_name);
+                        }
+                        if (matched) {
+                            selected_arm = &arm;
+                            break;
+                        }
+                    }
+                } else {
+                    for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+                        if (stmt.match_arms[ai].is_wildcard) {
+                            wildcard_arm = &stmt.match_arms[ai];
+                            break;
+                        }
+                    }
+                }
+
+                if (selected_arm == nullptr) selected_arm = wildcard_arm;
+                if (selected_arm == nullptr)
+                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                return analyze_control_stmt(*selected_arm->stmt, route, mod, binding);
+            }
+        }
+
+        route->control.kind = HirControlKind::Match;
+        route->control.match_expr = subject.value();
+        bool seen_wildcard = false;
+        bool seen_variant_cases[HirVariant::kMaxCases]{};
+        u32 seen_variant_case_count = 0;
+        route->control.match_arms.len = 0;
+        for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+            const auto& arm = stmt.match_arms[ai];
+            HirMatchArm hir_arm{};
+            hir_arm.span = arm.span;
+            hir_arm.is_wildcard = arm.is_wildcard;
+            MatchPayloadBinding arm_binding{};
+            const MatchPayloadBinding* arm_binding_ptr = binding;
+            if (seen_wildcard)
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            if (!arm.is_wildcard) {
+                auto analyzed_pattern =
+                    analyze_match_pattern(arm.pattern, subject.value(), route, mod, locals, local_count);
+                if (!analyzed_pattern) return core::make_unexpected(analyzed_pattern.error());
+                HirExpr pattern = analyzed_pattern.value();
+                if (pattern.kind != HirExprKind::BoolLit && pattern.kind != HirExprKind::IntLit &&
+                    pattern.kind != HirExprKind::VariantCase)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (pattern.type != subject->type &&
+                    !(subject_is_error_kind && pattern.kind == HirExprKind::VariantCase))
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (pattern.type == HirTypeKind::Variant &&
+                    ((subject_is_error_kind && pattern.variant_index != subject->error_variant_index) ||
+                     (!subject_is_error_kind && pattern.variant_index != subject->variant_index)))
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (pattern.kind == HirExprKind::VariantCase) {
+                    const u32 case_index = static_cast<u32>(pattern.int_value);
+                    if (case_index >= HirVariant::kMaxCases)
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                    if (seen_variant_cases[case_index])
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                    seen_variant_cases[case_index] = true;
+                    seen_variant_case_count++;
+                    const auto& variant = mod.variants[pattern.variant_index];
+                    const auto& case_decl = variant.cases[case_index];
+                    if (case_decl.has_payload && arm.pattern.lhs != nullptr) {
+                        hir_arm.bind_payload = true;
+                        hir_arm.bind_name = arm.pattern.lhs->name;
+                        hir_arm.bind_type = case_decl.payload_type;
+                        hir_arm.bind_variant_index = case_decl.payload_variant_index;
+                        hir_arm.bind_struct_index = case_decl.payload_struct_index;
+                        hir_arm.bind_tuple_len = case_decl.payload_tuple_len;
+                        for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
+                            hir_arm.bind_tuple_types[ti] = case_decl.payload_tuple_types[ti];
+                            hir_arm.bind_tuple_variant_indices[ti] = case_decl.payload_tuple_variant_indices[ti];
+                            hir_arm.bind_tuple_struct_indices[ti] = case_decl.payload_tuple_struct_indices[ti];
+                        }
+                        arm_binding.name = hir_arm.bind_name;
+                        arm_binding.type = hir_arm.bind_type;
+                        arm_binding.variant_index = hir_arm.bind_variant_index;
+                        arm_binding.struct_index = hir_arm.bind_struct_index;
+                        arm_binding.shape_index = case_decl.payload_shape_index;
+                        arm_binding.case_index = case_index;
+                        arm_binding.tuple_len = case_decl.payload_tuple_len;
+                        for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
+                            arm_binding.tuple_types[ti] = case_decl.payload_tuple_types[ti];
+                            arm_binding.tuple_variant_indices[ti] = case_decl.payload_tuple_variant_indices[ti];
+                            arm_binding.tuple_struct_indices[ti] = case_decl.payload_tuple_struct_indices[ti];
+                        }
+                        arm_binding.subject = &route->control.match_expr;
+                        arm_binding_ptr = &arm_binding;
+                    }
+                }
+                hir_arm.pattern = pattern;
+            } else {
+                seen_wildcard = true;
+            }
+            auto body = analyze_match_arm_body(
+                *arm.stmt, &hir_arm, route, mod, locals, local_count, arm_binding_ptr);
+            if (!body) return core::make_unexpected(body.error());
+            if (!route->control.match_arms.push(hir_arm))
+                return frontend_error(FrontendError::TooManyItems, arm.span);
+        }
+        if (!seen_wildcard) {
+            if (subject->type != HirTypeKind::Variant && !subject_is_error_kind)
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+            const auto& variant = mod.variants[subject_is_error_kind ? subject->error_variant_index
+                                                                     : subject->variant_index];
+            if (seen_variant_case_count != variant.cases.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        }
+        return {};
+    }
+
+    route->control.kind = HirControlKind::Direct;
+    auto term = analyze_term(stmt, mod);
+    if (!term) return core::make_unexpected(term.error());
+    route->control.direct_term = term.value();
+    return {};
+}
+
+}  // namespace
+
+
+static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
+                                                    Str source_path,
+                                                    std::vector<std::string>* import_stack,
+                                                    std::deque<std::string>* shared_owned_strings = nullptr);
+
+static Str import_visible_name(const ImportedModuleInfo& imported, Str original_name) {
+    if (imported.has_namespace_alias) {
+        return intern_generated_name(str_to_std_string(imported.namespace_alias) + "__" + str_to_std_string(original_name));
+    }
+    if (!imported.selective) return original_name;
+    for (u32 i = 0; i < imported.selected_names.len; i++) {
+        const auto& selected = imported.selected_names[i];
+        if (!selected.name.eq(original_name)) continue;
+        if (selected.has_alias) return selected.alias;
+        return selected.name;
+    }
+    return original_name;
+}
+
+static bool is_hidden_import_runtime_function(Str name) {
+    return (name.len >= 7 && __builtin_memcmp(name.ptr, "__impl_", 7) == 0) ||
+           (name.len >= 8 && __builtin_memcmp(name.ptr, "__proto_", 8) == 0);
+}
+
+static bool imported_module_exports_function_name(const HirModule& mod, Str name) {
+    for (u32 fi = 0; fi < mod.functions.len; fi++) {
+        const auto& fn = mod.functions[fi];
+        if (!is_hidden_import_runtime_function(fn.name) && fn.name.eq(name)) return true;
+    }
+    return false;
+}
+
+static bool imported_module_exports_selected_name(const HirModule& mod, Str name) {
+    if (imported_module_exports_function_name(mod, name)) return true;
+    for (u32 pi = 0; pi < mod.protocols.len; pi++) {
+        const auto& proto = mod.protocols[pi];
+        if (proto.kind == HirProtocolKind::Custom && proto.name.eq(name)) return true;
+    }
+    for (u32 si = 0; si < mod.structs.len; si++) {
+        const auto& st = mod.structs[si];
+        if (st.template_struct_index == 0xffffffffu && st.name.eq(name)) return true;
+    }
+    for (u32 vi = 0; vi < mod.variants.len; vi++) {
+        const auto& variant = mod.variants[vi];
+        if (variant.template_variant_index == 0xffffffffu && variant.name.eq(name)) return true;
+    }
+    return false;
+}
+
+static FrontendResult<void> validate_imported_selected_names(const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    for (u32 ii = 0; ii < imports.len; ii++) {
+        const auto& imported = imports[ii];
+        if (!imported.selective) continue;
+        for (u32 si = 0; si < imported.selected_names.len; si++) {
+            const auto& selected = imported.selected_names[si];
+            if (!imported_module_exports_selected_name(*imported.module, selected.name))
+                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, selected.name);
+        }
+    }
+    return {};
+}
+
+static FrontendResult<void> merge_imported_functions(HirModule* mod,
+                                                  const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    for (u32 ii = 0; ii < imports.len; ii++) {
+        const auto& imported = imports[ii];
+        for (u32 fi = 0; fi < imported.module->functions.len; fi++) {
+            const auto& fn = imported.module->functions[fi];
+            if (is_hidden_import_runtime_function(fn.name)) {
+                if (find_function_index(*mod, fn.name) != mod->functions.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, fn.name);
+                if (!mod->functions.push(fn))
+                    return frontend_error(FrontendError::TooManyItems, imported.span);
+                continue;
+            }
+            if (!imported.selective && !imported.has_namespace_alias) {
+                if (find_function_index(*mod, fn.name) != mod->functions.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, fn.name);
+                if (!mod->functions.push(fn))
+                    return frontend_error(FrontendError::TooManyItems, imported.span);
+                continue;
+            }
+            if (imported.has_namespace_alias) {
+                HirFunction imported_fn = fn;
+                imported_fn.name = import_visible_name(imported, fn.name);
+                if (find_function_index(*mod, imported_fn.name) != mod->functions.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_fn.name);
+                if (!mod->functions.push(imported_fn))
+                    return frontend_error(FrontendError::TooManyItems, imported.span);
+                continue;
+            }
+            for (u32 si = 0; si < imported.selected_names.len; si++) {
+                const auto& selected = imported.selected_names[si];
+                if (!selected.name.eq(fn.name)) continue;
+                HirFunction imported_fn = fn;
+                if (selected.has_alias) imported_fn.name = selected.alias;
+                if (find_function_index(*mod, imported_fn.name) != mod->functions.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_fn.name);
+                if (!mod->functions.push(imported_fn))
+                    return frontend_error(FrontendError::TooManyItems, imported.span);
+            }
+        }
+    }
+    return {};
+}
+
+static FrontendResult<void> merge_imported_simple_decls(HirModule* mod,
+                                                     const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    for (u32 ii = 0; ii < imports.len; ii++) {
+        const auto& imported = imports[ii];
+        for (u32 pi = 0; pi < imported.module->protocols.len; pi++) {
+            const auto& proto = imported.module->protocols[pi];
+            if (proto.kind != HirProtocolKind::Custom) continue;
+            if (imported.selective) {
+                bool selected = false;
+                for (u32 si = 0; si < imported.selected_names.len; si++) {
+                    if (imported.selected_names[si].name.eq(proto.name)) { selected = true; break; }
+                }
+                if (!selected) continue;
+            }
+            HirProtocol imported_proto = proto;
+            imported_proto.name = import_visible_name(imported, proto.name);
+            if (find_protocol_index(*mod, imported_proto.name) != mod->protocols.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_proto.name);
+            if (!mod->protocols.push(imported_proto))
+                return frontend_error(FrontendError::TooManyItems, imported.span);
+        }
+        for (u32 si = 0; si < imported.module->structs.len; si++) {
+            const auto& st = imported.module->structs[si];
+            if (st.template_struct_index != 0xffffffffu) continue;
+            if (imported.selective) {
+                bool selected = false;
+                for (u32 xi = 0; xi < imported.selected_names.len; xi++) {
+                    if (imported.selected_names[xi].name.eq(st.name)) { selected = true; break; }
+                }
+                if (!selected) continue;
+            }
+            HirStruct imported_struct = st;
+            imported_struct.name = import_visible_name(imported, st.name);
+            if (find_struct_index(*mod, imported_struct.name) != mod->structs.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_struct.name);
+            bool ok = true;
+            for (u32 fi = 0; fi < imported_struct.fields.len; fi++) {
+                const auto& field = imported_struct.fields[fi];
+                if (field.is_error_type) continue;
+                if (!type_shape_is_simple_importable(field.type,
+                                                     field.variant_index,
+                                                     field.struct_index,
+                                                     field.tuple_len,
+                                                     field.tuple_types,
+                                                     field.tuple_variant_indices,
+                                                     field.tuple_struct_indices)) {
+                    ok = false;
+                    break;
+                }
+            }
+            if (!ok) continue;
+            if (!mod->structs.push(imported_struct))
+                return frontend_error(FrontendError::TooManyItems, imported.span);
+        }
+        for (u32 vi = 0; vi < imported.module->variants.len; vi++) {
+            const auto& variant = imported.module->variants[vi];
+            if (variant.template_variant_index != 0xffffffffu) continue;
+            if (imported.selective) {
+                bool selected = false;
+                for (u32 xi = 0; xi < imported.selected_names.len; xi++) {
+                    if (imported.selected_names[xi].name.eq(variant.name)) { selected = true; break; }
+                }
+                if (!selected) continue;
+            }
+            HirVariant imported_variant = variant;
+            imported_variant.name = import_visible_name(imported, variant.name);
+            if (find_variant_index(*mod, imported_variant.name) != mod->variants.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_variant.name);
+            bool ok = true;
+            for (u32 ci = 0; ci < imported_variant.cases.len; ci++) {
+                const auto& c = imported_variant.cases[ci];
+                if (!c.has_payload) continue;
+                if (!type_shape_is_simple_importable(c.payload_type,
+                                                     c.payload_variant_index,
+                                                     c.payload_struct_index,
+                                                     c.payload_tuple_len,
+                                                     c.payload_tuple_types,
+                                                     c.payload_tuple_variant_indices,
+                                                     c.payload_tuple_struct_indices)) {
+                    ok = false;
+                    break;
+                }
+            }
+            if (!ok) continue;
+            if (!mod->variants.push(imported_variant))
+                return frontend_error(FrontendError::TooManyItems, imported.span);
+        }
+    }
+    return {};
+}
+
+static FrontendResult<void> remap_imported_impl_target(HirModule* mod,
+                                               const ImportedModuleInfo& imported,
+                                               const HirModule& imported_mod,
+                                               const HirImpl& imported_impl,
+                                               HirTypeKind* out_type,
+                                               u32* out_struct_index,
+                                               bool* out_is_generic_template,
+                                               Span span) {
+    *out_type = imported_impl.type;
+    *out_is_generic_template = imported_impl.is_generic_template;
+    *out_struct_index = imported_impl.struct_index;
+    if (imported_impl.type != HirTypeKind::Struct) return {};
+    if (imported_impl.struct_index >= imported_mod.structs.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, span);
+    const auto& imported_target = imported_mod.structs[imported_impl.struct_index];
+    if (imported_impl.is_generic_template || imported_target.template_struct_index == 0xffffffffu) {
+        const u32 mapped = find_struct_index(*mod, import_visible_name(imported, imported_target.name));
+        if (mapped >= mod->structs.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span, imported_target.name);
+        *out_struct_index = mapped;
+        return {};
+    }
+    if (imported_target.template_struct_index >= imported_mod.structs.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, span);
+    const auto& imported_template = imported_mod.structs[imported_target.template_struct_index];
+    const u32 mapped_template = find_struct_index(*mod, import_visible_name(imported, imported_template.name));
+    if (mapped_template >= mod->structs.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, span, imported_template.name);
+    GenericBinding bindings[HirStruct::kMaxTypeParams]{};
+    const u32 binding_count = imported_target.instance_type_arg_count;
+    for (u32 bi = 0; bi < binding_count; bi++) {
+        bindings[bi].bound = true;
+        bindings[bi].generic_index = imported_target.instance_generic_indices[bi];
+        if (imported_target.instance_variant_indices[bi] != 0xffffffffu) {
+            if (imported_target.instance_variant_indices[bi] >= imported_mod.variants.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, span);
+            const auto& imported_variant = imported_mod.variants[imported_target.instance_variant_indices[bi]];
+            const u32 mapped_variant = find_variant_index(*mod, import_visible_name(imported, imported_variant.name));
+            if (mapped_variant >= mod->variants.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, span, imported_variant.name);
+            bindings[bi].variant_index = mapped_variant;
+        } else {
+            bindings[bi].variant_index = 0xffffffffu;
+        }
+        if (imported_target.instance_struct_indices[bi] != 0xffffffffu) {
+            if (imported_target.instance_struct_indices[bi] >= imported_mod.structs.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, span);
+            const auto& imported_struct = imported_mod.structs[imported_target.instance_struct_indices[bi]];
+            const u32 mapped_struct = find_struct_index(*mod, import_visible_name(imported, imported_struct.name));
+            if (mapped_struct >= mod->structs.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, span, imported_struct.name);
+            bindings[bi].struct_index = mapped_struct;
+        } else {
+            bindings[bi].struct_index = 0xffffffffu;
+        }
+        auto filled = fill_bound_binding_from_type_metadata(&bindings[bi],
+                                                            mod,
+                                                            imported_target.instance_type_args[bi],
+                                                            imported_target.instance_generic_indices[bi],
+                                                            bindings[bi].variant_index,
+                                                            bindings[bi].struct_index,
+                                                            imported_target.instance_tuple_lens[bi],
+                                                            imported_target.instance_tuple_types[bi],
+                                                            imported_target.instance_tuple_variant_indices[bi],
+                                                            imported_target.instance_tuple_struct_indices[bi],
+                                                            imported_target.instance_shape_indices[bi],
+                                                            span);
+        if (!filled) return core::make_unexpected(filled.error());
+    }
+    auto concrete = instantiate_struct(mod, mapped_template, bindings, binding_count, span);
+    if (!concrete) return core::make_unexpected(concrete.error());
+    *out_struct_index = concrete.value();
+    return {};
+}
+
+static FrontendResult<void> merge_imported_impls(HirModule* mod,
+                                                 const FixedVec<ImportedModuleInfo, AstFile::kMaxItems>& imports) {
+    for (u32 ii = 0; ii < imports.len; ii++) {
+        const auto& imported = imports[ii];
+        for (u32 impl_i = 0; impl_i < imported.module->impls.len; impl_i++) {
+            const auto& imported_impl = imported.module->impls[impl_i];
+            if (imported_impl.protocol_index >= imported.module->protocols.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, imported.span);
+            const Str protocol_name = import_visible_name(imported, imported.module->protocols[imported_impl.protocol_index].name);
+            if (imported.selective) {
+                bool selected = false;
+                for (u32 si = 0; si < imported.selected_names.len; si++) {
+                    if (imported.selected_names[si].name.eq(imported.module->protocols[imported_impl.protocol_index].name)) { selected = true; break; }
+                }
+                if (!selected) continue;
+            }
+            const u32 mapped_protocol_index = find_protocol_index(*mod, protocol_name);
+            if (mapped_protocol_index >= mod->protocols.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, imported.span, protocol_name);
+            HirTypeKind mapped_type = HirTypeKind::Unknown;
+            u32 mapped_struct_index = 0xffffffffu;
+            bool mapped_is_generic_template = false;
+            auto remapped = remap_imported_impl_target(mod,
+                                                       imported,
+                                                       *imported.module,
+                                                       imported_impl,
+                                                       &mapped_type,
+                                                       &mapped_struct_index,
+                                                       &mapped_is_generic_template,
+                                                       imported.span);
+            if (!remapped) return core::make_unexpected(remapped.error());
+            for (u32 existing_i = 0; existing_i < mod->impls.len; existing_i++) {
+                const auto& existing = mod->impls[existing_i];
+                if (existing.protocol_index == mapped_protocol_index &&
+                    impl_targets_overlap(*mod, existing, mapped_type, mapped_struct_index, mapped_is_generic_template))
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, protocol_name);
+            }
+            HirConformance conf{};
+            conf.span = imported_impl.span;
+            conf.protocol_index = mapped_protocol_index;
+            conf.type = mapped_type;
+            conf.struct_index = mapped_struct_index;
+            conf.is_generic_template = mapped_is_generic_template;
+            for (u32 ci = 0; ci < mod->conformances.len; ci++) {
+                const auto& existing = mod->conformances[ci];
+                if (existing.protocol_index == conf.protocol_index &&
+                    existing.type == conf.type &&
+                    existing.struct_index == conf.struct_index &&
+                    existing.is_generic_template == conf.is_generic_template)
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, protocol_name);
+            }
+            if (!mod->conformances.push(conf))
+                return frontend_error(FrontendError::TooManyItems, imported.span);
+            HirImpl impl = imported_impl;
+            impl.span = imported_impl.span;
+            impl.protocol_index = mapped_protocol_index;
+            impl.type = mapped_type;
+            impl.struct_index = mapped_struct_index;
+            impl.is_generic_template = mapped_is_generic_template;
+            impl.methods.len = 0;
+            for (u32 mi = 0; mi < imported_impl.methods.len; mi++) {
+                const auto& imported_method = imported_impl.methods[mi];
+                if (imported_method.function_index >= imported.module->functions.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, imported_method.name);
+                const Str fn_name = imported.module->functions[imported_method.function_index].name;
+                const u32 mapped_fn_index = find_function_index(*mod, fn_name);
+                if (mapped_fn_index >= mod->functions.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, imported.span, fn_name);
+                HirImplMethod method{};
+                method.name = imported_method.name;
+                method.function_index = mapped_fn_index;
+                if (!impl.methods.push(method))
+                    return frontend_error(FrontendError::TooManyItems, imported.span);
+            }
+            if (!mod->impls.push(impl))
+                return frontend_error(FrontendError::TooManyItems, imported.span);
+        }
+    }
+    return {};
+}
+
+static FrontendResult<void> load_imported_modules(FixedVec<ImportedModuleInfo, AstFile::kMaxItems>* out,
+                                             const AstFile& file,
+                                             Str source_path,
+                                             std::deque<std::string>* owned_strings,
+                                             std::vector<std::string>* import_stack,
+                                             std::vector<std::unique_ptr<HirModule>>* imported_storage) {
+    if (source_path.len == 0) return {};
+    const auto base_dir = std::filesystem::path(str_to_std_string(source_path)).parent_path();
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Import) continue;
+        const auto normalized = (base_dir / str_to_std_string(item.import_decl.path)).lexically_normal().string();
+        ImportedModuleInfo* existing_info = nullptr;
+        for (u32 ii = 0; ii < out->len; ii++) {
+            if (out->operator[](ii).path.eq({normalized.c_str(), static_cast<u32>(normalized.size())}) &&
+                out->operator[](ii).has_namespace_alias == item.import_decl.has_namespace_alias &&
+                (!out->operator[](ii).has_namespace_alias || out->operator[](ii).namespace_alias.eq(item.import_decl.namespace_alias))) {
+                existing_info = &out->operator[](ii);
+                break;
+            }
+        }
+        if (existing_info != nullptr) {
+            if (!item.import_decl.selective) {
+                existing_info->selective = false;
+                existing_info->selected_names.len = 0;
+            } else if (existing_info->selective) {
+                for (u32 si = 0; si < item.import_decl.selected_names.len; si++) {
+                    const auto& selected = item.import_decl.selected_names[si];
+                    bool seen = false;
+                    for (u32 ei = 0; ei < existing_info->selected_names.len; ei++) {
+                        const auto& existing = existing_info->selected_names[ei];
+                        if (existing.name.eq(selected.name) &&
+                            existing.has_alias == selected.has_alias &&
+                            (!existing.has_alias || existing.alias.eq(selected.alias))) {
+                            seen = true;
+                            break;
+                        }
+                    }
+                    if (!seen) {
+                        if (!existing_info->selected_names.push(selected))
+                            return frontend_error(FrontendError::TooManyItems, item.import_decl.span);
+                    }
+                }
+            }
+            continue;
+        }
+        std::string content;
+        if (!read_text_file(normalized, &content))
+            return frontend_error(FrontendError::UnsupportedSyntax, item.import_decl.span, item.import_decl.path);
+        auto kept_source = stash_owned_string(owned_strings, content);
+        auto lexed = lex(kept_source);
+        if (!lexed) return core::make_unexpected(lexed.error());
+        auto ast = parse_file(lexed.value());
+        if (!ast) return core::make_unexpected(ast.error());
+        auto kept_path = stash_owned_string(owned_strings, normalized);
+        g_import_analysis_counter++;
+        auto imported = analyze_file_internal(*ast.value(), kept_path, import_stack, owned_strings);
+        if (!imported) return core::make_unexpected(imported.error());
+        imported_storage->push_back(std::unique_ptr<HirModule>(imported.value()));
+        ImportedModuleInfo info{};
+        info.span = item.import_decl.span;
+        info.path = kept_path;
+        info.module = imported_storage->back().get();
+        info.selective = item.import_decl.selective;
+        info.has_namespace_alias = item.import_decl.has_namespace_alias;
+        info.namespace_alias = item.import_decl.namespace_alias;
+        for (u32 si = 0; si < item.import_decl.selected_names.len; si++) {
+            if (!info.selected_names.push(item.import_decl.selected_names[si]))
+                return frontend_error(FrontendError::TooManyItems, item.import_decl.span);
+        }
+        if (!out->push(info))
+            return frontend_error(FrontendError::TooManyItems, item.import_decl.span);
+    }
+    return {};
+}
+
+static FrontendResult<HirModule*> analyze_file_internal(const AstFile& file,
+                                                    Str source_path,
+                                                    std::vector<std::string>* import_stack,
+                                                    std::deque<std::string>* shared_owned_strings) {
+    auto mod_ptr = std::make_unique<HirModule>();
+    HirModule& mod = *mod_ptr;
+    mod.has_package_decl = file.has_package_decl;
+    mod.package_span = file.package_span;
+    mod.package_name = file.package_name;
+    std::string normalized_source;
+    if (source_path.len != 0) {
+        normalized_source = std::filesystem::path(str_to_std_string(source_path)).lexically_normal().string();
+        if (import_stack != nullptr) {
+            for (const auto& existing : *import_stack) {
+                if (existing == normalized_source)
+                    return frontend_error(FrontendError::UnsupportedSyntax, {}, source_path);
+            }
+            import_stack->push_back(normalized_source);
+        }
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Upstream) continue;
+        for (u32 j = 0; j < mod.upstreams.len; j++) {
+            if (mod.upstreams[j].name.eq(item.upstream.name))
+                return frontend_error(FrontendError::DuplicateUpstream,
+                                      item.upstream.span,
+                                      item.upstream.name);
+        }
+        HirUpstream up{};
+        up.span = item.upstream.span;
+        up.name = item.upstream.name;
+        up.id = static_cast<u16>(mod.upstreams.len + 1);
+        if (!mod.upstreams.push(up))
+            return frontend_error(FrontendError::TooManyItems, item.upstream.span);
+    }
+
+    {
+        HirProtocol p{}; p.name = {"Error", 5}; p.kind = HirProtocolKind::Error; if (!mod.protocols.push(p)) return frontend_error(FrontendError::TooManyItems, {});
+        HirProtocol q{}; q.name = {"Eq", 2}; q.kind = HirProtocolKind::Eq; if (!mod.protocols.push(q)) return frontend_error(FrontendError::TooManyItems, {});
+        HirProtocol r{}; r.name = {"Ord", 3}; r.kind = HirProtocolKind::Ord; if (!mod.protocols.push(r)) return frontend_error(FrontendError::TooManyItems, {});
+    }
+
+    auto* owned_strings = shared_owned_strings != nullptr ? shared_owned_strings : &mod.owned_strings;
+    std::vector<std::unique_ptr<HirModule>> imported_storage;
+    FixedVec<ImportedModuleInfo, AstFile::kMaxItems> imported_modules;
+    auto loaded_imports = load_imported_modules(&imported_modules, file, source_path, owned_strings, import_stack, &imported_storage);
+    if (!loaded_imports) return core::make_unexpected(loaded_imports.error());
+    auto validated_namespaces = validate_import_namespaces(imported_modules);
+    if (!validated_namespaces) return core::make_unexpected(validated_namespaces.error());
+    auto validated_namespace_bindings = validate_import_namespace_bindings(file, imported_modules);
+    if (!validated_namespace_bindings) return core::make_unexpected(validated_namespace_bindings.error());
+    auto validated_imports = validate_imported_selected_names(imported_modules);
+    if (!validated_imports) return core::make_unexpected(validated_imports.error());
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Import) continue;
+        bool exists = false;
+        for (u32 ii = 0; ii < mod.imports.len; ii++) {
+            if (mod.imports[ii].path.eq(item.import_decl.path) &&
+                mod.imports[ii].has_namespace_alias == item.import_decl.has_namespace_alias &&
+                (!mod.imports[ii].has_namespace_alias || mod.imports[ii].namespace_alias.eq(item.import_decl.namespace_alias))) {
+                exists = true;
+                break;
+            }
+        }
+        if (!exists) {
+            HirImport imp{};
+            imp.span = item.import_decl.span;
+            imp.path = item.import_decl.path;
+            imp.selective = item.import_decl.selective;
+            imp.has_namespace_alias = item.import_decl.has_namespace_alias;
+            imp.namespace_alias = item.import_decl.namespace_alias;
+            std::string normalized_import_path;
+            if (source_path.len != 0) {
+                normalized_import_path =
+                    (std::filesystem::path(str_to_std_string(source_path)).parent_path() /
+                     str_to_std_string(item.import_decl.path))
+                        .lexically_normal()
+                        .string();
+            }
+            for (u32 ii = 0; ii < imported_modules.len; ii++) {
+                if (!normalized_import_path.empty() &&
+                    !imported_modules[ii].path.eq(
+                        {normalized_import_path.c_str(), static_cast<u32>(normalized_import_path.size())}))
+                    continue;
+                imp.has_package_decl = imported_modules[ii].module->has_package_decl;
+                imp.package_name = imported_modules[ii].module->package_name;
+                imp.same_package =
+                    mod.has_package_decl &&
+                    imported_modules[ii].module->has_package_decl &&
+                    mod.package_name.eq(imported_modules[ii].module->package_name);
+                break;
+            }
+            if (!mod.imports.push(imp))
+                return frontend_error(FrontendError::TooManyItems, item.import_decl.span);
+        }
+    }
+
+    auto imported_decls = merge_imported_simple_decls(&mod, imported_modules);
+    if (!imported_decls) return core::make_unexpected(imported_decls.error());
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Protocol) continue;
+        if (find_protocol_index(mod, item.protocol.name) < mod.protocols.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, item.protocol.name);
+        HirProtocol proto{};
+        proto.span = item.protocol.span;
+        proto.name = item.protocol.name;
+        proto.kind = HirProtocolKind::Custom;
+        for (u32 mi = 0; mi < item.protocol.methods.len; mi++) {
+            for (u32 seen = 0; seen < proto.methods.len; seen++) {
+                if (proto.methods[seen].name.eq(item.protocol.methods[mi].name))
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, item.protocol.methods[mi].name);
+            }
+            HirProtocol::MethodDecl method{};
+            method.name = item.protocol.methods[mi].name;
+            for (u32 pi = 0; pi < item.protocol.methods[mi].params.len; pi++) {
+                HirProtocol::MethodDecl::ParamDecl param{};
+                param.type_name = item.protocol.methods[mi].params[pi].type.name;
+                auto param_type = resolve_func_type_ref(mod,
+                                                        item.protocol.methods[mi].params[pi].type,
+                                                        nullptr,
+                                                        &param.generic_index,
+                                                        &param.variant_index,
+                                                        &param.struct_index,
+                                                        &param.tuple_len,
+                                                        param.tuple_types,
+                                                        param.tuple_variant_indices,
+                                                        param.tuple_struct_indices,
+                                                        item.protocol.span);
+                if (!param_type) return core::make_unexpected(param_type.error());
+                param.type = param_type.value();
+                auto param_shape = intern_hir_type_shape(&mod,
+                                                         param.type,
+                                                         param.generic_index,
+                                                         param.variant_index,
+                                                         param.struct_index,
+                                                         param.tuple_len,
+                                                         param.tuple_types,
+                                                         param.tuple_variant_indices,
+                                                         param.tuple_struct_indices,
+                                                         item.protocol.span);
+                if (!param_shape) return core::make_unexpected(param_shape.error());
+                param.shape_index = param_shape.value();
+                if (!method.params.push(param))
+                    return frontend_error(FrontendError::TooManyItems, item.protocol.span);
+            }
+            method.has_return_type = item.protocol.methods[mi].has_return_type;
+            method.return_type_name = item.protocol.methods[mi].return_type.name;
+            if (method.has_return_type) {
+                auto return_type = resolve_func_type_ref(mod,
+                                                         item.protocol.methods[mi].return_type,
+                                                         nullptr,
+                                                         &method.return_generic_index,
+                                                         &method.return_variant_index,
+                                                         &method.return_struct_index,
+                                                         &method.return_tuple_len,
+                                                         method.return_tuple_types,
+                                                         method.return_tuple_variant_indices,
+                                                         method.return_tuple_struct_indices,
+                                                         item.protocol.span);
+                if (!return_type) return core::make_unexpected(return_type.error());
+                method.return_type = return_type.value();
+                auto return_shape = intern_hir_type_shape(&mod,
+                                                          method.return_type,
+                                                          method.return_generic_index,
+                                                          method.return_variant_index,
+                                                          method.return_struct_index,
+                                                          method.return_tuple_len,
+                                                          method.return_tuple_types,
+                                                          method.return_tuple_variant_indices,
+                                                          method.return_tuple_struct_indices,
+                                                          item.protocol.span);
+                if (!return_shape) return core::make_unexpected(return_shape.error());
+                method.return_shape_index = return_shape.value();
+            }
+            if (!proto.methods.push(method))
+                return frontend_error(FrontendError::TooManyItems, item.protocol.span);
+        }
+        if (!mod.protocols.push(proto))
+            return frontend_error(FrontendError::TooManyItems, item.protocol.span);
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Struct) continue;
+        if (item.struct_decl.name.eq({"Error", 5}))
+            return frontend_error(FrontendError::UnsupportedSyntax, item.struct_decl.span, item.struct_decl.name);
+        if (find_struct_index(mod, item.struct_decl.name) != mod.structs.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, item.struct_decl.span, item.struct_decl.name);
+        HirStruct decl{};
+        decl.span = item.struct_decl.span;
+        decl.name = item.struct_decl.name;
+        decl.type_params = item.struct_decl.type_params;
+        if (!mod.structs.push(decl))
+            return frontend_error(FrontendError::TooManyItems, item.struct_decl.span);
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Variant) continue;
+        if (find_variant_index(mod, item.variant.name) != mod.variants.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, item.variant.span, item.variant.name);
+        HirVariant variant{};
+        variant.span = item.variant.span;
+        variant.name = item.variant.name;
+        variant.type_params = item.variant.type_params;
+        if (!mod.variants.push(variant))
+            return frontend_error(FrontendError::TooManyItems, item.variant.span);
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Variant) continue;
+        const u32 variant_decl_index = find_variant_index(mod, item.variant.name);
+        if (variant_decl_index == mod.variants.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, item.variant.span, item.variant.name);
+        HirVariant& variant = mod.variants[variant_decl_index];
+        for (u32 ci = 0; ci < item.variant.cases.len; ci++) {
+            for (u32 seen = 0; seen < variant.cases.len; seen++) {
+                if (variant.cases[seen].name.eq(item.variant.cases[ci].name))
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          item.variant.span,
+                                          item.variant.cases[ci].name);
+            }
+            HirVariant::CaseDecl case_decl{};
+            case_decl.name = item.variant.cases[ci].name;
+            case_decl.has_payload = item.variant.cases[ci].has_payload;
+            if (case_decl.has_payload) {
+                FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> variant_type_params;
+                for (u32 ti = 0; ti < variant.type_params.len; ti++) {
+                    HirFunction::TypeParamDecl tp{};
+                    tp.name = variant.type_params[ti];
+                    if (!variant_type_params.push(tp))
+                        return frontend_error(FrontendError::TooManyItems, item.variant.span);
+                }
+                const auto& payload_ref = item.variant.cases[ci].payload_type;
+                if (!payload_ref.is_tuple && payload_ref.type_arg_names.len != 0) {
+                    u32 template_variant_index = 0xffffffffu;
+                    u32 template_struct_index = 0xffffffffu;
+                    const auto named_kind =
+                        resolve_named_type(mod, payload_ref.name, &template_variant_index, &template_struct_index);
+                    const bool is_generic_named =
+                        (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
+                         mod.variants[template_variant_index].type_params.len == payload_ref.type_arg_names.len) ||
+                        (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
+                         mod.structs[template_struct_index].type_params.len == payload_ref.type_arg_names.len);
+                    if (is_generic_named) {
+                        bool has_generic_arg = false;
+                        case_decl.payload_type = named_kind;
+                        case_decl.payload_template_variant_index = template_variant_index;
+                        case_decl.payload_template_struct_index = template_struct_index;
+                        case_decl.payload_type_arg_count = payload_ref.type_arg_names.len;
+                        for (u32 ai = 0; ai < payload_ref.type_arg_names.len; ai++) {
+                            AstTypeRef arg_ref = get_ast_type_arg_ref(payload_ref, ai);
+                            auto arg_type = resolve_func_type_ref(mod,
+                                                                  arg_ref,
+                                                                  &variant_type_params,
+                                                                  &case_decl.payload_type_args[ai].generic_index,
+                                                                  &case_decl.payload_type_args[ai].variant_index,
+                                                                  &case_decl.payload_type_args[ai].struct_index,
+                                                                  &case_decl.payload_type_args[ai].tuple_len,
+                                                                  case_decl.payload_type_args[ai].tuple_types,
+                                                                  case_decl.payload_type_args[ai].tuple_variant_indices,
+                                                                  case_decl.payload_type_args[ai].tuple_struct_indices,
+                                                                  item.variant.span);
+                            if (!arg_type) return core::make_unexpected(arg_type.error());
+                            case_decl.payload_type_args[ai].type = arg_type.value();
+                            auto arg_shape = intern_hir_type_shape(&mod,
+                                                                   case_decl.payload_type_args[ai].type,
+                                                                   case_decl.payload_type_args[ai].generic_index,
+                                                                   case_decl.payload_type_args[ai].variant_index,
+                                                                   case_decl.payload_type_args[ai].struct_index,
+                                                                   case_decl.payload_type_args[ai].tuple_len,
+                                                                   case_decl.payload_type_args[ai].tuple_types,
+                                                                   case_decl.payload_type_args[ai].tuple_variant_indices,
+                                                                   case_decl.payload_type_args[ai].tuple_struct_indices,
+                                                                   item.variant.span);
+                            if (!arg_shape) return core::make_unexpected(arg_shape.error());
+                            case_decl.payload_type_args[ai].shape_index = arg_shape.value();
+                            if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
+                        }
+                        if (has_generic_arg) {
+                            GenericBinding bindings[HirVariant::kMaxTypeParams]{};
+                            for (u32 ai = 0; ai < payload_ref.type_arg_names.len; ai++) {
+                                auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
+                                                                                    &mod,
+                                                                                    case_decl.payload_type_args[ai].type,
+                                                                                    case_decl.payload_type_args[ai].generic_index,
+                                                                                    case_decl.payload_type_args[ai].variant_index,
+                                                                                    case_decl.payload_type_args[ai].struct_index,
+                                                                                    case_decl.payload_type_args[ai].tuple_len,
+                                                                                    case_decl.payload_type_args[ai].tuple_types,
+                                                                                    case_decl.payload_type_args[ai].tuple_variant_indices,
+                                                                                    case_decl.payload_type_args[ai].tuple_struct_indices,
+                                                                                    case_decl.payload_type_args[ai].shape_index,
+                                                                                    item.variant.span);
+                                if (!filled) return core::make_unexpected(filled.error());
+                            }
+                            if (named_kind == HirTypeKind::Variant) {
+                                auto concrete = instantiate_variant(&mod,
+                                                                    template_variant_index,
+                                                                    bindings,
+                                                                    payload_ref.type_arg_names.len,
+                                                                    item.variant.span);
+                                if (!concrete) return core::make_unexpected(concrete.error());
+                                case_decl.payload_variant_index = concrete.value();
+                                case_decl.payload_struct_index = 0xffffffffu;
+                            } else {
+                                auto concrete = instantiate_struct(&mod,
+                                                                   template_struct_index,
+                                                                   bindings,
+                                                                   payload_ref.type_arg_names.len,
+                                                                   item.variant.span);
+                                if (!concrete) return core::make_unexpected(concrete.error());
+                                case_decl.payload_struct_index = concrete.value();
+                                case_decl.payload_variant_index = 0xffffffffu;
+                            }
+                            auto payload_shape = intern_hir_type_shape(&mod,
+                                                                       case_decl.payload_type,
+                                                                       case_decl.payload_generic_index,
+                                                                       case_decl.payload_variant_index,
+                                                                       case_decl.payload_struct_index,
+                                                                       case_decl.payload_tuple_len,
+                                                                       case_decl.payload_tuple_types,
+                                                                       case_decl.payload_tuple_variant_indices,
+                                                                       case_decl.payload_tuple_struct_indices,
+                                                                       item.variant.span);
+                            if (!payload_shape) return core::make_unexpected(payload_shape.error());
+                            case_decl.payload_shape_index = payload_shape.value();
+                            if (!variant.cases.push(case_decl))
+                                return frontend_error(FrontendError::TooManyItems, item.variant.span);
+                            continue;
+                        }
+                    }
+                }
+                auto payload_type = resolve_func_type_ref(mod,
+                                                          payload_ref,
+                                                          &variant_type_params,
+                                                          &case_decl.payload_generic_index,
+                                                          &case_decl.payload_variant_index,
+                                                          &case_decl.payload_struct_index,
+                                                          &case_decl.payload_tuple_len,
+                                                          case_decl.payload_tuple_types,
+                                                          case_decl.payload_tuple_variant_indices,
+                                                          case_decl.payload_tuple_struct_indices,
+                                                          item.variant.span);
+                if (!payload_type) return core::make_unexpected(payload_type.error());
+                case_decl.payload_type = payload_type.value();
+                auto payload_shape = intern_hir_type_shape(&mod,
+                                                           case_decl.payload_type,
+                                                           case_decl.payload_generic_index,
+                                                           case_decl.payload_variant_index,
+                                                           case_decl.payload_struct_index,
+                                                           case_decl.payload_tuple_len,
+                                                           case_decl.payload_tuple_types,
+                                                           case_decl.payload_tuple_variant_indices,
+                                                           case_decl.payload_tuple_struct_indices,
+                                                           item.variant.span);
+                if (!payload_shape) return core::make_unexpected(payload_shape.error());
+                case_decl.payload_shape_index = payload_shape.value();
+            }
+            if (!variant.cases.push(case_decl))
+                return frontend_error(FrontendError::TooManyItems, item.variant.span);
+        }
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Struct) continue;
+        const u32 struct_decl_index = find_struct_index(mod, item.struct_decl.name);
+        if (struct_decl_index == mod.structs.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, item.struct_decl.span, item.struct_decl.name);
+        HirStruct& decl = mod.structs[struct_decl_index];
+        for (u32 fi = 0; fi < item.struct_decl.fields.len; fi++) {
+            for (u32 seen = 0; seen < decl.fields.len; seen++) {
+                if (decl.fields[seen].name.eq(item.struct_decl.fields[fi].name))
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          item.struct_decl.span,
+                                          item.struct_decl.fields[fi].name);
+            }
+            HirStruct::FieldDecl field{};
+            field.name = item.struct_decl.fields[fi].name;
+            if (!item.struct_decl.fields[fi].type.is_tuple &&
+                item.struct_decl.fields[fi].type.name.eq({"Error", 5})) {
+                field.type_name = item.struct_decl.fields[fi].type.name;
+                field.is_error_type = true;
+            } else {
+                FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> struct_type_params;
+                for (u32 ti = 0; ti < decl.type_params.len; ti++) {
+                    HirFunction::TypeParamDecl tp{};
+                    tp.name = decl.type_params[ti];
+                    if (!struct_type_params.push(tp))
+                        return frontend_error(FrontendError::TooManyItems, item.struct_decl.span);
+                }
+                const auto& type_ref = item.struct_decl.fields[fi].type;
+                if (!type_ref.is_tuple && type_ref.type_arg_names.len != 0) {
+                    u32 template_variant_index = 0xffffffffu;
+                    u32 template_struct_index = 0xffffffffu;
+                    const auto named_kind =
+                        resolve_named_type(mod, type_ref.name, &template_variant_index, &template_struct_index);
+                    const bool is_generic_named =
+                        (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
+                         mod.variants[template_variant_index].type_params.len == type_ref.type_arg_names.len) ||
+                        (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
+                         mod.structs[template_struct_index].type_params.len == type_ref.type_arg_names.len);
+                    if (is_generic_named) {
+                        bool has_generic_arg = false;
+                        field.type = named_kind;
+                        field.template_variant_index = template_variant_index;
+                        field.template_struct_index = template_struct_index;
+                        field.type_arg_count = type_ref.type_arg_names.len;
+                        for (u32 ai = 0; ai < type_ref.type_arg_names.len; ai++) {
+                            AstTypeRef arg_ref = get_ast_type_arg_ref(type_ref, ai);
+                            auto arg_type = resolve_func_type_ref(mod,
+                                                                  arg_ref,
+                                                                  &struct_type_params,
+                                                                  &field.type_args[ai].generic_index,
+                                                                  &field.type_args[ai].variant_index,
+                                                                  &field.type_args[ai].struct_index,
+                                                                  &field.type_args[ai].tuple_len,
+                                                                  field.type_args[ai].tuple_types,
+                                                                  field.type_args[ai].tuple_variant_indices,
+                                                                  field.type_args[ai].tuple_struct_indices,
+                                                                  item.struct_decl.span);
+                            if (!arg_type) return core::make_unexpected(arg_type.error());
+                            field.type_args[ai].type = arg_type.value();
+                            auto arg_shape = intern_hir_type_shape(&mod,
+                                                                   field.type_args[ai].type,
+                                                                   field.type_args[ai].generic_index,
+                                                                   field.type_args[ai].variant_index,
+                                                                   field.type_args[ai].struct_index,
+                                                                   field.type_args[ai].tuple_len,
+                                                                   field.type_args[ai].tuple_types,
+                                                                   field.type_args[ai].tuple_variant_indices,
+                                                                   field.type_args[ai].tuple_struct_indices,
+                                                                   item.struct_decl.span);
+                            if (!arg_shape) return core::make_unexpected(arg_shape.error());
+                            field.type_args[ai].shape_index = arg_shape.value();
+                            if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
+                        }
+                        if (has_generic_arg) {
+                            GenericBinding bindings[HirStruct::kMaxTypeParams]{};
+                            for (u32 ai = 0; ai < type_ref.type_arg_names.len; ai++) {
+                                auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
+                                                                                    &mod,
+                                                                                    field.type_args[ai].type,
+                                                                                    field.type_args[ai].generic_index,
+                                                                                    field.type_args[ai].variant_index,
+                                                                                    field.type_args[ai].struct_index,
+                                                                                    field.type_args[ai].tuple_len,
+                                                                                    field.type_args[ai].tuple_types,
+                                                                                    field.type_args[ai].tuple_variant_indices,
+                                                                                    field.type_args[ai].tuple_struct_indices,
+                                                                                    field.type_args[ai].shape_index,
+                                                                                    item.struct_decl.span);
+                                if (!filled) return core::make_unexpected(filled.error());
+                            }
+                            if (named_kind == HirTypeKind::Variant) {
+                                auto concrete = instantiate_variant(&mod,
+                                                                    template_variant_index,
+                                                                    bindings,
+                                                                    type_ref.type_arg_names.len,
+                                                                    item.struct_decl.span);
+                                if (!concrete) return core::make_unexpected(concrete.error());
+                                field.variant_index = concrete.value();
+                                field.struct_index = 0xffffffffu;
+                            } else {
+                                auto concrete = instantiate_struct(&mod,
+                                                                   template_struct_index,
+                                                                   bindings,
+                                                                   type_ref.type_arg_names.len,
+                                                                   item.struct_decl.span);
+                                if (!concrete) return core::make_unexpected(concrete.error());
+                                field.struct_index = concrete.value();
+                                field.variant_index = 0xffffffffu;
+                            }
+                            field.type_name = type_ref.name;
+                            if (!decl.fields.push(field))
+                                return frontend_error(FrontendError::TooManyItems, item.struct_decl.span);
+                            continue;
+                        }
+                    }
+                }
+                u32 variant_index = 0xffffffffu;
+                u32 struct_index = 0xffffffffu;
+                u32 tuple_len = 0;
+                HirTypeKind tuple_types[kMaxTupleSlots]{};
+                u32 tuple_variant_indices[kMaxTupleSlots]{};
+                u32 tuple_struct_indices[kMaxTupleSlots]{};
+                auto resolved = resolve_func_type_ref(mod,
+                                                      type_ref,
+                                                      &struct_type_params,
+                                                      &field.generic_index,
+                                                      &variant_index,
+                                                      &struct_index,
+                                                      &tuple_len,
+                                                      tuple_types,
+                                                      tuple_variant_indices,
+                                                      tuple_struct_indices,
+                                                      item.struct_decl.span);
+                if (!resolved) return core::make_unexpected(resolved.error());
+                field.type = resolved.value();
+                field.variant_index = variant_index;
+                field.struct_index = struct_index;
+                field.tuple_len = tuple_len;
+                field.type_name = item.struct_decl.fields[fi].type.name;
+                for (u32 ti = 0; ti < tuple_len; ti++) {
+                    field.tuple_types[ti] = tuple_types[ti];
+                    field.tuple_variant_indices[ti] = tuple_variant_indices[ti];
+                    field.tuple_struct_indices[ti] = tuple_struct_indices[ti];
+                }
+            }
+            if (!field.is_error_type) {
+                auto field_shape = intern_hir_type_shape(&mod,
+                                                         field.type,
+                                                         field.generic_index,
+                                                         field.variant_index,
+                                                         field.struct_index,
+                                                         field.tuple_len,
+                                                         field.tuple_types,
+                                                         field.tuple_variant_indices,
+                                                         field.tuple_struct_indices,
+                                                         item.struct_decl.span);
+                if (!field_shape) return core::make_unexpected(field_shape.error());
+                field.shape_index = field_shape.value();
+            }
+            if (!decl.fields.push(field))
+                return frontend_error(FrontendError::TooManyItems, item.struct_decl.span);
+        }
+        for (u32 fi = 0; fi < decl.fields.len; fi++) {
+            if (decl.fields[fi].name.eq({"err", 3}) && decl.fields[fi].is_error_type) {
+                decl.conforms_error = true;
+                break;
+            }
+        }
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind == AstItemKind::Import) continue;
+        if (item.kind != AstItemKind::Using) continue;
+        for (u32 ai = 0; ai < mod.aliases.len; ai++) {
+            if (mod.aliases[ai].name.eq(item.using_decl.name))
+                return frontend_error(FrontendError::UnsupportedSyntax, item.using_decl.span, item.using_decl.name);
+        }
+        HirAlias alias{};
+        alias.span = item.using_decl.span;
+        alias.name = item.using_decl.name;
+        for (u32 pi = 0; pi < item.using_decl.target_parts.len; pi++) {
+            if (!alias.target_parts.push(item.using_decl.target_parts[pi]))
+                return frontend_error(FrontendError::TooManyItems, item.using_decl.span);
+        }
+        if (!mod.aliases.push(alias))
+            return frontend_error(FrontendError::TooManyItems, item.using_decl.span);
+    }
+
+    auto imported = merge_imported_functions(&mod, imported_modules);
+    if (!imported) return core::make_unexpected(imported.error());
+    auto imported_impls = merge_imported_impls(&mod, imported_modules);
+    if (!imported_impls) return core::make_unexpected(imported_impls.error());
+
+    auto refreshed_structs = refresh_concrete_struct_instances(&mod);
+    if (!refreshed_structs) {
+        if (source_path.len != 0 && import_stack != nullptr && !import_stack->empty()) import_stack->pop_back();
+        return core::make_unexpected(refreshed_structs.error());
+    }
+    auto refreshed_variants = refresh_concrete_variant_instances(&mod);
+    if (!refreshed_variants) {
+        if (source_path.len != 0 && import_stack != nullptr && !import_stack->empty()) import_stack->pop_back();
+        return core::make_unexpected(refreshed_variants.error());
+    }
+
+    auto declare_function_like = [&](const AstFunctionDecl& ast_func, Span span, Str fn_name, const FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>* extra_type_params = nullptr) -> FrontendResult<HirFunction> {
+        HirFunction fn{};
+        fn.span = span;
+        fn.name = fn_name;
+        if (extra_type_params != nullptr) {
+            for (u32 ti = 0; ti < extra_type_params->len; ti++) {
+                if (!fn.type_params.push((*extra_type_params)[ti]))
+                    return frontend_error(FrontendError::TooManyItems, span);
+            }
+        }
+        for (u32 ti = 0; ti < ast_func.type_params.len; ti++) {
+            for (u32 seen = 0; seen < fn.type_params.len; seen++) {
+                if (fn.type_params[seen].name.eq(ast_func.type_params[ti].name))
+                    return frontend_error(FrontendError::UnsupportedSyntax, span, ast_func.type_params[ti].name);
+            }
+            HirFunction::TypeParamDecl type_param{};
+            type_param.name = ast_func.type_params[ti].name;
+            if (ast_func.type_params[ti].has_constraint) {
+                type_param.has_constraint = true;
+                type_param.constraint = ast_func.type_params[ti].constraint;
+                for (u32 ci = 0; ci < ast_func.type_params[ti].constraints.len; ci++) {
+                    const auto constraint = ast_func.type_params[ti].constraints[ci];
+                    Str resolved_constraint = constraint;
+                    if (ci < ast_func.type_params[ti].constraint_namespaces.len && ast_func.type_params[ti].constraint_namespaces[ci].len != 0) {
+                        if (!resolve_import_namespace_type_name(mod,
+                                                                ast_func.type_params[ti].constraint_namespaces[ci],
+                                                                constraint,
+                                                                &resolved_constraint))
+                            return frontend_error(FrontendError::UnsupportedSyntax, span, constraint);
+                    }
+                    const auto kind = resolve_protocol_kind(mod, resolved_constraint);
+                    if (kind == static_cast<HirProtocolKind>(0xff))
+                        return frontend_error(FrontendError::UnsupportedSyntax, span, constraint);
+                    type_param.constraints[ci] = resolved_constraint;
+                    type_param.constraint_kinds[ci] = kind;
+                    if (kind == HirProtocolKind::Error) type_param.has_error_constraint = true;
+                    if (kind == HirProtocolKind::Eq) type_param.has_eq_constraint = true;
+                    if (kind == HirProtocolKind::Ord) type_param.has_ord_constraint = true;
+                    if (kind == HirProtocolKind::Custom) {
+                        const u32 pi = find_protocol_index(mod, resolved_constraint);
+                        if (pi >= mod.protocols.len)
+                            return frontend_error(FrontendError::UnsupportedSyntax, span, constraint);
+                        type_param.custom_protocol_indices[type_param.custom_protocol_count++] = pi;
+                    }
+                }
+                type_param.constraint_kind = ast_func.type_params[ti].constraints.len != 0 ? type_param.constraint_kinds[0] : HirProtocolKind::Custom;
+            }
+            if (!fn.type_params.push(type_param))
+                return frontend_error(FrontendError::TooManyItems, span);
+        }
+        if (ast_func.has_return_type) {
+            const auto& ret_ref = ast_func.return_type;
+            if (!ret_ref.is_tuple && ret_ref.type_arg_names.len != 0) {
+                u32 template_variant_index = 0xffffffffu;
+                u32 template_struct_index = 0xffffffffu;
+                const auto named_kind = resolve_named_type(mod, ret_ref.name, &template_variant_index, &template_struct_index);
+                const bool is_generic_named =
+                    (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
+                     mod.variants[template_variant_index].type_params.len == ret_ref.type_arg_names.len) ||
+                    (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
+                     mod.structs[template_struct_index].type_params.len == ret_ref.type_arg_names.len);
+                if (is_generic_named) {
+                    bool has_generic_arg = false;
+                    GenericBinding bindings[HirFunction::kMaxTypeParams]{};
+                    fn.return_type = named_kind;
+                    fn.return_template_variant_index = template_variant_index;
+                    fn.return_template_struct_index = template_struct_index;
+                    fn.return_type_arg_count = ret_ref.type_arg_names.len;
+                    for (u32 ai = 0; ai < ret_ref.type_arg_names.len; ai++) {
+                        AstTypeRef arg_ref = get_ast_type_arg_ref(ret_ref, ai);
+                        auto arg_type = resolve_func_type_ref(mod, arg_ref, &fn.type_params,
+                                                              &fn.return_type_args[ai].generic_index,
+                                                              &fn.return_type_args[ai].variant_index,
+                                                              &fn.return_type_args[ai].struct_index,
+                                                              &fn.return_type_args[ai].tuple_len,
+                                                              fn.return_type_args[ai].tuple_types,
+                                                              fn.return_type_args[ai].tuple_variant_indices,
+                                                              fn.return_type_args[ai].tuple_struct_indices,
+                                                              span);
+                        if (!arg_type) return core::make_unexpected(arg_type.error());
+                        fn.return_type_args[ai].type = arg_type.value();
+                        auto arg_shape = intern_hir_type_shape(&mod,
+                                                               fn.return_type_args[ai].type,
+                                                               fn.return_type_args[ai].generic_index,
+                                                               fn.return_type_args[ai].variant_index,
+                                                               fn.return_type_args[ai].struct_index,
+                                                               fn.return_type_args[ai].tuple_len,
+                                                               fn.return_type_args[ai].tuple_types,
+                                                               fn.return_type_args[ai].tuple_variant_indices,
+                                                               fn.return_type_args[ai].tuple_struct_indices,
+                                                               span);
+                        if (!arg_shape) return core::make_unexpected(arg_shape.error());
+                        fn.return_type_args[ai].shape_index = arg_shape.value();
+                        auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
+                                                                            &mod,
+                                                                            fn.return_type_args[ai].type,
+                                                                            fn.return_type_args[ai].generic_index,
+                                                                            fn.return_type_args[ai].variant_index,
+                                                                            fn.return_type_args[ai].struct_index,
+                                                                            fn.return_type_args[ai].tuple_len,
+                                                                            fn.return_type_args[ai].tuple_types,
+                                                                            fn.return_type_args[ai].tuple_variant_indices,
+                                                                            fn.return_type_args[ai].tuple_struct_indices,
+                                                                            fn.return_type_args[ai].shape_index,
+                                                                            span);
+                        if (!filled) return core::make_unexpected(filled.error());
+                        if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
+                    }
+                    if (has_generic_arg) {
+                        if (named_kind == HirTypeKind::Variant) {
+                            auto concrete = instantiate_variant(&mod, template_variant_index, bindings, ret_ref.type_arg_names.len, span);
+                            if (!concrete) return core::make_unexpected(concrete.error());
+                            fn.return_variant_index = concrete.value();
+                        } else {
+                            auto concrete = instantiate_struct(&mod, template_struct_index, bindings, ret_ref.type_arg_names.len, span);
+                            if (!concrete) return core::make_unexpected(concrete.error());
+                            fn.return_struct_index = concrete.value();
+                        }
+                    } else {
+                        auto ret_type = resolve_func_type_ref(mod, ret_ref, &fn.type_params,
+                                                              &fn.return_generic_index,
+                                                              &fn.return_variant_index,
+                                                              &fn.return_struct_index,
+                                                              &fn.return_tuple_len,
+                                                              fn.return_tuple_types,
+                                                              fn.return_tuple_variant_indices,
+                                                              fn.return_tuple_struct_indices,
+                                                              span);
+                        if (!ret_type) return core::make_unexpected(ret_type.error());
+                        fn.return_type = ret_type.value();
+                    }
+                } else {
+                    auto ret_type = resolve_func_type_ref(mod, ret_ref, &fn.type_params,
+                                                          &fn.return_generic_index,
+                                                          &fn.return_variant_index,
+                                                          &fn.return_struct_index,
+                                                          &fn.return_tuple_len,
+                                                          fn.return_tuple_types,
+                                                          fn.return_tuple_variant_indices,
+                                                          fn.return_tuple_struct_indices,
+                                                          span);
+                    if (!ret_type) return core::make_unexpected(ret_type.error());
+                    fn.return_type = ret_type.value();
+                }
+            } else {
+                auto ret_type = resolve_func_type_ref(mod, ast_func.return_type, &fn.type_params,
+                                                      &fn.return_generic_index,
+                                                      &fn.return_variant_index,
+                                                      &fn.return_struct_index,
+                                                      &fn.return_tuple_len,
+                                                      fn.return_tuple_types,
+                                                      fn.return_tuple_variant_indices,
+                                                      fn.return_tuple_struct_indices,
+                                                      span);
+                if (!ret_type) return core::make_unexpected(ret_type.error());
+                fn.return_type = ret_type.value();
+            }
+        }
+        for (u32 pi = 0; pi < ast_func.params.len; pi++) {
+            for (u32 seen = 0; seen < fn.params.len; seen++) {
+                if (fn.params[seen].name.eq(ast_func.params[pi].name))
+                    return frontend_error(FrontendError::UnsupportedSyntax, span, ast_func.params[pi].name);
+            }
+            HirFunction::ParamDecl param{};
+            param.name = ast_func.params[pi].name;
+            const auto& param_ref = ast_func.params[pi].type;
+            if (!param_ref.is_tuple && param_ref.type_arg_names.len != 0) {
+                u32 template_variant_index = 0xffffffffu;
+                u32 template_struct_index = 0xffffffffu;
+                const auto named_kind = resolve_named_type(mod, param_ref.name, &template_variant_index, &template_struct_index);
+                const bool is_generic_named =
+                    (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
+                     mod.variants[template_variant_index].type_params.len == param_ref.type_arg_names.len) ||
+                    (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
+                     mod.structs[template_struct_index].type_params.len == param_ref.type_arg_names.len);
+                if (is_generic_named) {
+                    bool has_generic_arg = false;
+                    GenericBinding bindings[HirFunction::kMaxTypeParams]{};
+                    param.type = named_kind;
+                    param.template_variant_index = template_variant_index;
+                    param.template_struct_index = template_struct_index;
+                    param.type_arg_count = param_ref.type_arg_names.len;
+                    for (u32 ai = 0; ai < param_ref.type_arg_names.len; ai++) {
+                        AstTypeRef arg_ref = get_ast_type_arg_ref(param_ref, ai);
+                        auto arg_type = resolve_func_type_ref(mod, arg_ref, &fn.type_params,
+                                                              &param.type_args[ai].generic_index,
+                                                              &param.type_args[ai].variant_index,
+                                                              &param.type_args[ai].struct_index,
+                                                              &param.type_args[ai].tuple_len,
+                                                              param.type_args[ai].tuple_types,
+                                                              param.type_args[ai].tuple_variant_indices,
+                                                              param.type_args[ai].tuple_struct_indices,
+                                                              span);
+                        if (!arg_type) return core::make_unexpected(arg_type.error());
+                        param.type_args[ai].type = arg_type.value();
+                        auto arg_shape = intern_hir_type_shape(&mod,
+                                                               param.type_args[ai].type,
+                                                               param.type_args[ai].generic_index,
+                                                               param.type_args[ai].variant_index,
+                                                               param.type_args[ai].struct_index,
+                                                               param.type_args[ai].tuple_len,
+                                                               param.type_args[ai].tuple_types,
+                                                               param.type_args[ai].tuple_variant_indices,
+                                                               param.type_args[ai].tuple_struct_indices,
+                                                               span);
+                        if (!arg_shape) return core::make_unexpected(arg_shape.error());
+                        param.type_args[ai].shape_index = arg_shape.value();
+                        auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
+                                                                            &mod,
+                                                                            param.type_args[ai].type,
+                                                                            param.type_args[ai].generic_index,
+                                                                            param.type_args[ai].variant_index,
+                                                                            param.type_args[ai].struct_index,
+                                                                            param.type_args[ai].tuple_len,
+                                                                            param.type_args[ai].tuple_types,
+                                                                            param.type_args[ai].tuple_variant_indices,
+                                                                            param.type_args[ai].tuple_struct_indices,
+                                                                            param.type_args[ai].shape_index,
+                                                                            span);
+                        if (!filled) return core::make_unexpected(filled.error());
+                        if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
+                    }
+                    if (has_generic_arg) {
+                        if (named_kind == HirTypeKind::Variant) {
+                            auto concrete = instantiate_variant(&mod, template_variant_index, bindings, param_ref.type_arg_names.len, span);
+                            if (!concrete) return core::make_unexpected(concrete.error());
+                            param.variant_index = concrete.value();
+                        } else {
+                            auto concrete = instantiate_struct(&mod, template_struct_index, bindings, param_ref.type_arg_names.len, span);
+                            if (!concrete) return core::make_unexpected(concrete.error());
+                            param.struct_index = concrete.value();
+                        }
+                    } else {
+                        auto param_type = resolve_func_type_ref(mod, param_ref, &fn.type_params,
+                                                                &param.generic_index,
+                                                                &param.variant_index,
+                                                                &param.struct_index,
+                                                                &param.tuple_len,
+                                                                param.tuple_types,
+                                                                param.tuple_variant_indices,
+                                                                param.tuple_struct_indices,
+                                                                span);
+                        if (!param_type) return core::make_unexpected(param_type.error());
+                        param.type = param_type.value();
+                    }
+                } else {
+                    auto param_type = resolve_func_type_ref(mod, param_ref, &fn.type_params,
+                                                            &param.generic_index,
+                                                            &param.variant_index,
+                                                            &param.struct_index,
+                                                            &param.tuple_len,
+                                                            param.tuple_types,
+                                                            param.tuple_variant_indices,
+                                                            param.tuple_struct_indices,
+                                                            span);
+                    if (!param_type) return core::make_unexpected(param_type.error());
+                    param.type = param_type.value();
+                }
+            } else {
+                auto param_type = resolve_func_type_ref(mod, param_ref, &fn.type_params,
+                                                        &param.generic_index,
+                                                        &param.variant_index,
+                                                        &param.struct_index,
+                                                        &param.tuple_len,
+                                                        param.tuple_types,
+                                                        param.tuple_variant_indices,
+                                                        param.tuple_struct_indices,
+                                                        span);
+                if (!param_type) return core::make_unexpected(param_type.error());
+                param.type = param_type.value();
+            }
+            if (param.type == HirTypeKind::Generic && param.generic_index < fn.type_params.len)
+                param.generic_has_error_constraint = fn.type_params[param.generic_index].has_error_constraint;
+            if (param.type == HirTypeKind::Generic && param.generic_index < fn.type_params.len) {
+                param.generic_has_eq_constraint = fn.type_params[param.generic_index].has_eq_constraint;
+                param.generic_has_ord_constraint = fn.type_params[param.generic_index].has_ord_constraint;
+            param.generic_protocol_index = fn.type_params[param.generic_index].custom_protocol_count != 0 ?
+                fn.type_params[param.generic_index].custom_protocol_indices[0] : 0xffffffffu;
+            param.generic_protocol_count = fn.type_params[param.generic_index].custom_protocol_count;
+            for (u32 cpi = 0; cpi < param.generic_protocol_count; cpi++)
+                param.generic_protocol_indices[cpi] = fn.type_params[param.generic_index].custom_protocol_indices[cpi];
+            }
+            if (!fn.params.push(param))
+                return frontend_error(FrontendError::TooManyItems, span);
+        }
+        if (fn.return_type != HirTypeKind::Unknown) {
+            auto return_shape = intern_hir_type_shape(&mod,
+                                                      fn.return_type,
+                                                      fn.return_generic_index,
+                                                      fn.return_variant_index,
+                                                      fn.return_struct_index,
+                                                      fn.return_tuple_len,
+                                                      fn.return_tuple_types,
+                                                      fn.return_tuple_variant_indices,
+                                                      fn.return_tuple_struct_indices,
+                                                      span);
+            if (!return_shape) return core::make_unexpected(return_shape.error());
+            fn.return_shape_index = return_shape.value();
+        }
+        for (u32 pi = 0; pi < fn.params.len; pi++) {
+            auto param_shape = intern_hir_type_shape(&mod,
+                                                     fn.params[pi].type,
+                                                     fn.params[pi].generic_index,
+                                                     fn.params[pi].variant_index,
+                                                     fn.params[pi].struct_index,
+                                                     fn.params[pi].tuple_len,
+                                                     fn.params[pi].tuple_types,
+                                                     fn.params[pi].tuple_variant_indices,
+                                                     fn.params[pi].tuple_struct_indices,
+                                                     span);
+            if (!param_shape) return core::make_unexpected(param_shape.error());
+            fn.params[pi].shape_index = param_shape.value();
+        }
+        return fn;
+    };
+
+    auto analyze_function_body_like = [&](HirFunction& fn, const AstFunctionDecl& ast_func, Span span) -> FrontendResult<void> {
+        HirRoute scratch{};
+        FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> ast_named_error_cases;
+        auto ast_collected = collect_named_error_cases_ast(*ast_func.body, &ast_named_error_cases);
+        if (!ast_collected) return core::make_unexpected(ast_collected.error());
+        if (ast_named_error_cases.len != 0) {
+            HirVariant error_variant{};
+            error_variant.span = span;
+            error_variant.name = {"__error_func", 12};
+            for (u32 ci = 0; ci < ast_named_error_cases.len; ci++) {
+                HirVariant::CaseDecl case_decl{};
+                case_decl.name = ast_named_error_cases[ci].name;
+                if (!error_variant.cases.push(case_decl))
+                    return frontend_error(FrontendError::TooManyItems, span);
+            }
+            if (!mod.variants.push(error_variant))
+                return frontend_error(FrontendError::TooManyItems, span);
+            scratch.error_variant_index = mod.variants.len - 1;
+        }
+        HirLocal param_locals[AstFunctionDecl::kMaxParams]{};
+        for (u32 pi = 0; pi < fn.params.len; pi++) {
+            param_locals[pi].span = span;
+            param_locals[pi].name = fn.params[pi].name;
+            param_locals[pi].ref_index = pi;
+            param_locals[pi].type = fn.params[pi].type;
+            param_locals[pi].generic_index = fn.params[pi].generic_index;
+            param_locals[pi].generic_has_error_constraint = fn.params[pi].generic_has_error_constraint;
+            param_locals[pi].generic_has_eq_constraint = fn.params[pi].generic_has_eq_constraint;
+            param_locals[pi].generic_has_ord_constraint = fn.params[pi].generic_has_ord_constraint;
+            param_locals[pi].generic_protocol_index = fn.params[pi].generic_protocol_index;
+            param_locals[pi].generic_protocol_count = fn.params[pi].generic_protocol_count;
+            for (u32 cpi = 0; cpi < param_locals[pi].generic_protocol_count; cpi++)
+                param_locals[pi].generic_protocol_indices[cpi] = fn.params[pi].generic_protocol_indices[cpi];
+            param_locals[pi].variant_index = fn.params[pi].variant_index;
+            param_locals[pi].struct_index = fn.params[pi].struct_index;
+            param_locals[pi].shape_index = fn.params[pi].shape_index;
+            param_locals[pi].tuple_len = fn.params[pi].tuple_len;
+            for (u32 ti = 0; ti < fn.params[pi].tuple_len; ti++) {
+                param_locals[pi].tuple_types[ti] = fn.params[pi].tuple_types[ti];
+                param_locals[pi].tuple_variant_indices[ti] = fn.params[pi].tuple_variant_indices[ti];
+                param_locals[pi].tuple_struct_indices[ti] = fn.params[pi].tuple_struct_indices[ti];
+            }
+            param_locals[pi].init.kind = HirExprKind::LocalRef;
+            param_locals[pi].init.type = fn.params[pi].type;
+            param_locals[pi].init.generic_index = fn.params[pi].generic_index;
+            param_locals[pi].init.generic_has_error_constraint = fn.params[pi].generic_has_error_constraint;
+            param_locals[pi].init.generic_has_eq_constraint = fn.params[pi].generic_has_eq_constraint;
+            param_locals[pi].init.generic_has_ord_constraint = fn.params[pi].generic_has_ord_constraint;
+            param_locals[pi].init.generic_protocol_index = fn.params[pi].generic_protocol_index;
+            param_locals[pi].init.generic_protocol_count = fn.params[pi].generic_protocol_count;
+            for (u32 cpi = 0; cpi < param_locals[pi].init.generic_protocol_count; cpi++)
+                param_locals[pi].init.generic_protocol_indices[cpi] = fn.params[pi].generic_protocol_indices[cpi];
+            param_locals[pi].init.local_index = pi;
+            param_locals[pi].init.variant_index = fn.params[pi].variant_index;
+            param_locals[pi].init.struct_index = fn.params[pi].struct_index;
+            param_locals[pi].init.shape_index = fn.params[pi].shape_index;
+            param_locals[pi].init.tuple_len = fn.params[pi].tuple_len;
+            for (u32 ti = 0; ti < fn.params[pi].tuple_len; ti++) {
+                param_locals[pi].init.tuple_types[ti] = fn.params[pi].tuple_types[ti];
+                param_locals[pi].init.tuple_variant_indices[ti] = fn.params[pi].tuple_variant_indices[ti];
+                param_locals[pi].init.tuple_struct_indices[ti] = fn.params[pi].tuple_struct_indices[ti];
+            }
+        }
+        auto body = analyze_function_body_stmt(*ast_func.body, &scratch, mod, param_locals, fn.params.len, nullptr);
+        if (!body) return core::make_unexpected(body.error());
+        FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> named_error_cases;
+        for (u32 li = 0; li < scratch.locals.len; li++) {
+            auto collected = collect_named_error_cases(scratch.locals[li].init, &named_error_cases);
+            if (!collected) return core::make_unexpected(collected.error());
+        }
+        auto collected = collect_named_error_cases(body.value(), &named_error_cases);
+        if (!collected) return core::make_unexpected(collected.error());
+        if (named_error_cases.len != 0 && scratch.error_variant_index == 0xffffffffu) {
+            HirVariant error_variant{};
+            error_variant.span = span;
+            error_variant.name = {"__error_func", 12};
+            for (u32 ci = 0; ci < named_error_cases.len; ci++) {
+                HirVariant::CaseDecl case_decl{};
+                case_decl.name = named_error_cases[ci].name;
+                if (!error_variant.cases.push(case_decl))
+                    return frontend_error(FrontendError::TooManyItems, span);
+            }
+            if (!mod.variants.push(error_variant))
+                return frontend_error(FrontendError::TooManyItems, span);
+            scratch.error_variant_index = mod.variants.len - 1;
+        }
+        if (named_error_cases.len != 0 && scratch.error_variant_index != 0xffffffffu) {
+            const u32 error_variant_index = scratch.error_variant_index;
+            for (u32 li = 0; li < scratch.locals.len; li++) {
+                patch_named_error_variant(&scratch.locals[li].init, error_variant_index, named_error_cases);
+                patch_error_variant_refs(&scratch.locals[li].init, error_variant_index);
+                if (scratch.locals[li].may_error && scratch.locals[li].error_variant_index == 0xffffffffu)
+                    scratch.locals[li].error_variant_index = error_variant_index;
+            }
+            patch_named_error_variant(&body.value(), error_variant_index, named_error_cases);
+            patch_error_variant_refs(&body.value(), error_variant_index);
+        }
+        if (fn.return_type == HirTypeKind::Unknown) {
+            if (body->type == HirTypeKind::Unknown)
+                return frontend_error(FrontendError::UnsupportedSyntax, ast_func.body->span);
+            fn.return_type = body->type;
+            fn.return_generic_index = body->generic_index;
+            if (body->type == HirTypeKind::Variant) fn.return_variant_index = body->variant_index;
+            if (body->type == HirTypeKind::Struct) fn.return_struct_index = body->struct_index;
+            if (body->type == HirTypeKind::Tuple) {
+                fn.return_tuple_len = body->tuple_len;
+                for (u32 ti = 0; ti < body->tuple_len; ti++) {
+                    fn.return_tuple_types[ti] = body->tuple_types[ti];
+                    fn.return_tuple_variant_indices[ti] = body->tuple_variant_indices[ti];
+                    fn.return_tuple_struct_indices[ti] = body->tuple_struct_indices[ti];
+                }
+            }
+        } else {
+            if (body->type == HirTypeKind::Unknown && (body->may_nil || body->may_error)) {
+                body->type = fn.return_type;
+                body->generic_index = fn.return_generic_index;
+                body->shape_index = fn.return_shape_index;
+                if (fn.return_generic_index < fn.type_params.len) {
+                    body->generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
+                    body->generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
+                    body->generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+                    body->generic_protocol_index =
+                        fn.type_params[fn.return_generic_index].custom_protocol_count != 0
+                            ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
+                            : 0xffffffffu;
+                    body->generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+                    for (u32 cpi = 0; cpi < body->generic_protocol_count; cpi++)
+                        body->generic_protocol_indices[cpi] =
+                            fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
+                }
+                if (fn.return_type == HirTypeKind::Variant) body->variant_index = fn.return_variant_index;
+                if (fn.return_type == HirTypeKind::Struct) body->struct_index = fn.return_struct_index;
+                if (fn.return_type == HirTypeKind::Tuple) {
+                    body->tuple_len = fn.return_tuple_len;
+                    for (u32 ti = 0; ti < fn.return_tuple_len; ti++) {
+                        body->tuple_types[ti] = fn.return_tuple_types[ti];
+                        body->tuple_variant_indices[ti] = fn.return_tuple_variant_indices[ti];
+                        body->tuple_struct_indices[ti] = fn.return_tuple_struct_indices[ti];
+                    }
+                }
+            }
+            auto expected = make_expected_type_expr(fn.return_type,
+                                                    fn.return_variant_index,
+                                                    fn.return_struct_index,
+                                                    fn.return_tuple_len,
+                                                    fn.return_tuple_types,
+                                                    fn.return_tuple_variant_indices,
+                                                    fn.return_tuple_struct_indices,
+                                                    fn.return_shape_index);
+            expected.generic_index = fn.return_generic_index;
+            if (fn.return_generic_index < fn.type_params.len) {
+                expected.generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
+                expected.generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
+                expected.generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+                expected.generic_protocol_index =
+                    fn.type_params[fn.return_generic_index].custom_protocol_count != 0
+                        ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
+                        : 0xffffffffu;
+                expected.generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+                for (u32 cpi = 0; cpi < expected.generic_protocol_count; cpi++)
+                    expected.generic_protocol_indices[cpi] =
+                        fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
+            }
+            if (!same_hir_type_shape(mod, body.value(), expected))
+                return frontend_error(FrontendError::UnsupportedSyntax, ast_func.body->span);
+            if (body->type == HirTypeKind::Variant && body->variant_index != fn.return_variant_index)
+                return frontend_error(FrontendError::UnsupportedSyntax, ast_func.body->span);
+        }
+        if (fn.return_type != HirTypeKind::Unknown) {
+            auto return_shape = intern_hir_type_shape(&mod,
+                                                      fn.return_type,
+                                                      fn.return_generic_index,
+                                                      fn.return_variant_index,
+                                                      fn.return_struct_index,
+                                                      fn.return_tuple_len,
+                                                      fn.return_tuple_types,
+                                                      fn.return_tuple_variant_indices,
+                                                      fn.return_tuple_struct_indices,
+                                                      span);
+            if (!return_shape) return core::make_unexpected(return_shape.error());
+            fn.return_shape_index = return_shape.value();
+        }
+        HirLocal all_locals[AstFunctionDecl::kMaxParams + HirRoute::kMaxLocals]{};
+        u32 all_local_count = 0;
+        for (u32 pi = 0; pi < fn.params.len; pi++) all_locals[all_local_count++] = param_locals[pi];
+        for (u32 li = 0; li < scratch.locals.len; li++) all_locals[all_local_count++] = scratch.locals[li];
+        fn.exprs.len = 0;
+        auto normalized = normalize_function_expr(body.value(), &fn, all_locals, all_local_count, fn.params.len);
+        if (!normalized) return core::make_unexpected(normalized.error());
+        fn.body = normalized.value();
+        return {};
+    };
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Func) continue;
+        if (find_function_index(mod, item.func.name) != mod.functions.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, item.func.span, item.func.name);
+        HirFunction fn{};
+        fn.span = item.func.span;
+        fn.name = item.func.name;
+        for (u32 ti = 0; ti < item.func.type_params.len; ti++) {
+            for (u32 seen = 0; seen < fn.type_params.len; seen++) {
+                if (fn.type_params[seen].name.eq(item.func.type_params[ti].name))
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, item.func.span, item.func.type_params[ti].name);
+            }
+            HirFunction::TypeParamDecl type_param{};
+            type_param.name = item.func.type_params[ti].name;
+            if (item.func.type_params[ti].has_constraint) {
+                type_param.has_constraint = true;
+                type_param.constraint = item.func.type_params[ti].constraint;
+                for (u32 ci = 0; ci < item.func.type_params[ti].constraints.len; ci++) {
+                    const auto constraint = item.func.type_params[ti].constraints[ci];
+                    Str resolved_constraint = constraint;
+                    if (ci < item.func.type_params[ti].constraint_namespaces.len && item.func.type_params[ti].constraint_namespaces[ci].len != 0) {
+                        if (!resolve_import_namespace_type_name(mod,
+                                                                item.func.type_params[ti].constraint_namespaces[ci],
+                                                                constraint,
+                                                                &resolved_constraint)) {
+                            return frontend_error(
+                                FrontendError::UnsupportedSyntax, item.func.span, constraint);
+                        }
+                    }
+                    const auto kind = resolve_protocol_kind(mod, resolved_constraint);
+                    if (kind == static_cast<HirProtocolKind>(0xff)) {
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, item.func.span, constraint);
+                    }
+                    type_param.constraints[ci] = resolved_constraint;
+                    type_param.constraint_kinds[ci] = kind;
+                    if (kind == HirProtocolKind::Error) type_param.has_error_constraint = true;
+                    if (kind == HirProtocolKind::Eq) type_param.has_eq_constraint = true;
+                    if (kind == HirProtocolKind::Ord) type_param.has_ord_constraint = true;
+                    if (kind == HirProtocolKind::Custom) {
+                        const u32 pi = find_protocol_index(mod, resolved_constraint);
+                        if (pi >= mod.protocols.len)
+                            return frontend_error(FrontendError::UnsupportedSyntax, item.func.span, constraint);
+                        type_param.custom_protocol_indices[type_param.custom_protocol_count++] = pi;
+                    }
+                }
+                type_param.constraint_kind = item.func.type_params[ti].constraints.len != 0 ? type_param.constraint_kinds[0] : HirProtocolKind::Custom;
+            }
+            if (!fn.type_params.push(type_param))
+                return frontend_error(FrontendError::TooManyItems, item.func.span);
+        }
+        if (item.func.has_return_type) {
+            const auto& ret_ref = item.func.return_type;
+            if (!ret_ref.is_tuple && ret_ref.type_arg_names.len != 0) {
+                u32 template_variant_index = 0xffffffffu;
+                u32 template_struct_index = 0xffffffffu;
+                const auto named_kind =
+                    resolve_named_type(mod, ret_ref.name, &template_variant_index, &template_struct_index);
+                const bool is_generic_named =
+                    (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
+                     mod.variants[template_variant_index].type_params.len == ret_ref.type_arg_names.len) ||
+                    (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
+                     mod.structs[template_struct_index].type_params.len == ret_ref.type_arg_names.len);
+                if (is_generic_named) {
+                    bool has_generic_arg = false;
+                    GenericBinding bindings[HirFunction::kMaxTypeParams]{};
+                    fn.return_type = named_kind;
+                    fn.return_template_variant_index = template_variant_index;
+                    fn.return_template_struct_index = template_struct_index;
+                    fn.return_type_arg_count = ret_ref.type_arg_names.len;
+                    for (u32 ai = 0; ai < ret_ref.type_arg_names.len; ai++) {
+                        AstTypeRef arg_ref = get_ast_type_arg_ref(ret_ref, ai);
+                        auto arg_type = resolve_func_type_ref(mod,
+                                                              arg_ref,
+                                                              &fn.type_params,
+                                                              &fn.return_type_args[ai].generic_index,
+                                                              &fn.return_type_args[ai].variant_index,
+                                                              &fn.return_type_args[ai].struct_index,
+                                                              &fn.return_type_args[ai].tuple_len,
+                                                              fn.return_type_args[ai].tuple_types,
+                                                              fn.return_type_args[ai].tuple_variant_indices,
+                                                              fn.return_type_args[ai].tuple_struct_indices,
+                                                              item.func.span);
+                        if (!arg_type) return core::make_unexpected(arg_type.error());
+                        fn.return_type_args[ai].type = arg_type.value();
+                        auto arg_shape = intern_hir_type_shape(&mod,
+                                                               fn.return_type_args[ai].type,
+                                                               fn.return_type_args[ai].generic_index,
+                                                               fn.return_type_args[ai].variant_index,
+                                                               fn.return_type_args[ai].struct_index,
+                                                               fn.return_type_args[ai].tuple_len,
+                                                               fn.return_type_args[ai].tuple_types,
+                                                               fn.return_type_args[ai].tuple_variant_indices,
+                                                               fn.return_type_args[ai].tuple_struct_indices,
+                                                               item.func.span);
+                        if (!arg_shape) return core::make_unexpected(arg_shape.error());
+                        fn.return_type_args[ai].shape_index = arg_shape.value();
+                        auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
+                                                                            &mod,
+                                                                            fn.return_type_args[ai].type,
+                                                                            fn.return_type_args[ai].generic_index,
+                                                                            fn.return_type_args[ai].variant_index,
+                                                                            fn.return_type_args[ai].struct_index,
+                                                                            fn.return_type_args[ai].tuple_len,
+                                                                            fn.return_type_args[ai].tuple_types,
+                                                                            fn.return_type_args[ai].tuple_variant_indices,
+                                                                            fn.return_type_args[ai].tuple_struct_indices,
+                                                                            fn.return_type_args[ai].shape_index,
+                                                                            item.func.span);
+                        if (!filled) return core::make_unexpected(filled.error());
+                        if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
+                    }
+                    if (has_generic_arg) {
+                        if (named_kind == HirTypeKind::Variant) {
+                            auto concrete = instantiate_variant(&mod,
+                                                                template_variant_index,
+                                                                bindings,
+                                                                ret_ref.type_arg_names.len,
+                                                                item.func.span);
+                            if (!concrete) return core::make_unexpected(concrete.error());
+                            fn.return_variant_index = concrete.value();
+                        } else {
+                            auto concrete = instantiate_struct(&mod,
+                                                               template_struct_index,
+                                                               bindings,
+                                                               ret_ref.type_arg_names.len,
+                                                               item.func.span);
+                            if (!concrete) return core::make_unexpected(concrete.error());
+                            fn.return_struct_index = concrete.value();
+                        }
+                    } else {
+                        auto ret_type = resolve_func_type_ref(mod,
+                                                              ret_ref,
+                                                              &fn.type_params,
+                                                              &fn.return_generic_index,
+                                                              &fn.return_variant_index,
+                                                              &fn.return_struct_index,
+                                                              &fn.return_tuple_len,
+                                                              fn.return_tuple_types,
+                                                              fn.return_tuple_variant_indices,
+                                                              fn.return_tuple_struct_indices,
+                                                              item.func.span);
+                        if (!ret_type) return core::make_unexpected(ret_type.error());
+                        fn.return_type = ret_type.value();
+                    }
+                } else {
+                    auto ret_type = resolve_func_type_ref(mod,
+                                                          ret_ref,
+                                                          &fn.type_params,
+                                                          &fn.return_generic_index,
+                                                          &fn.return_variant_index,
+                                                          &fn.return_struct_index,
+                                                          &fn.return_tuple_len,
+                                                          fn.return_tuple_types,
+                                                          fn.return_tuple_variant_indices,
+                                                          fn.return_tuple_struct_indices,
+                                                          item.func.span);
+                    if (!ret_type) return core::make_unexpected(ret_type.error());
+                    fn.return_type = ret_type.value();
+                }
+            } else {
+                auto ret_type = resolve_func_type_ref(mod,
+                                                      ret_ref,
+                                                      &fn.type_params,
+                                                      &fn.return_generic_index,
+                                                      &fn.return_variant_index,
+                                                      &fn.return_struct_index,
+                                                      &fn.return_tuple_len,
+                                                      fn.return_tuple_types,
+                                                      fn.return_tuple_variant_indices,
+                                                      fn.return_tuple_struct_indices,
+                                                      item.func.span);
+                if (!ret_type) return core::make_unexpected(ret_type.error());
+                fn.return_type = ret_type.value();
+            }
+        }
+        for (u32 pi = 0; pi < item.func.params.len; pi++) {
+            for (u32 seen = 0; seen < fn.params.len; seen++) {
+                if (fn.params[seen].name.eq(item.func.params[pi].name))
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.func.span, item.func.params[pi].name);
+            }
+            HirFunction::ParamDecl param{};
+            param.name = item.func.params[pi].name;
+            const auto& param_ref = item.func.params[pi].type;
+            if (!param_ref.is_tuple && param_ref.type_arg_names.len != 0) {
+                u32 template_variant_index = 0xffffffffu;
+                u32 template_struct_index = 0xffffffffu;
+                const auto named_kind =
+                    resolve_named_type(mod, param_ref.name, &template_variant_index, &template_struct_index);
+                const bool is_generic_named =
+                    (named_kind == HirTypeKind::Variant && template_variant_index < mod.variants.len &&
+                     mod.variants[template_variant_index].type_params.len == param_ref.type_arg_names.len) ||
+                    (named_kind == HirTypeKind::Struct && template_struct_index < mod.structs.len &&
+                     mod.structs[template_struct_index].type_params.len == param_ref.type_arg_names.len);
+                if (is_generic_named) {
+                    bool has_generic_arg = false;
+                    GenericBinding bindings[HirFunction::kMaxTypeParams]{};
+                    param.type = named_kind;
+                    param.template_variant_index = template_variant_index;
+                    param.template_struct_index = template_struct_index;
+                    param.type_arg_count = param_ref.type_arg_names.len;
+                    for (u32 ai = 0; ai < param_ref.type_arg_names.len; ai++) {
+                        AstTypeRef arg_ref = get_ast_type_arg_ref(param_ref, ai);
+                        auto arg_type = resolve_func_type_ref(mod,
+                                                              arg_ref,
+                                                              &fn.type_params,
+                                                              &param.type_args[ai].generic_index,
+                                                              &param.type_args[ai].variant_index,
+                                                              &param.type_args[ai].struct_index,
+                                                              &param.type_args[ai].tuple_len,
+                                                              param.type_args[ai].tuple_types,
+                                                              param.type_args[ai].tuple_variant_indices,
+                                                              param.type_args[ai].tuple_struct_indices,
+                                                              item.func.span);
+                        if (!arg_type) return core::make_unexpected(arg_type.error());
+                        param.type_args[ai].type = arg_type.value();
+                        auto arg_shape = intern_hir_type_shape(&mod,
+                                                               param.type_args[ai].type,
+                                                               param.type_args[ai].generic_index,
+                                                               param.type_args[ai].variant_index,
+                                                               param.type_args[ai].struct_index,
+                                                               param.type_args[ai].tuple_len,
+                                                               param.type_args[ai].tuple_types,
+                                                               param.type_args[ai].tuple_variant_indices,
+                                                               param.type_args[ai].tuple_struct_indices,
+                                                               item.func.span);
+                        if (!arg_shape) return core::make_unexpected(arg_shape.error());
+                        param.type_args[ai].shape_index = arg_shape.value();
+                        auto filled = fill_bound_binding_from_type_metadata(&bindings[ai],
+                                                                            &mod,
+                                                                            param.type_args[ai].type,
+                                                                            param.type_args[ai].generic_index,
+                                                                            param.type_args[ai].variant_index,
+                                                                            param.type_args[ai].struct_index,
+                                                                            param.type_args[ai].tuple_len,
+                                                                            param.type_args[ai].tuple_types,
+                                                                            param.type_args[ai].tuple_variant_indices,
+                                                                            param.type_args[ai].tuple_struct_indices,
+                                                                            param.type_args[ai].shape_index,
+                                                                            item.func.span);
+                        if (!filled) return core::make_unexpected(filled.error());
+                        if (arg_type.value() == HirTypeKind::Generic) has_generic_arg = true;
+                    }
+                    if (has_generic_arg) {
+                        if (named_kind == HirTypeKind::Variant) {
+                            auto concrete = instantiate_variant(&mod,
+                                                                template_variant_index,
+                                                                bindings,
+                                                                param_ref.type_arg_names.len,
+                                                                item.func.span);
+                            if (!concrete) return core::make_unexpected(concrete.error());
+                            param.variant_index = concrete.value();
+                        } else {
+                            auto concrete = instantiate_struct(&mod,
+                                                               template_struct_index,
+                                                               bindings,
+                                                               param_ref.type_arg_names.len,
+                                                               item.func.span);
+                            if (!concrete) return core::make_unexpected(concrete.error());
+                            param.struct_index = concrete.value();
+                        }
+                    } else {
+                        auto param_type = resolve_func_type_ref(mod,
+                                                                param_ref,
+                                                                &fn.type_params,
+                                                                &param.generic_index,
+                                                                &param.variant_index,
+                                                                &param.struct_index,
+                                                                &param.tuple_len,
+                                                                param.tuple_types,
+                                                                param.tuple_variant_indices,
+                                                                param.tuple_struct_indices,
+                                                                item.func.span);
+                        if (!param_type) return core::make_unexpected(param_type.error());
+                        param.type = param_type.value();
+                    }
+                } else {
+                    auto param_type = resolve_func_type_ref(mod,
+                                                            param_ref,
+                                                            &fn.type_params,
+                                                            &param.generic_index,
+                                                            &param.variant_index,
+                                                            &param.struct_index,
+                                                            &param.tuple_len,
+                                                            param.tuple_types,
+                                                            param.tuple_variant_indices,
+                                                            param.tuple_struct_indices,
+                                                            item.func.span);
+                    if (!param_type) return core::make_unexpected(param_type.error());
+                    param.type = param_type.value();
+                }
+            } else {
+                auto param_type = resolve_func_type_ref(mod,
+                                                        param_ref,
+                                                        &fn.type_params,
+                                                        &param.generic_index,
+                                                        &param.variant_index,
+                                                        &param.struct_index,
+                                                        &param.tuple_len,
+                                                        param.tuple_types,
+                                                        param.tuple_variant_indices,
+                                                        param.tuple_struct_indices,
+                                                        item.func.span);
+                if (!param_type) return core::make_unexpected(param_type.error());
+                param.type = param_type.value();
+            }
+            if (param.type == HirTypeKind::Generic && param.generic_index < fn.type_params.len)
+                param.generic_has_error_constraint = fn.type_params[param.generic_index].has_error_constraint;
+            if (param.type == HirTypeKind::Generic && param.generic_index < fn.type_params.len) {
+                param.generic_has_eq_constraint = fn.type_params[param.generic_index].has_eq_constraint;
+                param.generic_has_ord_constraint = fn.type_params[param.generic_index].has_ord_constraint;
+            param.generic_protocol_index = fn.type_params[param.generic_index].custom_protocol_count != 0 ?
+                fn.type_params[param.generic_index].custom_protocol_indices[0] : 0xffffffffu;
+            param.generic_protocol_count = fn.type_params[param.generic_index].custom_protocol_count;
+            for (u32 cpi = 0; cpi < param.generic_protocol_count; cpi++)
+                param.generic_protocol_indices[cpi] = fn.type_params[param.generic_index].custom_protocol_indices[cpi];
+            }
+            auto param_shape = intern_hir_type_shape(&mod,
+                                                     param.type,
+                                                     param.generic_index,
+                                                     param.variant_index,
+                                                     param.struct_index,
+                                                     param.tuple_len,
+                                                     param.tuple_types,
+                                                     param.tuple_variant_indices,
+                                                     param.tuple_struct_indices,
+                                                     item.func.span);
+            if (!param_shape) return core::make_unexpected(param_shape.error());
+            param.shape_index = param_shape.value();
+            if (!fn.params.push(param))
+                return frontend_error(FrontendError::TooManyItems, item.func.span);
+        }
+        if (fn.return_type != HirTypeKind::Unknown) {
+            auto return_shape = intern_hir_type_shape(&mod,
+                                                      fn.return_type,
+                                                      fn.return_generic_index,
+                                                      fn.return_variant_index,
+                                                      fn.return_struct_index,
+                                                      fn.return_tuple_len,
+                                                      fn.return_tuple_types,
+                                                      fn.return_tuple_variant_indices,
+                                                      fn.return_tuple_struct_indices,
+                                                      item.func.span);
+            if (!return_shape) return core::make_unexpected(return_shape.error());
+            fn.return_shape_index = return_shape.value();
+        }
+        if (!mod.functions.push(fn))
+            return frontend_error(FrontendError::TooManyItems, item.func.span);
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Protocol) continue;
+        const u32 protocol_index = find_protocol_index(mod, item.protocol.name);
+        if (protocol_index >= mod.protocols.len) continue;
+        for (u32 mi = 0; mi < item.protocol.methods.len; mi++) {
+            const auto& method_ast = item.protocol.methods[mi];
+            if (method_ast.default_body == nullptr) continue;
+            auto* method = find_protocol_method_mut(mod.protocols[protocol_index], method_ast.name);
+            if (method == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, method_ast.name);
+            auto mangled = make_protocol_default_function_name(item.protocol.name, method_ast.name);
+            if (!mangled) return core::make_unexpected(mangled.error());
+            if (find_function_index(mod, mangled.value()) != mod.functions.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, mangled.value());
+
+            AstFunctionDecl synthetic{};
+            synthetic.span = item.protocol.span;
+            synthetic.name = mangled.value();
+            synthetic.has_return_type = method_ast.has_return_type;
+            synthetic.return_type = method_ast.return_type;
+            AstFunctionDecl::ParamDecl self_param{};
+            self_param.name = Str{"self", 4};
+            self_param.type.name = Str{"Self", 4};
+            if (!synthetic.params.push(self_param))
+                return frontend_error(FrontendError::TooManyItems, item.protocol.span);
+            for (u32 pi = 0; pi < method_ast.params.len; pi++) {
+                AstFunctionDecl::ParamDecl param{};
+                param.name = method_ast.params[pi].name;
+                param.type = method_ast.params[pi].type;
+                if (!synthetic.params.push(param))
+                    return frontend_error(FrontendError::TooManyItems, item.protocol.span);
+            }
+            synthetic.body = method_ast.default_body;
+
+            FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> extra_type_params;
+            HirFunction::TypeParamDecl self_tp{};
+            self_tp.name = Str{"Self", 4};
+            self_tp.has_constraint = true;
+            self_tp.constraint = item.protocol.name;
+            self_tp.constraint_kind = HirProtocolKind::Custom;
+            if (!extra_type_params.push(self_tp))
+                return frontend_error(FrontendError::TooManyItems, item.protocol.span);
+
+            auto fn = declare_function_like(synthetic, synthetic.span, mangled.value(), &extra_type_params);
+            if (!fn) return core::make_unexpected(fn.error());
+            if (!mod.functions.push(fn.value()))
+                return frontend_error(FrontendError::TooManyItems, item.protocol.span);
+            method->function_index = mod.functions.len - 1;
+        }
+    }
+
+    auto resolve_impl_target = [&](const AstImplDecl& decl,
+                                  HirTypeKind* out_type,
+                                  u32* out_struct_index,
+                                  bool* out_is_generic_template,
+                                  FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams>* out_type_params)
+        -> FrontendResult<void> {
+        *out_type = HirTypeKind::Unknown;
+        *out_struct_index = 0xffffffffu;
+        *out_is_generic_template = false;
+        out_type_params->len = 0;
+        if (!decl.target.is_tuple) {
+            const u32 templ_struct_index = find_struct_index(mod, decl.target.name);
+            if (templ_struct_index < mod.structs.len && mod.structs[templ_struct_index].type_params.len != 0 &&
+                decl.target.type_arg_names.len == mod.structs[templ_struct_index].type_params.len) {
+                bool all_are_placeholders = true;
+                for (u32 i = 0; i < decl.target.type_arg_names.len; i++) {
+                    if (decl.target.type_arg_names[i].len == 0)
+                        return frontend_error(FrontendError::UnsupportedSyntax, decl.span, decl.target.name);
+                    u32 concrete_variant_index = 0xffffffffu;
+                    u32 concrete_struct_index = 0xffffffffu;
+                    if (resolve_named_type(mod,
+                                           decl.target.type_arg_names[i],
+                                           &concrete_variant_index,
+                                           &concrete_struct_index) != HirTypeKind::Unknown) {
+                        all_are_placeholders = false;
+                        break;
+                    }
+                    for (u32 j = i + 1; j < decl.target.type_arg_names.len; j++) {
+                        if (decl.target.type_arg_names[i].eq(decl.target.type_arg_names[j]))
+                            return frontend_error(FrontendError::UnsupportedSyntax, decl.span, decl.target.type_arg_names[i]);
+                    }
+                }
+                if (!all_are_placeholders) goto resolve_concrete_impl_target;
+                *out_type = HirTypeKind::Struct;
+                *out_struct_index = templ_struct_index;
+                *out_is_generic_template = true;
+                for (u32 i = 0; i < decl.target.type_arg_names.len; i++) {
+                    HirFunction::TypeParamDecl tp{};
+                    tp.name = decl.target.type_arg_names[i];
+                    if (!out_type_params->push(tp))
+                        return frontend_error(FrontendError::TooManyItems, decl.span);
+                }
+                return {};
+            }
+        }
+resolve_concrete_impl_target:
+        u32 target_variant_index = 0xffffffffu;
+        u32 target_tuple_len = 0;
+        HirTypeKind target_tuple_types[kMaxTupleSlots]{};
+        u32 target_tuple_variant_indices[kMaxTupleSlots]{};
+        u32 target_tuple_struct_indices[kMaxTupleSlots]{};
+        auto target_type = resolve_func_type_ref(mod,
+                                                 decl.target,
+                                                 nullptr,
+                                                 nullptr,
+                                                 &target_variant_index,
+                                                 out_struct_index,
+                                                 &target_tuple_len,
+                                                 target_tuple_types,
+                                                 target_tuple_variant_indices,
+                                                 target_tuple_struct_indices,
+                                                 decl.span);
+        if (!target_type) return core::make_unexpected(target_type.error());
+        *out_type = target_type.value();
+        return {};
+    };
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Impl) continue;
+        if (item.impl_decl.protocols.len == 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span);
+        HirTypeKind target_type = HirTypeKind::Unknown;
+        u32 target_struct_index = 0xffffffffu;
+        bool target_is_generic_template = false;
+        FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> impl_target_type_params;
+        auto resolved_target = resolve_impl_target(
+            item.impl_decl, &target_type, &target_struct_index, &target_is_generic_template, &impl_target_type_params);
+        if (!resolved_target) return core::make_unexpected(resolved_target.error());
+        if (!(target_type == HirTypeKind::Bool || target_type == HirTypeKind::I32 ||
+              target_type == HirTypeKind::Str || target_type == HirTypeKind::Struct))
+            return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span);
+
+        FixedVec<u32, AstImplDecl::kMaxProtocols> protocol_indices;
+        FixedVec<HirImpl, AstImplDecl::kMaxProtocols> pending_impls;
+        for (u32 pi = 0; pi < item.impl_decl.protocols.len; pi++) {
+            const Str proto_name = item.impl_decl.protocols[pi];
+            Str resolved_proto_name = proto_name;
+            if (pi < item.impl_decl.protocol_namespaces.len && item.impl_decl.protocol_namespaces[pi].len != 0) {
+                if (!resolve_import_namespace_type_name(mod,
+                                                        item.impl_decl.protocol_namespaces[pi],
+                                                        proto_name,
+                                                        &resolved_proto_name))
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
+            }
+            const u32 protocol_index = find_protocol_index(mod, resolved_proto_name);
+            if (protocol_index >= mod.protocols.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
+            if (mod.protocols[protocol_index].kind != HirProtocolKind::Custom)
+                return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
+            for (u32 seen = 0; seen < protocol_indices.len; seen++) {
+                if (protocol_indices[seen] == protocol_index)
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
+            }
+            for (u32 ii = 0; ii < mod.impls.len; ii++) {
+                if (mod.impls[ii].protocol_index == protocol_index &&
+                    impl_targets_overlap(mod, mod.impls[ii], target_type, target_struct_index, target_is_generic_template))
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span);
+            }
+            if (!protocol_indices.push(protocol_index))
+                return frontend_error(FrontendError::TooManyItems, item.impl_decl.span);
+            HirImpl impl{};
+            impl.span = item.impl_decl.span;
+            impl.protocol_index = protocol_index;
+            impl.type = target_type;
+            impl.struct_index = target_struct_index;
+            impl.is_generic_template = target_is_generic_template;
+            if (!pending_impls.push(impl))
+                return frontend_error(FrontendError::TooManyItems, item.impl_decl.span);
+            for (u32 ci = 0; ci < mod.conformances.len; ci++) {
+                const auto& existing = mod.conformances[ci];
+                if (existing.protocol_index == protocol_index &&
+                    existing.type == target_type &&
+                    existing.struct_index == target_struct_index &&
+                    existing.is_generic_template == target_is_generic_template)
+                    return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, proto_name);
+            }
+            HirConformance conf{};
+            conf.span = item.impl_decl.span;
+            conf.protocol_index = protocol_index;
+            conf.type = target_type;
+            conf.struct_index = target_struct_index;
+            conf.is_generic_template = target_is_generic_template;
+            if (!mod.conformances.push(conf))
+                return frontend_error(FrontendError::TooManyItems, item.impl_decl.span);
+        }
+
+        for (u32 pi = 0; pi < protocol_indices.len; pi++) {
+            const auto& lhs = mod.protocols[protocol_indices[pi]];
+            for (u32 pj = pi + 1; pj < protocol_indices.len; pj++) {
+                const auto& rhs = mod.protocols[protocol_indices[pj]];
+                for (u32 li = 0; li < lhs.methods.len; li++) {
+                    for (u32 ri = 0; ri < rhs.methods.len; ri++) {
+                        if (lhs.methods[li].name.eq(rhs.methods[ri].name))
+                            return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, lhs.methods[li].name);
+                    }
+                }
+            }
+        }
+
+        for (u32 mi = 0; mi < item.impl_decl.methods.len; mi++) {
+            const auto& method_ast = item.impl_decl.methods[mi];
+            if (method_ast.type_params.len != 0)
+                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span);
+            if (method_ast.params.len == 0)
+                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+
+            u32 matched_protocol_slot = 0xffffffffu;
+            const HirProtocol::MethodDecl* req = nullptr;
+            for (u32 pi = 0; pi < protocol_indices.len; pi++) {
+                const auto* candidate = find_protocol_method(mod.protocols[protocol_indices[pi]], method_ast.name);
+                if (candidate == nullptr) continue;
+                if (matched_protocol_slot != 0xffffffffu)
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                matched_protocol_slot = pi;
+                req = candidate;
+            }
+            if (matched_protocol_slot == 0xffffffffu || req == nullptr)
+                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+
+            auto& impl = pending_impls[matched_protocol_slot];
+            for (u32 seen = 0; seen < impl.methods.len; seen++) {
+                if (impl.methods[seen].name.eq(method_ast.name))
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+            }
+
+            if (method_ast.params.len != req->params.len + 1)
+                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+            for (u32 pi = 0; pi < req->params.len; pi++) {
+                u32 method_variant_index = 0xffffffffu;
+                u32 method_struct_index = 0xffffffffu;
+                u32 method_tuple_len = 0;
+                HirTypeKind method_tuple_types[kMaxTupleSlots]{};
+                u32 method_tuple_variant_indices[kMaxTupleSlots]{};
+                u32 method_tuple_struct_indices[kMaxTupleSlots]{};
+                auto method_type = resolve_func_type_ref(mod,
+                                                         method_ast.params[pi + 1].type,
+                                                         nullptr,
+                                                         nullptr,
+                                                         &method_variant_index,
+                                                         &method_struct_index,
+                                                         &method_tuple_len,
+                                                         method_tuple_types,
+                                                         method_tuple_variant_indices,
+                                                         method_tuple_struct_indices,
+                                                         method_ast.span);
+                if (!method_type) return core::make_unexpected(method_type.error());
+                auto method_shape = intern_hir_type_shape(&mod,
+                                                          method_type.value(),
+                                                          0xffffffffu,
+                                                          method_variant_index,
+                                                          method_struct_index,
+                                                          method_tuple_len,
+                                                          method_tuple_types,
+                                                          method_tuple_variant_indices,
+                                                          method_tuple_struct_indices,
+                                                          method_ast.span);
+                if (!method_shape) return core::make_unexpected(method_shape.error());
+                HirExpr actual{};
+                actual.type = method_type.value();
+                actual.variant_index = method_variant_index;
+                actual.struct_index = method_struct_index;
+                actual.shape_index = method_shape.value();
+                actual.tuple_len = method_tuple_len;
+                for (u32 ti = 0; ti < method_tuple_len; ti++) {
+                    actual.tuple_types[ti] = method_tuple_types[ti];
+                    actual.tuple_variant_indices[ti] = method_tuple_variant_indices[ti];
+                    actual.tuple_struct_indices[ti] = method_tuple_struct_indices[ti];
+                }
+                HirExpr expected{};
+                expected.type = req->params[pi].type;
+                expected.generic_index = req->params[pi].generic_index;
+                expected.variant_index = req->params[pi].variant_index;
+                expected.struct_index = req->params[pi].struct_index;
+                expected.shape_index = req->params[pi].shape_index;
+                expected.tuple_len = req->params[pi].tuple_len;
+                for (u32 ti = 0; ti < req->params[pi].tuple_len; ti++) {
+                    expected.tuple_types[ti] = req->params[pi].tuple_types[ti];
+                    expected.tuple_variant_indices[ti] = req->params[pi].tuple_variant_indices[ti];
+                    expected.tuple_struct_indices[ti] = req->params[pi].tuple_struct_indices[ti];
+                }
+                if (!same_hir_type_shape(mod, actual, expected))
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+            }
+            if (req->has_return_type != method_ast.has_return_type)
+                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+            if (req->has_return_type) {
+                u32 method_variant_index = 0xffffffffu;
+                u32 method_struct_index = 0xffffffffu;
+                u32 method_tuple_len = 0;
+                HirTypeKind method_tuple_types[kMaxTupleSlots]{};
+                u32 method_tuple_variant_indices[kMaxTupleSlots]{};
+                u32 method_tuple_struct_indices[kMaxTupleSlots]{};
+                auto method_type = resolve_func_type_ref(mod,
+                                                         method_ast.return_type,
+                                                         nullptr,
+                                                         nullptr,
+                                                         &method_variant_index,
+                                                         &method_struct_index,
+                                                         &method_tuple_len,
+                                                         method_tuple_types,
+                                                         method_tuple_variant_indices,
+                                                         method_tuple_struct_indices,
+                                                         method_ast.span);
+                if (!method_type) return core::make_unexpected(method_type.error());
+                auto method_shape = intern_hir_type_shape(&mod,
+                                                          method_type.value(),
+                                                          0xffffffffu,
+                                                          method_variant_index,
+                                                          method_struct_index,
+                                                          method_tuple_len,
+                                                          method_tuple_types,
+                                                          method_tuple_variant_indices,
+                                                          method_tuple_struct_indices,
+                                                          method_ast.span);
+                if (!method_shape) return core::make_unexpected(method_shape.error());
+                HirExpr actual{};
+                actual.type = method_type.value();
+                actual.variant_index = method_variant_index;
+                actual.struct_index = method_struct_index;
+                actual.shape_index = method_shape.value();
+                actual.tuple_len = method_tuple_len;
+                for (u32 ti = 0; ti < method_tuple_len; ti++) {
+                    actual.tuple_types[ti] = method_tuple_types[ti];
+                    actual.tuple_variant_indices[ti] = method_tuple_variant_indices[ti];
+                    actual.tuple_struct_indices[ti] = method_tuple_struct_indices[ti];
+                }
+                HirExpr expected{};
+                expected.type = req->return_type;
+                expected.generic_index = req->return_generic_index;
+                expected.variant_index = req->return_variant_index;
+                expected.struct_index = req->return_struct_index;
+                expected.shape_index = req->return_shape_index;
+                expected.tuple_len = req->return_tuple_len;
+                for (u32 ti = 0; ti < req->return_tuple_len; ti++) {
+                    expected.tuple_types[ti] = req->return_tuple_types[ti];
+                    expected.tuple_variant_indices[ti] = req->return_tuple_variant_indices[ti];
+                    expected.tuple_struct_indices[ti] = req->return_tuple_struct_indices[ti];
+                }
+                if (!same_hir_type_shape(mod, actual, expected))
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+            }
+            Str type_name = item.impl_decl.target.name;
+            auto mangled = make_impl_function_name(mod.protocols[impl.protocol_index].name, type_name, method_ast.name);
+            if (!mangled) return core::make_unexpected(mangled.error());
+            if (find_function_index(mod, mangled.value()) != mod.functions.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, mangled.value());
+            auto fn = declare_function_like(method_ast, method_ast.span, mangled.value(), &impl_target_type_params);
+            if (!fn) return core::make_unexpected(fn.error());
+            if (fn->params.len == 0 || fn->params[0].type != impl.type)
+                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+            if (fn->params[0].type == HirTypeKind::Struct) {
+                const auto& recv_param = fn->params[0];
+                if (!impl.is_generic_template && recv_param.struct_index != impl.struct_index)
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                if (impl.is_generic_template) {
+                    const bool matches_template = recv_param.template_struct_index == impl.struct_index ||
+                        (recv_param.struct_index < mod.structs.len &&
+                         mod.structs[recv_param.struct_index].template_struct_index == impl.struct_index);
+                    if (!matches_template)
+                        return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                }
+            }
+            if (!mod.functions.push(fn.value()))
+                return frontend_error(FrontendError::TooManyItems, method_ast.span);
+            HirImplMethod impl_method{};
+            impl_method.name = method_ast.name;
+            impl_method.function_index = mod.functions.len - 1;
+            if (!impl.methods.push(impl_method))
+                return frontend_error(FrontendError::TooManyItems, method_ast.span);
+        }
+        for (u32 pi = 0; pi < pending_impls.len; pi++) {
+            const auto& proto = mod.protocols[pending_impls[pi].protocol_index];
+            for (u32 mi = 0; mi < proto.methods.len; mi++) {
+                const auto& req = proto.methods[mi];
+                if (req.function_index != 0xffffffffu) continue;
+                if (find_impl_method(pending_impls[pi], req.name) != nullptr) continue;
+                return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span, req.name);
+            }
+            if (!mod.impls.push(pending_impls[pi]))
+                return frontend_error(FrontendError::TooManyItems, item.impl_decl.span);
+        }
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Func) continue;
+        const u32 fn_index = find_function_index(mod, item.func.name);
+        if (fn_index == mod.functions.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, item.func.span, item.func.name);
+        HirFunction& fn = mod.functions[fn_index];
+        HirRoute scratch{};
+        FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> ast_named_error_cases;
+        auto ast_collected = collect_named_error_cases_ast(*item.func.body, &ast_named_error_cases);
+        if (!ast_collected) return core::make_unexpected(ast_collected.error());
+        if (ast_named_error_cases.len != 0) {
+            HirVariant error_variant{};
+            error_variant.span = item.func.span;
+            error_variant.name = {"__error_func", 12};
+            for (u32 ci = 0; ci < ast_named_error_cases.len; ci++) {
+                HirVariant::CaseDecl case_decl{};
+                case_decl.name = ast_named_error_cases[ci].name;
+                if (!error_variant.cases.push(case_decl))
+                    return frontend_error(FrontendError::TooManyItems, item.func.span);
+            }
+            if (!mod.variants.push(error_variant))
+                return frontend_error(FrontendError::TooManyItems, item.func.span);
+            scratch.error_variant_index = mod.variants.len - 1;
+        }
+        HirLocal param_locals[AstFunctionDecl::kMaxParams]{};
+        for (u32 pi = 0; pi < fn.params.len; pi++) {
+            param_locals[pi].span = item.func.span;
+            param_locals[pi].name = fn.params[pi].name;
+            param_locals[pi].ref_index = pi;
+            param_locals[pi].type = fn.params[pi].type;
+            param_locals[pi].generic_index = fn.params[pi].generic_index;
+            param_locals[pi].generic_has_error_constraint = fn.params[pi].generic_has_error_constraint;
+            param_locals[pi].generic_has_eq_constraint = fn.params[pi].generic_has_eq_constraint;
+            param_locals[pi].generic_has_ord_constraint = fn.params[pi].generic_has_ord_constraint;
+            param_locals[pi].generic_protocol_index = fn.params[pi].generic_protocol_index;
+            param_locals[pi].generic_protocol_count = fn.params[pi].generic_protocol_count;
+            for (u32 cpi = 0; cpi < param_locals[pi].generic_protocol_count; cpi++)
+                param_locals[pi].generic_protocol_indices[cpi] = fn.params[pi].generic_protocol_indices[cpi];
+            param_locals[pi].variant_index = fn.params[pi].variant_index;
+            param_locals[pi].struct_index = fn.params[pi].struct_index;
+            param_locals[pi].shape_index = fn.params[pi].shape_index;
+            param_locals[pi].tuple_len = fn.params[pi].tuple_len;
+            for (u32 ti = 0; ti < fn.params[pi].tuple_len; ti++) {
+                param_locals[pi].tuple_types[ti] = fn.params[pi].tuple_types[ti];
+                param_locals[pi].tuple_variant_indices[ti] = fn.params[pi].tuple_variant_indices[ti];
+                param_locals[pi].tuple_struct_indices[ti] = fn.params[pi].tuple_struct_indices[ti];
+            }
+            param_locals[pi].init.kind = HirExprKind::LocalRef;
+            param_locals[pi].init.type = fn.params[pi].type;
+            param_locals[pi].init.generic_index = fn.params[pi].generic_index;
+            param_locals[pi].init.generic_has_error_constraint = fn.params[pi].generic_has_error_constraint;
+            param_locals[pi].init.generic_has_eq_constraint = fn.params[pi].generic_has_eq_constraint;
+            param_locals[pi].init.generic_has_ord_constraint = fn.params[pi].generic_has_ord_constraint;
+            param_locals[pi].init.generic_protocol_index = fn.params[pi].generic_protocol_index;
+            param_locals[pi].init.generic_protocol_count = fn.params[pi].generic_protocol_count;
+            for (u32 cpi = 0; cpi < param_locals[pi].init.generic_protocol_count; cpi++)
+                param_locals[pi].init.generic_protocol_indices[cpi] = fn.params[pi].generic_protocol_indices[cpi];
+            param_locals[pi].init.local_index = pi;
+            param_locals[pi].init.variant_index = fn.params[pi].variant_index;
+            param_locals[pi].init.struct_index = fn.params[pi].struct_index;
+            param_locals[pi].init.shape_index = fn.params[pi].shape_index;
+            param_locals[pi].init.tuple_len = fn.params[pi].tuple_len;
+            for (u32 ti = 0; ti < fn.params[pi].tuple_len; ti++) {
+                param_locals[pi].init.tuple_types[ti] = fn.params[pi].tuple_types[ti];
+                param_locals[pi].init.tuple_variant_indices[ti] = fn.params[pi].tuple_variant_indices[ti];
+                param_locals[pi].init.tuple_struct_indices[ti] = fn.params[pi].tuple_struct_indices[ti];
+            }
+        }
+        auto body = analyze_function_body_stmt(*item.func.body, &scratch, mod, param_locals, fn.params.len, nullptr);
+        if (!body) return core::make_unexpected(body.error());
+        FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> named_error_cases;
+        for (u32 li = 0; li < scratch.locals.len; li++) {
+            auto collected = collect_named_error_cases(scratch.locals[li].init, &named_error_cases);
+            if (!collected) return core::make_unexpected(collected.error());
+        }
+        auto collected = collect_named_error_cases(body.value(), &named_error_cases);
+        if (!collected) return core::make_unexpected(collected.error());
+        if (named_error_cases.len != 0 && scratch.error_variant_index == 0xffffffffu) {
+            HirVariant error_variant{};
+            error_variant.span = item.func.span;
+            error_variant.name = {"__error_func", 12};
+            for (u32 ci = 0; ci < named_error_cases.len; ci++) {
+                HirVariant::CaseDecl case_decl{};
+                case_decl.name = named_error_cases[ci].name;
+                if (!error_variant.cases.push(case_decl))
+                    return frontend_error(FrontendError::TooManyItems, item.func.span);
+            }
+            if (!mod.variants.push(error_variant))
+                return frontend_error(FrontendError::TooManyItems, item.func.span);
+            scratch.error_variant_index = mod.variants.len - 1;
+        }
+        if (named_error_cases.len != 0 && scratch.error_variant_index != 0xffffffffu) {
+            const u32 error_variant_index = scratch.error_variant_index;
+            for (u32 li = 0; li < scratch.locals.len; li++) {
+                patch_named_error_variant(&scratch.locals[li].init, error_variant_index, named_error_cases);
+                patch_error_variant_refs(&scratch.locals[li].init, error_variant_index);
+                if (scratch.locals[li].may_error && scratch.locals[li].error_variant_index == 0xffffffffu)
+                    scratch.locals[li].error_variant_index = error_variant_index;
+            }
+            patch_named_error_variant(&body.value(), error_variant_index, named_error_cases);
+            patch_error_variant_refs(&body.value(), error_variant_index);
+        }
+        if (fn.return_type == HirTypeKind::Unknown) {
+            if (body->type == HirTypeKind::Unknown)
+                return frontend_error(FrontendError::UnsupportedSyntax, item.func.body->span);
+            fn.return_type = body->type;
+            fn.return_generic_index = body->generic_index;
+            if (body->type == HirTypeKind::Variant) fn.return_variant_index = body->variant_index;
+            if (body->type == HirTypeKind::Struct) fn.return_struct_index = body->struct_index;
+            if (body->type == HirTypeKind::Tuple) {
+                fn.return_tuple_len = body->tuple_len;
+                for (u32 ti = 0; ti < body->tuple_len; ti++) {
+                    fn.return_tuple_types[ti] = body->tuple_types[ti];
+                    fn.return_tuple_variant_indices[ti] = body->tuple_variant_indices[ti];
+                    fn.return_tuple_struct_indices[ti] = body->tuple_struct_indices[ti];
+                }
+            }
+        } else {
+            if (body->type == HirTypeKind::Unknown && (body->may_nil || body->may_error)) {
+                body->type = fn.return_type;
+                body->generic_index = fn.return_generic_index;
+                body->shape_index = fn.return_shape_index;
+                if (fn.return_generic_index < fn.type_params.len) {
+                    body->generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
+                    body->generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
+                    body->generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+                    body->generic_protocol_index =
+                        fn.type_params[fn.return_generic_index].custom_protocol_count != 0
+                            ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
+                            : 0xffffffffu;
+                    body->generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+                    for (u32 cpi = 0; cpi < body->generic_protocol_count; cpi++)
+                        body->generic_protocol_indices[cpi] =
+                            fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
+                }
+                if (fn.return_type == HirTypeKind::Variant)
+                    body->variant_index = fn.return_variant_index;
+                if (fn.return_type == HirTypeKind::Struct)
+                    body->struct_index = fn.return_struct_index;
+                if (fn.return_type == HirTypeKind::Tuple) {
+                    body->tuple_len = fn.return_tuple_len;
+                    for (u32 ti = 0; ti < fn.return_tuple_len; ti++) {
+                        body->tuple_types[ti] = fn.return_tuple_types[ti];
+                        body->tuple_variant_indices[ti] = fn.return_tuple_variant_indices[ti];
+                        body->tuple_struct_indices[ti] = fn.return_tuple_struct_indices[ti];
+                    }
+                }
+            }
+            auto expected = make_expected_type_expr(fn.return_type,
+                                                    fn.return_variant_index,
+                                                    fn.return_struct_index,
+                                                    fn.return_tuple_len,
+                                                    fn.return_tuple_types,
+                                                    fn.return_tuple_variant_indices,
+                                                    fn.return_tuple_struct_indices,
+                                                    fn.return_shape_index);
+            expected.generic_index = fn.return_generic_index;
+            if (fn.return_generic_index < fn.type_params.len) {
+                expected.generic_has_error_constraint = fn.type_params[fn.return_generic_index].has_error_constraint;
+                expected.generic_has_eq_constraint = fn.type_params[fn.return_generic_index].has_eq_constraint;
+                expected.generic_has_ord_constraint = fn.type_params[fn.return_generic_index].has_ord_constraint;
+                expected.generic_protocol_index =
+                    fn.type_params[fn.return_generic_index].custom_protocol_count != 0
+                        ? fn.type_params[fn.return_generic_index].custom_protocol_indices[0]
+                        : 0xffffffffu;
+                expected.generic_protocol_count = fn.type_params[fn.return_generic_index].custom_protocol_count;
+                for (u32 cpi = 0; cpi < expected.generic_protocol_count; cpi++)
+                    expected.generic_protocol_indices[cpi] =
+                        fn.type_params[fn.return_generic_index].custom_protocol_indices[cpi];
+            }
+            if (!same_hir_type_shape(mod, body.value(), expected))
+                return frontend_error(FrontendError::UnsupportedSyntax, item.func.body->span);
+            if (body->type == HirTypeKind::Variant && body->variant_index != fn.return_variant_index)
+                return frontend_error(FrontendError::UnsupportedSyntax, item.func.body->span);
+        }
+        HirLocal all_locals[AstFunctionDecl::kMaxParams + HirRoute::kMaxLocals]{};
+        u32 all_local_count = 0;
+        for (u32 pi = 0; pi < fn.params.len; pi++) all_locals[all_local_count++] = param_locals[pi];
+        for (u32 li = 0; li < scratch.locals.len; li++) all_locals[all_local_count++] = scratch.locals[li];
+        fn.exprs.len = 0;
+        auto normalized =
+            normalize_function_expr(body.value(), &fn, all_locals, all_local_count, fn.params.len);
+        if (!normalized) return core::make_unexpected(normalized.error());
+        fn.body = normalized.value();
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Protocol) continue;
+        const u32 protocol_index = find_protocol_index(mod, item.protocol.name);
+        if (protocol_index >= mod.protocols.len) continue;
+        for (u32 mi = 0; mi < item.protocol.methods.len; mi++) {
+            const auto& method_ast = item.protocol.methods[mi];
+            if (method_ast.default_body == nullptr) continue;
+            auto* method = find_protocol_method_mut(mod.protocols[protocol_index], method_ast.name);
+            if (method == nullptr || method->function_index >= mod.functions.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, item.protocol.span, method_ast.name);
+
+            AstFunctionDecl synthetic{};
+            synthetic.span = item.protocol.span;
+            synthetic.name = mod.functions[method->function_index].name;
+            synthetic.has_return_type = method_ast.has_return_type;
+            synthetic.return_type = method_ast.return_type;
+            AstFunctionDecl::ParamDecl self_param{};
+            self_param.name = Str{"self", 4};
+            self_param.type.name = Str{"Self", 4};
+            if (!synthetic.params.push(self_param))
+                return frontend_error(FrontendError::TooManyItems, item.protocol.span);
+            for (u32 pi = 0; pi < method_ast.params.len; pi++) {
+                AstFunctionDecl::ParamDecl param{};
+                param.name = method_ast.params[pi].name;
+                param.type = method_ast.params[pi].type;
+                if (!synthetic.params.push(param))
+                    return frontend_error(FrontendError::TooManyItems, item.protocol.span);
+            }
+            synthetic.body = method_ast.default_body;
+            auto body_ok = analyze_function_body_like(mod.functions[method->function_index], synthetic, synthetic.span);
+            if (!body_ok) return core::make_unexpected(body_ok.error());
+        }
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Impl) continue;
+        HirTypeKind target_type = HirTypeKind::Unknown;
+        u32 target_struct_index = 0xffffffffu;
+        bool target_is_generic_template = false;
+        FixedVec<HirFunction::TypeParamDecl, HirFunction::kMaxTypeParams> impl_target_type_params;
+        auto resolved_target = resolve_impl_target(
+            item.impl_decl, &target_type, &target_struct_index, &target_is_generic_template, &impl_target_type_params);
+        if (!resolved_target) return core::make_unexpected(resolved_target.error());
+        for (u32 mi = 0; mi < item.impl_decl.methods.len; mi++) {
+            const auto& method_ast = item.impl_decl.methods[mi];
+            u32 matched_protocol_index = 0xffffffffu;
+            for (u32 pi = 0; pi < item.impl_decl.protocols.len; pi++) {
+                Str resolved_proto_name = item.impl_decl.protocols[pi];
+                if (pi < item.impl_decl.protocol_namespaces.len && item.impl_decl.protocol_namespaces[pi].len != 0) {
+                    if (!resolve_import_namespace_type_name(mod,
+                                                            item.impl_decl.protocol_namespaces[pi],
+                                                            item.impl_decl.protocols[pi],
+                                                            &resolved_proto_name))
+                        return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, item.impl_decl.protocols[pi]);
+                }
+                const u32 protocol_index = find_protocol_index(mod, resolved_proto_name);
+                if (protocol_index >= mod.protocols.len) continue;
+                if (find_protocol_method(mod.protocols[protocol_index], method_ast.name) == nullptr) continue;
+                if (matched_protocol_index != 0xffffffffu)
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+                matched_protocol_index = protocol_index;
+            }
+            if (matched_protocol_index == 0xffffffffu)
+                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+            const HirImpl* impl_ptr = nullptr;
+            for (u32 ii = 0; ii < mod.impls.len; ii++) {
+                if (mod.impls[ii].protocol_index == matched_protocol_index &&
+                    impl_matches_exact_target(mod.impls[ii], target_type, target_struct_index, target_is_generic_template)) {
+                    impl_ptr = &mod.impls[ii];
+                    break;
+                }
+            }
+            if (impl_ptr == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, item.impl_decl.span);
+            const auto* method = find_impl_method(*impl_ptr, method_ast.name);
+            if (method == nullptr || method->function_index >= mod.functions.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, method_ast.span, method_ast.name);
+            auto body_ok = analyze_function_body_like(mod.functions[method->function_index], method_ast, method_ast.span);
+            if (!body_ok) return core::make_unexpected(body_ok.error());
+        }
+    }
+
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Route) continue;
+
+        HirRoute route{};
+        route.span = item.route.span;
+        route.path = item.route.path;
+        route.method = method_char(item.route.method);
+        if (route.method == 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
+
+        for (u32 si = 0; si < item.route.statements.len; si++) {
+            const auto& stmt = item.route.statements[si];
+            if (stmt.kind == AstStmtKind::Let) {
+                HirLocal local{};
+                local.span = stmt.span;
+                local.name = stmt.name;
+                local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
+                auto init = analyze_expr(stmt.expr, &route, mod, route.locals.data, route.locals.len);
+                if (!init) return core::make_unexpected(init.error());
+                auto typed = apply_declared_type_to_expr(&init.value(), mod, stmt);
+                if (!typed) return core::make_unexpected(typed.error());
+                local.type = init->type;
+                local.generic_index = init->generic_index;
+                local.generic_has_error_constraint = init->generic_has_error_constraint;
+                local.generic_has_eq_constraint = init->generic_has_eq_constraint;
+                local.generic_has_ord_constraint = init->generic_has_ord_constraint;
+                local.generic_protocol_index = init->generic_protocol_index;
+                local.generic_protocol_count = init->generic_protocol_count;
+                for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                    local.generic_protocol_indices[cpi] = init->generic_protocol_indices[cpi];
+                local.may_nil = init->may_nil;
+                local.may_error = init->may_error;
+                local.variant_index = init->variant_index;
+                local.struct_index = init->struct_index;
+                local.tuple_len = init->tuple_len;
+                for (u32 ti = 0; ti < init->tuple_len; ti++) {
+                    local.tuple_types[ti] = init->tuple_types[ti];
+                    local.tuple_variant_indices[ti] = init->tuple_variant_indices[ti];
+                    local.tuple_struct_indices[ti] = init->tuple_struct_indices[ti];
+                }
+                local.error_struct_index = init->error_struct_index;
+                local.error_variant_index = init->error_variant_index;
+                local.shape_index = init->shape_index;
+                local.init = init.value();
+                if (!route.locals.push(local))
+                    return frontend_error(FrontendError::TooManyItems, stmt.span);
+                continue;
+            }
+            if (stmt.kind == AstStmtKind::Guard) {
+                if (si + 1 >= item.route.statements.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                HirGuard guard{};
+                guard.span = stmt.span;
+                auto bound = analyze_expr(stmt.expr, &route, mod, route.locals.data, route.locals.len);
+                if (!bound) return core::make_unexpected(bound.error());
+                auto cond = analyze_guard_cond(stmt.expr, &route, mod, route.locals.data, route.locals.len);
+                if (!cond) return core::make_unexpected(cond.error());
+                guard.cond = cond.value();
+                if (stmt.match_arms.len != 0) {
+                    if (!bound->may_error) {
+                        u32 fallback_arm = 0;
+                        for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+                            if (stmt.match_arms[ai].is_wildcard) {
+                                fallback_arm = ai;
+                                break;
+                            }
+                        }
+                        auto fail_term = analyze_term(*stmt.match_arms[fallback_arm].stmt, mod);
+                        if (!fail_term) return core::make_unexpected(fail_term.error());
+                        guard.fail_term = fail_term.value();
+                    } else {
+                        guard.fail_kind = HirGuard::FailKind::Match;
+                        guard.fail_match_expr = bound.value();
+                        auto fail_match = analyze_guard_match_arms(stmt.match_arms,
+                                                                   bound.value(),
+                                                                   &route,
+                                                                   mod,
+                                                                   route.locals.data,
+                                                                   route.locals.len,
+                                                                   &mod.guard_match_arms,
+                                                                   &guard);
+                        if (!fail_match) return core::make_unexpected(fail_match.error());
+                    }
+                } else {
+                    if (stmt.else_stmt->kind == AstStmtKind::ReturnStatus ||
+                        stmt.else_stmt->kind == AstStmtKind::ForwardUpstream) {
+                        auto fail_term = analyze_term(*stmt.else_stmt, mod);
+                        if (!fail_term) return core::make_unexpected(fail_term.error());
+                        guard.fail_term = fail_term.value();
+                    } else {
+                        guard.fail_kind = HirGuard::FailKind::Body;
+                        auto fail_body = analyze_guard_fail_body(*stmt.else_stmt,
+                                                                 &guard.fail_body,
+                                                                 &route,
+                                                                 mod,
+                                                                 route.locals.data,
+                                                                 route.locals.len,
+                                                                 nullptr);
+                        if (!fail_body) return core::make_unexpected(fail_body.error());
+                    }
+                }
+                if (stmt.bind_value) {
+                    if (known_value_state(bound.value(), route.locals.data, route.locals.len) ==
+                        KnownValueState::Error)
+                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                    HirLocal local{};
+                    local.span = stmt.span;
+                    local.name = stmt.name;
+                    local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
+                    local.type = bound->type;
+                    local.generic_index = bound->generic_index;
+                    local.generic_has_error_constraint = bound->generic_has_error_constraint;
+                    local.generic_has_eq_constraint = bound->generic_has_eq_constraint;
+                    local.generic_has_ord_constraint = bound->generic_has_ord_constraint;
+                    local.generic_protocol_index = bound->generic_protocol_index;
+                    local.generic_protocol_count = bound->generic_protocol_count;
+                    for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                        local.generic_protocol_indices[cpi] = bound->generic_protocol_indices[cpi];
+                    local.may_nil = bound->may_nil;
+                    local.may_error = false;
+                    local.variant_index = bound->variant_index;
+                    local.struct_index = bound->struct_index;
+                    local.tuple_len = bound->tuple_len;
+                    for (u32 ti = 0; ti < bound->tuple_len; ti++) {
+                        local.tuple_types[ti] = bound->tuple_types[ti];
+                        local.tuple_variant_indices[ti] = bound->tuple_variant_indices[ti];
+                        local.tuple_struct_indices[ti] = bound->tuple_struct_indices[ti];
+                    }
+                    local.error_struct_index = bound->error_struct_index;
+                    local.error_variant_index = 0xffffffffu;
+                    local.shape_index = bound->shape_index;
+                    auto init = make_guard_bound_init(&route, bound.value(), stmt.span);
+                    if (!init) return core::make_unexpected(init.error());
+                    local.init = init.value();
+                    if (!route.locals.push(local))
+                        return frontend_error(FrontendError::TooManyItems, stmt.span);
+                }
+                if (!route.guards.push(guard))
+                    return frontend_error(FrontendError::TooManyItems, stmt.span);
+                continue;
+            }
+            auto control = analyze_control_stmt(stmt, &route, mod, nullptr);
+            if (!control) return core::make_unexpected(control.error());
+            if (si + 1 != item.route.statements.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, item.route.statements[si + 1].span);
+            break;
+        }
+
+        if (route.control.kind == HirControlKind::Direct && route.control.direct_term.span.end == 0 &&
+            route.control.direct_term.span.start == 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
+
+        FixedVec<RouteNamedErrorCase, HirVariant::kMaxCases> named_error_cases;
+        for (u32 li = 0; li < route.locals.len; li++) {
+            auto collected = collect_named_error_cases(route.locals[li].init, &named_error_cases);
+            if (!collected) return core::make_unexpected(collected.error());
+        }
+        for (u32 gi = 0; gi < route.guards.len; gi++) {
+            auto collected = collect_named_error_cases(route.guards[gi].cond, &named_error_cases);
+            if (!collected) return core::make_unexpected(collected.error());
+            collected = collect_named_error_cases(route.guards[gi].fail_match_expr, &named_error_cases);
+            if (!collected) return core::make_unexpected(collected.error());
+            for (u32 ai = 0; ai < route.guards[gi].fail_match_count; ai++) {
+                collected = collect_named_error_cases(
+                    mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern, &named_error_cases);
+                if (!collected) return core::make_unexpected(collected.error());
+            }
+        }
+        if (route.control.kind == HirControlKind::If) {
+            auto collected = collect_named_error_cases(route.control.cond, &named_error_cases);
+            if (!collected) return core::make_unexpected(collected.error());
+        } else if (route.control.kind == HirControlKind::Match) {
+            auto collected = collect_named_error_cases(route.control.match_expr, &named_error_cases);
+            if (!collected) return core::make_unexpected(collected.error());
+            for (u32 ai = 0; ai < route.control.match_arms.len; ai++) {
+                collected = collect_named_error_cases(route.control.match_arms[ai].pattern, &named_error_cases);
+                if (!collected) return core::make_unexpected(collected.error());
+                for (u32 gi = 0; gi < route.control.match_arms[ai].guards.len; gi++) {
+                    collected =
+                        collect_named_error_cases(route.control.match_arms[ai].guards[gi].cond, &named_error_cases);
+                    if (!collected) return core::make_unexpected(collected.error());
+                    collected = collect_named_error_cases(
+                        route.control.match_arms[ai].guards[gi].fail_match_expr, &named_error_cases);
+                    if (!collected) return core::make_unexpected(collected.error());
+                    for (u32 fai = 0; fai < route.control.match_arms[ai].guards[gi].fail_match_count; fai++) {
+                        collected = collect_named_error_cases(
+                            mod.guard_match_arms[route.control.match_arms[ai].guards[gi].fail_match_start + fai]
+                                .pattern,
+                            &named_error_cases);
+                        if (!collected) return core::make_unexpected(collected.error());
+                    }
+                }
+                collected = collect_named_error_cases(route.control.match_arms[ai].cond, &named_error_cases);
+                if (!collected) return core::make_unexpected(collected.error());
+            }
+        }
+        if (named_error_cases.len != 0) {
+            HirVariant error_variant{};
+            error_variant.span = item.route.span;
+            error_variant.name = {"__error_route", 13};
+            for (u32 ci = 0; ci < named_error_cases.len; ci++) {
+                HirVariant::CaseDecl case_decl{};
+                case_decl.name = named_error_cases[ci].name;
+                if (!error_variant.cases.push(case_decl))
+                    return frontend_error(FrontendError::TooManyItems, item.route.span);
+            }
+            if (!mod.variants.push(error_variant))
+                return frontend_error(FrontendError::TooManyItems, item.route.span);
+            route.error_variant_index = mod.variants.len - 1;
+            for (u32 li = 0; li < route.locals.len; li++) {
+                patch_named_error_variant(&route.locals[li].init, route.error_variant_index, named_error_cases);
+                patch_error_variant_refs(&route.locals[li].init, route.error_variant_index);
+                if (route.locals[li].may_error && route.locals[li].error_variant_index == 0xffffffffu)
+                    route.locals[li].error_variant_index = route.error_variant_index;
+            }
+            for (u32 gi = 0; gi < route.guards.len; gi++) {
+                patch_named_error_variant(&route.guards[gi].cond, route.error_variant_index, named_error_cases);
+                patch_error_variant_refs(&route.guards[gi].cond, route.error_variant_index);
+                patch_named_error_variant(
+                    &route.guards[gi].fail_match_expr, route.error_variant_index, named_error_cases);
+                patch_error_variant_refs(&route.guards[gi].fail_match_expr, route.error_variant_index);
+                for (u32 ai = 0; ai < route.guards[gi].fail_match_count; ai++) {
+                    patch_named_error_variant(
+                        &mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern,
+                        route.error_variant_index,
+                        named_error_cases);
+                    patch_error_variant_refs(
+                        &mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern,
+                        route.error_variant_index);
+                }
+            }
+            if (route.control.kind == HirControlKind::If) {
+                patch_named_error_variant(&route.control.cond, route.error_variant_index, named_error_cases);
+                patch_error_variant_refs(&route.control.cond, route.error_variant_index);
+            } else if (route.control.kind == HirControlKind::Match) {
+                patch_named_error_variant(&route.control.match_expr, route.error_variant_index, named_error_cases);
+                patch_error_variant_refs(&route.control.match_expr, route.error_variant_index);
+                for (u32 ai = 0; ai < route.control.match_arms.len; ai++) {
+                    patch_named_error_variant(
+                        &route.control.match_arms[ai].pattern, route.error_variant_index, named_error_cases);
+                    patch_error_variant_refs(
+                        &route.control.match_arms[ai].pattern, route.error_variant_index);
+                    for (u32 gi = 0; gi < route.control.match_arms[ai].guards.len; gi++) {
+                        patch_named_error_variant(
+                            &route.control.match_arms[ai].guards[gi].cond,
+                            route.error_variant_index,
+                            named_error_cases);
+                        patch_error_variant_refs(
+                            &route.control.match_arms[ai].guards[gi].cond, route.error_variant_index);
+                        patch_named_error_variant(
+                            &route.control.match_arms[ai].guards[gi].fail_match_expr,
+                            route.error_variant_index,
+                            named_error_cases);
+                        patch_error_variant_refs(
+                            &route.control.match_arms[ai].guards[gi].fail_match_expr,
+                            route.error_variant_index);
+                        for (u32 fai = 0; fai < route.control.match_arms[ai].guards[gi].fail_match_count; fai++) {
+                            patch_named_error_variant(
+                                &mod.guard_match_arms[route.control.match_arms[ai].guards[gi].fail_match_start +
+                                                      fai]
+                                     .pattern,
+                                route.error_variant_index,
+                                named_error_cases);
+                            patch_error_variant_refs(
+                                &mod.guard_match_arms[route.control.match_arms[ai].guards[gi].fail_match_start +
+                                                      fai]
+                                     .pattern,
+                                route.error_variant_index);
+                        }
+                    }
+                    patch_named_error_variant(
+                        &route.control.match_arms[ai].cond, route.error_variant_index, named_error_cases);
+                    patch_error_variant_refs(
+                        &route.control.match_arms[ai].cond, route.error_variant_index);
+                }
+            }
+        }
+
+        if (!mod.routes.push(route))
+            return frontend_error(FrontendError::TooManyItems, item.route.span);
+    }
+
+    if (source_path.len != 0 && import_stack != nullptr && !import_stack->empty())
+        import_stack->pop_back();
+    return mod_ptr.release();
+}
+
+FrontendResult<HirModule*> analyze_file(const AstFile& file, Str source_path) {
+    std::vector<std::string> import_stack;
+    return analyze_file_internal(file, source_path, &import_stack);
+}
+
+FrontendResult<HirModule*> analyze_file(const AstFile& file) {
+    return analyze_file(file, {});
+}
+
+void reset_import_analysis_counter() {
+    g_import_analysis_counter = 0;
+}
+
+u32 get_import_analysis_counter() {
+    return g_import_analysis_counter;
+}
+
+}  // namespace rut

--- a/src/compiler/lexer.cc
+++ b/src/compiler/lexer.cc
@@ -109,7 +109,8 @@ LexResult lex(Str source) {
             tok.text = source.slice(tok.start, tok.end);
             tok.type = tok.text.len == 1 && tok.text.ptr[0] == '_' ? TokenType::Underscore
                                                                    : keyword_type(tok.text);
-            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            if (!out.tokens.push(tok))
+                return frontend_error(FrontendError::TooManyTokens, token_span(tok));
             continue;
         }
 
@@ -123,7 +124,8 @@ LexResult lex(Str source) {
             tok.end = pos;
             tok.text = source.slice(tok.start, tok.end);
             tok.type = TokenType::IntLit;
-            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            if (!out.tokens.push(tok))
+                return frontend_error(FrontendError::TooManyTokens, token_span(tok));
             continue;
         }
 
@@ -136,23 +138,23 @@ LexResult lex(Str source) {
                 if (cur == '"') break;
                 if (cur == '\\') {
                     if (pos + 1 >= source.len) {
-                        return frontend_error(
-                            FrontendError::UnterminatedString, Span{quote_start, pos, tok.line, tok.col});
+                        return frontend_error(FrontendError::UnterminatedString,
+                                              Span{quote_start, pos, tok.line, tok.col});
                     }
                     pos += 2;
                     col += 2;
                     continue;
                 }
                 if (cur == '\n') {
-                    return frontend_error(
-                        FrontendError::UnterminatedString, Span{quote_start, pos, tok.line, tok.col});
+                    return frontend_error(FrontendError::UnterminatedString,
+                                          Span{quote_start, pos, tok.line, tok.col});
                 }
                 pos++;
                 col++;
             }
             if (pos >= source.len || source.ptr[pos] != '"') {
-                return frontend_error(
-                    FrontendError::UnterminatedString, Span{quote_start, pos, tok.line, tok.col});
+                return frontend_error(FrontendError::UnterminatedString,
+                                      Span{quote_start, pos, tok.line, tok.col});
             }
             tok.type = TokenType::StringLit;
             tok.start = quote_start + 1;
@@ -160,7 +162,8 @@ LexResult lex(Str source) {
             tok.text = source.slice(tok.start, tok.end);
             pos++;
             col++;
-            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            if (!out.tokens.push(tok))
+                return frontend_error(FrontendError::TooManyTokens, token_span(tok));
             continue;
         }
 
@@ -174,7 +177,8 @@ LexResult lex(Str source) {
             tok.end = pos;
             tok.text = source.slice(tok.start, tok.end);
             tok.type = TokenType::EqEq;
-            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            if (!out.tokens.push(tok))
+                return frontend_error(FrontendError::TooManyTokens, token_span(tok));
             continue;
         }
         if (c == '=' && pos < source.len && source.ptr[pos] == '>') {
@@ -183,7 +187,8 @@ LexResult lex(Str source) {
             tok.end = pos;
             tok.text = source.slice(tok.start, tok.end);
             tok.type = TokenType::Arrow;
-            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            if (!out.tokens.push(tok))
+                return frontend_error(FrontendError::TooManyTokens, token_span(tok));
             continue;
         }
         if (c == '-' && pos < source.len && source.ptr[pos] == '>') {
@@ -192,7 +197,8 @@ LexResult lex(Str source) {
             tok.end = pos;
             tok.text = source.slice(tok.start, tok.end);
             tok.type = TokenType::ThinArrow;
-            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            if (!out.tokens.push(tok))
+                return frontend_error(FrontendError::TooManyTokens, token_span(tok));
             continue;
         }
         switch (c) {
@@ -238,7 +244,8 @@ LexResult lex(Str source) {
             default:
                 return frontend_error(FrontendError::UnexpectedChar, token_span(tok), tok.text);
         }
-        if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+        if (!out.tokens.push(tok))
+            return frontend_error(FrontendError::TooManyTokens, token_span(tok));
     }
 
     Token eof{};

--- a/src/compiler/lexer.cc
+++ b/src/compiler/lexer.cc
@@ -47,13 +47,13 @@ static TokenType keyword_type(Str text) {
     if (text.eq({"forward", 7})) return TokenType::KwForward;
     if (text.eq({"true", 4})) return TokenType::KwTrue;
     if (text.eq({"false", 5})) return TokenType::KwFalse;
-    if (text.eq({"GET", 3})) return TokenType::KwGet;
-    if (text.eq({"POST", 4})) return TokenType::KwPost;
-    if (text.eq({"PUT", 3})) return TokenType::KwPut;
-    if (text.eq({"DELETE", 6})) return TokenType::KwDelete;
-    if (text.eq({"PATCH", 5})) return TokenType::KwPatch;
-    if (text.eq({"HEAD", 4})) return TokenType::KwHead;
-    if (text.eq({"OPTIONS", 7})) return TokenType::KwOptions;
+    if (text.eq({"GET", 3}) || text.eq({"get", 3})) return TokenType::KwGet;
+    if (text.eq({"POST", 4}) || text.eq({"post", 4})) return TokenType::KwPost;
+    if (text.eq({"PUT", 3}) || text.eq({"put", 3})) return TokenType::KwPut;
+    if (text.eq({"DELETE", 6}) || text.eq({"delete", 6})) return TokenType::KwDelete;
+    if (text.eq({"PATCH", 5}) || text.eq({"patch", 5})) return TokenType::KwPatch;
+    if (text.eq({"HEAD", 4}) || text.eq({"head", 4})) return TokenType::KwHead;
+    if (text.eq({"OPTIONS", 7}) || text.eq({"options", 7})) return TokenType::KwOptions;
     return TokenType::Ident;
 }
 
@@ -231,6 +231,9 @@ LexResult lex(Str source) {
                 break;
             case '=':
                 tok.type = TokenType::Eq;
+                break;
+            case '@':
+                tok.type = TokenType::At;
                 break;
             default:
                 return frontend_error(FrontendError::UnexpectedChar, token_span(tok), tok.text);

--- a/src/compiler/lexer.cc
+++ b/src/compiler/lexer.cc
@@ -2,6 +2,251 @@
 
 namespace rut {
 
-// Lexer implementation — Phase 2
+namespace {
+
+static bool is_space(char c) {
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+static bool is_digit(char c) {
+    return c >= '0' && c <= '9';
+}
+
+static bool is_ident_start(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
+}
+
+static bool is_ident_continue(char c) {
+    return is_ident_start(c) || is_digit(c);
+}
+
+static TokenType keyword_type(Str text) {
+    if (text.eq({"func", 4})) return TokenType::KwFunc;
+    if (text.eq({"let", 3})) return TokenType::KwLet;
+    if (text.eq({"const", 5})) return TokenType::KwConst;
+    if (text.eq({"guard", 5})) return TokenType::KwGuard;
+    if (text.eq({"case", 4})) return TokenType::KwCase;
+    if (text.eq({"error", 5})) return TokenType::KwError;
+    if (text.eq({"protocol", 8})) return TokenType::KwProtocol;
+    if (text.eq({"impl", 4})) return TokenType::KwImpl;
+    if (text.eq({"import", 6})) return TokenType::KwImport;
+    if (text.eq({"package", 7})) return TokenType::KwPackage;
+    if (text.eq({"using", 5})) return TokenType::KwUsing;
+    if (text.eq({"as", 2})) return TokenType::KwAs;
+    if (text.eq({"variant", 7})) return TokenType::KwVariant;
+    if (text.eq({"struct", 6})) return TokenType::KwStruct;
+    if (text.eq({"match", 5})) return TokenType::KwMatch;
+    if (text.eq({"if", 2})) return TokenType::KwIf;
+    if (text.eq({"else", 4})) return TokenType::KwElse;
+    if (text.eq({"for", 3})) return TokenType::KwFor;
+    if (text.eq({"or", 2})) return TokenType::KwOr;
+    if (text.eq({"nil", 3})) return TokenType::KwNil;
+    if (text.eq({"upstream", 8})) return TokenType::KwUpstream;
+    if (text.eq({"route", 5})) return TokenType::KwRoute;
+    if (text.eq({"return", 6})) return TokenType::KwReturn;
+    if (text.eq({"forward", 7})) return TokenType::KwForward;
+    if (text.eq({"true", 4})) return TokenType::KwTrue;
+    if (text.eq({"false", 5})) return TokenType::KwFalse;
+    if (text.eq({"GET", 3})) return TokenType::KwGet;
+    if (text.eq({"POST", 4})) return TokenType::KwPost;
+    if (text.eq({"PUT", 3})) return TokenType::KwPut;
+    if (text.eq({"DELETE", 6})) return TokenType::KwDelete;
+    if (text.eq({"PATCH", 5})) return TokenType::KwPatch;
+    if (text.eq({"HEAD", 4})) return TokenType::KwHead;
+    if (text.eq({"OPTIONS", 7})) return TokenType::KwOptions;
+    return TokenType::Ident;
+}
+
+static Span token_span(const Token& tok) {
+    return Span{tok.start, tok.end, tok.line, tok.col};
+}
+
+}  // namespace
+
+LexResult lex(Str source) {
+    LexedTokens out{};
+    u32 pos = 0;
+    u32 line = 1;
+    u32 col = 1;
+
+    while (pos < source.len) {
+        const char c = source.ptr[pos];
+
+        if (is_space(c)) {
+            if (c == '\n') {
+                line++;
+                col = 1;
+            } else {
+                col++;
+            }
+            pos++;
+            continue;
+        }
+
+        if (c == '/' && pos + 1 < source.len && source.ptr[pos + 1] == '/') {
+            pos += 2;
+            col += 2;
+            while (pos < source.len && source.ptr[pos] != '\n') {
+                pos++;
+                col++;
+            }
+            continue;
+        }
+
+        Token tok{};
+        tok.start = pos;
+        tok.line = line;
+        tok.col = col;
+
+        if (is_ident_start(c)) {
+            pos++;
+            col++;
+            while (pos < source.len && is_ident_continue(source.ptr[pos])) {
+                pos++;
+                col++;
+            }
+            tok.end = pos;
+            tok.text = source.slice(tok.start, tok.end);
+            tok.type = tok.text.len == 1 && tok.text.ptr[0] == '_' ? TokenType::Underscore
+                                                                   : keyword_type(tok.text);
+            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            continue;
+        }
+
+        if (is_digit(c)) {
+            pos++;
+            col++;
+            while (pos < source.len && is_digit(source.ptr[pos])) {
+                pos++;
+                col++;
+            }
+            tok.end = pos;
+            tok.text = source.slice(tok.start, tok.end);
+            tok.type = TokenType::IntLit;
+            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            continue;
+        }
+
+        if (c == '"') {
+            const u32 quote_start = pos;
+            pos++;
+            col++;
+            while (pos < source.len) {
+                const char cur = source.ptr[pos];
+                if (cur == '"') break;
+                if (cur == '\\') {
+                    if (pos + 1 >= source.len) {
+                        return frontend_error(
+                            FrontendError::UnterminatedString, Span{quote_start, pos, tok.line, tok.col});
+                    }
+                    pos += 2;
+                    col += 2;
+                    continue;
+                }
+                if (cur == '\n') {
+                    return frontend_error(
+                        FrontendError::UnterminatedString, Span{quote_start, pos, tok.line, tok.col});
+                }
+                pos++;
+                col++;
+            }
+            if (pos >= source.len || source.ptr[pos] != '"') {
+                return frontend_error(
+                    FrontendError::UnterminatedString, Span{quote_start, pos, tok.line, tok.col});
+            }
+            tok.type = TokenType::StringLit;
+            tok.start = quote_start + 1;
+            tok.end = pos;
+            tok.text = source.slice(tok.start, tok.end);
+            pos++;
+            col++;
+            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            continue;
+        }
+
+        pos++;
+        col++;
+        tok.end = pos;
+        tok.text = source.slice(tok.start, tok.end);
+        if (c == '=' && pos < source.len && source.ptr[pos] == '=') {
+            pos++;
+            col++;
+            tok.end = pos;
+            tok.text = source.slice(tok.start, tok.end);
+            tok.type = TokenType::EqEq;
+            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            continue;
+        }
+        if (c == '=' && pos < source.len && source.ptr[pos] == '>') {
+            pos++;
+            col++;
+            tok.end = pos;
+            tok.text = source.slice(tok.start, tok.end);
+            tok.type = TokenType::Arrow;
+            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            continue;
+        }
+        if (c == '-' && pos < source.len && source.ptr[pos] == '>') {
+            pos++;
+            col++;
+            tok.end = pos;
+            tok.text = source.slice(tok.start, tok.end);
+            tok.type = TokenType::ThinArrow;
+            if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+            continue;
+        }
+        switch (c) {
+            case '{':
+                tok.type = TokenType::LBrace;
+                break;
+            case '}':
+                tok.type = TokenType::RBrace;
+                break;
+            case '(':
+                tok.type = TokenType::LParen;
+                break;
+            case ')':
+                tok.type = TokenType::RParen;
+                break;
+            case ',':
+                tok.type = TokenType::Comma;
+                break;
+            case ':':
+                tok.type = TokenType::Colon;
+                break;
+            case '.':
+                tok.type = TokenType::Dot;
+                break;
+            case '<':
+                tok.type = TokenType::Lt;
+                break;
+            case '>':
+                tok.type = TokenType::Gt;
+                break;
+            case '*':
+                tok.type = TokenType::Star;
+                break;
+            case '|':
+                tok.type = TokenType::Pipe;
+                break;
+            case '=':
+                tok.type = TokenType::Eq;
+                break;
+            default:
+                return frontend_error(FrontendError::UnexpectedChar, token_span(tok), tok.text);
+        }
+        if (!out.tokens.push(tok)) return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+    }
+
+    Token eof{};
+    eof.type = TokenType::Eof;
+    eof.start = source.len;
+    eof.end = source.len;
+    eof.line = line;
+    eof.col = col;
+    eof.text = {source.ptr + source.len, 0};
+    if (!out.tokens.push(eof)) return frontend_error(FrontendError::TooManyTokens, token_span(eof));
+    return out;
+}
 
 }  // namespace rut

--- a/src/compiler/lexer.cc
+++ b/src/compiler/lexer.cc
@@ -158,6 +158,7 @@ LexResult lex(Str source) {
             }
             tok.type = TokenType::StringLit;
             tok.start = quote_start + 1;
+            tok.col++;  // keep col in sync with start, which now points past the opening quote
             tok.end = pos;
             tok.text = source.slice(tok.start, tok.end);
             pos++;

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2552,15 +2552,15 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                     field_ty = i32_ty.value();
                 } else if (field_shape.type == MirTypeKind::Str) {
                     field_ty = str_ty.value();
-                } else if (field_shape.type == MirTypeKind::Variant &&
-                           field_shape.variant_index < mir.variants.len &&
-                           variant_infos[field_shape.variant_index].struct_type != nullptr) {
-                    field_ty = variant_infos[field_shape.variant_index].struct_type;
                 } else if (field_shape.type == MirTypeKind::Variant) {
-                    return false;
-                } else if (field_shape.type == MirTypeKind::Struct &&
-                           field_shape.struct_index < mir.structs.len &&
-                           user_struct_defs[field_shape.struct_index] != nullptr) {
+                    if (field_shape.variant_index >= mir.variants.len ||
+                        variant_infos[field_shape.variant_index].struct_type == nullptr)
+                        return false;
+                    field_ty = variant_infos[field_shape.variant_index].struct_type;
+                } else if (field_shape.type == MirTypeKind::Struct) {
+                    if (field_shape.struct_index >= mir.structs.len ||
+                        user_struct_defs[field_shape.struct_index] == nullptr)
+                        return false;
                     auto ty = b.make_type(
                         rir::TypeKind::Struct,
                         nullptr,
@@ -2568,8 +2568,6 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                     if (!ty)
                         return frontend_error(FrontendError::OutOfMemory, mir.structs[si].span);
                     field_ty = ty.value();
-                } else if (field_shape.type == MirTypeKind::Struct) {
-                    return false;
                 } else if (field_shape.type == MirTypeKind::Tuple) {
                     auto tuple_info =
                         get_or_create_tuple_lowering(field_shape.tuple_len,

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -1,0 +1,2849 @@
+#include "rut/compiler/lower_rir.h"
+
+#include "rut/compiler/rir_builder.h"
+
+namespace rut {
+
+namespace {
+
+struct VariantLoweringInfo {
+    const rir::Type* struct_type = nullptr;
+    const rir::Type* payload_bool_type = nullptr;
+    const rir::Type* payload_i32_type = nullptr;
+    const rir::Type* payload_str_type = nullptr;
+    const rir::Type* payload_tuple_type = nullptr;
+    const rir::Type* payload_variant_type = nullptr;
+    const rir::Type* payload_struct_type = nullptr;
+    const rir::Type* payload_bool_opt_type = nullptr;
+    const rir::Type* payload_i32_opt_type = nullptr;
+    const rir::Type* payload_str_opt_type = nullptr;
+    const rir::Type* payload_tuple_opt_type = nullptr;
+    const rir::Type* payload_variant_opt_type = nullptr;
+    const rir::Type* payload_struct_opt_type = nullptr;
+    rir::StructDef* payload_tuple_struct_def = nullptr;
+    u32 payload_tuple_len = 0;
+    MirTypeKind payload_tuple_types[kMaxMirTupleSlots]{};
+    u32 payload_tuple_variant_indices[kMaxMirTupleSlots]{};
+    u32 payload_tuple_struct_indices[kMaxMirTupleSlots]{};
+    u32 payload_variant_index = 0xffffffffu;
+    u32 payload_struct_index = 0xffffffffu;
+    u32 payload_shape_index = 0xffffffffu;
+    rir::StructDef* struct_def = nullptr;
+};
+
+struct ErrorLoweringInfo {
+    const rir::Type* struct_type = nullptr;
+    const rir::Type* error_type = nullptr;
+    const rir::Type* error_opt_type = nullptr;
+    const rir::Type* payload_inner_type = nullptr;
+    const rir::Type* payload_opt_type = nullptr;
+    rir::StructDef* struct_def = nullptr;
+};
+
+struct TupleLoweringInfo {
+    const rir::Type* struct_type = nullptr;
+    rir::StructDef* struct_def = nullptr;
+    u32 tuple_len = 0;
+    MirTypeKind tuple_types[kMaxMirTupleSlots]{};
+    u32 tuple_variant_indices[kMaxMirTupleSlots]{};
+    u32 tuple_struct_indices[kMaxMirTupleSlots]{};
+};
+
+struct FlatMirShape {
+    MirTypeKind type = MirTypeKind::Unknown;
+    u32 variant_index = 0xffffffffu;
+    u32 struct_index = 0xffffffffu;
+    u32 tuple_len = 0;
+    MirTypeKind tuple_types[kMaxMirTupleSlots]{};
+    u32 tuple_variant_indices[kMaxMirTupleSlots]{};
+    u32 tuple_struct_indices[kMaxMirTupleSlots]{};
+};
+
+static Str lit(const char* s) {
+    u32 n = 0;
+    while (s[n]) n++;
+    return {s, n};
+}
+
+static Str payload_field_name(MirTypeKind kind) {
+    if (kind == MirTypeKind::Bool) return lit("payload_bool");
+    if (kind == MirTypeKind::Str) return lit("payload_str");
+    if (kind == MirTypeKind::Tuple) return lit("payload_tuple");
+    if (kind == MirTypeKind::Variant) return lit("payload_variant");
+    if (kind == MirTypeKind::Struct) return lit("payload_struct");
+    return lit("payload_i32");
+}
+
+static const rir::Type* payload_inner_type(const VariantLoweringInfo& info, MirTypeKind kind) {
+    if (kind == MirTypeKind::Bool) return info.payload_bool_type;
+    if (kind == MirTypeKind::Str) return info.payload_str_type;
+    if (kind == MirTypeKind::Tuple) return info.payload_tuple_type;
+    if (kind == MirTypeKind::Variant) return info.payload_variant_type;
+    if (kind == MirTypeKind::Struct) return info.payload_struct_type;
+    return info.payload_i32_type;
+}
+
+static const rir::Type* payload_opt_type(const VariantLoweringInfo& info, MirTypeKind kind) {
+    if (kind == MirTypeKind::Bool) return info.payload_bool_opt_type;
+    if (kind == MirTypeKind::Str) return info.payload_str_opt_type;
+    if (kind == MirTypeKind::Tuple) return info.payload_tuple_opt_type;
+    if (kind == MirTypeKind::Variant) return info.payload_variant_opt_type;
+    if (kind == MirTypeKind::Struct) return info.payload_struct_opt_type;
+    return info.payload_i32_opt_type;
+}
+
+static ErrorLoweringInfo& error_info_for(MirTypeKind kind,
+                                         u32 variant_index,
+                                         u32 error_struct_index,
+                                         ErrorLoweringInfo* scalar_infos,
+                                         ErrorLoweringInfo* variant_infos,
+                                         ErrorLoweringInfo* struct_infos) {
+    if (error_struct_index != 0xffffffffu) return struct_infos[error_struct_index];
+    if (kind == MirTypeKind::Bool) return scalar_infos[0];
+    if (kind == MirTypeKind::I32) return scalar_infos[1];
+    if (kind == MirTypeKind::Str) return scalar_infos[2];
+    if (kind == MirTypeKind::Variant) return variant_infos[variant_index];
+    return scalar_infos[3];
+}
+
+static ErrorLoweringInfo& error_info_for(const FlatMirShape& shape,
+                                         u32 error_struct_index,
+                                         ErrorLoweringInfo* scalar_infos,
+                                         ErrorLoweringInfo* variant_infos,
+                                         ErrorLoweringInfo* struct_infos) {
+    return error_info_for(shape.type,
+                          shape.variant_index,
+                          error_struct_index,
+                          scalar_infos,
+                          variant_infos,
+                          struct_infos);
+}
+
+static Str error_payload_field_name() {
+    return lit("payload");
+}
+
+static Str error_field_name() {
+    return lit("err");
+}
+
+static Str error_code_field_name() {
+    return lit("code");
+}
+
+static Str error_msg_field_name() {
+    return lit("msg");
+}
+
+static Str error_file_field_name() {
+    return lit("file");
+}
+
+static Str error_func_field_name() {
+    return lit("func");
+}
+
+static Str error_line_field_name() {
+    return lit("line");
+}
+
+static bool copy_str(MmapArena& arena, Str src, Str* out) {
+    char* mem = arena.alloc_array<char>(src.len + 1);
+    if (!mem) return false;
+    for (u32 i = 0; i < src.len; i++) mem[i] = src.ptr[i];
+    mem[src.len] = '\0';
+    out->ptr = mem;
+    out->len = src.len;
+    return true;
+}
+
+static bool build_route_name(MmapArena& arena, u32 index, Str* out) {
+    char buf[32];
+    buf[0] = 'r';
+    buf[1] = 'o';
+    buf[2] = 'u';
+    buf[3] = 't';
+    buf[4] = 'e';
+    buf[5] = '_';
+    u32 pos = 6;
+    char tmp[10];
+    u32 n = 0;
+    u32 v = index;
+    if (v == 0) {
+        tmp[n++] = '0';
+    } else {
+        while (v > 0) {
+            tmp[n++] = static_cast<char>('0' + (v % 10));
+            v /= 10;
+        }
+    }
+    while (n > 0) buf[pos++] = tmp[--n];
+    return copy_str(arena, {buf, pos}, out);
+}
+
+static bool same_tuple_shape(const VariantLoweringInfo& info,
+                             u32 tuple_len,
+                             const MirTypeKind* tuple_types,
+                             const u32* tuple_variant_indices,
+                             const u32* tuple_struct_indices) {
+    if (info.payload_tuple_len != tuple_len) return false;
+    for (u32 i = 0; i < tuple_len; i++) {
+        if (info.payload_tuple_types[i] != tuple_types[i]) return false;
+        if (info.payload_tuple_types[i] == MirTypeKind::Variant &&
+            info.payload_tuple_variant_indices[i] != tuple_variant_indices[i])
+            return false;
+        if (info.payload_tuple_types[i] == MirTypeKind::Struct &&
+            info.payload_tuple_struct_indices[i] != tuple_struct_indices[i])
+            return false;
+    }
+    return true;
+}
+
+static bool build_tuple_field_name(MmapArena& arena, u32 index, Str* out) {
+    char buf[8];
+    u32 pos = 0;
+    buf[pos++] = '_';
+    u32 n = index + 1;
+    char tmp[4];
+    u32 tn = 0;
+    do {
+        tmp[tn++] = static_cast<char>('0' + (n % 10));
+        n /= 10;
+    } while (n != 0);
+    while (tn > 0) buf[pos++] = tmp[--tn];
+    return copy_str(arena, {buf, pos}, out);
+}
+
+static bool same_tuple_shape(const TupleLoweringInfo& info,
+                             u32 tuple_len,
+                             const MirTypeKind* tuple_types,
+                             const u32* tuple_variant_indices,
+                             const u32* tuple_struct_indices) {
+    if (info.tuple_len != tuple_len) return false;
+    for (u32 i = 0; i < tuple_len; i++) {
+        if (info.tuple_types[i] != tuple_types[i]) return false;
+        if (info.tuple_types[i] == MirTypeKind::Variant && info.tuple_variant_indices[i] != tuple_variant_indices[i])
+            return false;
+        if (info.tuple_types[i] == MirTypeKind::Struct && info.tuple_struct_indices[i] != tuple_struct_indices[i])
+            return false;
+    }
+    return true;
+}
+
+static FlatMirShape fallback_shape(const MirValue& value) {
+    FlatMirShape out{};
+    out.type = value.type;
+    out.variant_index = value.variant_index;
+    out.struct_index = value.struct_index;
+    out.tuple_len = value.tuple_len;
+    for (u32 i = 0; i < value.tuple_len; i++) {
+        out.tuple_types[i] = value.tuple_types[i];
+        out.tuple_variant_indices[i] = value.tuple_variant_indices[i];
+        out.tuple_struct_indices[i] = value.tuple_struct_indices[i];
+    }
+    return out;
+}
+
+static bool instance_arg_concrete(const MirModule& mir, MirTypeKind type, u32 shape_index) {
+    if (shape_index != 0xffffffffu) {
+        if (shape_index >= mir.type_shapes.len) return false;
+        return mir.type_shapes[shape_index].is_concrete;
+    }
+    return type != MirTypeKind::Unknown;
+}
+
+static bool instance_fully_concrete(const MirModule& mir,
+                                    u32 arg_count,
+                                    const MirTypeKind* arg_types,
+                                    const u32* shape_indices) {
+    for (u32 ai = 0; ai < arg_count; ai++) {
+        if (!instance_arg_concrete(mir, arg_types[ai], shape_indices[ai])) return false;
+    }
+    return true;
+}
+
+static bool is_open_generic_struct_decl(const MirStruct& st) {
+    return st.type_params.len != 0 && st.template_struct_index == 0xffffffffu;
+}
+
+static bool is_open_generic_variant_decl(const MirVariant& variant) {
+    return variant.type_params.len != 0 && variant.template_variant_index == 0xffffffffu;
+}
+
+static FlatMirShape fallback_shape(const MirStruct::FieldDecl& field) {
+    FlatMirShape out{};
+    out.type = field.type;
+    out.variant_index = field.variant_index;
+    out.struct_index = field.struct_index;
+    out.tuple_len = field.tuple_len;
+    for (u32 i = 0; i < field.tuple_len; i++) {
+        out.tuple_types[i] = field.tuple_types[i];
+        out.tuple_variant_indices[i] = field.tuple_variant_indices[i];
+        out.tuple_struct_indices[i] = field.tuple_struct_indices[i];
+    }
+    return out;
+}
+
+static FlatMirShape fallback_shape(const MirVariant::CaseDecl& c) {
+    FlatMirShape out{};
+    out.type = c.payload_type;
+    out.variant_index = c.payload_variant_index;
+    out.struct_index = c.payload_struct_index;
+    out.tuple_len = c.payload_tuple_len;
+    for (u32 i = 0; i < c.payload_tuple_len; i++) {
+        out.tuple_types[i] = c.payload_tuple_types[i];
+        out.tuple_variant_indices[i] = c.payload_tuple_variant_indices[i];
+        out.tuple_struct_indices[i] = c.payload_tuple_struct_indices[i];
+    }
+    return out;
+}
+
+static FlatMirShape fallback_payload_shape(const VariantLoweringInfo& info) {
+    FlatMirShape out{};
+    if (info.payload_tuple_len != 0) {
+        out.type = MirTypeKind::Tuple;
+        out.tuple_len = info.payload_tuple_len;
+        for (u32 i = 0; i < info.payload_tuple_len; i++) {
+            out.tuple_types[i] = info.payload_tuple_types[i];
+            out.tuple_variant_indices[i] = info.payload_tuple_variant_indices[i];
+            out.tuple_struct_indices[i] = info.payload_tuple_struct_indices[i];
+        }
+        return out;
+    }
+    if (info.payload_variant_index != 0xffffffffu) {
+        out.type = MirTypeKind::Variant;
+        out.variant_index = info.payload_variant_index;
+        return out;
+    }
+    if (info.payload_struct_index != 0xffffffffu) {
+        out.type = MirTypeKind::Struct;
+        out.struct_index = info.payload_struct_index;
+    }
+    return out;
+}
+
+static FlatMirShape tuple_elem_shape(u32 index,
+                                     const MirTypeKind* tuple_types,
+                                     const u32* tuple_variant_indices,
+                                     const u32* tuple_struct_indices) {
+    FlatMirShape out{};
+    out.type = tuple_types[index];
+    if (out.type == MirTypeKind::Variant) out.variant_index = tuple_variant_indices[index];
+    if (out.type == MirTypeKind::Struct) out.struct_index = tuple_struct_indices[index];
+    return out;
+}
+
+static bool expand_flat_shape(const MirModule& mir, u32 shape_index, FlatMirShape* out) {
+    if (shape_index == 0xffffffffu || shape_index >= mir.type_shapes.len) return false;
+    const auto& shape = mir.type_shapes[shape_index];
+    if (!shape.carrier_ready) return false;
+    out->type = shape.type;
+    out->variant_index = shape.variant_index;
+    out->struct_index = shape.struct_index;
+    out->tuple_len = shape.tuple_len;
+    if (shape.type != MirTypeKind::Tuple) return true;
+    for (u32 i = 0; i < shape.tuple_len; i++) {
+        const u32 elem_index = shape.tuple_elem_shape_indices[i];
+        if (elem_index >= mir.type_shapes.len) return false;
+        const auto& elem = mir.type_shapes[elem_index];
+        if (!elem.carrier_ready) return false;
+        if (elem.type == MirTypeKind::Tuple) return false;
+        out->tuple_types[i] = elem.type;
+        out->tuple_variant_indices[i] = elem.variant_index;
+        out->tuple_struct_indices[i] = elem.struct_index;
+    }
+    return true;
+}
+
+static FlatMirShape resolved_shape(const MirModule& mir, const MirValue& value) {
+    auto out = fallback_shape(value);
+    expand_flat_shape(mir, value.shape_index, &out);
+    return out;
+}
+
+static FlatMirShape resolved_shape(const MirModule& mir, const MirStruct::FieldDecl& field) {
+    auto out = fallback_shape(field);
+    expand_flat_shape(mir, field.shape_index, &out);
+    return out;
+}
+
+static FlatMirShape resolved_shape(const MirModule& mir, const MirVariant::CaseDecl& c) {
+    auto out = fallback_shape(c);
+    expand_flat_shape(mir, c.payload_shape_index, &out);
+    return out;
+}
+
+static FlatMirShape resolved_payload_shape(const MirModule& mir, const VariantLoweringInfo& info) {
+    auto out = fallback_payload_shape(info);
+    expand_flat_shape(mir, info.payload_shape_index, &out);
+    return out;
+}
+
+static bool build_indexed_name(MmapArena& arena, Str prefix, u32 index, Str* out) {
+    char buf[64];
+    u32 pos = 0;
+    for (u32 i = 0; i < prefix.len; i++) buf[pos++] = prefix.ptr[i];
+    char tmp[16];
+    u32 tn = 0;
+    u32 n = index;
+    do {
+        tmp[tn++] = static_cast<char>('0' + (n % 10));
+        n /= 10;
+    } while (n != 0);
+    while (tn > 0) buf[pos++] = tmp[--tn];
+    return copy_str(arena, {buf, pos}, out);
+}
+
+static FrontendResult<const TupleLoweringInfo*> get_or_create_tuple_lowering(
+    u32 tuple_len,
+    const MirTypeKind* tuple_types,
+    const u32* tuple_variant_indices,
+    const u32* tuple_struct_indices,
+    const VariantLoweringInfo* variant_infos,
+    const rir::StructDef* const* user_struct_defs,
+    TupleLoweringInfo* tuple_infos,
+    u32* tuple_info_count,
+    rir::Builder& b,
+    Span span) {
+    for (u32 i = 0; i < *tuple_info_count; i++) {
+        if (same_tuple_shape(tuple_infos[i], tuple_len, tuple_types, tuple_variant_indices, tuple_struct_indices))
+            return &tuple_infos[i];
+    }
+    if (*tuple_info_count >= 64) return frontend_error(FrontendError::TooManyItems, span);
+    auto& info = tuple_infos[*tuple_info_count];
+    info.tuple_len = tuple_len;
+    for (u32 i = 0; i < tuple_len; i++) {
+        info.tuple_types[i] = tuple_types[i];
+        info.tuple_variant_indices[i] = tuple_variant_indices[i];
+        info.tuple_struct_indices[i] = tuple_struct_indices[i];
+    }
+    rir::FieldDef fields[kMaxMirTupleSlots]{};
+    for (u32 i = 0; i < tuple_len; i++) {
+        if (!build_tuple_field_name(*b.mod->arena, i, &fields[i].name))
+            return frontend_error(FrontendError::OutOfMemory, span);
+        const rir::Type* elem_ty = nullptr;
+        if (tuple_types[i] == MirTypeKind::Bool) {
+            auto ty = b.make_type(rir::TypeKind::Bool);
+            if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+            elem_ty = ty.value();
+        } else if (tuple_types[i] == MirTypeKind::I32) {
+            auto ty = b.make_type(rir::TypeKind::I32);
+            if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+            elem_ty = ty.value();
+        } else if (tuple_types[i] == MirTypeKind::Str) {
+            auto ty = b.make_type(rir::TypeKind::Str);
+            if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+            elem_ty = ty.value();
+        } else if (tuple_types[i] == MirTypeKind::Variant &&
+                   variant_infos[tuple_variant_indices[i]].struct_type != nullptr) {
+            elem_ty = variant_infos[tuple_variant_indices[i]].struct_type;
+        } else if (tuple_types[i] == MirTypeKind::Variant) {
+            auto ty = b.make_type(rir::TypeKind::I32);
+            if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+            elem_ty = ty.value();
+        } else if (tuple_types[i] == MirTypeKind::Struct && tuple_struct_indices[i] != 0xffffffffu &&
+                   user_struct_defs[tuple_struct_indices[i]] != nullptr) {
+            elem_ty = b.make_type(rir::TypeKind::Struct, nullptr,
+                                  const_cast<rir::StructDef*>(user_struct_defs[tuple_struct_indices[i]])).value();
+            if (elem_ty == nullptr) return frontend_error(FrontendError::OutOfMemory, span);
+        } else {
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
+        }
+        fields[i].type = elem_ty;
+    }
+    Str name{};
+    if (!build_indexed_name(*b.mod->arena, lit("__tuple_"), *tuple_info_count, &name))
+        return frontend_error(FrontendError::OutOfMemory, span);
+    auto sd = b.create_struct(name, fields, tuple_len);
+    if (!sd) return frontend_error(FrontendError::OutOfMemory, span);
+    auto struct_ty = b.make_type(rir::TypeKind::Struct, nullptr, sd.value());
+    if (!struct_ty) return frontend_error(FrontendError::OutOfMemory, span);
+    info.struct_def = sd.value();
+    info.struct_type = struct_ty.value();
+    (*tuple_info_count)++;
+    return &info;
+}
+
+static FrontendResult<const rir::Type*> rir_type_for_shape(MirTypeKind type,
+                                                           u32 variant_index,
+                                                           u32 struct_index,
+                                                           u32 tuple_len,
+                                                           const MirTypeKind* tuple_types,
+                                                           const u32* tuple_variant_indices,
+                                                           const u32* tuple_struct_indices,
+                                                           const VariantLoweringInfo* variant_infos,
+                                                           TupleLoweringInfo* tuple_infos,
+                                                           u32* tuple_info_count,
+                                                           const rir::StructDef* const* user_struct_defs,
+                                                           rir::Builder& b,
+                                                           Span span) {
+    if (type == MirTypeKind::Bool) {
+        auto ty = b.make_type(rir::TypeKind::Bool);
+        if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+        return ty.value();
+    }
+    if (type == MirTypeKind::I32) {
+        auto ty = b.make_type(rir::TypeKind::I32);
+        if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+        return ty.value();
+    }
+    if (type == MirTypeKind::Str) {
+        auto ty = b.make_type(rir::TypeKind::Str);
+        if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+        return ty.value();
+    }
+    if (type == MirTypeKind::Variant && variant_index != 0xffffffffu &&
+        variant_infos[variant_index].struct_type != nullptr)
+        return variant_infos[variant_index].struct_type;
+    if (type == MirTypeKind::Variant) {
+        auto ty = b.make_type(rir::TypeKind::I32);
+        if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+        return ty.value();
+    }
+    if (type == MirTypeKind::Tuple) {
+        auto tuple_info = get_or_create_tuple_lowering(tuple_len,
+                                                       tuple_types,
+                                                       tuple_variant_indices,
+                                                       tuple_struct_indices,
+                                                       variant_infos,
+                                                       user_struct_defs,
+                                                       tuple_infos,
+                                                       tuple_info_count,
+                                                       b,
+                                                       span);
+        if (!tuple_info) return core::make_unexpected(tuple_info.error());
+        return tuple_info.value()->struct_type;
+    }
+    if (type == MirTypeKind::Struct && struct_index != 0xffffffffu &&
+        user_struct_defs[struct_index] != nullptr) {
+        auto ty = b.make_type(rir::TypeKind::Struct, nullptr,
+                              const_cast<rir::StructDef*>(user_struct_defs[struct_index]));
+        if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+        return ty.value();
+    }
+    return frontend_error(FrontendError::UnsupportedSyntax, span);
+}
+
+static FrontendResult<const rir::Type*> rir_type_for_flat_shape(const FlatMirShape& shape,
+                                                                const VariantLoweringInfo* variant_infos,
+                                                                TupleLoweringInfo* tuple_infos,
+                                                                u32* tuple_info_count,
+                                                                const rir::StructDef* const* user_struct_defs,
+                                                                rir::Builder& b,
+                                                                Span span) {
+    return rir_type_for_shape(shape.type,
+                              shape.variant_index,
+                              shape.struct_index,
+                              shape.tuple_len,
+                              shape.tuple_types,
+                              shape.tuple_variant_indices,
+                              shape.tuple_struct_indices,
+                              variant_infos,
+                              tuple_infos,
+                              tuple_info_count,
+                              user_struct_defs,
+                              b,
+                              span);
+}
+
+static FrontendResult<rir::ValueId> emit_eq_for_flat_shape(const FlatMirShape& shape,
+                                                           rir::ValueId lhs,
+                                                           rir::ValueId rhs,
+                                                           const MirModule& mir,
+                                                           const VariantLoweringInfo* variant_infos,
+                                                           TupleLoweringInfo* tuple_infos,
+                                                           u32* tuple_info_count,
+                                                           ErrorLoweringInfo* error_scalar_infos,
+                                                           ErrorLoweringInfo* error_variant_infos,
+                                                           ErrorLoweringInfo* error_struct_infos,
+                                                           const rir::StructDef* const* user_struct_defs,
+                                                           rir::Builder& b,
+                                                           Span span);
+
+static FrontendResult<rir::ValueId> emit_ord_for_flat_shape(const FlatMirShape& shape,
+                                                            rir::ValueId lhs,
+                                                            rir::ValueId rhs,
+                                                            const MirModule& mir,
+                                                            const VariantLoweringInfo* variant_infos,
+                                                            TupleLoweringInfo* tuple_infos,
+                                                            u32* tuple_info_count,
+                                                            ErrorLoweringInfo* error_scalar_infos,
+                                                            ErrorLoweringInfo* error_variant_infos,
+                                                            ErrorLoweringInfo* error_struct_infos,
+                                                            const rir::StructDef* const* user_struct_defs,
+                                                            rir::Builder& b,
+                                                            Span span,
+                                                            bool less_than);
+
+static FrontendResult<rir::ValueId> emit_eq_for_standard_error(rir::ValueId lhs,
+                                                               rir::ValueId rhs,
+                                                               rir::Builder& b,
+                                                               Span span) {
+    auto i32_ty = b.make_type(rir::TypeKind::I32);
+    if (!i32_ty) return frontend_error(FrontendError::OutOfMemory, span);
+    auto str_ty = b.make_type(rir::TypeKind::Str);
+    if (!str_ty) return frontend_error(FrontendError::OutOfMemory, span);
+    struct FieldSpec {
+        Str name;
+        const rir::Type* type;
+    };
+    const FieldSpec fields[] = {
+        {error_code_field_name(), i32_ty.value()},
+        {error_msg_field_name(), str_ty.value()},
+        {error_file_field_name(), str_ty.value()},
+        {error_func_field_name(), str_ty.value()},
+        {error_line_field_name(), i32_ty.value()},
+    };
+    auto result = b.emit_const_bool(true, {span.line, span.col});
+    if (!result) return frontend_error(FrontendError::OutOfMemory, span);
+    for (const auto& field : fields) {
+        auto lhs_field = b.emit_struct_field(lhs, field.name, field.type, {span.line, span.col});
+        if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+        auto rhs_field = b.emit_struct_field(rhs, field.name, field.type, {span.line, span.col});
+        if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+        auto eq = b.emit_cmp(rir::Opcode::CmpEq, lhs_field.value(), rhs_field.value(), {span.line, span.col});
+        if (!eq) return frontend_error(FrontendError::OutOfMemory, span);
+        auto next = b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
+        if (!next) return frontend_error(FrontendError::OutOfMemory, span);
+        result = next;
+    }
+    return result.value();
+}
+
+static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
+                                                      u32 variant_index,
+                                                      u32 struct_index,
+                                                      u32 tuple_len,
+                                                      const MirTypeKind* tuple_types,
+                                                      const u32* tuple_variant_indices,
+                                                      const u32* tuple_struct_indices,
+                                                      rir::ValueId lhs,
+                                                      rir::ValueId rhs,
+                                                      const MirModule& mir,
+                                                      const VariantLoweringInfo* variant_infos,
+                                                      TupleLoweringInfo* tuple_infos,
+                                                      u32* tuple_info_count,
+                                                      ErrorLoweringInfo* error_scalar_infos,
+                                                      ErrorLoweringInfo* error_variant_infos,
+                                                      ErrorLoweringInfo* error_struct_infos,
+                                                      const rir::StructDef* const* user_struct_defs,
+                                                      rir::Builder& b,
+                                                      Span span) {
+    if (type == MirTypeKind::Bool || type == MirTypeKind::I32 || type == MirTypeKind::Str) {
+        auto cmp = b.emit_cmp(rir::Opcode::CmpEq, lhs, rhs, {span.line, span.col});
+        if (!cmp) return frontend_error(FrontendError::OutOfMemory, span);
+        return cmp.value();
+    }
+    if (type == MirTypeKind::Tuple) {
+        auto result = b.emit_const_bool(true, {span.line, span.col});
+        if (!result) return frontend_error(FrontendError::OutOfMemory, span);
+        for (u32 i = 0; i < tuple_len; i++) {
+            Str field_name{};
+            if (!build_tuple_field_name(*b.mod->arena, i, &field_name))
+                return frontend_error(FrontendError::OutOfMemory, span);
+            const auto elem_shape =
+                tuple_elem_shape(i, tuple_types, tuple_variant_indices, tuple_struct_indices);
+            auto field_ty = rir_type_for_flat_shape(elem_shape,
+                                                    variant_infos,
+                                                    tuple_infos,
+                                                    tuple_info_count,
+                                                    user_struct_defs,
+                                                    b,
+                                                    span);
+            if (!field_ty) return core::make_unexpected(field_ty.error());
+            auto lhs_field = b.emit_struct_field(lhs, field_name, field_ty.value(), {span.line, span.col});
+            if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+            auto rhs_field = b.emit_struct_field(rhs, field_name, field_ty.value(), {span.line, span.col});
+            if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+            auto eq = emit_eq_for_flat_shape(elem_shape,
+                                             lhs_field.value(),
+                                             rhs_field.value(),
+                                             mir,
+                                             variant_infos,
+                                             tuple_infos,
+                                             tuple_info_count,
+                                             error_scalar_infos,
+                                             error_variant_infos,
+                                             error_struct_infos,
+                                             user_struct_defs,
+                                             b,
+                                             span);
+            if (!eq) return core::make_unexpected(eq.error());
+            auto next = b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
+            if (!next) return frontend_error(FrontendError::OutOfMemory, span);
+            result = next;
+        }
+        return result.value();
+    }
+    if (type == MirTypeKind::Struct) {
+        if (struct_index >= mir.structs.len) return frontend_error(FrontendError::UnsupportedSyntax, span);
+        auto result = b.emit_const_bool(true, {span.line, span.col});
+        if (!result) return frontend_error(FrontendError::OutOfMemory, span);
+        const auto& st = mir.structs[struct_index];
+        for (u32 i = 0; i < st.fields.len; i++) {
+            const auto& field = st.fields[i];
+            const auto field_shape = resolved_shape(mir, field);
+            if (field.is_error_type) {
+                const rir::Type* error_ty = error_scalar_infos[0].error_type;
+                if (error_ty == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, span);
+                auto lhs_field = b.emit_struct_field(lhs, field.name, error_ty, {span.line, span.col});
+                if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+                auto rhs_field = b.emit_struct_field(rhs, field.name, error_ty, {span.line, span.col});
+                if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+                auto eq = emit_eq_for_standard_error(lhs_field.value(), rhs_field.value(), b, span);
+                if (!eq) return core::make_unexpected(eq.error());
+                auto next = b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
+                if (!next) return frontend_error(FrontendError::OutOfMemory, span);
+                result = next;
+                continue;
+            }
+            auto field_ty = rir_type_for_flat_shape(field_shape,
+                                                    variant_infos,
+                                                    tuple_infos,
+                                                    tuple_info_count,
+                                                    user_struct_defs,
+                                                    b,
+                                                    span);
+            if (!field_ty) return core::make_unexpected(field_ty.error());
+            auto lhs_field = b.emit_struct_field(lhs, field.name, field_ty.value(), {span.line, span.col});
+            if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+            auto rhs_field = b.emit_struct_field(rhs, field.name, field_ty.value(), {span.line, span.col});
+            if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+            auto eq = emit_eq_for_flat_shape(field_shape,
+                                             lhs_field.value(),
+                                             rhs_field.value(),
+                                             mir,
+                                             variant_infos,
+                                             tuple_infos,
+                                             tuple_info_count,
+                                             error_scalar_infos,
+                                             error_variant_infos,
+                                             error_struct_infos,
+                                             user_struct_defs,
+                                             b,
+                                             span);
+            if (!eq) return core::make_unexpected(eq.error());
+            auto next = b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
+            if (!next) return frontend_error(FrontendError::OutOfMemory, span);
+            result = next;
+        }
+        return result.value();
+    }
+    if (type == MirTypeKind::Variant) {
+        if (variant_index >= mir.variants.len) return frontend_error(FrontendError::UnsupportedSyntax, span);
+        if (variant_infos[variant_index].struct_type == nullptr) {
+            auto cmp = b.emit_cmp(rir::Opcode::CmpEq, lhs, rhs, {span.line, span.col});
+            if (!cmp) return frontend_error(FrontendError::OutOfMemory, span);
+            return cmp.value();
+        }
+        auto i32_ty = b.make_type(rir::TypeKind::I32);
+        if (!i32_ty) return frontend_error(FrontendError::OutOfMemory, span);
+        auto lhs_tag = b.emit_struct_field(lhs, lit("tag"), i32_ty.value(), {span.line, span.col});
+        if (!lhs_tag) return frontend_error(FrontendError::OutOfMemory, span);
+        auto rhs_tag = b.emit_struct_field(rhs, lit("tag"), i32_ty.value(), {span.line, span.col});
+        if (!rhs_tag) return frontend_error(FrontendError::OutOfMemory, span);
+        auto result = b.emit_cmp(rir::Opcode::CmpEq, lhs_tag.value(), rhs_tag.value(), {span.line, span.col});
+        if (!result) return frontend_error(FrontendError::OutOfMemory, span);
+        const auto& variant = mir.variants[variant_index];
+        for (u32 i = 0; i < variant.cases.len; i++) {
+            const auto& c = variant.cases[i];
+            if (!c.has_payload) continue;
+            const auto payload_shape = resolved_shape(mir, c);
+            auto case_tag = b.emit_const_i32(static_cast<i32>(i), {span.line, span.col});
+            if (!case_tag) return frontend_error(FrontendError::OutOfMemory, span);
+            auto case_match = b.emit_cmp(rir::Opcode::CmpEq, lhs_tag.value(), case_tag.value(), {span.line, span.col});
+            if (!case_match) return frontend_error(FrontendError::OutOfMemory, span);
+            auto payload_opt_ty = payload_opt_type(variant_infos[variant_index], c.payload_type);
+            auto payload_inner_ty = payload_inner_type(variant_infos[variant_index], c.payload_type);
+            auto lhs_payload_opt = b.emit_struct_field(lhs,
+                                                       payload_field_name(c.payload_type),
+                                                       payload_opt_ty,
+                                                       {span.line, span.col});
+            if (!lhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
+            auto rhs_payload_opt = b.emit_struct_field(rhs,
+                                                       payload_field_name(c.payload_type),
+                                                       payload_opt_ty,
+                                                       {span.line, span.col});
+            if (!rhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
+            auto lhs_payload = b.emit_opt_unwrap(lhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
+            if (!lhs_payload) return frontend_error(FrontendError::OutOfMemory, span);
+            auto rhs_payload = b.emit_opt_unwrap(rhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
+            if (!rhs_payload) return frontend_error(FrontendError::OutOfMemory, span);
+            auto payload_eq = emit_eq_for_flat_shape(payload_shape,
+                                                     lhs_payload.value(),
+                                                     rhs_payload.value(),
+                                                     mir,
+                                                     variant_infos,
+                                                     tuple_infos,
+                                                     tuple_info_count,
+                                                     error_scalar_infos,
+                                                     error_variant_infos,
+                                                     error_struct_infos,
+                                                     user_struct_defs,
+                                                     b,
+                                                     span);
+            if (!payload_eq) return core::make_unexpected(payload_eq.error());
+            auto next = b.emit_select(case_match.value(), payload_eq.value(), result.value(), {span.line, span.col});
+            if (!next) return frontend_error(FrontendError::OutOfMemory, span);
+            result = next;
+        }
+        return result.value();
+    }
+    return frontend_error(FrontendError::UnsupportedSyntax, span);
+}
+
+static FrontendResult<rir::ValueId> emit_eq_for_flat_shape(const FlatMirShape& shape,
+                                                           rir::ValueId lhs,
+                                                           rir::ValueId rhs,
+                                                           const MirModule& mir,
+                                                           const VariantLoweringInfo* variant_infos,
+                                                           TupleLoweringInfo* tuple_infos,
+                                                           u32* tuple_info_count,
+                                                           ErrorLoweringInfo* error_scalar_infos,
+                                                           ErrorLoweringInfo* error_variant_infos,
+                                                           ErrorLoweringInfo* error_struct_infos,
+                                                           const rir::StructDef* const* user_struct_defs,
+                                                           rir::Builder& b,
+                                                           Span span) {
+    return emit_eq_for_shape(shape.type,
+                             shape.variant_index,
+                             shape.struct_index,
+                             shape.tuple_len,
+                             shape.tuple_types,
+                             shape.tuple_variant_indices,
+                             shape.tuple_struct_indices,
+                             lhs,
+                             rhs,
+                             mir,
+                             variant_infos,
+                             tuple_infos,
+                             tuple_info_count,
+                             error_scalar_infos,
+                             error_variant_infos,
+                             error_struct_infos,
+                             user_struct_defs,
+                             b,
+                             span);
+}
+
+static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
+                                                       u32 variant_index,
+                                                       u32 struct_index,
+                                                       u32 tuple_len,
+                                                       const MirTypeKind* tuple_types,
+                                                       const u32* tuple_variant_indices,
+                                                       const u32* tuple_struct_indices,
+                                                       rir::ValueId lhs,
+                                                       rir::ValueId rhs,
+                                                       const MirModule& mir,
+                                                       const VariantLoweringInfo* variant_infos,
+                                                       TupleLoweringInfo* tuple_infos,
+                                                       u32* tuple_info_count,
+                                                       ErrorLoweringInfo* error_scalar_infos,
+                                                       ErrorLoweringInfo* error_variant_infos,
+                                                       ErrorLoweringInfo* error_struct_infos,
+                                                       const rir::StructDef* const* user_struct_defs,
+                                                       rir::Builder& b,
+                                                       Span span,
+                                                       bool less_than) {
+    if (type == MirTypeKind::I32 || type == MirTypeKind::Str) {
+        auto op = less_than ? rir::Opcode::CmpLt : rir::Opcode::CmpGt;
+        auto cmp = b.emit_cmp(op, lhs, rhs, {span.line, span.col});
+        if (!cmp) return frontend_error(FrontendError::OutOfMemory, span);
+        return cmp.value();
+    }
+    if (type == MirTypeKind::Tuple) {
+        auto result = b.emit_const_bool(false, {span.line, span.col});
+        if (!result) return frontend_error(FrontendError::OutOfMemory, span);
+        for (i32 i = static_cast<i32>(tuple_len) - 1; i >= 0; i--) {
+            Str field_name{};
+            if (!build_tuple_field_name(*b.mod->arena, static_cast<u32>(i), &field_name))
+                return frontend_error(FrontendError::OutOfMemory, span);
+            const auto elem_shape =
+                tuple_elem_shape(static_cast<u32>(i), tuple_types, tuple_variant_indices, tuple_struct_indices);
+            auto field_ty = rir_type_for_flat_shape(elem_shape,
+                                                    variant_infos,
+                                                    tuple_infos,
+                                                    tuple_info_count,
+                                                    user_struct_defs,
+                                                    b,
+                                                    span);
+            if (!field_ty) return core::make_unexpected(field_ty.error());
+            auto lhs_field = b.emit_struct_field(lhs, field_name, field_ty.value(), {span.line, span.col});
+            if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+            auto rhs_field = b.emit_struct_field(rhs, field_name, field_ty.value(), {span.line, span.col});
+            if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+            auto eq = emit_eq_for_flat_shape(elem_shape,
+                                             lhs_field.value(),
+                                             rhs_field.value(),
+                                             mir,
+                                             variant_infos,
+                                             tuple_infos,
+                                             tuple_info_count,
+                                             error_scalar_infos,
+                                             error_variant_infos,
+                                             error_struct_infos,
+                                             user_struct_defs,
+                                             b,
+                                             span);
+            if (!eq) return core::make_unexpected(eq.error());
+            auto ord = emit_ord_for_flat_shape(elem_shape,
+                                               lhs_field.value(),
+                                               rhs_field.value(),
+                                               mir,
+                                               variant_infos,
+                                               tuple_infos,
+                                               tuple_info_count,
+                                               error_scalar_infos,
+                                               error_variant_infos,
+                                               error_struct_infos,
+                                               user_struct_defs,
+                                               b,
+                                               span,
+                                               less_than);
+            if (!ord) return core::make_unexpected(ord.error());
+            auto next = b.emit_select(eq.value(), result.value(), ord.value(), {span.line, span.col});
+            if (!next) return frontend_error(FrontendError::OutOfMemory, span);
+            result = next;
+        }
+        return result.value();
+    }
+    if (type == MirTypeKind::Struct) {
+        if (struct_index >= mir.structs.len) return frontend_error(FrontendError::UnsupportedSyntax, span);
+        auto result = b.emit_const_bool(false, {span.line, span.col});
+        if (!result) return frontend_error(FrontendError::OutOfMemory, span);
+        const auto& st = mir.structs[struct_index];
+        for (i32 i = static_cast<i32>(st.fields.len) - 1; i >= 0; i--) {
+            const auto& field = st.fields[static_cast<u32>(i)];
+            const auto field_shape = resolved_shape(mir, field);
+            if (field.is_error_type) return frontend_error(FrontendError::UnsupportedSyntax, span);
+            auto field_ty = rir_type_for_flat_shape(field_shape,
+                                                    variant_infos,
+                                                    tuple_infos,
+                                                    tuple_info_count,
+                                                    user_struct_defs,
+                                                    b,
+                                                    span);
+            if (!field_ty) return core::make_unexpected(field_ty.error());
+            auto lhs_field = b.emit_struct_field(lhs, field.name, field_ty.value(), {span.line, span.col});
+            if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+            auto rhs_field = b.emit_struct_field(rhs, field.name, field_ty.value(), {span.line, span.col});
+            if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
+            auto eq = emit_eq_for_flat_shape(field_shape,
+                                             lhs_field.value(),
+                                             rhs_field.value(),
+                                             mir,
+                                             variant_infos,
+                                             tuple_infos,
+                                             tuple_info_count,
+                                             error_scalar_infos,
+                                             error_variant_infos,
+                                             error_struct_infos,
+                                             user_struct_defs,
+                                             b,
+                                             span);
+            if (!eq) return core::make_unexpected(eq.error());
+            auto ord = emit_ord_for_flat_shape(field_shape,
+                                               lhs_field.value(),
+                                               rhs_field.value(),
+                                               mir,
+                                               variant_infos,
+                                               tuple_infos,
+                                               tuple_info_count,
+                                               error_scalar_infos,
+                                               error_variant_infos,
+                                               error_struct_infos,
+                                               user_struct_defs,
+                                               b,
+                                               span,
+                                               less_than);
+            if (!ord) return core::make_unexpected(ord.error());
+            auto next = b.emit_select(eq.value(), result.value(), ord.value(), {span.line, span.col});
+            if (!next) return frontend_error(FrontendError::OutOfMemory, span);
+            result = next;
+        }
+        return result.value();
+    }
+    if (type == MirTypeKind::Variant) {
+        if (variant_index >= mir.variants.len) return frontend_error(FrontendError::UnsupportedSyntax, span);
+        const auto& info = variant_infos[variant_index];
+        auto i32_ty = b.make_type(rir::TypeKind::I32);
+        if (!i32_ty) return frontend_error(FrontendError::OutOfMemory, span);
+        if (info.struct_type == nullptr) {
+            auto op = less_than ? rir::Opcode::CmpLt : rir::Opcode::CmpGt;
+            auto cmp = b.emit_cmp(op, lhs, rhs, {span.line, span.col});
+            if (!cmp) return frontend_error(FrontendError::OutOfMemory, span);
+            return cmp.value();
+        }
+        auto lhs_tag = b.emit_struct_field(lhs, lit("tag"), i32_ty.value(), {span.line, span.col});
+        if (!lhs_tag) return frontend_error(FrontendError::OutOfMemory, span);
+        auto rhs_tag = b.emit_struct_field(rhs, lit("tag"), i32_ty.value(), {span.line, span.col});
+        if (!rhs_tag) return frontend_error(FrontendError::OutOfMemory, span);
+        auto initial = b.emit_cmp(less_than ? rir::Opcode::CmpLt : rir::Opcode::CmpGt,
+                                  lhs_tag.value(),
+                                  rhs_tag.value(),
+                                  {span.line, span.col});
+        if (!initial) return frontend_error(FrontendError::OutOfMemory, span);
+        auto result = initial.value();
+        const auto& variant = mir.variants[variant_index];
+        for (i32 i = static_cast<i32>(variant.cases.len) - 1; i >= 0; i--) {
+            const auto& c = variant.cases[static_cast<u32>(i)];
+            if (!c.has_payload) continue;
+            const auto payload_shape = resolved_shape(mir, c);
+            auto case_tag = b.emit_const_i32(i, {span.line, span.col});
+            if (!case_tag) return frontend_error(FrontendError::OutOfMemory, span);
+            auto case_match = b.emit_cmp(rir::Opcode::CmpEq, lhs_tag.value(), case_tag.value(), {span.line, span.col});
+            if (!case_match) return frontend_error(FrontendError::OutOfMemory, span);
+            auto payload_opt_ty = payload_opt_type(info, c.payload_type);
+            auto payload_inner_ty = payload_inner_type(info, c.payload_type);
+            auto lhs_payload_opt = b.emit_struct_field(lhs, payload_field_name(c.payload_type), payload_opt_ty, {span.line, span.col});
+            if (!lhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
+            auto rhs_payload_opt = b.emit_struct_field(rhs, payload_field_name(c.payload_type), payload_opt_ty, {span.line, span.col});
+            if (!rhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
+            auto lhs_payload = b.emit_opt_unwrap(lhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
+            if (!lhs_payload) return frontend_error(FrontendError::OutOfMemory, span);
+            auto rhs_payload = b.emit_opt_unwrap(rhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
+            if (!rhs_payload) return frontend_error(FrontendError::OutOfMemory, span);
+            auto payload_ord = emit_ord_for_flat_shape(payload_shape,
+                                                       lhs_payload.value(),
+                                                       rhs_payload.value(),
+                                                       mir,
+                                                       variant_infos,
+                                                       tuple_infos,
+                                                       tuple_info_count,
+                                                       error_scalar_infos,
+                                                       error_variant_infos,
+                                                       error_struct_infos,
+                                                       user_struct_defs,
+                                                       b,
+                                                       span,
+                                                       less_than);
+            if (!payload_ord) return core::make_unexpected(payload_ord.error());
+            auto next = b.emit_select(case_match.value(), payload_ord.value(), result, {span.line, span.col});
+            if (!next) return frontend_error(FrontendError::OutOfMemory, span);
+            result = next.value();
+        }
+        return result;
+    }
+    return frontend_error(FrontendError::UnsupportedSyntax, span);
+}
+
+static FrontendResult<rir::ValueId> emit_ord_for_flat_shape(const FlatMirShape& shape,
+                                                            rir::ValueId lhs,
+                                                            rir::ValueId rhs,
+                                                            const MirModule& mir,
+                                                            const VariantLoweringInfo* variant_infos,
+                                                            TupleLoweringInfo* tuple_infos,
+                                                            u32* tuple_info_count,
+                                                            ErrorLoweringInfo* error_scalar_infos,
+                                                            ErrorLoweringInfo* error_variant_infos,
+                                                            ErrorLoweringInfo* error_struct_infos,
+                                                            const rir::StructDef* const* user_struct_defs,
+                                                            rir::Builder& b,
+                                                            Span span,
+                                                            bool less_than) {
+    return emit_ord_for_shape(shape.type,
+                              shape.variant_index,
+                              shape.struct_index,
+                              shape.tuple_len,
+                              shape.tuple_types,
+                              shape.tuple_variant_indices,
+                              shape.tuple_struct_indices,
+                              lhs,
+                              rhs,
+                              mir,
+                              variant_infos,
+                              tuple_infos,
+                              tuple_info_count,
+                              error_scalar_infos,
+                              error_variant_infos,
+                              error_struct_infos,
+                              user_struct_defs,
+                              b,
+                              span,
+                              less_than);
+}
+
+static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
+                                                      const MirModule& mir,
+                                                      const VariantLoweringInfo* variant_infos,
+                                                      TupleLoweringInfo* tuple_infos,
+                                                      u32* tuple_info_count,
+                                                      ErrorLoweringInfo* error_scalar_infos,
+                                                      ErrorLoweringInfo* error_variant_infos,
+                                                      ErrorLoweringInfo* error_struct_infos,
+                                                      const rir::StructDef* const* user_struct_defs,
+                                                      rir::Builder& b,
+                                                      const rir::ValueId* locals,
+                                                      u32 local_count,
+                                                      Span span) {
+    auto make_inner_type = [&](const FlatMirShape& shape) -> FrontendResult<const rir::Type*> {
+        return rir_type_for_flat_shape(shape,
+                                       variant_infos,
+                                       tuple_infos,
+                                       tuple_info_count,
+                                       user_struct_defs,
+                                       b,
+                                       span);
+    };
+
+    if (value.kind == MirValueKind::BoolConst) {
+        auto v = b.emit_const_bool(value.bool_value, {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::IntConst) {
+        auto v = b.emit_const_i32(value.int_value, {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::StrConst) {
+        auto v = b.emit_const_str(value.str_value, {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::Tuple) {
+        const auto tuple_shape = resolved_shape(mir, value);
+        auto tuple_info = get_or_create_tuple_lowering(tuple_shape.tuple_len,
+                                                       tuple_shape.tuple_types,
+                                                       tuple_shape.tuple_variant_indices,
+                                                       tuple_shape.tuple_struct_indices,
+                                                       variant_infos,
+                                                       user_struct_defs,
+                                                       tuple_infos,
+                                                       tuple_info_count,
+                                                       b,
+                                                       span);
+        if (!tuple_info) return core::make_unexpected(tuple_info.error());
+        rir::ValueId field_vals[kMaxMirTupleSlots]{};
+        for (u32 i = 0; i < value.args.len; i++) {
+            auto elem = materialize_value(*value.args[i],
+                                          mir,
+                                          variant_infos,
+                                          tuple_infos,
+                                          tuple_info_count,
+                                          error_scalar_infos,
+                                          error_variant_infos,
+                                          error_struct_infos,
+                                          user_struct_defs,
+                                          b,
+                                          locals,
+                                          local_count,
+                                          span);
+            if (!elem) return core::make_unexpected(elem.error());
+            field_vals[i] = elem.value();
+        }
+        auto created =
+            b.emit_struct_create((*tuple_info)->struct_def, field_vals, value.tuple_len, {span.line, span.col});
+        if (!created) return frontend_error(FrontendError::OutOfMemory, span);
+        return created.value();
+    }
+    if (value.kind == MirValueKind::StructInit) {
+        const auto struct_shape = resolved_shape(mir, value);
+        const u32 struct_index = struct_shape.struct_index;
+        if (struct_index >= mir.structs.len || user_struct_defs[struct_index] == nullptr)
+            return frontend_error(FrontendError::UnsupportedSyntax, span, value.str_value);
+        rir::ValueId field_vals[MirStruct::kMaxFields]{};
+        for (u32 fi = 0; fi < mir.structs[struct_index].fields.len; fi++) {
+            const auto& field = mir.structs[struct_index].fields[fi];
+            u32 init_index = value.field_inits.len;
+            for (u32 ii = 0; ii < value.field_inits.len; ii++) {
+                if (value.field_inits[ii].name.eq(field.name)) {
+                    init_index = ii;
+                    break;
+                }
+            }
+            if (init_index == value.field_inits.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, span, field.name);
+            auto field_value = materialize_value(*value.field_inits[init_index].value,
+                                                 mir,
+                                                 variant_infos,
+                                                 tuple_infos,
+                                                 tuple_info_count,
+                                                 error_scalar_infos,
+                                                 error_variant_infos,
+                                                 error_struct_infos,
+                                                 user_struct_defs,
+                                                 b,
+                                                 locals,
+                                                 local_count,
+                                                 span);
+            if (!field_value) return core::make_unexpected(field_value.error());
+            field_vals[fi] = field_value.value();
+        }
+        auto created = b.emit_struct_create(const_cast<rir::StructDef*>(user_struct_defs[struct_index]),
+                                            field_vals,
+                                            mir.structs[struct_index].fields.len,
+                                            {span.line, span.col});
+        if (!created) return frontend_error(FrontendError::OutOfMemory, span);
+        return created.value();
+    }
+    if (value.kind == MirValueKind::VariantCase) {
+        const auto variant_shape = resolved_shape(mir, value);
+        const u32 variant_index = variant_shape.variant_index;
+        const auto& variant = mir.variants[variant_index];
+        bool has_any_payload = false;
+        for (u32 i = 0; i < variant.cases.len; i++) {
+            if (variant.cases[i].has_payload) {
+                has_any_payload = true;
+                break;
+            }
+        }
+        if (!has_any_payload && variant_infos[variant_index].struct_type == nullptr) {
+            auto v = b.emit_const_i32(value.int_value, {span.line, span.col});
+            if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+            return v.value();
+        }
+        auto tag = b.emit_const_i32(value.int_value, {span.line, span.col});
+        if (!tag) return frontend_error(FrontendError::OutOfMemory, span);
+        rir::ValueId payload_bool{};
+        rir::ValueId payload_i32{};
+        rir::ValueId payload_str{};
+        rir::ValueId payload_tuple{};
+        auto nil_bool =
+            b.emit_opt_nil(variant_infos[variant_index].payload_bool_type, {span.line, span.col});
+        if (!nil_bool) return frontend_error(FrontendError::OutOfMemory, span);
+        payload_bool = nil_bool.value();
+        auto nil_i32 =
+            b.emit_opt_nil(variant_infos[variant_index].payload_i32_type, {span.line, span.col});
+        if (!nil_i32) return frontend_error(FrontendError::OutOfMemory, span);
+        payload_i32 = nil_i32.value();
+        payload_tuple = nil_i32.value();
+        rir::ValueId payload_variant = nil_i32.value();
+        rir::ValueId payload_struct = nil_i32.value();
+        auto nil_str =
+            b.emit_opt_nil(variant_infos[variant_index].payload_str_type, {span.line, span.col});
+        if (!nil_str) return frontend_error(FrontendError::OutOfMemory, span);
+        payload_str = nil_str.value();
+        if (variant_infos[variant_index].payload_tuple_type != nullptr) {
+            auto nil_tuple =
+                b.emit_opt_nil(variant_infos[variant_index].payload_tuple_type, {span.line, span.col});
+            if (!nil_tuple) return frontend_error(FrontendError::OutOfMemory, span);
+            payload_tuple = nil_tuple.value();
+        }
+        if (variant_infos[variant_index].payload_variant_type != nullptr) {
+            auto nil_variant =
+                b.emit_opt_nil(variant_infos[variant_index].payload_variant_type, {span.line, span.col});
+            if (!nil_variant) return frontend_error(FrontendError::OutOfMemory, span);
+            payload_variant = nil_variant.value();
+        }
+        if (variant_infos[variant_index].payload_struct_type != nullptr) {
+            auto nil_struct =
+                b.emit_opt_nil(variant_infos[variant_index].payload_struct_type, {span.line, span.col});
+            if (!nil_struct) return frontend_error(FrontendError::OutOfMemory, span);
+            payload_struct = nil_struct.value();
+        }
+
+        if (variant.cases[value.case_index].has_payload && value.lhs != nullptr) {
+            const auto payload_shape = resolved_shape(mir, variant.cases[value.case_index]);
+            const auto payload_kind = payload_shape.type;
+            auto payload_val =
+                materialize_value(*value.lhs,
+                                  mir,
+                                  variant_infos,
+                                  tuple_infos,
+                                  tuple_info_count,
+                                  error_scalar_infos,
+                                  error_variant_infos,
+                                  error_struct_infos,
+                                  user_struct_defs,
+                                  b,
+                                  locals,
+                                  local_count,
+                                  span);
+            if (!payload_val) return core::make_unexpected(payload_val.error());
+            auto wrapped = b.emit_opt_wrap(payload_val.value(), {span.line, span.col});
+            if (!wrapped) return frontend_error(FrontendError::OutOfMemory, span);
+            if (payload_kind == MirTypeKind::Bool) payload_bool = wrapped.value();
+            else if (payload_kind == MirTypeKind::Str) payload_str = wrapped.value();
+            else if (payload_kind == MirTypeKind::Tuple) payload_tuple = wrapped.value();
+            else if (payload_kind == MirTypeKind::Variant) payload_variant = wrapped.value();
+            else if (payload_kind == MirTypeKind::Struct) payload_struct = wrapped.value();
+            else payload_i32 = wrapped.value();
+        }
+        rir::ValueId fields[] = {
+            tag.value(), payload_bool, payload_i32, payload_str, payload_tuple, payload_variant, payload_struct};
+        auto created = b.emit_struct_create(
+            variant_infos[variant_index].struct_def, fields, 7, {span.line, span.col});
+        if (!created) return frontend_error(FrontendError::OutOfMemory, span);
+        return created.value();
+    }
+    if (value.kind == MirValueKind::TupleSlot) {
+        auto subject = materialize_value(*value.lhs,
+                                         mir,
+                                         variant_infos,
+                                         tuple_infos,
+                                         tuple_info_count,
+                                         error_scalar_infos,
+                                         error_variant_infos,
+                                         error_struct_infos,
+                                         user_struct_defs,
+                                         b,
+                                         locals,
+                                         local_count,
+                                         span);
+        if (!subject) return core::make_unexpected(subject.error());
+        Str field_name{};
+        if (!build_tuple_field_name(*b.mod->arena, static_cast<u32>(value.int_value), &field_name))
+            return frontend_error(FrontendError::OutOfMemory, span);
+        const auto slot_shape = resolved_shape(mir, value);
+        auto field_type = rir_type_for_flat_shape(slot_shape,
+                                                  variant_infos,
+                                                  tuple_infos,
+                                                  tuple_info_count,
+                                                  user_struct_defs,
+                                                  b,
+                                                  span);
+        if (!field_type) return core::make_unexpected(field_type.error());
+        auto field = b.emit_struct_field(subject.value(), field_name, field_type.value(), {span.line, span.col});
+        if (!field) return frontend_error(FrontendError::OutOfMemory, span);
+        return field.value();
+    }
+    if (value.kind == MirValueKind::ReqHeader) {
+        auto v = b.emit_req_header(value.str_value, {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::Nil) {
+        auto v = b.emit_const_i32(0, {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::Error) {
+        auto v = b.emit_const_i32(value.int_value, {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::Field) {
+        auto lhs = materialize_value(*value.lhs,
+                                     mir,
+                                     variant_infos,
+                                     tuple_infos,
+                                     tuple_info_count,
+                                     error_scalar_infos,
+                                     error_variant_infos,
+                                     error_struct_infos,
+                                     user_struct_defs,
+                                     b,
+                                     locals,
+                                     local_count,
+                                     span);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto& err_info = error_info_for(value.lhs->type,
+                                        value.lhs->variant_index,
+                                        value.lhs->error_struct_index,
+                                        error_scalar_infos,
+                                        error_variant_infos,
+                                        error_struct_infos);
+        if (value.lhs->may_error &&
+            (value.str_value.eq(error_code_field_name()) || value.str_value.eq(error_msg_field_name()) ||
+             value.str_value.eq(error_file_field_name()) || value.str_value.eq(error_func_field_name()) ||
+             value.str_value.eq(error_line_field_name()))) {
+            auto err = b.emit_struct_field(lhs.value(),
+                                           error_field_name(),
+                                           err_info.error_opt_type,
+                                           {span.line, span.col});
+            if (!err) return frontend_error(FrontendError::OutOfMemory, span);
+            auto err_value =
+                b.emit_opt_unwrap(err.value(), err_info.error_type, {span.line, span.col});
+            if (!err_value) return frontend_error(FrontendError::OutOfMemory, span);
+            const auto field_shape = resolved_shape(mir, value);
+            auto field_type = rir_type_for_flat_shape(field_shape,
+                                                      variant_infos,
+                                                      tuple_infos,
+                                                      tuple_info_count,
+                                                      user_struct_defs,
+                                                      b,
+                                                      span);
+            if (!field_type) return core::make_unexpected(field_type.error());
+            auto field = b.emit_struct_field(
+                err_value.value(), value.str_value, field_type.value(), {span.line, span.col});
+            if (!field) return frontend_error(FrontendError::OutOfMemory, span);
+            return field.value();
+        }
+        if (value.lhs->type == MirTypeKind::Struct && value.lhs->struct_index < mir.structs.len) {
+            const auto& st = mir.structs[value.lhs->struct_index];
+            u32 field_index = st.fields.len;
+            for (u32 i = 0; i < st.fields.len; i++) {
+                if (st.fields[i].name.eq(value.str_value)) {
+                    field_index = i;
+                    break;
+                }
+            }
+            if (field_index == st.fields.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, span, value.str_value);
+            const auto& field = st.fields[field_index];
+            const auto field_shape = resolved_shape(mir, field);
+            const rir::Type* field_type = nullptr;
+            if (field.is_error_type) field_type = err_info.error_type;
+            else {
+                auto ty = rir_type_for_flat_shape(field_shape,
+                                                  variant_infos,
+                                                  tuple_infos,
+                                                  tuple_info_count,
+                                                  user_struct_defs,
+                                                  b,
+                                                  span);
+                if (!ty) return core::make_unexpected(ty.error());
+                field_type = ty.value();
+            }
+            auto field_v = b.emit_struct_field(lhs.value(), value.str_value, field_type, {span.line, span.col});
+            if (!field_v) return frontend_error(FrontendError::OutOfMemory, span);
+            return field_v.value();
+        }
+        return frontend_error(FrontendError::UnsupportedSyntax, span, value.str_value);
+    }
+    if (value.kind == MirValueKind::Or) {
+        auto lhs = materialize_value(*value.lhs,
+                                     mir,
+                                     variant_infos,
+                                     tuple_infos,
+                                     tuple_info_count,
+                                     error_scalar_infos,
+                                     error_variant_infos,
+                                     error_struct_infos,
+                                     user_struct_defs,
+                                     b,
+                                     locals,
+                                     local_count,
+                                     span);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto rhs = materialize_value(*value.rhs,
+                                     mir,
+                                     variant_infos,
+                                     tuple_infos,
+                                     tuple_info_count,
+                                     error_scalar_infos,
+                                     error_variant_infos,
+                                     error_struct_infos,
+                                     user_struct_defs,
+                                     b,
+                                     locals,
+                                     local_count,
+                                     span);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        const auto value_shape = resolved_shape(mir, value);
+        auto inner = make_inner_type(value_shape);
+        if (!inner) return core::make_unexpected(inner.error());
+        if (value.lhs->may_error) {
+            auto& err_info = error_info_for(value_shape,
+                                            value.error_struct_index,
+                                            error_scalar_infos,
+                                            error_variant_infos,
+                                            error_struct_infos);
+            auto err = b.emit_struct_field(lhs.value(),
+                                           error_field_name(),
+                                           err_info.error_opt_type,
+                                           {span.line, span.col});
+            if (!err) return frontend_error(FrontendError::OutOfMemory, span);
+            auto err_is_nil = b.emit_opt_is_nil(err.value(), {span.line, span.col});
+            if (!err_is_nil) return frontend_error(FrontendError::OutOfMemory, span);
+            auto false_v = b.emit_const_bool(false, {span.line, span.col});
+            if (!false_v) return frontend_error(FrontendError::OutOfMemory, span);
+            auto error_missing = b.emit_cmp(
+                rir::Opcode::CmpEq, err_is_nil.value(), false_v.value(), {span.line, span.col});
+            if (!error_missing) return frontend_error(FrontendError::OutOfMemory, span);
+            auto payload = b.emit_struct_field(lhs.value(),
+                                               error_payload_field_name(),
+                                               err_info.payload_opt_type,
+                                               {span.line, span.col});
+            if (!payload) return frontend_error(FrontendError::OutOfMemory, span);
+            auto payload_nil = b.emit_opt_is_nil(payload.value(), {span.line, span.col});
+            if (!payload_nil) return frontend_error(FrontendError::OutOfMemory, span);
+            auto missing = b.emit_select(error_missing.value(),
+                                         error_missing.value(),
+                                         payload_nil.value(),
+                                         {span.line, span.col});
+            if (!missing) return frontend_error(FrontendError::OutOfMemory, span);
+            auto unwrapped =
+                b.emit_opt_unwrap(payload.value(), inner.value(), {span.line, span.col});
+            if (!unwrapped) return frontend_error(FrontendError::OutOfMemory, span);
+            auto selected = b.emit_select(
+                missing.value(), rhs.value(), unwrapped.value(), {span.line, span.col});
+            if (!selected) return frontend_error(FrontendError::OutOfMemory, span);
+            return selected.value();
+        }
+        auto is_nil = b.emit_opt_is_nil(lhs.value(), {span.line, span.col});
+        if (!is_nil) return frontend_error(FrontendError::OutOfMemory, span);
+        auto unwrapped = b.emit_opt_unwrap(lhs.value(), inner.value(), {span.line, span.col});
+        if (!unwrapped) return frontend_error(FrontendError::OutOfMemory, span);
+        auto selected =
+            b.emit_select(is_nil.value(), rhs.value(), unwrapped.value(), {span.line, span.col});
+        if (!selected) return frontend_error(FrontendError::OutOfMemory, span);
+        return selected.value();
+    }
+    if (value.kind == MirValueKind::IfElse) {
+        auto cond = materialize_value(*value.lhs,
+                                      mir,
+                                      variant_infos,
+                                      tuple_infos,
+                                      tuple_info_count,
+                                      error_scalar_infos,
+                                      error_variant_infos,
+                                      error_struct_infos,
+                                      user_struct_defs,
+                                      b,
+                                      locals,
+                                      local_count,
+                                      span);
+        if (!cond) return core::make_unexpected(cond.error());
+        auto then_v = materialize_value(*value.rhs,
+                                        mir,
+                                        variant_infos,
+                                        tuple_infos,
+                                        tuple_info_count,
+                                        error_scalar_infos,
+                                        error_variant_infos,
+                                        error_struct_infos,
+                                        user_struct_defs,
+                                        b,
+                                        locals,
+                                        local_count,
+                                        span);
+        if (!then_v) return core::make_unexpected(then_v.error());
+        auto else_v = materialize_value(*value.args[0],
+                                        mir,
+                                        variant_infos,
+                                        tuple_infos,
+                                        tuple_info_count,
+                                        error_scalar_infos,
+                                        error_variant_infos,
+                                        error_struct_infos,
+                                        user_struct_defs,
+                                        b,
+                                        locals,
+                                        local_count,
+                                        span);
+        if (!else_v) return core::make_unexpected(else_v.error());
+        const auto value_shape = resolved_shape(mir, value);
+        if (value.may_error) {
+            auto& err_info = error_info_for(value_shape,
+                                            value.error_struct_index,
+                                            error_scalar_infos,
+                                            error_variant_infos,
+                                            error_struct_infos);
+            auto wrap_error_branch = [&](const MirValue& branch,
+                                         rir::ValueId branch_id) -> FrontendResult<rir::ValueId> {
+                if (branch.may_error) {
+                    if (branch.kind != MirValueKind::Error) return branch_id;
+                    const i32 tag_value = branch.error_variant_index != 0xffffffffu
+                                              ? static_cast<i32>(branch.error_case_index)
+                                              : branch.int_value;
+                    auto code = b.emit_const_i32(tag_value, {span.line, span.col});
+                    if (!code) return frontend_error(FrontendError::OutOfMemory, span);
+                    auto msg = b.emit_const_str(branch.msg, {span.line, span.col});
+                    if (!msg) return frontend_error(FrontendError::OutOfMemory, span);
+                    auto file = b.emit_const_str(Str{}, {span.line, span.col});
+                    if (!file) return frontend_error(FrontendError::OutOfMemory, span);
+                    auto func = b.emit_const_str(Str{}, {span.line, span.col});
+                    if (!func) return frontend_error(FrontendError::OutOfMemory, span);
+                    auto line = b.emit_const_i32(static_cast<i32>(span.line), {span.line, span.col});
+                    if (!line) return frontend_error(FrontendError::OutOfMemory, span);
+                    rir::ValueId error_fields[] = {
+                        code.value(), msg.value(), file.value(), func.value(), line.value()};
+                    auto error_val =
+                        b.emit_struct_create(const_cast<rir::StructDef*>(err_info.error_type->struct_def),
+                                             error_fields,
+                                             5,
+                                             {span.line, span.col});
+                    if (!error_val) return frontend_error(FrontendError::OutOfMemory, span);
+                    auto wrapped_err = b.emit_opt_wrap(error_val.value(), {span.line, span.col});
+                    if (!wrapped_err) return frontend_error(FrontendError::OutOfMemory, span);
+                    auto nil_payload =
+                        b.emit_opt_nil(err_info.payload_inner_type, {span.line, span.col});
+                    if (!nil_payload) return frontend_error(FrontendError::OutOfMemory, span);
+                    rir::ValueId fields[] = {wrapped_err.value(), nil_payload.value()};
+                    auto created = b.emit_struct_create(
+                        err_info.struct_def, fields, 2, {span.line, span.col});
+                    if (!created) return frontend_error(FrontendError::OutOfMemory, span);
+                    return created.value();
+                }
+                rir::ValueId err{};
+                auto nil_err = b.emit_opt_nil(err_info.error_type, {span.line, span.col});
+                if (!nil_err) return frontend_error(FrontendError::OutOfMemory, span);
+                err = nil_err.value();
+                rir::ValueId payload{};
+                if (branch.may_nil) {
+                    if (branch.kind == MirValueKind::Nil) {
+                        auto nil_payload =
+                            b.emit_opt_nil(err_info.payload_inner_type, {span.line, span.col});
+                        if (!nil_payload) return frontend_error(FrontendError::OutOfMemory, span);
+                        payload = nil_payload.value();
+                    } else {
+                        payload = branch_id;
+                    }
+                } else {
+                    auto wrapped = b.emit_opt_wrap(branch_id, {span.line, span.col});
+                    if (!wrapped) return frontend_error(FrontendError::OutOfMemory, span);
+                    payload = wrapped.value();
+                }
+                rir::ValueId fields[] = {err, payload};
+                auto created =
+                    b.emit_struct_create(err_info.struct_def, fields, 2, {span.line, span.col});
+                if (!created) return frontend_error(FrontendError::OutOfMemory, span);
+                return created.value();
+            };
+            auto then_wrapped = wrap_error_branch(*value.rhs, then_v.value());
+            if (!then_wrapped) return core::make_unexpected(then_wrapped.error());
+            auto else_wrapped = wrap_error_branch(*value.args[0], else_v.value());
+            if (!else_wrapped) return core::make_unexpected(else_wrapped.error());
+            auto selected = b.emit_select(
+                cond.value(), then_wrapped.value(), else_wrapped.value(), {span.line, span.col});
+            if (!selected) return frontend_error(FrontendError::OutOfMemory, span);
+            return selected.value();
+        }
+        if (value.may_nil) {
+            auto inner = make_inner_type(value_shape);
+            if (!inner) return core::make_unexpected(inner.error());
+            auto wrap_optional_branch = [&](const MirValue& branch,
+                                            rir::ValueId branch_id) -> FrontendResult<rir::ValueId> {
+                if (branch.may_nil) {
+                    if (branch.kind == MirValueKind::Nil) {
+                        auto nil = b.emit_opt_nil(inner.value(), {span.line, span.col});
+                        if (!nil) return frontend_error(FrontendError::OutOfMemory, span);
+                        return nil.value();
+                    }
+                    return branch_id;
+                }
+                auto wrapped = b.emit_opt_wrap(branch_id, {span.line, span.col});
+                if (!wrapped) return frontend_error(FrontendError::OutOfMemory, span);
+                return wrapped.value();
+            };
+            auto then_wrapped = wrap_optional_branch(*value.rhs, then_v.value());
+            if (!then_wrapped) return core::make_unexpected(then_wrapped.error());
+            auto else_wrapped = wrap_optional_branch(*value.args[0], else_v.value());
+            if (!else_wrapped) return core::make_unexpected(else_wrapped.error());
+            auto selected = b.emit_select(
+                cond.value(), then_wrapped.value(), else_wrapped.value(), {span.line, span.col});
+            if (!selected) return frontend_error(FrontendError::OutOfMemory, span);
+            return selected.value();
+        }
+        auto selected = b.emit_select(cond.value(), then_v.value(), else_v.value(), {span.line, span.col});
+        if (!selected) return frontend_error(FrontendError::OutOfMemory, span);
+        return selected.value();
+    }
+    if (value.kind == MirValueKind::NoError) {
+        auto lhs = materialize_value(*value.lhs,
+                                     mir,
+                                     variant_infos,
+                                     tuple_infos,
+                                     tuple_info_count,
+                                     error_scalar_infos,
+                                     error_variant_infos,
+                                     error_struct_infos,
+                                     user_struct_defs,
+                                     b,
+                                     locals,
+                                     local_count,
+                                     span);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        const auto lhs_shape = resolved_shape(mir, *value.lhs);
+        auto& err_info = error_info_for(lhs_shape,
+                                        value.lhs->error_struct_index,
+                                        error_scalar_infos,
+                                        error_variant_infos,
+                                        error_struct_infos);
+        auto err = b.emit_struct_field(lhs.value(),
+                                       error_field_name(),
+                                       err_info.error_opt_type,
+                                       {span.line, span.col});
+        if (!err) return frontend_error(FrontendError::OutOfMemory, span);
+        auto is_nil = b.emit_opt_is_nil(err.value(), {span.line, span.col});
+        if (!is_nil) return frontend_error(FrontendError::OutOfMemory, span);
+        return is_nil.value();
+    }
+    if (value.kind == MirValueKind::HasValue) {
+        auto lhs = materialize_value(*value.lhs,
+                                     mir,
+                                     variant_infos,
+                                     tuple_infos,
+                                     tuple_info_count,
+                                     error_scalar_infos,
+                                     error_variant_infos,
+                                     error_struct_infos,
+                                     user_struct_defs,
+                                     b,
+                                     locals,
+                                     local_count,
+                                     span);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (value.lhs->may_error) {
+            const auto lhs_shape = resolved_shape(mir, *value.lhs);
+            auto& err_info = error_info_for(lhs_shape,
+                                            value.lhs->error_struct_index,
+                                            error_scalar_infos,
+                                            error_variant_infos,
+                                            error_struct_infos);
+            auto err = b.emit_struct_field(lhs.value(),
+                                           error_field_name(),
+                                           err_info.error_opt_type,
+                                           {span.line, span.col});
+            if (!err) return frontend_error(FrontendError::OutOfMemory, span);
+            auto err_is_nil = b.emit_opt_is_nil(err.value(), {span.line, span.col});
+            if (!err_is_nil) return frontend_error(FrontendError::OutOfMemory, span);
+            if (!value.lhs->may_nil) return err_is_nil.value();
+            auto payload = b.emit_struct_field(lhs.value(),
+                                               error_payload_field_name(),
+                                               err_info.payload_opt_type,
+                                               {span.line, span.col});
+            if (!payload) return frontend_error(FrontendError::OutOfMemory, span);
+            auto payload_is_nil = b.emit_opt_is_nil(payload.value(), {span.line, span.col});
+            if (!payload_is_nil) return frontend_error(FrontendError::OutOfMemory, span);
+            auto false_v = b.emit_const_bool(false, {span.line, span.col});
+            if (!false_v) return frontend_error(FrontendError::OutOfMemory, span);
+            auto has_payload = b.emit_cmp(
+                rir::Opcode::CmpEq, payload_is_nil.value(), false_v.value(), {span.line, span.col});
+            if (!has_payload) return frontend_error(FrontendError::OutOfMemory, span);
+            auto has_value =
+                b.emit_select(err_is_nil.value(), has_payload.value(), false_v.value(), {span.line, span.col});
+            if (!has_value) return frontend_error(FrontendError::OutOfMemory, span);
+            return has_value.value();
+        }
+        auto is_nil = b.emit_opt_is_nil(lhs.value(), {span.line, span.col});
+        if (!is_nil) return frontend_error(FrontendError::OutOfMemory, span);
+        auto false_v = b.emit_const_bool(false, {span.line, span.col});
+        if (!false_v) return frontend_error(FrontendError::OutOfMemory, span);
+        auto has_value =
+            b.emit_cmp(rir::Opcode::CmpEq, is_nil.value(), false_v.value(), {span.line, span.col});
+        if (!has_value) return frontend_error(FrontendError::OutOfMemory, span);
+        return has_value.value();
+    }
+    if (value.kind == MirValueKind::ValueOf) {
+        auto lhs = materialize_value(*value.lhs,
+                                     mir,
+                                     variant_infos,
+                                     tuple_infos,
+                                     tuple_info_count,
+                                     error_scalar_infos,
+                                     error_variant_infos,
+                                     error_struct_infos,
+                                     user_struct_defs,
+                                     b,
+                                     locals,
+                                     local_count,
+                                     span);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (value.lhs->may_error) {
+            const auto value_shape = resolved_shape(mir, value);
+            auto& err_info = error_info_for(value_shape,
+                                            value.error_struct_index,
+                                            error_scalar_infos,
+                                            error_variant_infos,
+                                            error_struct_infos);
+            auto payload = b.emit_struct_field(lhs.value(),
+                                               error_payload_field_name(),
+                                               err_info.payload_opt_type,
+                                               {span.line, span.col});
+            if (!payload) return frontend_error(FrontendError::OutOfMemory, span);
+            auto inner = make_inner_type(resolved_shape(mir, value));
+            if (!inner) return core::make_unexpected(inner.error());
+            auto unwrapped = b.emit_opt_unwrap(payload.value(), inner.value(), {span.line, span.col});
+            if (!unwrapped) return frontend_error(FrontendError::OutOfMemory, span);
+            return unwrapped.value();
+        }
+        auto inner = make_inner_type(resolved_shape(mir, value));
+        if (!inner) return core::make_unexpected(inner.error());
+        auto unwrapped = b.emit_opt_unwrap(lhs.value(), inner.value(), {span.line, span.col});
+        if (!unwrapped) return frontend_error(FrontendError::OutOfMemory, span);
+        return unwrapped.value();
+    }
+    if (value.kind == MirValueKind::MissingOf) {
+        auto lhs = materialize_value(*value.lhs,
+                                     mir,
+                                     variant_infos,
+                                     tuple_infos,
+                                     tuple_info_count,
+                                     error_scalar_infos,
+                                     error_variant_infos,
+                                     error_struct_infos,
+                                     user_struct_defs,
+                                     b,
+                                     locals,
+                                     local_count,
+                                     span);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto inner = make_inner_type(resolved_shape(mir, value));
+        if (!inner) return core::make_unexpected(inner.error());
+        if (value.may_error) {
+            const auto value_shape = resolved_shape(mir, value);
+            auto& err_info = error_info_for(value_shape,
+                                            value.error_struct_index,
+                                            error_scalar_infos,
+                                            error_variant_infos,
+                                            error_struct_infos);
+            rir::ValueId err{};
+            if (value.lhs->may_error) {
+                auto lhs_err = b.emit_struct_field(lhs.value(),
+                                                   error_field_name(),
+                                                   err_info.error_opt_type,
+                                                   {span.line, span.col});
+                if (!lhs_err) return frontend_error(FrontendError::OutOfMemory, span);
+                err = lhs_err.value();
+            } else {
+                auto nil_err = b.emit_opt_nil(err_info.error_type, {span.line, span.col});
+                if (!nil_err) return frontend_error(FrontendError::OutOfMemory, span);
+                err = nil_err.value();
+            }
+            auto nil_payload = b.emit_opt_nil(inner.value(), {span.line, span.col});
+            if (!nil_payload) return frontend_error(FrontendError::OutOfMemory, span);
+            rir::ValueId fields[] = {err, nil_payload.value()};
+            auto created =
+                b.emit_struct_create(err_info.struct_def, fields, 2, {span.line, span.col});
+            if (!created) return frontend_error(FrontendError::OutOfMemory, span);
+            return created.value();
+        }
+        auto nil = b.emit_opt_nil(inner.value(), {span.line, span.col});
+        if (!nil) return frontend_error(FrontendError::OutOfMemory, span);
+        return nil.value();
+    }
+    if (value.kind == MirValueKind::MatchPayload) {
+        auto subject = materialize_value(*value.lhs,
+                                         mir,
+                                         variant_infos,
+                                         tuple_infos,
+                                         tuple_info_count,
+                                         error_scalar_infos,
+                                         error_variant_infos,
+                                         error_struct_infos,
+                                         user_struct_defs,
+                                         b,
+                                         locals,
+                                         local_count,
+                                         span);
+        if (!subject) return core::make_unexpected(subject.error());
+        const u32 subject_variant_index = value.lhs->variant_index;
+        const auto& payload_case = mir.variants[subject_variant_index].cases[value.case_index];
+        const auto payload_shape = resolved_shape(mir, payload_case);
+        const auto payload_kind = payload_case.payload_type;
+        const rir::Type* payload_opt_ty = payload_opt_type(variant_infos[subject_variant_index], payload_kind);
+        const rir::Type* payload_inner_ty = payload_inner_type(variant_infos[subject_variant_index], payload_kind);
+        if (payload_opt_ty == nullptr || payload_inner_ty == nullptr) {
+            auto ty = rir_type_for_flat_shape(payload_shape,
+                                              variant_infos,
+                                              tuple_infos,
+                                              tuple_info_count,
+                                              user_struct_defs,
+                                              b,
+                                              span);
+            if (!ty) return core::make_unexpected(ty.error());
+            payload_inner_ty = ty.value();
+            auto opt_ty = b.make_type(rir::TypeKind::Optional, payload_inner_ty);
+            if (!opt_ty) return frontend_error(FrontendError::OutOfMemory, span);
+            payload_opt_ty = opt_ty.value();
+        }
+        auto payload_opt = b.emit_struct_field(subject.value(),
+                                              payload_field_name(payload_kind),
+                                              payload_opt_ty,
+                                              {span.line, span.col});
+        if (!payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
+        auto unwrapped = b.emit_opt_unwrap(payload_opt.value(), payload_inner_ty, {span.line, span.col});
+        if (!unwrapped) return frontend_error(FrontendError::OutOfMemory, span);
+        return unwrapped.value();
+    }
+    if (value.kind == MirValueKind::Eq || value.kind == MirValueKind::Lt || value.kind == MirValueKind::Gt) {
+        const MirValue& lhs_expr = *value.lhs;
+        const auto lhs_shape = resolved_shape(mir, lhs_expr);
+        auto lhs = materialize_value(*value.lhs,
+                                     mir,
+                                     variant_infos,
+                                     tuple_infos,
+                                     tuple_info_count,
+                                     error_scalar_infos,
+                                     error_variant_infos,
+                                     error_struct_infos,
+                                     user_struct_defs,
+                                     b,
+                                     locals,
+                                     local_count,
+                                     span);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto rhs = materialize_value(*value.rhs,
+                                     mir,
+                                     variant_infos,
+                                     tuple_infos,
+                                     tuple_info_count,
+                                     error_scalar_infos,
+                                     error_variant_infos,
+                                     error_struct_infos,
+                                     user_struct_defs,
+                                     b,
+                                     locals,
+                                     local_count,
+                                     span);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        if (value.kind == MirValueKind::Eq)
+            return emit_eq_for_flat_shape(lhs_shape,
+                                          lhs.value(),
+                                          rhs.value(),
+                                          mir,
+                                          variant_infos,
+                                          tuple_infos,
+                                          tuple_info_count,
+                                          error_scalar_infos,
+                                          error_variant_infos,
+                                          error_struct_infos,
+                                          user_struct_defs,
+                                          b,
+                                          span);
+        return emit_ord_for_flat_shape(lhs_shape,
+                                       lhs.value(),
+                                       rhs.value(),
+                                       mir,
+                                       variant_infos,
+                                       tuple_infos,
+                                       tuple_info_count,
+                                       error_scalar_infos,
+                                       error_variant_infos,
+                                       error_struct_infos,
+                                       user_struct_defs,
+                                       b,
+                                       span,
+                                       value.kind == MirValueKind::Lt);
+    }
+    if (value.local_index >= local_count) return frontend_error(FrontendError::UnsupportedSyntax, span);
+    return locals[value.local_index];
+}
+
+static FrontendResult<rir::ValueId> materialize_local_init(const MirLocal& local,
+                                                           const MirModule& mir,
+                                                           const VariantLoweringInfo* variant_infos,
+                                                           TupleLoweringInfo* tuple_infos,
+                                                           u32* tuple_info_count,
+                                                           ErrorLoweringInfo* error_scalar_infos,
+                                                           ErrorLoweringInfo* error_variant_infos,
+                                                           ErrorLoweringInfo* error_struct_infos,
+                                                           const rir::StructDef* error_struct_def,
+                                                           const rir::StructDef* const* user_struct_defs,
+                                                           rir::Builder& b,
+                                                           const rir::ValueId* locals,
+                                                           u32 local_count,
+                                                           Str func_name,
+                                                           Str source_name) {
+    auto make_inner_type = [&](MirTypeKind tkind, Span span) -> FrontendResult<const rir::Type*> {
+        if (tkind == MirTypeKind::Variant) {
+            if (local.variant_index < mir.variants.len && variant_infos[local.variant_index].struct_type)
+                return variant_infos[local.variant_index].struct_type;
+            auto inner = b.make_type(rir::TypeKind::I32);
+            if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
+            return inner.value();
+        }
+        if (tkind == MirTypeKind::Struct) {
+            if (local.struct_index >= mir.structs.len || user_struct_defs[local.struct_index] == nullptr)
+                return frontend_error(FrontendError::UnsupportedSyntax, span);
+            auto inner = b.make_type(rir::TypeKind::Struct, nullptr,
+                                     const_cast<rir::StructDef*>(user_struct_defs[local.struct_index]));
+            if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
+            return inner.value();
+        }
+        const rir::TypeKind inner_kind = tkind == MirTypeKind::Str ? rir::TypeKind::Str
+                                                                   : rir::TypeKind::I32;
+        auto inner = b.make_type(inner_kind);
+        if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
+        return inner.value();
+    };
+
+    if (local.may_error) {
+        if (local.type != MirTypeKind::I32 && local.type != MirTypeKind::Str &&
+            local.type != MirTypeKind::Variant && local.type != MirTypeKind::Struct &&
+            local.type != MirTypeKind::Unknown)
+            return frontend_error(FrontendError::UnsupportedSyntax, local.span);
+        auto inner = make_inner_type(local.type, local.span);
+        if (!inner) return core::make_unexpected(inner.error());
+        auto payload_opt = b.make_type(rir::TypeKind::Optional, inner.value());
+        if (!payload_opt) return frontend_error(FrontendError::OutOfMemory, local.span);
+        auto& err_info = error_info_for(local.type,
+                                        local.variant_index,
+                                        local.error_struct_index,
+                                        error_scalar_infos,
+                                        error_variant_infos,
+                                        error_struct_infos);
+
+        if (local.init.may_error && local.init.kind != MirValueKind::Error) {
+            auto init = materialize_value(local.init,
+                                          mir,
+                                          variant_infos,
+                                          tuple_infos,
+                                          tuple_info_count,
+                                          error_scalar_infos,
+                                          error_variant_infos,
+                                          error_struct_infos,
+                                          user_struct_defs,
+                                          b,
+                                          locals,
+                                          local_count,
+                                          local.span);
+            if (!init) return core::make_unexpected(init.error());
+            return init.value();
+        }
+
+        rir::ValueId err{};
+        rir::ValueId payload{};
+        if (local.init.kind == MirValueKind::Error) {
+            const i32 tag_value = local.init.error_variant_index != 0xffffffffu
+                                      ? static_cast<i32>(local.init.error_case_index)
+                                      : local.init.int_value;
+            auto code = b.emit_const_i32(tag_value, {local.span.line, local.span.col});
+            if (!code) return frontend_error(FrontendError::OutOfMemory, local.span);
+            auto msg = b.emit_const_str(local.init.msg, {local.span.line, local.span.col});
+            if (!msg) return frontend_error(FrontendError::OutOfMemory, local.span);
+            auto file = b.emit_const_str(source_name, {local.span.line, local.span.col});
+            if (!file) return frontend_error(FrontendError::OutOfMemory, local.span);
+            auto func = b.emit_const_str(func_name, {local.span.line, local.span.col});
+            if (!func) return frontend_error(FrontendError::OutOfMemory, local.span);
+            auto line = b.emit_const_i32(static_cast<i32>(local.span.line), {local.span.line, local.span.col});
+            if (!line) return frontend_error(FrontendError::OutOfMemory, local.span);
+            rir::ValueId error_fields[] = {code.value(), msg.value(), file.value(), func.value(), line.value()};
+            auto error_val =
+                b.emit_struct_create(const_cast<rir::StructDef*>(error_struct_def),
+                                     error_fields,
+                                     5,
+                                     {local.span.line, local.span.col});
+            if (!error_val) return frontend_error(FrontendError::OutOfMemory, local.span);
+            rir::ValueId err_value = error_val.value();
+            if (local.init.error_struct_index != 0xffffffffu) {
+                if (local.init.error_struct_index >= mir.structs.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, local.span);
+                auto* custom_struct_def =
+                    const_cast<rir::StructDef*>(user_struct_defs[local.init.error_struct_index]);
+                if (!custom_struct_def) return frontend_error(FrontendError::UnsupportedSyntax, local.span);
+                rir::ValueId custom_fields[MirStruct::kMaxFields]{};
+                for (u32 fi = 0; fi < mir.structs[local.init.error_struct_index].fields.len; fi++) {
+                    const auto& field = mir.structs[local.init.error_struct_index].fields[fi];
+                    if (field.name.eq({"err", 3}) && field.is_error_type) {
+                        custom_fields[fi] = error_val.value();
+                        continue;
+                    }
+                    u32 init_index = local.init.field_inits.len;
+                    for (u32 ii = 0; ii < local.init.field_inits.len; ii++) {
+                        if (local.init.field_inits[ii].name.eq(field.name)) {
+                            init_index = ii;
+                            break;
+                        }
+                    }
+                    if (init_index == local.init.field_inits.len)
+                        return frontend_error(FrontendError::UnsupportedSyntax, local.span, field.name);
+                    auto field_value = materialize_value(*local.init.field_inits[init_index].value,
+                                                         mir,
+                                                         variant_infos,
+                                                         tuple_infos,
+                                                         tuple_info_count,
+                                                         error_scalar_infos,
+                                                         error_variant_infos,
+                                                         error_struct_infos,
+                                                         user_struct_defs,
+                                                         b,
+                                                         locals,
+                                                         local_count,
+                                                         local.span);
+                    if (!field_value) return core::make_unexpected(field_value.error());
+                    custom_fields[fi] = field_value.value();
+                }
+                auto custom_error =
+                    b.emit_struct_create(custom_struct_def,
+                                         custom_fields,
+                                         mir.structs[local.init.error_struct_index].fields.len,
+                                         {local.span.line, local.span.col});
+                if (!custom_error) return frontend_error(FrontendError::OutOfMemory, local.span);
+                auto extracted_err = b.emit_struct_field(custom_error.value(),
+                                                         error_field_name(),
+                                                         err_info.error_type,
+                                                         {local.span.line, local.span.col});
+                if (!extracted_err) return frontend_error(FrontendError::OutOfMemory, local.span);
+                err_value = extracted_err.value();
+            }
+            auto wrapped_err = b.emit_opt_wrap(err_value, {local.span.line, local.span.col});
+            if (!wrapped_err) return frontend_error(FrontendError::OutOfMemory, local.span);
+            err = wrapped_err.value();
+            if (payload.id == 0) {
+                auto nil_payload =
+                    b.emit_opt_nil(err_info.payload_inner_type, {local.span.line, local.span.col});
+                if (!nil_payload) return frontend_error(FrontendError::OutOfMemory, local.span);
+                payload = nil_payload.value();
+            }
+        } else {
+            auto nil_err = b.emit_opt_nil(err_info.error_type, {local.span.line, local.span.col});
+            if (!nil_err) return frontend_error(FrontendError::OutOfMemory, local.span);
+            err = nil_err.value();
+            if (local.init.kind == MirValueKind::Nil) {
+                auto nil_payload = b.emit_opt_nil(inner.value(), {local.span.line, local.span.col});
+                if (!nil_payload) return frontend_error(FrontendError::OutOfMemory, local.span);
+                payload = nil_payload.value();
+            } else {
+                auto init = materialize_value(local.init,
+                                              mir,
+                                              variant_infos,
+                                              tuple_infos,
+                                              tuple_info_count,
+                                              error_scalar_infos,
+                                              error_variant_infos,
+                                              error_struct_infos,
+                                              user_struct_defs,
+                                              b,
+                                              locals,
+                                              local_count,
+                                              local.span);
+                if (!init) return core::make_unexpected(init.error());
+                if (local.init.may_nil) {
+                    payload = init.value();
+                } else {
+                    auto wrapped = b.emit_opt_wrap(init.value(), {local.span.line, local.span.col});
+                    if (!wrapped) return frontend_error(FrontendError::OutOfMemory, local.span);
+                    payload = wrapped.value();
+                }
+            }
+        }
+
+        rir::ValueId fields[] = {err, payload};
+        auto created =
+            b.emit_struct_create(err_info.struct_def, fields, 2, {local.span.line, local.span.col});
+        if (!created) return frontend_error(FrontendError::OutOfMemory, local.span);
+        return created.value();
+    }
+    if (!local.may_nil)
+        return materialize_value(local.init,
+                                 mir,
+                                 variant_infos,
+                                 tuple_infos,
+                                 tuple_info_count,
+                                 error_scalar_infos,
+                                 error_variant_infos,
+                                 error_struct_infos,
+                                 user_struct_defs,
+                                 b,
+                                 locals,
+                                 local_count,
+                                 local.span);
+
+    if (local.type != MirTypeKind::I32 && local.type != MirTypeKind::Str &&
+        local.type != MirTypeKind::Variant && local.type != MirTypeKind::Struct)
+        return frontend_error(FrontendError::UnsupportedSyntax, local.span);
+
+    auto inner = make_inner_type(local.type, local.span);
+    if (!inner) return core::make_unexpected(inner.error());
+    if (local.init.kind == MirValueKind::Nil) {
+        auto nil = b.emit_opt_nil(inner.value(), {local.span.line, local.span.col});
+        if (!nil) return frontend_error(FrontendError::OutOfMemory, local.span);
+        return nil.value();
+    }
+
+    auto init = materialize_value(local.init,
+                                  mir,
+                                  variant_infos,
+                                  tuple_infos,
+                                  tuple_info_count,
+                                  error_scalar_infos,
+                                  error_variant_infos,
+                                  error_struct_infos,
+                                  user_struct_defs,
+                                  b,
+                                  locals,
+                                  local_count,
+                                  local.span);
+    if (!init) return core::make_unexpected(init.error());
+    if (local.init.may_nil) return init.value();
+
+    auto wrapped = b.emit_opt_wrap(init.value(), {local.span.line, local.span.col});
+    if (!wrapped) return frontend_error(FrontendError::OutOfMemory, local.span);
+    return wrapped.value();
+}
+
+static FrontendResult<void> emit_term(const MirTerminator& term,
+                                      const MirModule& mir,
+                                      const VariantLoweringInfo* variant_infos,
+                                      TupleLoweringInfo* tuple_infos,
+                                      u32* tuple_info_count,
+                                      ErrorLoweringInfo* error_scalar_infos,
+                                      ErrorLoweringInfo* error_variant_infos,
+                                      ErrorLoweringInfo* error_struct_infos,
+                                      const rir::StructDef* const* user_struct_defs,
+                                      rir::Builder& b,
+                                      const rir::BlockId* block_ids,
+                                      const rir::ValueId* locals,
+                                      u32 local_count) {
+    if (term.kind == MirTerminatorKind::Branch) {
+        rir::ValueId cond_id{};
+        if (term.use_cmp) {
+            auto lhs = materialize_value(term.lhs,
+                                         mir,
+                                         variant_infos,
+                                         tuple_infos,
+                                         tuple_info_count,
+                                         error_scalar_infos,
+                                         error_variant_infos,
+                                         error_struct_infos,
+                                         user_struct_defs,
+                                         b,
+                                         locals,
+                                         local_count,
+                                         term.span);
+            if (!lhs) return core::make_unexpected(lhs.error());
+            auto rhs = materialize_value(term.rhs,
+                                         mir,
+                                         variant_infos,
+                                         tuple_infos,
+                                         tuple_info_count,
+                                         error_scalar_infos,
+                                         error_variant_infos,
+                                         error_struct_infos,
+                                         user_struct_defs,
+                                         b,
+                                         locals,
+                                         local_count,
+                                         term.span);
+            if (!rhs) return core::make_unexpected(rhs.error());
+            if (term.lhs.may_error && term.lhs.error_variant_index != 0xffffffffu) {
+                auto& err_info = error_info_for(term.lhs.type,
+                                                term.lhs.variant_index,
+                                                term.lhs.error_struct_index,
+                                                error_scalar_infos,
+                                                error_variant_infos,
+                                                error_struct_infos);
+                auto err = b.emit_struct_field(lhs.value(),
+                                               error_field_name(),
+                                               err_info.error_opt_type,
+                                               {term.span.line, term.span.col});
+                if (!err) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto err_is_nil = b.emit_opt_is_nil(err.value(), {term.span.line, term.span.col});
+                if (!err_is_nil) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto false_v = b.emit_const_bool(false, {term.span.line, term.span.col});
+                if (!false_v) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto has_error = b.emit_cmp(
+                    rir::Opcode::CmpEq, err_is_nil.value(), false_v.value(), {term.span.line, term.span.col});
+                if (!has_error) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto err_value =
+                    b.emit_opt_unwrap(err.value(), err_info.error_type, {term.span.line, term.span.col});
+                if (!err_value) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto i32_ty = b.make_type(rir::TypeKind::I32);
+                if (!i32_ty) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto tag_value =
+                    b.emit_struct_field(err_value.value(),
+                                        error_code_field_name(),
+                                        i32_ty.value(),
+                                        {term.span.line, term.span.col});
+                if (!tag_value) return frontend_error(FrontendError::OutOfMemory, term.span);
+                rir::ValueId rhs_tag = rhs.value();
+                if (term.rhs.type == MirTypeKind::Variant && term.rhs.variant_index < mir.variants.len &&
+                    variant_infos[term.rhs.variant_index].struct_type != nullptr) {
+                    auto rhs_tag_field =
+                        b.emit_struct_field(rhs.value(), lit("tag"), i32_ty.value(), {term.span.line, term.span.col});
+                    if (!rhs_tag_field) return frontend_error(FrontendError::OutOfMemory, term.span);
+                    rhs_tag = rhs_tag_field.value();
+                }
+                auto cmp = b.emit_cmp(
+                    rir::Opcode::CmpEq, tag_value.value(), rhs_tag, {term.span.line, term.span.col});
+                if (!cmp) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto cond = b.emit_select(
+                    has_error.value(), cmp.value(), false_v.value(), {term.span.line, term.span.col});
+                if (!cond) return frontend_error(FrontendError::OutOfMemory, term.span);
+                cond_id = cond.value();
+            } else
+            if (term.lhs.type == MirTypeKind::Variant && term.lhs.variant_index < mir.variants.len &&
+                variant_infos[term.lhs.variant_index].struct_type != nullptr) {
+                auto* i32_ty = b.make_type(rir::TypeKind::I32).value();
+                auto lhs_tag =
+                    b.emit_struct_field(lhs.value(), lit("tag"), i32_ty, {term.span.line, term.span.col});
+                if (!lhs_tag) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto rhs_tag =
+                    b.emit_struct_field(rhs.value(), lit("tag"), i32_ty, {term.span.line, term.span.col});
+                if (!rhs_tag) return frontend_error(FrontendError::OutOfMemory, term.span);
+                lhs = lhs_tag.value();
+                rhs = rhs_tag.value();
+                auto cmp = b.emit_cmp(
+                    rir::Opcode::CmpEq, lhs.value(), rhs.value(), {term.span.line, term.span.col});
+                if (!cmp) return frontend_error(FrontendError::OutOfMemory, term.span);
+                cond_id = cmp.value();
+            } else {
+                auto cmp =
+                    b.emit_cmp(rir::Opcode::CmpEq, lhs.value(), rhs.value(), {term.span.line, term.span.col});
+                if (!cmp) return frontend_error(FrontendError::OutOfMemory, term.span);
+                cond_id = cmp.value();
+            }
+        } else {
+            auto cond = materialize_value(term.cond,
+                                          mir,
+                                          variant_infos,
+                                          tuple_infos,
+                                          tuple_info_count,
+                                          error_scalar_infos,
+                                          error_variant_infos,
+                                          error_struct_infos,
+                                          user_struct_defs,
+                                          b,
+                                          locals,
+                                          local_count,
+                                          term.span);
+            if (!cond) return core::make_unexpected(cond.error());
+            cond_id = cond.value();
+        }
+        if (!b.emit_br(cond_id,
+                       block_ids[term.then_block],
+                       block_ids[term.else_block],
+                       {term.span.line, term.span.col})) {
+            return frontend_error(FrontendError::OutOfMemory, term.span);
+        }
+        return {};
+    }
+    if (term.kind == MirTerminatorKind::ReturnStatus) {
+        if (!b.emit_ret_status(term.status_code, {term.span.line, term.span.col}))
+            return frontend_error(FrontendError::OutOfMemory, term.span);
+        return {};
+    }
+    if (term.kind == MirTerminatorKind::ForwardUpstream) {
+        const u16 upstream_id = mir.upstreams[term.upstream_index].id;
+        auto upstream = b.emit_const_i32(static_cast<i32>(upstream_id), {term.span.line, term.span.col});
+        if (!upstream || !b.emit_ret_forward(upstream.value(), {term.span.line, term.span.col}))
+            return frontend_error(FrontendError::OutOfMemory, term.span);
+        return {};
+    }
+    return frontend_error(FrontendError::UnsupportedSyntax, term.span);
+}
+
+}  // namespace
+
+bool FrontendRirModule::init(u32 func_cap, u32 struct_cap) {
+    destroy();
+    if (!arena.init(4096)) return false;
+    module.name = source_name.len != 0 ? source_name : lit("frontend.rut");
+    module.arena = &arena;
+    module.functions = arena.alloc_array<rir::Function>(func_cap);
+    if (!module.functions) {
+        destroy();
+        return false;
+    }
+    module.func_count = 0;
+    module.func_cap = func_cap;
+    module.struct_defs = arena.alloc_array<rir::StructDef*>(struct_cap);
+    if (!module.struct_defs) {
+        destroy();
+        return false;
+    }
+    module.struct_count = 0;
+    module.struct_cap = struct_cap;
+    return true;
+}
+
+void FrontendRirModule::destroy() {
+    arena.destroy();
+    auto saved_source_name = source_name;
+    module = {};
+    source_name = saved_source_name;
+}
+
+FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) {
+    if (!out.init(mir.functions.len == 0 ? 1 : mir.functions.len,
+                  mir.variants.len * 2 + mir.structs.len + 8))
+        return frontend_error(FrontendError::OutOfMemory);
+
+    rir::Builder b;
+    b.init(&out.module);
+
+    VariantLoweringInfo variant_infos[MirModule::kMaxVariants]{};
+    TupleLoweringInfo tuple_infos[64]{};
+    u32 tuple_info_count = 0;
+    ErrorLoweringInfo error_scalar_infos[4]{};
+    ErrorLoweringInfo error_variant_infos[MirModule::kMaxVariants]{};
+    ErrorLoweringInfo error_struct_infos[MirModule::kMaxStructs]{};
+    const rir::StructDef* user_struct_defs[MirModule::kMaxStructs]{};
+
+    auto i32_ty = b.make_type(rir::TypeKind::I32);
+    if (!i32_ty) return frontend_error(FrontendError::OutOfMemory);
+    auto str_ty = b.make_type(rir::TypeKind::Str);
+    if (!str_ty) return frontend_error(FrontendError::OutOfMemory);
+    rir::FieldDef error_fields[5] = {
+        {error_code_field_name(), i32_ty.value()},
+        {error_msg_field_name(), str_ty.value()},
+        {error_file_field_name(), str_ty.value()},
+        {error_func_field_name(), str_ty.value()},
+        {error_line_field_name(), i32_ty.value()},
+    };
+    auto error_struct_def = b.create_struct(lit("Error"), error_fields, 5);
+    if (!error_struct_def) return frontend_error(FrontendError::OutOfMemory);
+    auto error_struct_ty = b.make_type(rir::TypeKind::Struct, nullptr, error_struct_def.value());
+    if (!error_struct_ty) return frontend_error(FrontendError::OutOfMemory);
+
+    bool variant_has_tuple_payload[MirModule::kMaxVariants]{};
+    bool variant_has_variant_payload[MirModule::kMaxVariants]{};
+    bool variant_has_struct_payload[MirModule::kMaxVariants]{};
+    bool variant_built[MirModule::kMaxVariants]{};
+    for (u32 vi = 0; vi < mir.variants.len; vi++) {
+        const bool unresolved_generic_instance =
+            !instance_fully_concrete(mir,
+                                     mir.variants[vi].instance_type_arg_count,
+                                     mir.variants[vi].instance_type_args,
+                                     mir.variants[vi].instance_shape_indices);
+        if (is_open_generic_variant_decl(mir.variants[vi])) {
+            variant_built[vi] = true;
+            continue;
+        }
+        if (unresolved_generic_instance) {
+            variant_built[vi] = true;
+            continue;
+        }
+        bool has_tuple_payload = false;
+        bool has_variant_payload = false;
+        bool has_struct_payload = false;
+        for (u32 ci = 0; ci < mir.variants[vi].cases.len; ci++) {
+            const auto payload_shape = resolved_shape(mir, mir.variants[vi].cases[ci]);
+            if (!mir.variants[vi].cases[ci].has_payload) continue;
+            if (payload_shape.type == MirTypeKind::Tuple) {
+                if (!has_tuple_payload) {
+                    has_tuple_payload = true;
+                    variant_infos[vi].payload_shape_index = mir.variants[vi].cases[ci].payload_shape_index;
+                    variant_infos[vi].payload_tuple_len = payload_shape.tuple_len;
+                    for (u32 ti = 0; ti < payload_shape.tuple_len; ti++) {
+                        variant_infos[vi].payload_tuple_types[ti] = payload_shape.tuple_types[ti];
+                        variant_infos[vi].payload_tuple_variant_indices[ti] =
+                            payload_shape.tuple_variant_indices[ti];
+                        variant_infos[vi].payload_tuple_struct_indices[ti] =
+                            payload_shape.tuple_struct_indices[ti];
+                    }
+                } else if (!same_tuple_shape(variant_infos[vi],
+                                             payload_shape.tuple_len,
+                                             payload_shape.tuple_types,
+                                             payload_shape.tuple_variant_indices,
+                                             payload_shape.tuple_struct_indices)) {
+                    out.destroy();
+                    return frontend_error(FrontendError::UnsupportedSyntax, mir.variants[vi].span);
+                }
+            } else if (payload_shape.type == MirTypeKind::Variant) {
+                if (!has_variant_payload) {
+                    has_variant_payload = true;
+                    variant_infos[vi].payload_shape_index = mir.variants[vi].cases[ci].payload_shape_index;
+                    variant_infos[vi].payload_variant_index = payload_shape.variant_index;
+                } else if (variant_infos[vi].payload_variant_index != payload_shape.variant_index) {
+                    out.destroy();
+                    return frontend_error(FrontendError::UnsupportedSyntax, mir.variants[vi].span);
+                }
+            } else if (payload_shape.type == MirTypeKind::Struct) {
+                if (!has_struct_payload) {
+                    has_struct_payload = true;
+                    variant_infos[vi].payload_shape_index = mir.variants[vi].cases[ci].payload_shape_index;
+                    variant_infos[vi].payload_struct_index = payload_shape.struct_index;
+                } else if (variant_infos[vi].payload_struct_index != payload_shape.struct_index) {
+                    out.destroy();
+                    return frontend_error(FrontendError::UnsupportedSyntax, mir.variants[vi].span);
+                }
+            }
+        }
+        variant_has_tuple_payload[vi] = has_tuple_payload;
+        variant_has_variant_payload[vi] = has_variant_payload;
+        variant_has_struct_payload[vi] = has_struct_payload;
+    }
+
+    bool struct_built[MirModule::kMaxStructs]{};
+    auto build_user_struct = [&](u32 si) -> FrontendResult<bool> {
+        if (struct_built[si]) return true;
+        if (!instance_fully_concrete(mir,
+                                     mir.structs[si].instance_type_arg_count,
+                                     mir.structs[si].instance_type_args,
+                                     mir.structs[si].instance_shape_indices)) {
+            struct_built[si] = true;
+            return true;
+        }
+        if (is_open_generic_struct_decl(mir.structs[si])) {
+            struct_built[si] = true;
+            return true;
+        }
+        rir::FieldDef fields[MirStruct::kMaxFields]{};
+        for (u32 fi = 0; fi < mir.structs[si].fields.len; fi++) {
+            const auto& field = mir.structs[si].fields[fi];
+            const rir::Type* field_ty = nullptr;
+            if (field.is_error_type) {
+                field_ty = error_struct_ty.value();
+            } else {
+                const auto field_shape = resolved_shape(mir, field);
+                if (field_shape.type == MirTypeKind::Bool) {
+                    auto ty = b.make_type(rir::TypeKind::Bool);
+                    if (!ty) return frontend_error(FrontendError::OutOfMemory, mir.structs[si].span);
+                    field_ty = ty.value();
+                } else if (field_shape.type == MirTypeKind::I32) {
+                    field_ty = i32_ty.value();
+                } else if (field_shape.type == MirTypeKind::Str) {
+                    field_ty = str_ty.value();
+                } else if (field_shape.type == MirTypeKind::Variant &&
+                           field_shape.variant_index < mir.variants.len &&
+                           variant_infos[field_shape.variant_index].struct_type != nullptr) {
+                    field_ty = variant_infos[field_shape.variant_index].struct_type;
+                } else if (field_shape.type == MirTypeKind::Variant) {
+                    return false;
+                } else if (field_shape.type == MirTypeKind::Struct &&
+                           field_shape.struct_index < mir.structs.len &&
+                           user_struct_defs[field_shape.struct_index] != nullptr) {
+                    auto ty = b.make_type(rir::TypeKind::Struct,
+                                          nullptr,
+                                          const_cast<rir::StructDef*>(user_struct_defs[field_shape.struct_index]));
+                    if (!ty) return frontend_error(FrontendError::OutOfMemory, mir.structs[si].span);
+                    field_ty = ty.value();
+                } else if (field_shape.type == MirTypeKind::Struct) {
+                    return false;
+                } else if (field_shape.type == MirTypeKind::Tuple) {
+                    auto tuple_info = get_or_create_tuple_lowering(field_shape.tuple_len,
+                                                                   field_shape.tuple_types,
+                                                                   field_shape.tuple_variant_indices,
+                                                                   field_shape.tuple_struct_indices,
+                                                                   variant_infos,
+                                                                   user_struct_defs,
+                                                                   tuple_infos,
+                                                                   &tuple_info_count,
+                                                                   b,
+                                                                   mir.structs[si].span);
+                    if (!tuple_info) return core::make_unexpected(tuple_info.error());
+                    field_ty = tuple_info.value()->struct_type;
+                } else {
+                    return frontend_error(FrontendError::UnsupportedSyntax, mir.structs[si].span, field.type_name);
+                }
+            }
+            fields[fi] = {field.name, field_ty};
+        }
+        auto sd = b.create_struct(mir.structs[si].name, fields, mir.structs[si].fields.len);
+        if (!sd) return frontend_error(FrontendError::OutOfMemory, mir.structs[si].span);
+        user_struct_defs[si] = sd.value();
+        struct_built[si] = true;
+        return true;
+    };
+
+    auto build_variant_carrier = [&](u32 vi) -> FrontendResult<bool> {
+        if (variant_built[vi]) return true;
+        const bool has_tuple_payload = variant_has_tuple_payload[vi];
+        const bool has_variant_payload = variant_has_variant_payload[vi];
+        const bool has_struct_payload = variant_has_struct_payload[vi];
+        const auto payload_shape = resolved_payload_shape(mir, variant_infos[vi]);
+        u32 payload_variant_index = payload_shape.variant_index;
+        u32 payload_struct_index = payload_shape.struct_index;
+        if (has_variant_payload) {
+            if (payload_variant_index >= mir.variants.len ||
+                !variant_built[payload_variant_index] ||
+                variant_infos[payload_variant_index].struct_type == nullptr) {
+                return false;
+            }
+        }
+        if (has_struct_payload) {
+            if (payload_struct_index >= mir.structs.len ||
+                user_struct_defs[payload_struct_index] == nullptr) {
+                return false;
+            }
+        }
+        auto bool_ty = b.make_type(rir::TypeKind::Bool);
+        if (!bool_ty) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+        }
+        auto i32_ty = b.make_type(rir::TypeKind::I32);
+        if (!i32_ty) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+        }
+        auto str_ty = b.make_type(rir::TypeKind::Str);
+        if (!str_ty) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+        }
+        auto bool_opt_ty = b.make_type(rir::TypeKind::Optional, bool_ty.value());
+        if (!bool_opt_ty) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+        }
+        auto i32_opt_ty = b.make_type(rir::TypeKind::Optional, i32_ty.value());
+        if (!i32_opt_ty) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+        }
+        auto str_opt_ty = b.make_type(rir::TypeKind::Optional, str_ty.value());
+        if (!str_opt_ty) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+        }
+        const rir::Type* tuple_ty = nullptr;
+        const rir::Type* tuple_opt_ty = nullptr;
+        const rir::Type* variant_ty = nullptr;
+        const rir::Type* variant_opt_ty = nullptr;
+        const rir::Type* struct_ty_payload = nullptr;
+        const rir::Type* struct_opt_ty = nullptr;
+        if (has_tuple_payload) {
+            auto tuple_info = get_or_create_tuple_lowering(payload_shape.tuple_len,
+                                                           payload_shape.tuple_types,
+                                                           payload_shape.tuple_variant_indices,
+                                                           payload_shape.tuple_struct_indices,
+                                                           variant_infos,
+                                                           user_struct_defs,
+                                                           tuple_infos,
+                                                           &tuple_info_count,
+                                                           b,
+                                                           mir.variants[vi].span);
+            if (!tuple_info) {
+                out.destroy();
+                return core::make_unexpected(tuple_info.error());
+            }
+            auto tuple_optional_ty = b.make_type(rir::TypeKind::Optional, tuple_info.value()->struct_type);
+            if (!tuple_optional_ty) {
+                out.destroy();
+                return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+            }
+            variant_infos[vi].payload_tuple_struct_def = tuple_info.value()->struct_def;
+            variant_infos[vi].payload_tuple_type = tuple_info.value()->struct_type;
+            variant_infos[vi].payload_tuple_opt_type = tuple_optional_ty.value();
+            tuple_ty = tuple_info.value()->struct_type;
+            tuple_opt_ty = tuple_optional_ty.value();
+        }
+        if (has_variant_payload) {
+            variant_ty = variant_infos[payload_variant_index].struct_type;
+            auto opt_ty = b.make_type(rir::TypeKind::Optional, variant_ty);
+            if (!opt_ty) {
+                out.destroy();
+                return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+            }
+            variant_opt_ty = opt_ty.value();
+        }
+        if (has_struct_payload) {
+            auto ty = b.make_type(
+                rir::TypeKind::Struct, nullptr, const_cast<rir::StructDef*>(user_struct_defs[payload_struct_index]));
+            if (!ty) {
+                out.destroy();
+                return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+            }
+            struct_ty_payload = ty.value();
+            auto opt_ty = b.make_type(rir::TypeKind::Optional, struct_ty_payload);
+            if (!opt_ty) {
+                out.destroy();
+                return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+            }
+            struct_opt_ty = opt_ty.value();
+        }
+        rir::FieldDef fields[7] = {
+            {lit("tag"), i32_ty.value()},
+            {lit("payload_bool"), bool_opt_ty.value()},
+            {lit("payload_i32"), i32_opt_ty.value()},
+            {lit("payload_str"), str_opt_ty.value()},
+            {lit("payload_tuple"), has_tuple_payload ? tuple_opt_ty : i32_opt_ty.value()},
+            {lit("payload_variant"), has_variant_payload ? variant_opt_ty : i32_opt_ty.value()},
+            {lit("payload_struct"), has_struct_payload ? struct_opt_ty : i32_opt_ty.value()},
+        };
+        auto sd = b.create_struct(mir.variants[vi].name, fields, 7);
+        if (!sd) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+        }
+        auto struct_ty = b.make_type(rir::TypeKind::Struct, nullptr, sd.value());
+        if (!struct_ty) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
+        }
+        variant_infos[vi].payload_bool_type = bool_ty.value();
+        variant_infos[vi].payload_i32_type = i32_ty.value();
+        variant_infos[vi].payload_str_type = str_ty.value();
+        variant_infos[vi].payload_bool_opt_type = bool_opt_ty.value();
+        variant_infos[vi].payload_i32_opt_type = i32_opt_ty.value();
+        variant_infos[vi].payload_str_opt_type = str_opt_ty.value();
+        if (has_tuple_payload) {
+            variant_infos[vi].payload_tuple_type = tuple_ty;
+            variant_infos[vi].payload_tuple_opt_type = tuple_opt_ty;
+        }
+        if (has_variant_payload) {
+            variant_infos[vi].payload_variant_type = variant_ty;
+            variant_infos[vi].payload_variant_opt_type = variant_opt_ty;
+        }
+        if (has_struct_payload) {
+            variant_infos[vi].payload_struct_type = struct_ty_payload;
+            variant_infos[vi].payload_struct_opt_type = struct_opt_ty;
+        }
+        variant_infos[vi].struct_type = struct_ty.value();
+        variant_infos[vi].struct_def = sd.value();
+        variant_built[vi] = true;
+        return true;
+    };
+
+    for (;;) {
+        bool progress = false;
+        for (u32 si = 0; si < mir.structs.len; si++) {
+            if (struct_built[si]) continue;
+            auto built = build_user_struct(si);
+            if (!built) return core::make_unexpected(built.error());
+            if (built.value()) progress = true;
+        }
+        for (u32 vi = 0; vi < mir.variants.len; vi++) {
+            if (variant_built[vi]) continue;
+            auto built = build_variant_carrier(vi);
+            if (!built) return core::make_unexpected(built.error());
+            if (built.value()) progress = true;
+        }
+        if (!progress) {
+            for (u32 si = 0; si < mir.structs.len; si++) {
+                if (!struct_built[si]) {
+                    out.destroy();
+                    return frontend_error(FrontendError::UnsupportedSyntax, mir.structs[si].span);
+                }
+            }
+            for (u32 vi = 0; vi < mir.variants.len; vi++) {
+                if (!variant_built[vi]) {
+                    out.destroy();
+                    return frontend_error(FrontendError::UnsupportedSyntax, mir.variants[vi].span);
+                }
+            }
+            break;
+        }
+    }
+
+    auto make_error_info = [&](Str name, const rir::Type* payload_inner) -> FrontendResult<ErrorLoweringInfo> {
+        ErrorLoweringInfo info{};
+        auto error_opt_ty = b.make_type(rir::TypeKind::Optional, error_struct_ty.value());
+        if (!error_opt_ty) return frontend_error(FrontendError::OutOfMemory);
+        auto payload_opt_ty = b.make_type(rir::TypeKind::Optional, payload_inner);
+        if (!payload_opt_ty) return frontend_error(FrontendError::OutOfMemory);
+        rir::FieldDef fields[2] = {
+            {error_field_name(), error_opt_ty.value()},
+            {error_payload_field_name(), payload_opt_ty.value()},
+        };
+        auto sd = b.create_struct(name, fields, 2);
+        if (!sd) return frontend_error(FrontendError::OutOfMemory);
+        auto struct_ty = b.make_type(rir::TypeKind::Struct, nullptr, sd.value());
+        if (!struct_ty) return frontend_error(FrontendError::OutOfMemory);
+        info.struct_type = struct_ty.value();
+        info.error_type = error_struct_ty.value();
+        info.error_opt_type = error_opt_ty.value();
+        info.payload_inner_type = payload_inner;
+        info.payload_opt_type = payload_opt_ty.value();
+        info.struct_def = sd.value();
+        return info;
+    };
+
+    {
+        auto bool_ty = b.make_type(rir::TypeKind::Bool);
+        if (!bool_ty) return frontend_error(FrontendError::OutOfMemory);
+        auto err_bool = make_error_info(lit("__error_bool"), bool_ty.value());
+        if (!err_bool) return core::make_unexpected(err_bool.error());
+        error_scalar_infos[0] = err_bool.value();
+        auto err_i32 = make_error_info(lit("__error_i32"), i32_ty.value());
+        if (!err_i32) return core::make_unexpected(err_i32.error());
+        error_scalar_infos[1] = err_i32.value();
+        auto err_str = make_error_info(lit("__error_str"), str_ty.value());
+        if (!err_str) return core::make_unexpected(err_str.error());
+        error_scalar_infos[2] = err_str.value();
+        auto err_unknown = make_error_info(lit("__error_unknown"), i32_ty.value());
+        if (!err_unknown) return core::make_unexpected(err_unknown.error());
+        error_scalar_infos[3] = err_unknown.value();
+    }
+    for (u32 vi = 0; vi < mir.variants.len; vi++) {
+        const rir::Type* payload_inner = variant_infos[vi].struct_type;
+        if (!payload_inner) {
+            auto i32_ty = b.make_type(rir::TypeKind::I32);
+            if (!i32_ty) return frontend_error(FrontendError::OutOfMemory);
+            payload_inner = i32_ty.value();
+        }
+        char buf[32];
+        const char* prefix = "__error_variant_";
+        u32 pos = 0;
+        while (prefix[pos]) {
+            buf[pos] = prefix[pos];
+            pos++;
+        }
+        char tmp[10];
+        u32 n = 0;
+        u32 v = vi;
+        if (v == 0) tmp[n++] = '0';
+        else while (v > 0) {
+            tmp[n++] = static_cast<char>('0' + (v % 10));
+            v /= 10;
+        }
+        while (n > 0) buf[pos++] = tmp[--n];
+        auto err_variant = make_error_info({buf, pos}, payload_inner);
+        if (!err_variant) return core::make_unexpected(err_variant.error());
+        error_variant_infos[vi] = err_variant.value();
+    }
+    for (u32 si = 0; si < mir.structs.len; si++) {
+        if (!mir.structs[si].conforms_error) continue;
+        auto struct_ty =
+            b.make_type(rir::TypeKind::Struct, nullptr, const_cast<rir::StructDef*>(user_struct_defs[si]));
+        if (!struct_ty) return frontend_error(FrontendError::OutOfMemory, mir.structs[si].span);
+        char buf[64];
+        const char* prefix = "__error_struct_";
+        u32 pos = 0;
+        while (prefix[pos]) {
+            buf[pos] = prefix[pos];
+            pos++;
+        }
+        for (u32 i = 0; i < mir.structs[si].name.len && pos < sizeof(buf); i++) {
+            buf[pos++] = mir.structs[si].name.ptr[i];
+        }
+        auto err_struct = make_error_info({buf, pos}, struct_ty.value());
+        if (!err_struct) return core::make_unexpected(err_struct.error());
+        error_struct_infos[si] = err_struct.value();
+    }
+
+    for (u32 i = 0; i < mir.functions.len; i++) {
+        Str name{};
+        Str path{};
+        if (!build_route_name(out.arena, i, &name) || !copy_str(out.arena, mir.functions[i].path, &path)) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
+        }
+
+        auto fn = b.create_function(name, path, mir.functions[i].method);
+        if (!fn) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
+        }
+        rir::BlockId block_ids[MirFunction::kMaxBlocks]{};
+        for (u32 bi = 0; bi < mir.functions[i].blocks.len; bi++) {
+            auto block = b.create_block(fn.value(), mir.functions[i].blocks[bi].label);
+            if (!block) {
+                out.destroy();
+                return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
+            }
+            block_ids[bi] = block.value();
+        }
+        if (mir.functions[i].blocks.len == 0) {
+            out.destroy();
+            return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
+        }
+        b.set_insert_point(fn.value(), block_ids[0]);
+
+        rir::ValueId local_vals[MirFunction::kMaxLocals]{};
+        for (u32 li = 0; li < mir.functions[i].locals.len; li++) {
+            auto val = materialize_local_init(mir.functions[i].locals[li],
+                                              mir,
+                                              variant_infos,
+                                              tuple_infos,
+                                              &tuple_info_count,
+                                              error_scalar_infos,
+                                              error_variant_infos,
+                                              error_struct_infos,
+                                              error_struct_def.value(),
+                                              user_struct_defs,
+                                              b,
+                                              local_vals,
+                                              MirFunction::kMaxLocals,
+                                              mir.functions[i].name,
+                                              out.module.name);
+            if (!val) {
+                out.destroy();
+                return core::make_unexpected(val.error());
+            }
+            local_vals[mir.functions[i].locals[li].ref_index] = val.value();
+        }
+
+        for (u32 bi = 0; bi < mir.functions[i].blocks.len; bi++) {
+            b.set_insert_point(fn.value(), block_ids[bi]);
+            auto emitted = emit_term(mir.functions[i].blocks[bi].term,
+                                     mir,
+                                     variant_infos,
+                                     tuple_infos,
+                                     &tuple_info_count,
+                                     error_scalar_infos,
+                                     error_variant_infos,
+                                     error_struct_infos,
+                                     user_struct_defs,
+                                     b,
+                                     block_ids,
+                                     local_vals,
+                                     MirFunction::kMaxLocals);
+            if (!emitted) {
+                out.destroy();
+                return core::make_unexpected(emitted.error());
+            }
+        }
+    }
+
+    return {};
+}
+
+}  // namespace rut

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -59,6 +59,14 @@ struct FlatMirShape {
     u32 tuple_struct_indices[kMaxMirTupleSlots]{};
 };
 
+static FrontendResult<const rir::Type*> rir_type_for_flat_shape(const FlatMirShape& shape,
+                                                                const VariantLoweringInfo* variant_infos,
+                                                                TupleLoweringInfo* tuple_infos,
+                                                                u32* tuple_info_count,
+                                                                const rir::StructDef* const* user_struct_defs,
+                                                                rir::Builder& b,
+                                                                Span span);
+
 static Str lit(const char* s) {
     u32 n = 0;
     while (s[n]) n++;
@@ -284,6 +292,20 @@ static FlatMirShape fallback_shape(const MirStruct::FieldDecl& field) {
     return out;
 }
 
+static FlatMirShape fallback_shape(const MirLocal& local) {
+    FlatMirShape out{};
+    out.type = local.type;
+    out.variant_index = local.variant_index;
+    out.struct_index = local.struct_index;
+    out.tuple_len = local.tuple_len;
+    for (u32 i = 0; i < local.tuple_len; i++) {
+        out.tuple_types[i] = local.tuple_types[i];
+        out.tuple_variant_indices[i] = local.tuple_variant_indices[i];
+        out.tuple_struct_indices[i] = local.tuple_struct_indices[i];
+    }
+    return out;
+}
+
 static FlatMirShape fallback_shape(const MirVariant::CaseDecl& c) {
     FlatMirShape out{};
     out.type = c.payload_type;
@@ -367,6 +389,12 @@ static FlatMirShape resolved_shape(const MirModule& mir, const MirStruct::FieldD
     return out;
 }
 
+static FlatMirShape resolved_shape(const MirModule& mir, const MirLocal& local) {
+    auto out = fallback_shape(local);
+    expand_flat_shape(mir, local.shape_index, &out);
+    return out;
+}
+
 static FlatMirShape resolved_shape(const MirModule& mir, const MirVariant::CaseDecl& c) {
     auto out = fallback_shape(c);
     expand_flat_shape(mir, c.payload_shape_index, &out);
@@ -421,35 +449,17 @@ static FrontendResult<const TupleLoweringInfo*> get_or_create_tuple_lowering(
     for (u32 i = 0; i < tuple_len; i++) {
         if (!build_tuple_field_name(*b.mod->arena, i, &fields[i].name))
             return frontend_error(FrontendError::OutOfMemory, span);
-        const rir::Type* elem_ty = nullptr;
-        if (tuple_types[i] == MirTypeKind::Bool) {
-            auto ty = b.make_type(rir::TypeKind::Bool);
-            if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
-            elem_ty = ty.value();
-        } else if (tuple_types[i] == MirTypeKind::I32) {
-            auto ty = b.make_type(rir::TypeKind::I32);
-            if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
-            elem_ty = ty.value();
-        } else if (tuple_types[i] == MirTypeKind::Str) {
-            auto ty = b.make_type(rir::TypeKind::Str);
-            if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
-            elem_ty = ty.value();
-        } else if (tuple_types[i] == MirTypeKind::Variant &&
-                   variant_infos[tuple_variant_indices[i]].struct_type != nullptr) {
-            elem_ty = variant_infos[tuple_variant_indices[i]].struct_type;
-        } else if (tuple_types[i] == MirTypeKind::Variant) {
-            auto ty = b.make_type(rir::TypeKind::I32);
-            if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
-            elem_ty = ty.value();
-        } else if (tuple_types[i] == MirTypeKind::Struct && tuple_struct_indices[i] != 0xffffffffu &&
-                   user_struct_defs[tuple_struct_indices[i]] != nullptr) {
-            elem_ty = b.make_type(rir::TypeKind::Struct, nullptr,
-                                  const_cast<rir::StructDef*>(user_struct_defs[tuple_struct_indices[i]])).value();
-            if (elem_ty == nullptr) return frontend_error(FrontendError::OutOfMemory, span);
-        } else {
-            return frontend_error(FrontendError::UnsupportedSyntax, span);
-        }
-        fields[i].type = elem_ty;
+        const auto elem_shape =
+            tuple_elem_shape(i, tuple_types, tuple_variant_indices, tuple_struct_indices);
+        auto field_ty = rir_type_for_flat_shape(elem_shape,
+                                                variant_infos,
+                                                tuple_infos,
+                                                tuple_info_count,
+                                                user_struct_defs,
+                                                b,
+                                                span);
+        if (!field_ty) return core::make_unexpected(field_ty.error());
+        fields[i].type = field_ty.value();
     }
     Str name{};
     if (!build_indexed_name(*b.mod->arena, lit("__tuple_"), *tuple_info_count, &name))
@@ -749,19 +759,20 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
             const auto& c = variant.cases[i];
             if (!c.has_payload) continue;
             const auto payload_shape = resolved_shape(mir, c);
+            const auto payload_kind = payload_shape.type;
             auto case_tag = b.emit_const_i32(static_cast<i32>(i), {span.line, span.col});
             if (!case_tag) return frontend_error(FrontendError::OutOfMemory, span);
             auto case_match = b.emit_cmp(rir::Opcode::CmpEq, lhs_tag.value(), case_tag.value(), {span.line, span.col});
             if (!case_match) return frontend_error(FrontendError::OutOfMemory, span);
-            auto payload_opt_ty = payload_opt_type(variant_infos[variant_index], c.payload_type);
-            auto payload_inner_ty = payload_inner_type(variant_infos[variant_index], c.payload_type);
+            auto payload_opt_ty = payload_opt_type(variant_infos[variant_index], payload_kind);
+            auto payload_inner_ty = payload_inner_type(variant_infos[variant_index], payload_kind);
             auto lhs_payload_opt = b.emit_struct_field(lhs,
-                                                       payload_field_name(c.payload_type),
+                                                       payload_field_name(payload_kind),
                                                        payload_opt_ty,
                                                        {span.line, span.col});
             if (!lhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
             auto rhs_payload_opt = b.emit_struct_field(rhs,
-                                                       payload_field_name(c.payload_type),
+                                                       payload_field_name(payload_kind),
                                                        payload_opt_ty,
                                                        {span.line, span.col});
             if (!rhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
@@ -990,15 +1001,16 @@ static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
             const auto& c = variant.cases[static_cast<u32>(i)];
             if (!c.has_payload) continue;
             const auto payload_shape = resolved_shape(mir, c);
+            const auto payload_kind = payload_shape.type;
             auto case_tag = b.emit_const_i32(i, {span.line, span.col});
             if (!case_tag) return frontend_error(FrontendError::OutOfMemory, span);
             auto case_match = b.emit_cmp(rir::Opcode::CmpEq, lhs_tag.value(), case_tag.value(), {span.line, span.col});
             if (!case_match) return frontend_error(FrontendError::OutOfMemory, span);
-            auto payload_opt_ty = payload_opt_type(info, c.payload_type);
-            auto payload_inner_ty = payload_inner_type(info, c.payload_type);
-            auto lhs_payload_opt = b.emit_struct_field(lhs, payload_field_name(c.payload_type), payload_opt_ty, {span.line, span.col});
+            auto payload_opt_ty = payload_opt_type(info, payload_kind);
+            auto payload_inner_ty = payload_inner_type(info, payload_kind);
+            auto lhs_payload_opt = b.emit_struct_field(lhs, payload_field_name(payload_kind), payload_opt_ty, {span.line, span.col});
             if (!lhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
-            auto rhs_payload_opt = b.emit_struct_field(rhs, payload_field_name(c.payload_type), payload_opt_ty, {span.line, span.col});
+            auto rhs_payload_opt = b.emit_struct_field(rhs, payload_field_name(payload_kind), payload_opt_ty, {span.line, span.col});
             if (!rhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
             auto lhs_payload = b.emit_opt_unwrap(lhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
             if (!lhs_payload) return frontend_error(FrontendError::OutOfMemory, span);
@@ -1329,8 +1341,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                      local_count,
                                      span);
         if (!lhs) return core::make_unexpected(lhs.error());
-        auto& err_info = error_info_for(value.lhs->type,
-                                        value.lhs->variant_index,
+        const auto lhs_shape = resolved_shape(mir, *value.lhs);
+        auto& err_info = error_info_for(lhs_shape,
                                         value.lhs->error_struct_index,
                                         error_scalar_infos,
                                         error_variant_infos,
@@ -1361,8 +1373,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
             if (!field) return frontend_error(FrontendError::OutOfMemory, span);
             return field.value();
         }
-        if (value.lhs->type == MirTypeKind::Struct && value.lhs->struct_index < mir.structs.len) {
-            const auto& st = mir.structs[value.lhs->struct_index];
+        if (lhs_shape.type == MirTypeKind::Struct && lhs_shape.struct_index < mir.structs.len) {
+            const auto& st = mir.structs[lhs_shape.struct_index];
             u32 field_index = st.fields.len;
             for (u32 i = 0; i < st.fields.len; i++) {
                 if (st.fields[i].name.eq(value.str_value)) {
@@ -1422,6 +1434,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                      local_count,
                                      span);
         if (!rhs) return core::make_unexpected(rhs.error());
+        if (value.lhs->kind == MirValueKind::Nil || value.lhs->kind == MirValueKind::Error)
+            return rhs.value();
         const auto value_shape = resolved_shape(mir, value);
         auto inner = make_inner_type(value_shape);
         if (!inner) return core::make_unexpected(inner.error());
@@ -1811,10 +1825,13 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                          local_count,
                                          span);
         if (!subject) return core::make_unexpected(subject.error());
-        const u32 subject_variant_index = value.lhs->variant_index;
+        const auto subject_shape = resolved_shape(mir, *value.lhs);
+        const u32 subject_variant_index = subject_shape.variant_index;
+        if (subject_shape.type != MirTypeKind::Variant || subject_variant_index >= mir.variants.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
         const auto& payload_case = mir.variants[subject_variant_index].cases[value.case_index];
         const auto payload_shape = resolved_shape(mir, payload_case);
-        const auto payload_kind = payload_case.payload_type;
+        const auto payload_kind = payload_shape.type;
         const rir::Type* payload_opt_ty = payload_opt_type(variant_infos[subject_variant_index], payload_kind);
         const rir::Type* payload_inner_ty = payload_inner_type(variant_infos[subject_variant_index], payload_kind);
         if (payload_opt_ty == nullptr || payload_inner_ty == nullptr) {
@@ -1919,23 +1936,24 @@ static FrontendResult<rir::ValueId> materialize_local_init(const MirLocal& local
                                                            u32 local_count,
                                                            Str func_name,
                                                            Str source_name) {
-    auto make_inner_type = [&](MirTypeKind tkind, Span span) -> FrontendResult<const rir::Type*> {
-        if (tkind == MirTypeKind::Variant) {
-            if (local.variant_index < mir.variants.len && variant_infos[local.variant_index].struct_type)
-                return variant_infos[local.variant_index].struct_type;
+    const auto local_shape = resolved_shape(mir, local);
+    auto make_inner_type = [&](const FlatMirShape& shape, Span span) -> FrontendResult<const rir::Type*> {
+        if (shape.type == MirTypeKind::Variant) {
+            if (shape.variant_index < mir.variants.len && variant_infos[shape.variant_index].struct_type)
+                return variant_infos[shape.variant_index].struct_type;
             auto inner = b.make_type(rir::TypeKind::I32);
             if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
             return inner.value();
         }
-        if (tkind == MirTypeKind::Struct) {
-            if (local.struct_index >= mir.structs.len || user_struct_defs[local.struct_index] == nullptr)
+        if (shape.type == MirTypeKind::Struct) {
+            if (shape.struct_index >= mir.structs.len || user_struct_defs[shape.struct_index] == nullptr)
                 return frontend_error(FrontendError::UnsupportedSyntax, span);
             auto inner = b.make_type(rir::TypeKind::Struct, nullptr,
-                                     const_cast<rir::StructDef*>(user_struct_defs[local.struct_index]));
+                                     const_cast<rir::StructDef*>(user_struct_defs[shape.struct_index]));
             if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
             return inner.value();
         }
-        const rir::TypeKind inner_kind = tkind == MirTypeKind::Str ? rir::TypeKind::Str
+        const rir::TypeKind inner_kind = shape.type == MirTypeKind::Str ? rir::TypeKind::Str
                                                                    : rir::TypeKind::I32;
         auto inner = b.make_type(inner_kind);
         if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
@@ -1943,16 +1961,15 @@ static FrontendResult<rir::ValueId> materialize_local_init(const MirLocal& local
     };
 
     if (local.may_error) {
-        if (local.type != MirTypeKind::I32 && local.type != MirTypeKind::Str &&
-            local.type != MirTypeKind::Variant && local.type != MirTypeKind::Struct &&
-            local.type != MirTypeKind::Unknown)
+        if (local_shape.type != MirTypeKind::I32 && local_shape.type != MirTypeKind::Str &&
+            local_shape.type != MirTypeKind::Variant && local_shape.type != MirTypeKind::Struct &&
+            local_shape.type != MirTypeKind::Unknown)
             return frontend_error(FrontendError::UnsupportedSyntax, local.span);
-        auto inner = make_inner_type(local.type, local.span);
+        auto inner = make_inner_type(local_shape, local.span);
         if (!inner) return core::make_unexpected(inner.error());
         auto payload_opt = b.make_type(rir::TypeKind::Optional, inner.value());
         if (!payload_opt) return frontend_error(FrontendError::OutOfMemory, local.span);
-        auto& err_info = error_info_for(local.type,
-                                        local.variant_index,
+        auto& err_info = error_info_for(local_shape,
                                         local.error_struct_index,
                                         error_scalar_infos,
                                         error_variant_infos,
@@ -2114,11 +2131,11 @@ static FrontendResult<rir::ValueId> materialize_local_init(const MirLocal& local
                                  local_count,
                                  local.span);
 
-    if (local.type != MirTypeKind::I32 && local.type != MirTypeKind::Str &&
-        local.type != MirTypeKind::Variant && local.type != MirTypeKind::Struct)
+    if (local_shape.type != MirTypeKind::I32 && local_shape.type != MirTypeKind::Str &&
+        local_shape.type != MirTypeKind::Variant && local_shape.type != MirTypeKind::Struct)
         return frontend_error(FrontendError::UnsupportedSyntax, local.span);
 
-    auto inner = make_inner_type(local.type, local.span);
+    auto inner = make_inner_type(local_shape, local.span);
     if (!inner) return core::make_unexpected(inner.error());
     if (local.init.kind == MirValueKind::Nil) {
         auto nil = b.emit_opt_nil(inner.value(), {local.span.line, local.span.col});
@@ -2163,6 +2180,8 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
     if (term.kind == MirTerminatorKind::Branch) {
         rir::ValueId cond_id{};
         if (term.use_cmp) {
+            const auto lhs_shape = resolved_shape(mir, term.lhs);
+            const auto rhs_shape = resolved_shape(mir, term.rhs);
             auto lhs = materialize_value(term.lhs,
                                          mir,
                                          variant_infos,
@@ -2192,8 +2211,7 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
                                          term.span);
             if (!rhs) return core::make_unexpected(rhs.error());
             if (term.lhs.may_error && term.lhs.error_variant_index != 0xffffffffu) {
-                auto& err_info = error_info_for(term.lhs.type,
-                                                term.lhs.variant_index,
+                auto& err_info = error_info_for(lhs_shape,
                                                 term.lhs.error_struct_index,
                                                 error_scalar_infos,
                                                 error_variant_infos,
@@ -2222,8 +2240,8 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
                                         {term.span.line, term.span.col});
                 if (!tag_value) return frontend_error(FrontendError::OutOfMemory, term.span);
                 rir::ValueId rhs_tag = rhs.value();
-                if (term.rhs.type == MirTypeKind::Variant && term.rhs.variant_index < mir.variants.len &&
-                    variant_infos[term.rhs.variant_index].struct_type != nullptr) {
+                if (rhs_shape.type == MirTypeKind::Variant && rhs_shape.variant_index < mir.variants.len &&
+                    variant_infos[rhs_shape.variant_index].struct_type != nullptr) {
                     auto rhs_tag_field =
                         b.emit_struct_field(rhs.value(), lit("tag"), i32_ty.value(), {term.span.line, term.span.col});
                     if (!rhs_tag_field) return frontend_error(FrontendError::OutOfMemory, term.span);
@@ -2237,8 +2255,8 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
                 if (!cond) return frontend_error(FrontendError::OutOfMemory, term.span);
                 cond_id = cond.value();
             } else
-            if (term.lhs.type == MirTypeKind::Variant && term.lhs.variant_index < mir.variants.len &&
-                variant_infos[term.lhs.variant_index].struct_type != nullptr) {
+            if (lhs_shape.type == MirTypeKind::Variant && lhs_shape.variant_index < mir.variants.len &&
+                variant_infos[lhs_shape.variant_index].struct_type != nullptr) {
                 auto* i32_ty = b.make_type(rir::TypeKind::I32).value();
                 auto lhs_tag =
                     b.emit_struct_field(lhs.value(), lit("tag"), i32_ty, {term.span.line, term.span.col});

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2302,6 +2302,14 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
         return {};
     }
     if (term.kind == MirTerminatorKind::ReturnStatus) {
+        if (term.source_kind == MirTerminatorSourceKind::LocalRef) {
+            if (term.local_ref_index >= local_count)
+                return frontend_error(FrontendError::UnsupportedSyntax, term.span);
+            const auto code_id = locals[term.local_ref_index];
+            if (!b.emit_ret_status(code_id, {term.span.line, term.span.col}))
+                return frontend_error(FrontendError::OutOfMemory, term.span);
+            return {};
+        }
         if (!b.emit_ret_status(term.status_code, {term.span.line, term.span.col}))
             return frontend_error(FrontendError::OutOfMemory, term.span);
         return {};

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -59,13 +59,14 @@ struct FlatMirShape {
     u32 tuple_struct_indices[kMaxMirTupleSlots]{};
 };
 
-static FrontendResult<const rir::Type*> rir_type_for_flat_shape(const FlatMirShape& shape,
-                                                                const VariantLoweringInfo* variant_infos,
-                                                                TupleLoweringInfo* tuple_infos,
-                                                                u32* tuple_info_count,
-                                                                const rir::StructDef* const* user_struct_defs,
-                                                                rir::Builder& b,
-                                                                Span span);
+static FrontendResult<const rir::Type*> rir_type_for_flat_shape(
+    const FlatMirShape& shape,
+    const VariantLoweringInfo* variant_infos,
+    TupleLoweringInfo* tuple_infos,
+    u32* tuple_info_count,
+    const rir::StructDef* const* user_struct_defs,
+    rir::Builder& b,
+    Span span);
 
 static Str lit(const char* s) {
     u32 n = 0;
@@ -230,9 +231,11 @@ static bool same_tuple_shape(const TupleLoweringInfo& info,
     if (info.tuple_len != tuple_len) return false;
     for (u32 i = 0; i < tuple_len; i++) {
         if (info.tuple_types[i] != tuple_types[i]) return false;
-        if (info.tuple_types[i] == MirTypeKind::Variant && info.tuple_variant_indices[i] != tuple_variant_indices[i])
+        if (info.tuple_types[i] == MirTypeKind::Variant &&
+            info.tuple_variant_indices[i] != tuple_variant_indices[i])
             return false;
-        if (info.tuple_types[i] == MirTypeKind::Struct && info.tuple_struct_indices[i] != tuple_struct_indices[i])
+        if (info.tuple_types[i] == MirTypeKind::Struct &&
+            info.tuple_struct_indices[i] != tuple_struct_indices[i])
             return false;
     }
     return true;
@@ -434,7 +437,11 @@ static FrontendResult<const TupleLoweringInfo*> get_or_create_tuple_lowering(
     rir::Builder& b,
     Span span) {
     for (u32 i = 0; i < *tuple_info_count; i++) {
-        if (same_tuple_shape(tuple_infos[i], tuple_len, tuple_types, tuple_variant_indices, tuple_struct_indices))
+        if (same_tuple_shape(tuple_infos[i],
+                             tuple_len,
+                             tuple_types,
+                             tuple_variant_indices,
+                             tuple_struct_indices))
             return &tuple_infos[i];
     }
     if (*tuple_info_count >= 64) return frontend_error(FrontendError::TooManyItems, span);
@@ -451,13 +458,8 @@ static FrontendResult<const TupleLoweringInfo*> get_or_create_tuple_lowering(
             return frontend_error(FrontendError::OutOfMemory, span);
         const auto elem_shape =
             tuple_elem_shape(i, tuple_types, tuple_variant_indices, tuple_struct_indices);
-        auto field_ty = rir_type_for_flat_shape(elem_shape,
-                                                variant_infos,
-                                                tuple_infos,
-                                                tuple_info_count,
-                                                user_struct_defs,
-                                                b,
-                                                span);
+        auto field_ty = rir_type_for_flat_shape(
+            elem_shape, variant_infos, tuple_infos, tuple_info_count, user_struct_defs, b, span);
         if (!field_ty) return core::make_unexpected(field_ty.error());
         fields[i].type = field_ty.value();
     }
@@ -474,19 +476,20 @@ static FrontendResult<const TupleLoweringInfo*> get_or_create_tuple_lowering(
     return &info;
 }
 
-static FrontendResult<const rir::Type*> rir_type_for_shape(MirTypeKind type,
-                                                           u32 variant_index,
-                                                           u32 struct_index,
-                                                           u32 tuple_len,
-                                                           const MirTypeKind* tuple_types,
-                                                           const u32* tuple_variant_indices,
-                                                           const u32* tuple_struct_indices,
-                                                           const VariantLoweringInfo* variant_infos,
-                                                           TupleLoweringInfo* tuple_infos,
-                                                           u32* tuple_info_count,
-                                                           const rir::StructDef* const* user_struct_defs,
-                                                           rir::Builder& b,
-                                                           Span span) {
+static FrontendResult<const rir::Type*> rir_type_for_shape(
+    MirTypeKind type,
+    u32 variant_index,
+    u32 struct_index,
+    u32 tuple_len,
+    const MirTypeKind* tuple_types,
+    const u32* tuple_variant_indices,
+    const u32* tuple_struct_indices,
+    const VariantLoweringInfo* variant_infos,
+    TupleLoweringInfo* tuple_infos,
+    u32* tuple_info_count,
+    const rir::StructDef* const* user_struct_defs,
+    rir::Builder& b,
+    Span span) {
     if (type == MirTypeKind::Bool) {
         auto ty = b.make_type(rir::TypeKind::Bool);
         if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
@@ -526,7 +529,8 @@ static FrontendResult<const rir::Type*> rir_type_for_shape(MirTypeKind type,
     }
     if (type == MirTypeKind::Struct && struct_index != 0xffffffffu &&
         user_struct_defs[struct_index] != nullptr) {
-        auto ty = b.make_type(rir::TypeKind::Struct, nullptr,
+        auto ty = b.make_type(rir::TypeKind::Struct,
+                              nullptr,
                               const_cast<rir::StructDef*>(user_struct_defs[struct_index]));
         if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
         return ty.value();
@@ -534,13 +538,14 @@ static FrontendResult<const rir::Type*> rir_type_for_shape(MirTypeKind type,
     return frontend_error(FrontendError::UnsupportedSyntax, span);
 }
 
-static FrontendResult<const rir::Type*> rir_type_for_flat_shape(const FlatMirShape& shape,
-                                                                const VariantLoweringInfo* variant_infos,
-                                                                TupleLoweringInfo* tuple_infos,
-                                                                u32* tuple_info_count,
-                                                                const rir::StructDef* const* user_struct_defs,
-                                                                rir::Builder& b,
-                                                                Span span) {
+static FrontendResult<const rir::Type*> rir_type_for_flat_shape(
+    const FlatMirShape& shape,
+    const VariantLoweringInfo* variant_infos,
+    TupleLoweringInfo* tuple_infos,
+    u32* tuple_info_count,
+    const rir::StructDef* const* user_struct_defs,
+    rir::Builder& b,
+    Span span) {
     return rir_type_for_shape(shape.type,
                               shape.variant_index,
                               shape.struct_index,
@@ -556,34 +561,36 @@ static FrontendResult<const rir::Type*> rir_type_for_flat_shape(const FlatMirSha
                               span);
 }
 
-static FrontendResult<rir::ValueId> emit_eq_for_flat_shape(const FlatMirShape& shape,
-                                                           rir::ValueId lhs,
-                                                           rir::ValueId rhs,
-                                                           const MirModule& mir,
-                                                           const VariantLoweringInfo* variant_infos,
-                                                           TupleLoweringInfo* tuple_infos,
-                                                           u32* tuple_info_count,
-                                                           ErrorLoweringInfo* error_scalar_infos,
-                                                           ErrorLoweringInfo* error_variant_infos,
-                                                           ErrorLoweringInfo* error_struct_infos,
-                                                           const rir::StructDef* const* user_struct_defs,
-                                                           rir::Builder& b,
-                                                           Span span);
+static FrontendResult<rir::ValueId> emit_eq_for_flat_shape(
+    const FlatMirShape& shape,
+    rir::ValueId lhs,
+    rir::ValueId rhs,
+    const MirModule& mir,
+    const VariantLoweringInfo* variant_infos,
+    TupleLoweringInfo* tuple_infos,
+    u32* tuple_info_count,
+    ErrorLoweringInfo* error_scalar_infos,
+    ErrorLoweringInfo* error_variant_infos,
+    ErrorLoweringInfo* error_struct_infos,
+    const rir::StructDef* const* user_struct_defs,
+    rir::Builder& b,
+    Span span);
 
-static FrontendResult<rir::ValueId> emit_ord_for_flat_shape(const FlatMirShape& shape,
-                                                            rir::ValueId lhs,
-                                                            rir::ValueId rhs,
-                                                            const MirModule& mir,
-                                                            const VariantLoweringInfo* variant_infos,
-                                                            TupleLoweringInfo* tuple_infos,
-                                                            u32* tuple_info_count,
-                                                            ErrorLoweringInfo* error_scalar_infos,
-                                                            ErrorLoweringInfo* error_variant_infos,
-                                                            ErrorLoweringInfo* error_struct_infos,
-                                                            const rir::StructDef* const* user_struct_defs,
-                                                            rir::Builder& b,
-                                                            Span span,
-                                                            bool less_than);
+static FrontendResult<rir::ValueId> emit_ord_for_flat_shape(
+    const FlatMirShape& shape,
+    rir::ValueId lhs,
+    rir::ValueId rhs,
+    const MirModule& mir,
+    const VariantLoweringInfo* variant_infos,
+    TupleLoweringInfo* tuple_infos,
+    u32* tuple_info_count,
+    ErrorLoweringInfo* error_scalar_infos,
+    ErrorLoweringInfo* error_variant_infos,
+    ErrorLoweringInfo* error_struct_infos,
+    const rir::StructDef* const* user_struct_defs,
+    rir::Builder& b,
+    Span span,
+    bool less_than);
 
 static FrontendResult<rir::ValueId> emit_eq_for_standard_error(rir::ValueId lhs,
                                                                rir::ValueId rhs,
@@ -611,9 +618,11 @@ static FrontendResult<rir::ValueId> emit_eq_for_standard_error(rir::ValueId lhs,
         if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
         auto rhs_field = b.emit_struct_field(rhs, field.name, field.type, {span.line, span.col});
         if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
-        auto eq = b.emit_cmp(rir::Opcode::CmpEq, lhs_field.value(), rhs_field.value(), {span.line, span.col});
+        auto eq = b.emit_cmp(
+            rir::Opcode::CmpEq, lhs_field.value(), rhs_field.value(), {span.line, span.col});
         if (!eq) return frontend_error(FrontendError::OutOfMemory, span);
-        auto next = b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
+        auto next =
+            b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
         if (!next) return frontend_error(FrontendError::OutOfMemory, span);
         result = next;
     }
@@ -661,9 +670,11 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
                                                     b,
                                                     span);
             if (!field_ty) return core::make_unexpected(field_ty.error());
-            auto lhs_field = b.emit_struct_field(lhs, field_name, field_ty.value(), {span.line, span.col});
+            auto lhs_field =
+                b.emit_struct_field(lhs, field_name, field_ty.value(), {span.line, span.col});
             if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
-            auto rhs_field = b.emit_struct_field(rhs, field_name, field_ty.value(), {span.line, span.col});
+            auto rhs_field =
+                b.emit_struct_field(rhs, field_name, field_ty.value(), {span.line, span.col});
             if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
             auto eq = emit_eq_for_flat_shape(elem_shape,
                                              lhs_field.value(),
@@ -679,14 +690,16 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
                                              b,
                                              span);
             if (!eq) return core::make_unexpected(eq.error());
-            auto next = b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
+            auto next =
+                b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
             if (!next) return frontend_error(FrontendError::OutOfMemory, span);
             result = next;
         }
         return result.value();
     }
     if (type == MirTypeKind::Struct) {
-        if (struct_index >= mir.structs.len) return frontend_error(FrontendError::UnsupportedSyntax, span);
+        if (struct_index >= mir.structs.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
         auto result = b.emit_const_bool(true, {span.line, span.col});
         if (!result) return frontend_error(FrontendError::OutOfMemory, span);
         const auto& st = mir.structs[struct_index];
@@ -695,14 +708,18 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
             const auto field_shape = resolved_shape(mir, field);
             if (field.is_error_type) {
                 const rir::Type* error_ty = error_scalar_infos[0].error_type;
-                if (error_ty == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, span);
-                auto lhs_field = b.emit_struct_field(lhs, field.name, error_ty, {span.line, span.col});
+                if (error_ty == nullptr)
+                    return frontend_error(FrontendError::UnsupportedSyntax, span);
+                auto lhs_field =
+                    b.emit_struct_field(lhs, field.name, error_ty, {span.line, span.col});
                 if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
-                auto rhs_field = b.emit_struct_field(rhs, field.name, error_ty, {span.line, span.col});
+                auto rhs_field =
+                    b.emit_struct_field(rhs, field.name, error_ty, {span.line, span.col});
                 if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
                 auto eq = emit_eq_for_standard_error(lhs_field.value(), rhs_field.value(), b, span);
                 if (!eq) return core::make_unexpected(eq.error());
-                auto next = b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
+                auto next = b.emit_select(
+                    result.value(), eq.value(), result.value(), {span.line, span.col});
                 if (!next) return frontend_error(FrontendError::OutOfMemory, span);
                 result = next;
                 continue;
@@ -715,9 +732,11 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
                                                     b,
                                                     span);
             if (!field_ty) return core::make_unexpected(field_ty.error());
-            auto lhs_field = b.emit_struct_field(lhs, field.name, field_ty.value(), {span.line, span.col});
+            auto lhs_field =
+                b.emit_struct_field(lhs, field.name, field_ty.value(), {span.line, span.col});
             if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
-            auto rhs_field = b.emit_struct_field(rhs, field.name, field_ty.value(), {span.line, span.col});
+            auto rhs_field =
+                b.emit_struct_field(rhs, field.name, field_ty.value(), {span.line, span.col});
             if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
             auto eq = emit_eq_for_flat_shape(field_shape,
                                              lhs_field.value(),
@@ -733,14 +752,16 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
                                              b,
                                              span);
             if (!eq) return core::make_unexpected(eq.error());
-            auto next = b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
+            auto next =
+                b.emit_select(result.value(), eq.value(), result.value(), {span.line, span.col});
             if (!next) return frontend_error(FrontendError::OutOfMemory, span);
             result = next;
         }
         return result.value();
     }
     if (type == MirTypeKind::Variant) {
-        if (variant_index >= mir.variants.len) return frontend_error(FrontendError::UnsupportedSyntax, span);
+        if (variant_index >= mir.variants.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
         if (variant_infos[variant_index].struct_type == nullptr) {
             auto cmp = b.emit_cmp(rir::Opcode::CmpEq, lhs, rhs, {span.line, span.col});
             if (!cmp) return frontend_error(FrontendError::OutOfMemory, span);
@@ -752,7 +773,8 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
         if (!lhs_tag) return frontend_error(FrontendError::OutOfMemory, span);
         auto rhs_tag = b.emit_struct_field(rhs, lit("tag"), i32_ty.value(), {span.line, span.col});
         if (!rhs_tag) return frontend_error(FrontendError::OutOfMemory, span);
-        auto result = b.emit_cmp(rir::Opcode::CmpEq, lhs_tag.value(), rhs_tag.value(), {span.line, span.col});
+        auto result =
+            b.emit_cmp(rir::Opcode::CmpEq, lhs_tag.value(), rhs_tag.value(), {span.line, span.col});
         if (!result) return frontend_error(FrontendError::OutOfMemory, span);
         const auto& variant = mir.variants[variant_index];
         for (u32 i = 0; i < variant.cases.len; i++) {
@@ -762,23 +784,22 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
             const auto payload_kind = payload_shape.type;
             auto case_tag = b.emit_const_i32(static_cast<i32>(i), {span.line, span.col});
             if (!case_tag) return frontend_error(FrontendError::OutOfMemory, span);
-            auto case_match = b.emit_cmp(rir::Opcode::CmpEq, lhs_tag.value(), case_tag.value(), {span.line, span.col});
+            auto case_match = b.emit_cmp(
+                rir::Opcode::CmpEq, lhs_tag.value(), case_tag.value(), {span.line, span.col});
             if (!case_match) return frontend_error(FrontendError::OutOfMemory, span);
             auto payload_opt_ty = payload_opt_type(variant_infos[variant_index], payload_kind);
             auto payload_inner_ty = payload_inner_type(variant_infos[variant_index], payload_kind);
-            auto lhs_payload_opt = b.emit_struct_field(lhs,
-                                                       payload_field_name(payload_kind),
-                                                       payload_opt_ty,
-                                                       {span.line, span.col});
+            auto lhs_payload_opt = b.emit_struct_field(
+                lhs, payload_field_name(payload_kind), payload_opt_ty, {span.line, span.col});
             if (!lhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
-            auto rhs_payload_opt = b.emit_struct_field(rhs,
-                                                       payload_field_name(payload_kind),
-                                                       payload_opt_ty,
-                                                       {span.line, span.col});
+            auto rhs_payload_opt = b.emit_struct_field(
+                rhs, payload_field_name(payload_kind), payload_opt_ty, {span.line, span.col});
             if (!rhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
-            auto lhs_payload = b.emit_opt_unwrap(lhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
+            auto lhs_payload =
+                b.emit_opt_unwrap(lhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
             if (!lhs_payload) return frontend_error(FrontendError::OutOfMemory, span);
-            auto rhs_payload = b.emit_opt_unwrap(rhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
+            auto rhs_payload =
+                b.emit_opt_unwrap(rhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
             if (!rhs_payload) return frontend_error(FrontendError::OutOfMemory, span);
             auto payload_eq = emit_eq_for_flat_shape(payload_shape,
                                                      lhs_payload.value(),
@@ -794,7 +815,8 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
                                                      b,
                                                      span);
             if (!payload_eq) return core::make_unexpected(payload_eq.error());
-            auto next = b.emit_select(case_match.value(), payload_eq.value(), result.value(), {span.line, span.col});
+            auto next = b.emit_select(
+                case_match.value(), payload_eq.value(), result.value(), {span.line, span.col});
             if (!next) return frontend_error(FrontendError::OutOfMemory, span);
             result = next;
         }
@@ -803,19 +825,20 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
     return frontend_error(FrontendError::UnsupportedSyntax, span);
 }
 
-static FrontendResult<rir::ValueId> emit_eq_for_flat_shape(const FlatMirShape& shape,
-                                                           rir::ValueId lhs,
-                                                           rir::ValueId rhs,
-                                                           const MirModule& mir,
-                                                           const VariantLoweringInfo* variant_infos,
-                                                           TupleLoweringInfo* tuple_infos,
-                                                           u32* tuple_info_count,
-                                                           ErrorLoweringInfo* error_scalar_infos,
-                                                           ErrorLoweringInfo* error_variant_infos,
-                                                           ErrorLoweringInfo* error_struct_infos,
-                                                           const rir::StructDef* const* user_struct_defs,
-                                                           rir::Builder& b,
-                                                           Span span) {
+static FrontendResult<rir::ValueId> emit_eq_for_flat_shape(
+    const FlatMirShape& shape,
+    rir::ValueId lhs,
+    rir::ValueId rhs,
+    const MirModule& mir,
+    const VariantLoweringInfo* variant_infos,
+    TupleLoweringInfo* tuple_infos,
+    u32* tuple_info_count,
+    ErrorLoweringInfo* error_scalar_infos,
+    ErrorLoweringInfo* error_variant_infos,
+    ErrorLoweringInfo* error_struct_infos,
+    const rir::StructDef* const* user_struct_defs,
+    rir::Builder& b,
+    Span span) {
     return emit_eq_for_shape(shape.type,
                              shape.variant_index,
                              shape.struct_index,
@@ -837,26 +860,27 @@ static FrontendResult<rir::ValueId> emit_eq_for_flat_shape(const FlatMirShape& s
                              span);
 }
 
-static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
-                                                       u32 variant_index,
-                                                       u32 struct_index,
-                                                       u32 tuple_len,
-                                                       const MirTypeKind* tuple_types,
-                                                       const u32* tuple_variant_indices,
-                                                       const u32* tuple_struct_indices,
-                                                       rir::ValueId lhs,
-                                                       rir::ValueId rhs,
-                                                       const MirModule& mir,
-                                                       const VariantLoweringInfo* variant_infos,
-                                                       TupleLoweringInfo* tuple_infos,
-                                                       u32* tuple_info_count,
-                                                       ErrorLoweringInfo* error_scalar_infos,
-                                                       ErrorLoweringInfo* error_variant_infos,
-                                                       ErrorLoweringInfo* error_struct_infos,
-                                                       const rir::StructDef* const* user_struct_defs,
-                                                       rir::Builder& b,
-                                                       Span span,
-                                                       bool less_than) {
+static FrontendResult<rir::ValueId> emit_ord_for_shape(
+    MirTypeKind type,
+    u32 variant_index,
+    u32 struct_index,
+    u32 tuple_len,
+    const MirTypeKind* tuple_types,
+    const u32* tuple_variant_indices,
+    const u32* tuple_struct_indices,
+    rir::ValueId lhs,
+    rir::ValueId rhs,
+    const MirModule& mir,
+    const VariantLoweringInfo* variant_infos,
+    TupleLoweringInfo* tuple_infos,
+    u32* tuple_info_count,
+    ErrorLoweringInfo* error_scalar_infos,
+    ErrorLoweringInfo* error_variant_infos,
+    ErrorLoweringInfo* error_struct_infos,
+    const rir::StructDef* const* user_struct_defs,
+    rir::Builder& b,
+    Span span,
+    bool less_than) {
     if (type == MirTypeKind::I32 || type == MirTypeKind::Str) {
         auto op = less_than ? rir::Opcode::CmpLt : rir::Opcode::CmpGt;
         auto cmp = b.emit_cmp(op, lhs, rhs, {span.line, span.col});
@@ -870,8 +894,8 @@ static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
             Str field_name{};
             if (!build_tuple_field_name(*b.mod->arena, static_cast<u32>(i), &field_name))
                 return frontend_error(FrontendError::OutOfMemory, span);
-            const auto elem_shape =
-                tuple_elem_shape(static_cast<u32>(i), tuple_types, tuple_variant_indices, tuple_struct_indices);
+            const auto elem_shape = tuple_elem_shape(
+                static_cast<u32>(i), tuple_types, tuple_variant_indices, tuple_struct_indices);
             auto field_ty = rir_type_for_flat_shape(elem_shape,
                                                     variant_infos,
                                                     tuple_infos,
@@ -880,9 +904,11 @@ static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
                                                     b,
                                                     span);
             if (!field_ty) return core::make_unexpected(field_ty.error());
-            auto lhs_field = b.emit_struct_field(lhs, field_name, field_ty.value(), {span.line, span.col});
+            auto lhs_field =
+                b.emit_struct_field(lhs, field_name, field_ty.value(), {span.line, span.col});
             if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
-            auto rhs_field = b.emit_struct_field(rhs, field_name, field_ty.value(), {span.line, span.col});
+            auto rhs_field =
+                b.emit_struct_field(rhs, field_name, field_ty.value(), {span.line, span.col});
             if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
             auto eq = emit_eq_for_flat_shape(elem_shape,
                                              lhs_field.value(),
@@ -913,14 +939,16 @@ static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
                                                span,
                                                less_than);
             if (!ord) return core::make_unexpected(ord.error());
-            auto next = b.emit_select(eq.value(), result.value(), ord.value(), {span.line, span.col});
+            auto next =
+                b.emit_select(eq.value(), result.value(), ord.value(), {span.line, span.col});
             if (!next) return frontend_error(FrontendError::OutOfMemory, span);
             result = next;
         }
         return result.value();
     }
     if (type == MirTypeKind::Struct) {
-        if (struct_index >= mir.structs.len) return frontend_error(FrontendError::UnsupportedSyntax, span);
+        if (struct_index >= mir.structs.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
         auto result = b.emit_const_bool(false, {span.line, span.col});
         if (!result) return frontend_error(FrontendError::OutOfMemory, span);
         const auto& st = mir.structs[struct_index];
@@ -936,9 +964,11 @@ static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
                                                     b,
                                                     span);
             if (!field_ty) return core::make_unexpected(field_ty.error());
-            auto lhs_field = b.emit_struct_field(lhs, field.name, field_ty.value(), {span.line, span.col});
+            auto lhs_field =
+                b.emit_struct_field(lhs, field.name, field_ty.value(), {span.line, span.col});
             if (!lhs_field) return frontend_error(FrontendError::OutOfMemory, span);
-            auto rhs_field = b.emit_struct_field(rhs, field.name, field_ty.value(), {span.line, span.col});
+            auto rhs_field =
+                b.emit_struct_field(rhs, field.name, field_ty.value(), {span.line, span.col});
             if (!rhs_field) return frontend_error(FrontendError::OutOfMemory, span);
             auto eq = emit_eq_for_flat_shape(field_shape,
                                              lhs_field.value(),
@@ -969,14 +999,16 @@ static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
                                                span,
                                                less_than);
             if (!ord) return core::make_unexpected(ord.error());
-            auto next = b.emit_select(eq.value(), result.value(), ord.value(), {span.line, span.col});
+            auto next =
+                b.emit_select(eq.value(), result.value(), ord.value(), {span.line, span.col});
             if (!next) return frontend_error(FrontendError::OutOfMemory, span);
             result = next;
         }
         return result.value();
     }
     if (type == MirTypeKind::Variant) {
-        if (variant_index >= mir.variants.len) return frontend_error(FrontendError::UnsupportedSyntax, span);
+        if (variant_index >= mir.variants.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
         const auto& info = variant_infos[variant_index];
         auto i32_ty = b.make_type(rir::TypeKind::I32);
         if (!i32_ty) return frontend_error(FrontendError::OutOfMemory, span);
@@ -1004,17 +1036,22 @@ static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
             const auto payload_kind = payload_shape.type;
             auto case_tag = b.emit_const_i32(i, {span.line, span.col});
             if (!case_tag) return frontend_error(FrontendError::OutOfMemory, span);
-            auto case_match = b.emit_cmp(rir::Opcode::CmpEq, lhs_tag.value(), case_tag.value(), {span.line, span.col});
+            auto case_match = b.emit_cmp(
+                rir::Opcode::CmpEq, lhs_tag.value(), case_tag.value(), {span.line, span.col});
             if (!case_match) return frontend_error(FrontendError::OutOfMemory, span);
             auto payload_opt_ty = payload_opt_type(info, payload_kind);
             auto payload_inner_ty = payload_inner_type(info, payload_kind);
-            auto lhs_payload_opt = b.emit_struct_field(lhs, payload_field_name(payload_kind), payload_opt_ty, {span.line, span.col});
+            auto lhs_payload_opt = b.emit_struct_field(
+                lhs, payload_field_name(payload_kind), payload_opt_ty, {span.line, span.col});
             if (!lhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
-            auto rhs_payload_opt = b.emit_struct_field(rhs, payload_field_name(payload_kind), payload_opt_ty, {span.line, span.col});
+            auto rhs_payload_opt = b.emit_struct_field(
+                rhs, payload_field_name(payload_kind), payload_opt_ty, {span.line, span.col});
             if (!rhs_payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
-            auto lhs_payload = b.emit_opt_unwrap(lhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
+            auto lhs_payload =
+                b.emit_opt_unwrap(lhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
             if (!lhs_payload) return frontend_error(FrontendError::OutOfMemory, span);
-            auto rhs_payload = b.emit_opt_unwrap(rhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
+            auto rhs_payload =
+                b.emit_opt_unwrap(rhs_payload_opt.value(), payload_inner_ty, {span.line, span.col});
             if (!rhs_payload) return frontend_error(FrontendError::OutOfMemory, span);
             auto payload_ord = emit_ord_for_flat_shape(payload_shape,
                                                        lhs_payload.value(),
@@ -1031,7 +1068,8 @@ static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
                                                        span,
                                                        less_than);
             if (!payload_ord) return core::make_unexpected(payload_ord.error());
-            auto next = b.emit_select(case_match.value(), payload_ord.value(), result, {span.line, span.col});
+            auto next = b.emit_select(
+                case_match.value(), payload_ord.value(), result, {span.line, span.col});
             if (!next) return frontend_error(FrontendError::OutOfMemory, span);
             result = next.value();
         }
@@ -1040,20 +1078,21 @@ static FrontendResult<rir::ValueId> emit_ord_for_shape(MirTypeKind type,
     return frontend_error(FrontendError::UnsupportedSyntax, span);
 }
 
-static FrontendResult<rir::ValueId> emit_ord_for_flat_shape(const FlatMirShape& shape,
-                                                            rir::ValueId lhs,
-                                                            rir::ValueId rhs,
-                                                            const MirModule& mir,
-                                                            const VariantLoweringInfo* variant_infos,
-                                                            TupleLoweringInfo* tuple_infos,
-                                                            u32* tuple_info_count,
-                                                            ErrorLoweringInfo* error_scalar_infos,
-                                                            ErrorLoweringInfo* error_variant_infos,
-                                                            ErrorLoweringInfo* error_struct_infos,
-                                                            const rir::StructDef* const* user_struct_defs,
-                                                            rir::Builder& b,
-                                                            Span span,
-                                                            bool less_than) {
+static FrontendResult<rir::ValueId> emit_ord_for_flat_shape(
+    const FlatMirShape& shape,
+    rir::ValueId lhs,
+    rir::ValueId rhs,
+    const MirModule& mir,
+    const VariantLoweringInfo* variant_infos,
+    TupleLoweringInfo* tuple_infos,
+    u32* tuple_info_count,
+    ErrorLoweringInfo* error_scalar_infos,
+    ErrorLoweringInfo* error_variant_infos,
+    ErrorLoweringInfo* error_struct_infos,
+    const rir::StructDef* const* user_struct_defs,
+    rir::Builder& b,
+    Span span,
+    bool less_than) {
     return emit_ord_for_shape(shape.type,
                               shape.variant_index,
                               shape.struct_index,
@@ -1090,13 +1129,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                                       u32 local_count,
                                                       Span span) {
     auto make_inner_type = [&](const FlatMirShape& shape) -> FrontendResult<const rir::Type*> {
-        return rir_type_for_flat_shape(shape,
-                                       variant_infos,
-                                       tuple_infos,
-                                       tuple_info_count,
-                                       user_struct_defs,
-                                       b,
-                                       span);
+        return rir_type_for_flat_shape(
+            shape, variant_infos, tuple_infos, tuple_info_count, user_struct_defs, b, span);
     };
 
     if (value.kind == MirValueKind::BoolConst) {
@@ -1145,8 +1179,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
             if (!elem) return core::make_unexpected(elem.error());
             field_vals[i] = elem.value();
         }
-        auto created =
-            b.emit_struct_create((*tuple_info)->struct_def, field_vals, value.tuple_len, {span.line, span.col});
+        auto created = b.emit_struct_create(
+            (*tuple_info)->struct_def, field_vals, value.tuple_len, {span.line, span.col});
         if (!created) return frontend_error(FrontendError::OutOfMemory, span);
         return created.value();
     }
@@ -1183,10 +1217,11 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
             if (!field_value) return core::make_unexpected(field_value.error());
             field_vals[fi] = field_value.value();
         }
-        auto created = b.emit_struct_create(const_cast<rir::StructDef*>(user_struct_defs[struct_index]),
-                                            field_vals,
-                                            mir.structs[struct_index].fields.len,
-                                            {span.line, span.col});
+        auto created =
+            b.emit_struct_create(const_cast<rir::StructDef*>(user_struct_defs[struct_index]),
+                                 field_vals,
+                                 mir.structs[struct_index].fields.len,
+                                 {span.line, span.col});
         if (!created) return frontend_error(FrontendError::OutOfMemory, span);
         return created.value();
     }
@@ -1228,20 +1263,20 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
         if (!nil_str) return frontend_error(FrontendError::OutOfMemory, span);
         payload_str = nil_str.value();
         if (variant_infos[variant_index].payload_tuple_type != nullptr) {
-            auto nil_tuple =
-                b.emit_opt_nil(variant_infos[variant_index].payload_tuple_type, {span.line, span.col});
+            auto nil_tuple = b.emit_opt_nil(variant_infos[variant_index].payload_tuple_type,
+                                            {span.line, span.col});
             if (!nil_tuple) return frontend_error(FrontendError::OutOfMemory, span);
             payload_tuple = nil_tuple.value();
         }
         if (variant_infos[variant_index].payload_variant_type != nullptr) {
-            auto nil_variant =
-                b.emit_opt_nil(variant_infos[variant_index].payload_variant_type, {span.line, span.col});
+            auto nil_variant = b.emit_opt_nil(variant_infos[variant_index].payload_variant_type,
+                                              {span.line, span.col});
             if (!nil_variant) return frontend_error(FrontendError::OutOfMemory, span);
             payload_variant = nil_variant.value();
         }
         if (variant_infos[variant_index].payload_struct_type != nullptr) {
-            auto nil_struct =
-                b.emit_opt_nil(variant_infos[variant_index].payload_struct_type, {span.line, span.col});
+            auto nil_struct = b.emit_opt_nil(variant_infos[variant_index].payload_struct_type,
+                                             {span.line, span.col});
             if (!nil_struct) return frontend_error(FrontendError::OutOfMemory, span);
             payload_struct = nil_struct.value();
         }
@@ -1249,32 +1284,42 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
         if (variant.cases[value.case_index].has_payload && value.lhs != nullptr) {
             const auto payload_shape = resolved_shape(mir, variant.cases[value.case_index]);
             const auto payload_kind = payload_shape.type;
-            auto payload_val =
-                materialize_value(*value.lhs,
-                                  mir,
-                                  variant_infos,
-                                  tuple_infos,
-                                  tuple_info_count,
-                                  error_scalar_infos,
-                                  error_variant_infos,
-                                  error_struct_infos,
-                                  user_struct_defs,
-                                  b,
-                                  locals,
-                                  local_count,
-                                  span);
+            auto payload_val = materialize_value(*value.lhs,
+                                                 mir,
+                                                 variant_infos,
+                                                 tuple_infos,
+                                                 tuple_info_count,
+                                                 error_scalar_infos,
+                                                 error_variant_infos,
+                                                 error_struct_infos,
+                                                 user_struct_defs,
+                                                 b,
+                                                 locals,
+                                                 local_count,
+                                                 span);
             if (!payload_val) return core::make_unexpected(payload_val.error());
             auto wrapped = b.emit_opt_wrap(payload_val.value(), {span.line, span.col});
             if (!wrapped) return frontend_error(FrontendError::OutOfMemory, span);
-            if (payload_kind == MirTypeKind::Bool) payload_bool = wrapped.value();
-            else if (payload_kind == MirTypeKind::Str) payload_str = wrapped.value();
-            else if (payload_kind == MirTypeKind::Tuple) payload_tuple = wrapped.value();
-            else if (payload_kind == MirTypeKind::Variant) payload_variant = wrapped.value();
-            else if (payload_kind == MirTypeKind::Struct) payload_struct = wrapped.value();
-            else payload_i32 = wrapped.value();
+            if (payload_kind == MirTypeKind::Bool)
+                payload_bool = wrapped.value();
+            else if (payload_kind == MirTypeKind::Str)
+                payload_str = wrapped.value();
+            else if (payload_kind == MirTypeKind::Tuple)
+                payload_tuple = wrapped.value();
+            else if (payload_kind == MirTypeKind::Variant)
+                payload_variant = wrapped.value();
+            else if (payload_kind == MirTypeKind::Struct)
+                payload_struct = wrapped.value();
+            else
+                payload_i32 = wrapped.value();
         }
-        rir::ValueId fields[] = {
-            tag.value(), payload_bool, payload_i32, payload_str, payload_tuple, payload_variant, payload_struct};
+        rir::ValueId fields[] = {tag.value(),
+                                 payload_bool,
+                                 payload_i32,
+                                 payload_str,
+                                 payload_tuple,
+                                 payload_variant,
+                                 payload_struct};
         auto created = b.emit_struct_create(
             variant_infos[variant_index].struct_def, fields, 7, {span.line, span.col});
         if (!created) return frontend_error(FrontendError::OutOfMemory, span);
@@ -1299,15 +1344,11 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
         if (!build_tuple_field_name(*b.mod->arena, static_cast<u32>(value.int_value), &field_name))
             return frontend_error(FrontendError::OutOfMemory, span);
         const auto slot_shape = resolved_shape(mir, value);
-        auto field_type = rir_type_for_flat_shape(slot_shape,
-                                                  variant_infos,
-                                                  tuple_infos,
-                                                  tuple_info_count,
-                                                  user_struct_defs,
-                                                  b,
-                                                  span);
+        auto field_type = rir_type_for_flat_shape(
+            slot_shape, variant_infos, tuple_infos, tuple_info_count, user_struct_defs, b, span);
         if (!field_type) return core::make_unexpected(field_type.error());
-        auto field = b.emit_struct_field(subject.value(), field_name, field_type.value(), {span.line, span.col});
+        auto field = b.emit_struct_field(
+            subject.value(), field_name, field_type.value(), {span.line, span.col});
         if (!field) return frontend_error(FrontendError::OutOfMemory, span);
         return field.value();
     }
@@ -1347,14 +1388,13 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                         error_scalar_infos,
                                         error_variant_infos,
                                         error_struct_infos);
-        if (value.lhs->may_error &&
-            (value.str_value.eq(error_code_field_name()) || value.str_value.eq(error_msg_field_name()) ||
-             value.str_value.eq(error_file_field_name()) || value.str_value.eq(error_func_field_name()) ||
-             value.str_value.eq(error_line_field_name()))) {
-            auto err = b.emit_struct_field(lhs.value(),
-                                           error_field_name(),
-                                           err_info.error_opt_type,
-                                           {span.line, span.col});
+        if (value.lhs->may_error && (value.str_value.eq(error_code_field_name()) ||
+                                     value.str_value.eq(error_msg_field_name()) ||
+                                     value.str_value.eq(error_file_field_name()) ||
+                                     value.str_value.eq(error_func_field_name()) ||
+                                     value.str_value.eq(error_line_field_name()))) {
+            auto err = b.emit_struct_field(
+                lhs.value(), error_field_name(), err_info.error_opt_type, {span.line, span.col});
             if (!err) return frontend_error(FrontendError::OutOfMemory, span);
             auto err_value =
                 b.emit_opt_unwrap(err.value(), err_info.error_type, {span.line, span.col});
@@ -1387,7 +1427,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
             const auto& field = st.fields[field_index];
             const auto field_shape = resolved_shape(mir, field);
             const rir::Type* field_type = nullptr;
-            if (field.is_error_type) field_type = err_info.error_type;
+            if (field.is_error_type)
+                field_type = err_info.error_type;
             else {
                 auto ty = rir_type_for_flat_shape(field_shape,
                                                   variant_infos,
@@ -1399,7 +1440,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                 if (!ty) return core::make_unexpected(ty.error());
                 field_type = ty.value();
             }
-            auto field_v = b.emit_struct_field(lhs.value(), value.str_value, field_type, {span.line, span.col});
+            auto field_v = b.emit_struct_field(
+                lhs.value(), value.str_value, field_type, {span.line, span.col});
             if (!field_v) return frontend_error(FrontendError::OutOfMemory, span);
             return field_v.value();
         }
@@ -1445,10 +1487,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                             error_scalar_infos,
                                             error_variant_infos,
                                             error_struct_infos);
-            auto err = b.emit_struct_field(lhs.value(),
-                                           error_field_name(),
-                                           err_info.error_opt_type,
-                                           {span.line, span.col});
+            auto err = b.emit_struct_field(
+                lhs.value(), error_field_name(), err_info.error_opt_type, {span.line, span.col});
             if (!err) return frontend_error(FrontendError::OutOfMemory, span);
             auto err_is_nil = b.emit_opt_is_nil(err.value(), {span.line, span.col});
             if (!err_is_nil) return frontend_error(FrontendError::OutOfMemory, span);
@@ -1551,15 +1591,16 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                     if (!file) return frontend_error(FrontendError::OutOfMemory, span);
                     auto func = b.emit_const_str(Str{}, {span.line, span.col});
                     if (!func) return frontend_error(FrontendError::OutOfMemory, span);
-                    auto line = b.emit_const_i32(static_cast<i32>(span.line), {span.line, span.col});
+                    auto line =
+                        b.emit_const_i32(static_cast<i32>(span.line), {span.line, span.col});
                     if (!line) return frontend_error(FrontendError::OutOfMemory, span);
                     rir::ValueId error_fields[] = {
                         code.value(), msg.value(), file.value(), func.value(), line.value()};
-                    auto error_val =
-                        b.emit_struct_create(const_cast<rir::StructDef*>(err_info.error_type->struct_def),
-                                             error_fields,
-                                             5,
-                                             {span.line, span.col});
+                    auto error_val = b.emit_struct_create(
+                        const_cast<rir::StructDef*>(err_info.error_type->struct_def),
+                        error_fields,
+                        5,
+                        {span.line, span.col});
                     if (!error_val) return frontend_error(FrontendError::OutOfMemory, span);
                     auto wrapped_err = b.emit_opt_wrap(error_val.value(), {span.line, span.col});
                     if (!wrapped_err) return frontend_error(FrontendError::OutOfMemory, span);
@@ -1567,8 +1608,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                         b.emit_opt_nil(err_info.payload_inner_type, {span.line, span.col});
                     if (!nil_payload) return frontend_error(FrontendError::OutOfMemory, span);
                     rir::ValueId fields[] = {wrapped_err.value(), nil_payload.value()};
-                    auto created = b.emit_struct_create(
-                        err_info.struct_def, fields, 2, {span.line, span.col});
+                    auto created =
+                        b.emit_struct_create(err_info.struct_def, fields, 2, {span.line, span.col});
                     if (!created) return frontend_error(FrontendError::OutOfMemory, span);
                     return created.value();
                 }
@@ -1609,8 +1650,9 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
         if (value.may_nil) {
             auto inner = make_inner_type(value_shape);
             if (!inner) return core::make_unexpected(inner.error());
-            auto wrap_optional_branch = [&](const MirValue& branch,
-                                            rir::ValueId branch_id) -> FrontendResult<rir::ValueId> {
+            auto wrap_optional_branch =
+                [&](const MirValue& branch,
+                    rir::ValueId branch_id) -> FrontendResult<rir::ValueId> {
                 if (branch.may_nil) {
                     if (branch.kind == MirValueKind::Nil) {
                         auto nil = b.emit_opt_nil(inner.value(), {span.line, span.col});
@@ -1632,7 +1674,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
             if (!selected) return frontend_error(FrontendError::OutOfMemory, span);
             return selected.value();
         }
-        auto selected = b.emit_select(cond.value(), then_v.value(), else_v.value(), {span.line, span.col});
+        auto selected =
+            b.emit_select(cond.value(), then_v.value(), else_v.value(), {span.line, span.col});
         if (!selected) return frontend_error(FrontendError::OutOfMemory, span);
         return selected.value();
     }
@@ -1657,10 +1700,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                         error_scalar_infos,
                                         error_variant_infos,
                                         error_struct_infos);
-        auto err = b.emit_struct_field(lhs.value(),
-                                       error_field_name(),
-                                       err_info.error_opt_type,
-                                       {span.line, span.col});
+        auto err = b.emit_struct_field(
+            lhs.value(), error_field_name(), err_info.error_opt_type, {span.line, span.col});
         if (!err) return frontend_error(FrontendError::OutOfMemory, span);
         auto is_nil = b.emit_opt_is_nil(err.value(), {span.line, span.col});
         if (!is_nil) return frontend_error(FrontendError::OutOfMemory, span);
@@ -1688,10 +1729,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                             error_scalar_infos,
                                             error_variant_infos,
                                             error_struct_infos);
-            auto err = b.emit_struct_field(lhs.value(),
-                                           error_field_name(),
-                                           err_info.error_opt_type,
-                                           {span.line, span.col});
+            auto err = b.emit_struct_field(
+                lhs.value(), error_field_name(), err_info.error_opt_type, {span.line, span.col});
             if (!err) return frontend_error(FrontendError::OutOfMemory, span);
             auto err_is_nil = b.emit_opt_is_nil(err.value(), {span.line, span.col});
             if (!err_is_nil) return frontend_error(FrontendError::OutOfMemory, span);
@@ -1708,8 +1747,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
             auto has_payload = b.emit_cmp(
                 rir::Opcode::CmpEq, payload_is_nil.value(), false_v.value(), {span.line, span.col});
             if (!has_payload) return frontend_error(FrontendError::OutOfMemory, span);
-            auto has_value =
-                b.emit_select(err_is_nil.value(), has_payload.value(), false_v.value(), {span.line, span.col});
+            auto has_value = b.emit_select(
+                err_is_nil.value(), has_payload.value(), false_v.value(), {span.line, span.col});
             if (!has_value) return frontend_error(FrontendError::OutOfMemory, span);
             return has_value.value();
         }
@@ -1751,7 +1790,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
             if (!payload) return frontend_error(FrontendError::OutOfMemory, span);
             auto inner = make_inner_type(resolved_shape(mir, value));
             if (!inner) return core::make_unexpected(inner.error());
-            auto unwrapped = b.emit_opt_unwrap(payload.value(), inner.value(), {span.line, span.col});
+            auto unwrapped =
+                b.emit_opt_unwrap(payload.value(), inner.value(), {span.line, span.col});
             if (!unwrapped) return frontend_error(FrontendError::OutOfMemory, span);
             return unwrapped.value();
         }
@@ -1832,8 +1872,10 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
         const auto& payload_case = mir.variants[subject_variant_index].cases[value.case_index];
         const auto payload_shape = resolved_shape(mir, payload_case);
         const auto payload_kind = payload_shape.type;
-        const rir::Type* payload_opt_ty = payload_opt_type(variant_infos[subject_variant_index], payload_kind);
-        const rir::Type* payload_inner_ty = payload_inner_type(variant_infos[subject_variant_index], payload_kind);
+        const rir::Type* payload_opt_ty =
+            payload_opt_type(variant_infos[subject_variant_index], payload_kind);
+        const rir::Type* payload_inner_ty =
+            payload_inner_type(variant_infos[subject_variant_index], payload_kind);
         if (payload_opt_ty == nullptr || payload_inner_ty == nullptr) {
             auto ty = rir_type_for_flat_shape(payload_shape,
                                               variant_infos,
@@ -1849,15 +1891,17 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
             payload_opt_ty = opt_ty.value();
         }
         auto payload_opt = b.emit_struct_field(subject.value(),
-                                              payload_field_name(payload_kind),
-                                              payload_opt_ty,
-                                              {span.line, span.col});
+                                               payload_field_name(payload_kind),
+                                               payload_opt_ty,
+                                               {span.line, span.col});
         if (!payload_opt) return frontend_error(FrontendError::OutOfMemory, span);
-        auto unwrapped = b.emit_opt_unwrap(payload_opt.value(), payload_inner_ty, {span.line, span.col});
+        auto unwrapped =
+            b.emit_opt_unwrap(payload_opt.value(), payload_inner_ty, {span.line, span.col});
         if (!unwrapped) return frontend_error(FrontendError::OutOfMemory, span);
         return unwrapped.value();
     }
-    if (value.kind == MirValueKind::Eq || value.kind == MirValueKind::Lt || value.kind == MirValueKind::Gt) {
+    if (value.kind == MirValueKind::Eq || value.kind == MirValueKind::Lt ||
+        value.kind == MirValueKind::Gt) {
         const MirValue& lhs_expr = *value.lhs;
         const auto lhs_shape = resolved_shape(mir, lhs_expr);
         auto lhs = materialize_value(*value.lhs,
@@ -1917,44 +1961,51 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                        span,
                                        value.kind == MirValueKind::Lt);
     }
-    if (value.local_index >= local_count) return frontend_error(FrontendError::UnsupportedSyntax, span);
+    if (value.local_index >= local_count)
+        return frontend_error(FrontendError::UnsupportedSyntax, span);
     return locals[value.local_index];
 }
 
-static FrontendResult<rir::ValueId> materialize_local_init(const MirLocal& local,
-                                                           const MirModule& mir,
-                                                           const VariantLoweringInfo* variant_infos,
-                                                           TupleLoweringInfo* tuple_infos,
-                                                           u32* tuple_info_count,
-                                                           ErrorLoweringInfo* error_scalar_infos,
-                                                           ErrorLoweringInfo* error_variant_infos,
-                                                           ErrorLoweringInfo* error_struct_infos,
-                                                           const rir::StructDef* error_struct_def,
-                                                           const rir::StructDef* const* user_struct_defs,
-                                                           rir::Builder& b,
-                                                           const rir::ValueId* locals,
-                                                           u32 local_count,
-                                                           Str func_name,
-                                                           Str source_name) {
+static FrontendResult<rir::ValueId> materialize_local_init(
+    const MirLocal& local,
+    const MirModule& mir,
+    const VariantLoweringInfo* variant_infos,
+    TupleLoweringInfo* tuple_infos,
+    u32* tuple_info_count,
+    ErrorLoweringInfo* error_scalar_infos,
+    ErrorLoweringInfo* error_variant_infos,
+    ErrorLoweringInfo* error_struct_infos,
+    const rir::StructDef* error_struct_def,
+    const rir::StructDef* const* user_struct_defs,
+    rir::Builder& b,
+    const rir::ValueId* locals,
+    u32 local_count,
+    Str func_name,
+    Str source_name) {
     const auto local_shape = resolved_shape(mir, local);
-    auto make_inner_type = [&](const FlatMirShape& shape, Span span) -> FrontendResult<const rir::Type*> {
+    auto make_inner_type = [&](const FlatMirShape& shape,
+                               Span span) -> FrontendResult<const rir::Type*> {
         if (shape.type == MirTypeKind::Variant) {
-            if (shape.variant_index < mir.variants.len && variant_infos[shape.variant_index].struct_type)
+            if (shape.variant_index < mir.variants.len &&
+                variant_infos[shape.variant_index].struct_type)
                 return variant_infos[shape.variant_index].struct_type;
             auto inner = b.make_type(rir::TypeKind::I32);
             if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
             return inner.value();
         }
         if (shape.type == MirTypeKind::Struct) {
-            if (shape.struct_index >= mir.structs.len || user_struct_defs[shape.struct_index] == nullptr)
+            if (shape.struct_index >= mir.structs.len ||
+                user_struct_defs[shape.struct_index] == nullptr)
                 return frontend_error(FrontendError::UnsupportedSyntax, span);
-            auto inner = b.make_type(rir::TypeKind::Struct, nullptr,
-                                     const_cast<rir::StructDef*>(user_struct_defs[shape.struct_index]));
+            auto inner =
+                b.make_type(rir::TypeKind::Struct,
+                            nullptr,
+                            const_cast<rir::StructDef*>(user_struct_defs[shape.struct_index]));
             if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
             return inner.value();
         }
-        const rir::TypeKind inner_kind = shape.type == MirTypeKind::Str ? rir::TypeKind::Str
-                                                                   : rir::TypeKind::I32;
+        const rir::TypeKind inner_kind =
+            shape.type == MirTypeKind::Str ? rir::TypeKind::Str : rir::TypeKind::I32;
         auto inner = b.make_type(inner_kind);
         if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
         return inner.value();
@@ -2007,14 +2058,15 @@ static FrontendResult<rir::ValueId> materialize_local_init(const MirLocal& local
             if (!file) return frontend_error(FrontendError::OutOfMemory, local.span);
             auto func = b.emit_const_str(func_name, {local.span.line, local.span.col});
             if (!func) return frontend_error(FrontendError::OutOfMemory, local.span);
-            auto line = b.emit_const_i32(static_cast<i32>(local.span.line), {local.span.line, local.span.col});
+            auto line = b.emit_const_i32(static_cast<i32>(local.span.line),
+                                         {local.span.line, local.span.col});
             if (!line) return frontend_error(FrontendError::OutOfMemory, local.span);
-            rir::ValueId error_fields[] = {code.value(), msg.value(), file.value(), func.value(), line.value()};
-            auto error_val =
-                b.emit_struct_create(const_cast<rir::StructDef*>(error_struct_def),
-                                     error_fields,
-                                     5,
-                                     {local.span.line, local.span.col});
+            rir::ValueId error_fields[] = {
+                code.value(), msg.value(), file.value(), func.value(), line.value()};
+            auto error_val = b.emit_struct_create(const_cast<rir::StructDef*>(error_struct_def),
+                                                  error_fields,
+                                                  5,
+                                                  {local.span.line, local.span.col});
             if (!error_val) return frontend_error(FrontendError::OutOfMemory, local.span);
             rir::ValueId err_value = error_val.value();
             if (local.init.error_struct_index != 0xffffffffu) {
@@ -2022,7 +2074,8 @@ static FrontendResult<rir::ValueId> materialize_local_init(const MirLocal& local
                     return frontend_error(FrontendError::UnsupportedSyntax, local.span);
                 auto* custom_struct_def =
                     const_cast<rir::StructDef*>(user_struct_defs[local.init.error_struct_index]);
-                if (!custom_struct_def) return frontend_error(FrontendError::UnsupportedSyntax, local.span);
+                if (!custom_struct_def)
+                    return frontend_error(FrontendError::UnsupportedSyntax, local.span);
                 rir::ValueId custom_fields[MirStruct::kMaxFields]{};
                 for (u32 fi = 0; fi < mir.structs[local.init.error_struct_index].fields.len; fi++) {
                     const auto& field = mir.structs[local.init.error_struct_index].fields[fi];
@@ -2038,7 +2091,8 @@ static FrontendResult<rir::ValueId> materialize_local_init(const MirLocal& local
                         }
                     }
                     if (init_index == local.init.field_inits.len)
-                        return frontend_error(FrontendError::UnsupportedSyntax, local.span, field.name);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, local.span, field.name);
                     auto field_value = materialize_value(*local.init.field_inits[init_index].value,
                                                          mir,
                                                          variant_infos,
@@ -2225,44 +2279,51 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
                 if (!err_is_nil) return frontend_error(FrontendError::OutOfMemory, term.span);
                 auto false_v = b.emit_const_bool(false, {term.span.line, term.span.col});
                 if (!false_v) return frontend_error(FrontendError::OutOfMemory, term.span);
-                auto has_error = b.emit_cmp(
-                    rir::Opcode::CmpEq, err_is_nil.value(), false_v.value(), {term.span.line, term.span.col});
+                auto has_error = b.emit_cmp(rir::Opcode::CmpEq,
+                                            err_is_nil.value(),
+                                            false_v.value(),
+                                            {term.span.line, term.span.col});
                 if (!has_error) return frontend_error(FrontendError::OutOfMemory, term.span);
-                auto err_value =
-                    b.emit_opt_unwrap(err.value(), err_info.error_type, {term.span.line, term.span.col});
+                auto err_value = b.emit_opt_unwrap(
+                    err.value(), err_info.error_type, {term.span.line, term.span.col});
                 if (!err_value) return frontend_error(FrontendError::OutOfMemory, term.span);
                 auto i32_ty = b.make_type(rir::TypeKind::I32);
                 if (!i32_ty) return frontend_error(FrontendError::OutOfMemory, term.span);
-                auto tag_value =
-                    b.emit_struct_field(err_value.value(),
-                                        error_code_field_name(),
-                                        i32_ty.value(),
-                                        {term.span.line, term.span.col});
+                auto tag_value = b.emit_struct_field(err_value.value(),
+                                                     error_code_field_name(),
+                                                     i32_ty.value(),
+                                                     {term.span.line, term.span.col});
                 if (!tag_value) return frontend_error(FrontendError::OutOfMemory, term.span);
                 rir::ValueId rhs_tag = rhs.value();
-                if (rhs_shape.type == MirTypeKind::Variant && rhs_shape.variant_index < mir.variants.len &&
+                if (rhs_shape.type == MirTypeKind::Variant &&
+                    rhs_shape.variant_index < mir.variants.len &&
                     variant_infos[rhs_shape.variant_index].struct_type != nullptr) {
-                    auto rhs_tag_field =
-                        b.emit_struct_field(rhs.value(), lit("tag"), i32_ty.value(), {term.span.line, term.span.col});
-                    if (!rhs_tag_field) return frontend_error(FrontendError::OutOfMemory, term.span);
+                    auto rhs_tag_field = b.emit_struct_field(
+                        rhs.value(), lit("tag"), i32_ty.value(), {term.span.line, term.span.col});
+                    if (!rhs_tag_field)
+                        return frontend_error(FrontendError::OutOfMemory, term.span);
                     rhs_tag = rhs_tag_field.value();
                 }
-                auto cmp = b.emit_cmp(
-                    rir::Opcode::CmpEq, tag_value.value(), rhs_tag, {term.span.line, term.span.col});
+                auto cmp = b.emit_cmp(rir::Opcode::CmpEq,
+                                      tag_value.value(),
+                                      rhs_tag,
+                                      {term.span.line, term.span.col});
                 if (!cmp) return frontend_error(FrontendError::OutOfMemory, term.span);
-                auto cond = b.emit_select(
-                    has_error.value(), cmp.value(), false_v.value(), {term.span.line, term.span.col});
+                auto cond = b.emit_select(has_error.value(),
+                                          cmp.value(),
+                                          false_v.value(),
+                                          {term.span.line, term.span.col});
                 if (!cond) return frontend_error(FrontendError::OutOfMemory, term.span);
                 cond_id = cond.value();
-            } else
-            if (lhs_shape.type == MirTypeKind::Variant && lhs_shape.variant_index < mir.variants.len &&
-                variant_infos[lhs_shape.variant_index].struct_type != nullptr) {
+            } else if (lhs_shape.type == MirTypeKind::Variant &&
+                       lhs_shape.variant_index < mir.variants.len &&
+                       variant_infos[lhs_shape.variant_index].struct_type != nullptr) {
                 auto* i32_ty = b.make_type(rir::TypeKind::I32).value();
-                auto lhs_tag =
-                    b.emit_struct_field(lhs.value(), lit("tag"), i32_ty, {term.span.line, term.span.col});
+                auto lhs_tag = b.emit_struct_field(
+                    lhs.value(), lit("tag"), i32_ty, {term.span.line, term.span.col});
                 if (!lhs_tag) return frontend_error(FrontendError::OutOfMemory, term.span);
-                auto rhs_tag =
-                    b.emit_struct_field(rhs.value(), lit("tag"), i32_ty, {term.span.line, term.span.col});
+                auto rhs_tag = b.emit_struct_field(
+                    rhs.value(), lit("tag"), i32_ty, {term.span.line, term.span.col});
                 if (!rhs_tag) return frontend_error(FrontendError::OutOfMemory, term.span);
                 lhs = lhs_tag.value();
                 rhs = rhs_tag.value();
@@ -2271,8 +2332,8 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
                 if (!cmp) return frontend_error(FrontendError::OutOfMemory, term.span);
                 cond_id = cmp.value();
             } else {
-                auto cmp =
-                    b.emit_cmp(rir::Opcode::CmpEq, lhs.value(), rhs.value(), {term.span.line, term.span.col});
+                auto cmp = b.emit_cmp(
+                    rir::Opcode::CmpEq, lhs.value(), rhs.value(), {term.span.line, term.span.col});
                 if (!cmp) return frontend_error(FrontendError::OutOfMemory, term.span);
                 cond_id = cmp.value();
             }
@@ -2316,7 +2377,8 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
     }
     if (term.kind == MirTerminatorKind::ForwardUpstream) {
         const u16 upstream_id = mir.upstreams[term.upstream_index].id;
-        auto upstream = b.emit_const_i32(static_cast<i32>(upstream_id), {term.span.line, term.span.col});
+        auto upstream =
+            b.emit_const_i32(static_cast<i32>(upstream_id), {term.span.line, term.span.col});
         if (!upstream || !b.emit_ret_forward(upstream.value(), {term.span.line, term.span.col}))
             return frontend_error(FrontendError::OutOfMemory, term.span);
         return {};
@@ -2414,7 +2476,8 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
             if (payload_shape.type == MirTypeKind::Tuple) {
                 if (!has_tuple_payload) {
                     has_tuple_payload = true;
-                    variant_infos[vi].payload_shape_index = mir.variants[vi].cases[ci].payload_shape_index;
+                    variant_infos[vi].payload_shape_index =
+                        mir.variants[vi].cases[ci].payload_shape_index;
                     variant_infos[vi].payload_tuple_len = payload_shape.tuple_len;
                     for (u32 ti = 0; ti < payload_shape.tuple_len; ti++) {
                         variant_infos[vi].payload_tuple_types[ti] = payload_shape.tuple_types[ti];
@@ -2434,7 +2497,8 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
             } else if (payload_shape.type == MirTypeKind::Variant) {
                 if (!has_variant_payload) {
                     has_variant_payload = true;
-                    variant_infos[vi].payload_shape_index = mir.variants[vi].cases[ci].payload_shape_index;
+                    variant_infos[vi].payload_shape_index =
+                        mir.variants[vi].cases[ci].payload_shape_index;
                     variant_infos[vi].payload_variant_index = payload_shape.variant_index;
                 } else if (variant_infos[vi].payload_variant_index != payload_shape.variant_index) {
                     out.destroy();
@@ -2443,7 +2507,8 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
             } else if (payload_shape.type == MirTypeKind::Struct) {
                 if (!has_struct_payload) {
                     has_struct_payload = true;
-                    variant_infos[vi].payload_shape_index = mir.variants[vi].cases[ci].payload_shape_index;
+                    variant_infos[vi].payload_shape_index =
+                        mir.variants[vi].cases[ci].payload_shape_index;
                     variant_infos[vi].payload_struct_index = payload_shape.struct_index;
                 } else if (variant_infos[vi].payload_struct_index != payload_shape.struct_index) {
                     out.destroy();
@@ -2480,7 +2545,8 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 const auto field_shape = resolved_shape(mir, field);
                 if (field_shape.type == MirTypeKind::Bool) {
                     auto ty = b.make_type(rir::TypeKind::Bool);
-                    if (!ty) return frontend_error(FrontendError::OutOfMemory, mir.structs[si].span);
+                    if (!ty)
+                        return frontend_error(FrontendError::OutOfMemory, mir.structs[si].span);
                     field_ty = ty.value();
                 } else if (field_shape.type == MirTypeKind::I32) {
                     field_ty = i32_ty.value();
@@ -2495,28 +2561,32 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 } else if (field_shape.type == MirTypeKind::Struct &&
                            field_shape.struct_index < mir.structs.len &&
                            user_struct_defs[field_shape.struct_index] != nullptr) {
-                    auto ty = b.make_type(rir::TypeKind::Struct,
-                                          nullptr,
-                                          const_cast<rir::StructDef*>(user_struct_defs[field_shape.struct_index]));
-                    if (!ty) return frontend_error(FrontendError::OutOfMemory, mir.structs[si].span);
+                    auto ty = b.make_type(
+                        rir::TypeKind::Struct,
+                        nullptr,
+                        const_cast<rir::StructDef*>(user_struct_defs[field_shape.struct_index]));
+                    if (!ty)
+                        return frontend_error(FrontendError::OutOfMemory, mir.structs[si].span);
                     field_ty = ty.value();
                 } else if (field_shape.type == MirTypeKind::Struct) {
                     return false;
                 } else if (field_shape.type == MirTypeKind::Tuple) {
-                    auto tuple_info = get_or_create_tuple_lowering(field_shape.tuple_len,
-                                                                   field_shape.tuple_types,
-                                                                   field_shape.tuple_variant_indices,
-                                                                   field_shape.tuple_struct_indices,
-                                                                   variant_infos,
-                                                                   user_struct_defs,
-                                                                   tuple_infos,
-                                                                   &tuple_info_count,
-                                                                   b,
-                                                                   mir.structs[si].span);
+                    auto tuple_info =
+                        get_or_create_tuple_lowering(field_shape.tuple_len,
+                                                     field_shape.tuple_types,
+                                                     field_shape.tuple_variant_indices,
+                                                     field_shape.tuple_struct_indices,
+                                                     variant_infos,
+                                                     user_struct_defs,
+                                                     tuple_infos,
+                                                     &tuple_info_count,
+                                                     b,
+                                                     mir.structs[si].span);
                     if (!tuple_info) return core::make_unexpected(tuple_info.error());
                     field_ty = tuple_info.value()->struct_type;
                 } else {
-                    return frontend_error(FrontendError::UnsupportedSyntax, mir.structs[si].span, field.type_name);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, mir.structs[si].span, field.type_name);
                 }
             }
             fields[fi] = {field.name, field_ty};
@@ -2600,7 +2670,8 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 out.destroy();
                 return core::make_unexpected(tuple_info.error());
             }
-            auto tuple_optional_ty = b.make_type(rir::TypeKind::Optional, tuple_info.value()->struct_type);
+            auto tuple_optional_ty =
+                b.make_type(rir::TypeKind::Optional, tuple_info.value()->struct_type);
             if (!tuple_optional_ty) {
                 out.destroy();
                 return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
@@ -2621,8 +2692,10 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
             variant_opt_ty = opt_ty.value();
         }
         if (has_struct_payload) {
-            auto ty = b.make_type(
-                rir::TypeKind::Struct, nullptr, const_cast<rir::StructDef*>(user_struct_defs[payload_struct_index]));
+            auto ty =
+                b.make_type(rir::TypeKind::Struct,
+                            nullptr,
+                            const_cast<rir::StructDef*>(user_struct_defs[payload_struct_index]));
             if (!ty) {
                 out.destroy();
                 return frontend_error(FrontendError::OutOfMemory, mir.variants[vi].span);
@@ -2709,7 +2782,8 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
         }
     }
 
-    auto make_error_info = [&](Str name, const rir::Type* payload_inner) -> FrontendResult<ErrorLoweringInfo> {
+    auto make_error_info =
+        [&](Str name, const rir::Type* payload_inner) -> FrontendResult<ErrorLoweringInfo> {
         ErrorLoweringInfo info{};
         auto error_opt_ty = b.make_type(rir::TypeKind::Optional, error_struct_ty.value());
         if (!error_opt_ty) return frontend_error(FrontendError::OutOfMemory);
@@ -2765,11 +2839,13 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
         char tmp[10];
         u32 n = 0;
         u32 v = vi;
-        if (v == 0) tmp[n++] = '0';
-        else while (v > 0) {
-            tmp[n++] = static_cast<char>('0' + (v % 10));
-            v /= 10;
-        }
+        if (v == 0)
+            tmp[n++] = '0';
+        else
+            while (v > 0) {
+                tmp[n++] = static_cast<char>('0' + (v % 10));
+                v /= 10;
+            }
         while (n > 0) buf[pos++] = tmp[--n];
         auto err_variant = make_error_info({buf, pos}, payload_inner);
         if (!err_variant) return core::make_unexpected(err_variant.error());
@@ -2777,8 +2853,8 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
     }
     for (u32 si = 0; si < mir.structs.len; si++) {
         if (!mir.structs[si].conforms_error) continue;
-        auto struct_ty =
-            b.make_type(rir::TypeKind::Struct, nullptr, const_cast<rir::StructDef*>(user_struct_defs[si]));
+        auto struct_ty = b.make_type(
+            rir::TypeKind::Struct, nullptr, const_cast<rir::StructDef*>(user_struct_defs[si]));
         if (!struct_ty) return frontend_error(FrontendError::OutOfMemory, mir.structs[si].span);
         char buf[64];
         const char* prefix = "__error_struct_";
@@ -2798,7 +2874,8 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
     for (u32 i = 0; i < mir.functions.len; i++) {
         Str name{};
         Str path{};
-        if (!build_route_name(out.arena, i, &name) || !copy_str(out.arena, mir.functions[i].path, &path)) {
+        if (!build_route_name(out.arena, i, &name) ||
+            !copy_str(out.arena, mir.functions[i].path, &path)) {
             out.destroy();
             return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
         }

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -753,6 +753,10 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             out->upstream_index = term.upstream_index;
             out->kind = term.kind == HirTerminatorKind::ReturnStatus ? MirTerminatorKind::ReturnStatus
                                                                      : MirTerminatorKind::ForwardUpstream;
+            out->source_kind = term.source_kind == HirTerminatorSourceKind::LocalRef
+                                   ? MirTerminatorSourceKind::LocalRef
+                                   : MirTerminatorSourceKind::Literal;
+            out->local_ref_index = term.local_ref_index;
         };
         auto guard_fail_block_count = [&](const HirGuard& guard) -> u32 {
             if (guard.fail_kind == HirGuard::FailKind::Term) return 1;

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -227,6 +227,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
         v.type = MirTypeKind::Struct;
         v.struct_index = expr.struct_index;
         v.str_value = expr.str_value;
+        apply_expr_shape_if_available(module, expr, &v);
         for (u32 i = 0; i < expr.field_inits.len; i++) {
             auto field_value = mir_value(*expr.field_inits[i].value, module, fn);
             if (!field_value) return core::make_unexpected(field_value.error());
@@ -269,6 +270,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
         v.error_variant_index = expr.error_variant_index;
         v.error_case_index = expr.error_case_index;
         v.int_value = expr.int_value;
+        apply_expr_shape_if_available(module, expr, &v);
         if (expr.lhs != nullptr) {
             auto payload = mir_value(*expr.lhs, module, fn);
             if (!payload) return core::make_unexpected(payload.error());

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -1,6 +1,5 @@
 #include "rut/compiler/mir_build.h"
 
-
 namespace rut {
 
 namespace {
@@ -38,13 +37,13 @@ static Str match_default_label() {
 }
 
 static MirTypeKind mir_type_kind(HirTypeKind kind) {
-    return kind == HirTypeKind::Bool    ? MirTypeKind::Bool
-           : kind == HirTypeKind::I32   ? MirTypeKind::I32
-           : kind == HirTypeKind::Str   ? MirTypeKind::Str
+    return kind == HirTypeKind::Bool      ? MirTypeKind::Bool
+           : kind == HirTypeKind::I32     ? MirTypeKind::I32
+           : kind == HirTypeKind::Str     ? MirTypeKind::Str
            : kind == HirTypeKind::Variant ? MirTypeKind::Variant
-           : kind == HirTypeKind::Tuple ? MirTypeKind::Tuple
-           : kind == HirTypeKind::Struct ? MirTypeKind::Struct
-                                         : MirTypeKind::Unknown;
+           : kind == HirTypeKind::Tuple   ? MirTypeKind::Tuple
+           : kind == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                          : MirTypeKind::Unknown;
 }
 
 static bool expand_hir_flat_shape(const HirModule& module,
@@ -75,7 +74,9 @@ static bool expand_hir_flat_shape(const HirModule& module,
     return true;
 }
 
-static void apply_expr_shape_if_available(const HirModule& module, const HirExpr& expr, MirValue* out) {
+static void apply_expr_shape_if_available(const HirModule& module,
+                                          const HirExpr& expr,
+                                          MirValue* out) {
     expand_hir_flat_shape(module,
                           expr.shape_index,
                           &out->type,
@@ -94,7 +95,8 @@ static bool shape_carrier_ready(const MirModule& mir,
     if (shape_index >= mir.type_shapes.len) return false;
     const auto& shape = mir.type_shapes[shape_index];
     if (!shape.is_concrete) return false;
-    if (shape.type == MirTypeKind::Bool || shape.type == MirTypeKind::I32 || shape.type == MirTypeKind::Str)
+    if (shape.type == MirTypeKind::Bool || shape.type == MirTypeKind::I32 ||
+        shape.type == MirTypeKind::Str)
         return true;
     if (shape.type == MirTypeKind::Struct)
         return shape.struct_index < mir.structs.len && struct_ready[shape.struct_index];
@@ -102,7 +104,8 @@ static bool shape_carrier_ready(const MirModule& mir,
         return shape.variant_index < mir.variants.len && variant_ready[shape.variant_index];
     if (shape.type != MirTypeKind::Tuple) return false;
     for (u32 i = 0; i < shape.tuple_len; i++) {
-        if (!shape_carrier_ready(mir, shape.tuple_elem_shape_indices[i], struct_ready, variant_ready))
+        if (!shape_carrier_ready(
+                mir, shape.tuple_elem_shape_indices[i], struct_ready, variant_ready))
             return false;
     }
     return true;
@@ -141,7 +144,8 @@ static bool field_carrier_ready(const MirModule& mir,
     if (field.is_error_type) return true;
     if (field.shape_index != 0xffffffffu)
         return shape_carrier_ready(mir, field.shape_index, struct_ready, variant_ready);
-    if (field.type == MirTypeKind::Bool || field.type == MirTypeKind::I32 || field.type == MirTypeKind::Str)
+    if (field.type == MirTypeKind::Bool || field.type == MirTypeKind::I32 ||
+        field.type == MirTypeKind::Str)
         return true;
     if (field.type == MirTypeKind::Struct)
         return field.struct_index < mir.structs.len && struct_ready[field.struct_index];
@@ -157,7 +161,8 @@ static bool variant_payload_carrier_ready(const MirModule& mir,
     if (!c.has_payload) return true;
     if (c.payload_shape_index != 0xffffffffu)
         return shape_carrier_ready(mir, c.payload_shape_index, struct_ready, variant_ready);
-    if (c.payload_type == MirTypeKind::Bool || c.payload_type == MirTypeKind::I32 || c.payload_type == MirTypeKind::Str)
+    if (c.payload_type == MirTypeKind::Bool || c.payload_type == MirTypeKind::I32 ||
+        c.payload_type == MirTypeKind::Str)
         return true;
     if (c.payload_type == MirTypeKind::Struct)
         return c.payload_struct_index < mir.structs.len && struct_ready[c.payload_struct_index];
@@ -166,7 +171,9 @@ static bool variant_payload_carrier_ready(const MirModule& mir,
     return false;
 }
 
-static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& module, MirFunction* fn) {
+static FrontendResult<MirValue> mir_value(const HirExpr& expr,
+                                          const HirModule& module,
+                                          MirFunction* fn) {
     MirValue v{};
     v.shape_index = expr.shape_index;
     v.may_nil = expr.may_nil;
@@ -194,12 +201,12 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
         v.type = MirTypeKind::Tuple;
         v.tuple_len = expr.tuple_len;
         for (u32 i = 0; i < expr.tuple_len; i++) {
-            v.tuple_types[i] = expr.tuple_types[i] == HirTypeKind::Bool    ? MirTypeKind::Bool
-                             : expr.tuple_types[i] == HirTypeKind::I32     ? MirTypeKind::I32
-                             : expr.tuple_types[i] == HirTypeKind::Str     ? MirTypeKind::Str
-                             : expr.tuple_types[i] == HirTypeKind::Variant ? MirTypeKind::Variant
-                             : expr.tuple_types[i] == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                                            : MirTypeKind::Unknown;
+            v.tuple_types[i] = expr.tuple_types[i] == HirTypeKind::Bool      ? MirTypeKind::Bool
+                               : expr.tuple_types[i] == HirTypeKind::I32     ? MirTypeKind::I32
+                               : expr.tuple_types[i] == HirTypeKind::Str     ? MirTypeKind::Str
+                               : expr.tuple_types[i] == HirTypeKind::Variant ? MirTypeKind::Variant
+                               : expr.tuple_types[i] == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                                             : MirTypeKind::Unknown;
             v.tuple_variant_indices[i] = expr.tuple_variant_indices[i];
             v.tuple_struct_indices[i] = expr.tuple_struct_indices[i];
         }
@@ -247,12 +254,12 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::TupleSlot;
-        v.type = expr.type == HirTypeKind::Bool  ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32 ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str ? MirTypeKind::Str
+        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
                  : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
-                                                    : MirTypeKind::Unknown;
+                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                     : MirTypeKind::Unknown;
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.int_value = expr.int_value;
@@ -283,27 +290,28 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
     if (expr.kind == HirExprKind::Field) {
         auto lhs = mir_value(*expr.lhs, module, fn);
         if (!lhs) return core::make_unexpected(lhs.error());
-        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::Field;
-        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
                  : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
-                                                    : MirTypeKind::Unknown;
+                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                     : MirTypeKind::Unknown;
         v.str_value = expr.str_value;
         v.lhs = &fn->values[fn->values.len - 1];
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.tuple_len = expr.tuple_len;
         for (u32 i = 0; i < expr.tuple_len; i++) {
-            v.tuple_types[i] = expr.tuple_types[i] == HirTypeKind::Bool    ? MirTypeKind::Bool
-                             : expr.tuple_types[i] == HirTypeKind::I32     ? MirTypeKind::I32
-                             : expr.tuple_types[i] == HirTypeKind::Str     ? MirTypeKind::Str
-                             : expr.tuple_types[i] == HirTypeKind::Variant ? MirTypeKind::Variant
-                             : expr.tuple_types[i] == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                                            : MirTypeKind::Unknown;
+            v.tuple_types[i] = expr.tuple_types[i] == HirTypeKind::Bool      ? MirTypeKind::Bool
+                               : expr.tuple_types[i] == HirTypeKind::I32     ? MirTypeKind::I32
+                               : expr.tuple_types[i] == HirTypeKind::Str     ? MirTypeKind::Str
+                               : expr.tuple_types[i] == HirTypeKind::Variant ? MirTypeKind::Variant
+                               : expr.tuple_types[i] == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                                             : MirTypeKind::Unknown;
             v.tuple_variant_indices[i] = expr.tuple_variant_indices[i];
             v.tuple_struct_indices[i] = expr.tuple_struct_indices[i];
         }
@@ -345,16 +353,21 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
         }
         return v;
     }
-    if (expr.kind == HirExprKind::Eq || expr.kind == HirExprKind::Lt || expr.kind == HirExprKind::Gt) {
+    if (expr.kind == HirExprKind::Eq || expr.kind == HirExprKind::Lt ||
+        expr.kind == HirExprKind::Gt) {
         auto lhs = mir_value(*expr.lhs, module, fn);
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = mir_value(*expr.rhs, module, fn);
         if (!rhs) return core::make_unexpected(rhs.error());
-        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         MirValue* lhs_ptr = &fn->values[fn->values.len - 1];
-        if (!fn->values.push(rhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(rhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         MirValue* rhs_ptr = &fn->values[fn->values.len - 1];
-        v.kind = expr.kind == HirExprKind::Eq ? MirValueKind::Eq : (expr.kind == HirExprKind::Lt ? MirValueKind::Lt : MirValueKind::Gt);
+        v.kind = expr.kind == HirExprKind::Eq
+                     ? MirValueKind::Eq
+                     : (expr.kind == HirExprKind::Lt ? MirValueKind::Lt : MirValueKind::Gt);
         v.type = MirTypeKind::Bool;
         v.lhs = lhs_ptr;
         v.rhs = rhs_ptr;
@@ -368,20 +381,23 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
         if (!then_v) return core::make_unexpected(then_v.error());
         auto else_v = mir_value(*expr.args[0], module, fn);
         if (!else_v) return core::make_unexpected(else_v.error());
-        if (!fn->values.push(cond.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(cond.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         MirValue* cond_ptr = &fn->values[fn->values.len - 1];
-        if (!fn->values.push(then_v.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(then_v.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         MirValue* then_ptr = &fn->values[fn->values.len - 1];
-        if (!fn->values.push(else_v.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(else_v.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         MirValue* else_ptr = &fn->values[fn->values.len - 1];
         v.kind = MirValueKind::IfElse;
-        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
                  : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
-                                                    : MirTypeKind::Unknown;
+                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                     : MirTypeKind::Unknown;
         v.lhs = cond_ptr;
         v.rhs = then_ptr;
         if (!v.args.push(else_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -397,18 +413,20 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = mir_value(*expr.rhs, module, fn);
         if (!rhs) return core::make_unexpected(rhs.error());
-        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         MirValue* lhs_ptr = &fn->values[fn->values.len - 1];
-        if (!fn->values.push(rhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(rhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         MirValue* rhs_ptr = &fn->values[fn->values.len - 1];
         v.kind = MirValueKind::Or;
-        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
                  : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
-                                                    : MirTypeKind::Unknown;
+                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                     : MirTypeKind::Unknown;
         v.lhs = lhs_ptr;
         v.rhs = rhs_ptr;
         v.variant_index = expr.variant_index;
@@ -420,7 +438,8 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
     if (expr.kind == HirExprKind::NoError) {
         auto lhs = mir_value(*expr.lhs, module, fn);
         if (!lhs) return core::make_unexpected(lhs.error());
-        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::NoError;
         v.type = MirTypeKind::Bool;
         v.lhs = &fn->values[fn->values.len - 1];
@@ -430,7 +449,8 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
     if (expr.kind == HirExprKind::HasValue) {
         auto lhs = mir_value(*expr.lhs, module, fn);
         if (!lhs) return core::make_unexpected(lhs.error());
-        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::HasValue;
         v.type = MirTypeKind::Bool;
         v.lhs = &fn->values[fn->values.len - 1];
@@ -443,15 +463,16 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
     if (expr.kind == HirExprKind::ValueOf) {
         auto lhs = mir_value(*expr.lhs, module, fn);
         if (!lhs) return core::make_unexpected(lhs.error());
-        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::ValueOf;
-        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
                  : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
-                                                    : MirTypeKind::Unknown;
+                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                     : MirTypeKind::Unknown;
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.error_struct_index = expr.error_struct_index;
@@ -463,15 +484,16 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
     if (expr.kind == HirExprKind::MissingOf) {
         auto lhs = mir_value(*expr.lhs, module, fn);
         if (!lhs) return core::make_unexpected(lhs.error());
-        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::MissingOf;
-        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
                  : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
-                                                    : MirTypeKind::Unknown;
+                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                     : MirTypeKind::Unknown;
         v.may_nil = expr.may_nil;
         v.may_error = expr.may_error;
         v.variant_index = expr.variant_index;
@@ -485,15 +507,16 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
     if (expr.kind == HirExprKind::MatchPayload) {
         auto lhs = mir_value(*expr.lhs, module, fn);
         if (!lhs) return core::make_unexpected(lhs.error());
-        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::MatchPayload;
-        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
                  : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
-                                                    : MirTypeKind::Unknown;
+                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                     : MirTypeKind::Unknown;
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.case_index = expr.case_index;
@@ -504,13 +527,13 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& 
     }
     if (expr.kind == HirExprKind::LocalRef) {
         v.kind = MirValueKind::LocalRef;
-        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
                  : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
-                                                    : MirTypeKind::Unknown;
+                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                     : MirTypeKind::Unknown;
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.local_index = expr.local_index;
@@ -538,16 +561,14 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         for (u32 ti = 0; ti < shape.tuple_len; ti++) {
             shape.tuple_elem_shape_indices[ti] = module.type_shapes[i].tuple_elem_shape_indices[ti];
         }
-        if (!mir->type_shapes.push(shape))
-            return frontend_error(FrontendError::TooManyItems, {});
+        if (!mir->type_shapes.push(shape)) return frontend_error(FrontendError::TooManyItems, {});
     }
     for (u32 i = 0; i < module.upstreams.len; i++) {
         MirUpstream up{};
         up.span = module.upstreams[i].span;
         up.name = module.upstreams[i].name;
         up.id = module.upstreams[i].id;
-        if (!mir->upstreams.push(up))
-            return frontend_error(FrontendError::TooManyItems, up.span);
+        if (!mir->upstreams.push(up)) return frontend_error(FrontendError::TooManyItems, up.span);
     }
 
     for (u32 i = 0; i < module.structs.len; i++) {
@@ -560,13 +581,16 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         st.instance_type_arg_count = module.structs[i].instance_type_arg_count;
         for (u32 ai = 0; ai < st.instance_type_arg_count; ai++) {
             st.instance_type_args[ai] =
-                module.structs[i].instance_type_args[ai] == HirTypeKind::Bool    ? MirTypeKind::Bool
-                : module.structs[i].instance_type_args[ai] == HirTypeKind::I32   ? MirTypeKind::I32
-                : module.structs[i].instance_type_args[ai] == HirTypeKind::Str   ? MirTypeKind::Str
-                : module.structs[i].instance_type_args[ai] == HirTypeKind::Variant ? MirTypeKind::Variant
-                : module.structs[i].instance_type_args[ai] == HirTypeKind::Struct ? MirTypeKind::Struct
-                : module.structs[i].instance_type_args[ai] == HirTypeKind::Tuple ? MirTypeKind::Tuple
-                                                                                  : MirTypeKind::Unknown;
+                module.structs[i].instance_type_args[ai] == HirTypeKind::Bool  ? MirTypeKind::Bool
+                : module.structs[i].instance_type_args[ai] == HirTypeKind::I32 ? MirTypeKind::I32
+                : module.structs[i].instance_type_args[ai] == HirTypeKind::Str ? MirTypeKind::Str
+                : module.structs[i].instance_type_args[ai] == HirTypeKind::Variant
+                    ? MirTypeKind::Variant
+                : module.structs[i].instance_type_args[ai] == HirTypeKind::Struct
+                    ? MirTypeKind::Struct
+                : module.structs[i].instance_type_args[ai] == HirTypeKind::Tuple
+                    ? MirTypeKind::Tuple
+                    : MirTypeKind::Unknown;
             st.instance_generic_indices[ai] = module.structs[i].instance_generic_indices[ai];
             st.instance_shape_indices[ai] = module.structs[i].instance_shape_indices[ai];
         }
@@ -581,25 +605,26 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             field.struct_index = module.structs[i].fields[fi].struct_index;
             field.tuple_len = module.structs[i].fields[fi].tuple_len;
             for (u32 ti = 0; ti < field.tuple_len; ti++) {
-                field.tuple_types[ti] = module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Bool
-                                            ? MirTypeKind::Bool
-                                        : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::I32
-                                            ? MirTypeKind::I32
-                                        : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Str
-                                            ? MirTypeKind::Str
-                                        : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Variant
-                                            ? MirTypeKind::Variant
-                                        : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Struct
-                                            ? MirTypeKind::Struct
-                                            : MirTypeKind::Unknown;
-                field.tuple_variant_indices[ti] = module.structs[i].fields[fi].tuple_variant_indices[ti];
-                field.tuple_struct_indices[ti] = module.structs[i].fields[fi].tuple_struct_indices[ti];
+                field.tuple_types[ti] =
+                    module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Bool
+                        ? MirTypeKind::Bool
+                    : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::I32
+                        ? MirTypeKind::I32
+                    : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Str
+                        ? MirTypeKind::Str
+                    : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Variant
+                        ? MirTypeKind::Variant
+                    : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Struct
+                        ? MirTypeKind::Struct
+                        : MirTypeKind::Unknown;
+                field.tuple_variant_indices[ti] =
+                    module.structs[i].fields[fi].tuple_variant_indices[ti];
+                field.tuple_struct_indices[ti] =
+                    module.structs[i].fields[fi].tuple_struct_indices[ti];
             }
-            if (!st.fields.push(field))
-                return frontend_error(FrontendError::TooManyItems, st.span);
+            if (!st.fields.push(field)) return frontend_error(FrontendError::TooManyItems, st.span);
         }
-        if (!mir->structs.push(st))
-            return frontend_error(FrontendError::TooManyItems, st.span);
+        if (!mir->structs.push(st)) return frontend_error(FrontendError::TooManyItems, st.span);
     }
 
     for (u32 i = 0; i < module.variants.len; i++) {
@@ -611,13 +636,16 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         variant.instance_type_arg_count = module.variants[i].instance_type_arg_count;
         for (u32 ai = 0; ai < variant.instance_type_arg_count; ai++) {
             variant.instance_type_args[ai] =
-                module.variants[i].instance_type_args[ai] == HirTypeKind::Bool    ? MirTypeKind::Bool
-                : module.variants[i].instance_type_args[ai] == HirTypeKind::I32   ? MirTypeKind::I32
-                : module.variants[i].instance_type_args[ai] == HirTypeKind::Str   ? MirTypeKind::Str
-                : module.variants[i].instance_type_args[ai] == HirTypeKind::Variant ? MirTypeKind::Variant
-                : module.variants[i].instance_type_args[ai] == HirTypeKind::Struct ? MirTypeKind::Struct
-                : module.variants[i].instance_type_args[ai] == HirTypeKind::Tuple ? MirTypeKind::Tuple
-                                                                                   : MirTypeKind::Unknown;
+                module.variants[i].instance_type_args[ai] == HirTypeKind::Bool  ? MirTypeKind::Bool
+                : module.variants[i].instance_type_args[ai] == HirTypeKind::I32 ? MirTypeKind::I32
+                : module.variants[i].instance_type_args[ai] == HirTypeKind::Str ? MirTypeKind::Str
+                : module.variants[i].instance_type_args[ai] == HirTypeKind::Variant
+                    ? MirTypeKind::Variant
+                : module.variants[i].instance_type_args[ai] == HirTypeKind::Struct
+                    ? MirTypeKind::Struct
+                : module.variants[i].instance_type_args[ai] == HirTypeKind::Tuple
+                    ? MirTypeKind::Tuple
+                    : MirTypeKind::Unknown;
             variant.instance_generic_indices[ai] = module.variants[i].instance_generic_indices[ai];
             variant.instance_shape_indices[ai] = module.variants[i].instance_shape_indices[ai];
         }
@@ -632,9 +660,12 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             case_decl.payload_tuple_len = module.variants[i].cases[ci].payload_tuple_len;
             for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
                 case_decl.payload_tuple_types[ti] =
-                    module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Bool  ? MirTypeKind::Bool
-                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::I32 ? MirTypeKind::I32
-                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Str ? MirTypeKind::Str
+                    module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Bool
+                        ? MirTypeKind::Bool
+                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::I32
+                        ? MirTypeKind::I32
+                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Str
+                        ? MirTypeKind::Str
                     : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Variant
                         ? MirTypeKind::Variant
                     : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Struct
@@ -662,14 +693,14 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             const auto& st = mir->structs[i];
             bool ready = true;
             if (is_open_generic_struct_decl(st)) ready = false;
-            if (ready &&
-                !instance_fully_concrete(*mir,
-                                         st.instance_type_arg_count,
-                                         st.instance_type_args,
-                                         st.instance_shape_indices))
+            if (ready && !instance_fully_concrete(*mir,
+                                                  st.instance_type_arg_count,
+                                                  st.instance_type_args,
+                                                  st.instance_shape_indices))
                 ready = false;
             for (u32 fi = 0; ready && fi < st.fields.len; fi++) {
-                if (!field_carrier_ready(*mir, st.fields[fi], struct_ready, variant_ready)) ready = false;
+                if (!field_carrier_ready(*mir, st.fields[fi], struct_ready, variant_ready))
+                    ready = false;
             }
             if (ready) {
                 struct_ready[i] = true;
@@ -681,14 +712,15 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             const auto& variant = mir->variants[i];
             bool ready = true;
             if (is_open_generic_variant_decl(variant)) ready = false;
-            if (ready &&
-                !instance_fully_concrete(*mir,
-                                         variant.instance_type_arg_count,
-                                         variant.instance_type_args,
-                                         variant.instance_shape_indices))
+            if (ready && !instance_fully_concrete(*mir,
+                                                  variant.instance_type_arg_count,
+                                                  variant.instance_type_args,
+                                                  variant.instance_shape_indices))
                 ready = false;
             for (u32 ci = 0; ready && ci < variant.cases.len; ci++) {
-                if (!variant_payload_carrier_ready(*mir, variant.cases[ci], struct_ready, variant_ready)) ready = false;
+                if (!variant_payload_carrier_ready(
+                        *mir, variant.cases[ci], struct_ready, variant_ready))
+                    ready = false;
             }
             if (ready) {
                 variant_ready[i] = true;
@@ -697,7 +729,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         }
     }
     for (u32 i = 0; i < mir->type_shapes.len; i++) {
-        mir->type_shapes[i].carrier_ready = shape_carrier_ready(*mir, i, struct_ready, variant_ready);
+        mir->type_shapes[i].carrier_ready =
+            shape_carrier_ready(*mir, i, struct_ready, variant_ready);
     }
 
     for (u32 i = 0; i < module.routes.len; i++) {
@@ -709,8 +742,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         fn.error_variant_index = module.routes[i].error_variant_index;
 
         for (u32 li = 0; li < module.routes[i].locals.len; li++) {
-            if (module.routes[i].locals[li].type == HirTypeKind::Tuple)
-                continue;
+            if (module.routes[i].locals[li].type == HirTypeKind::Tuple) continue;
             MirLocal local{};
             local.span = module.routes[i].locals[li].span;
             local.name = module.routes[i].locals[li].name;
@@ -723,20 +755,22 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             local.struct_index = module.routes[i].locals[li].struct_index;
             local.tuple_len = module.routes[i].locals[li].tuple_len;
             for (u32 ti = 0; ti < local.tuple_len; ti++) {
-                local.tuple_types[ti] = module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Bool
-                                            ? MirTypeKind::Bool
-                                            : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::I32
-                                                ? MirTypeKind::I32
-                                                : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Str
-                                                    ? MirTypeKind::Str
-                                                    : module.routes[i].locals[li].tuple_types[ti] ==
-                                                              HirTypeKind::Variant
-                                                          ? MirTypeKind::Variant
-                                                          : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Struct
-                                                          ? MirTypeKind::Struct
-                                                          : MirTypeKind::Unknown;
-                local.tuple_variant_indices[ti] = module.routes[i].locals[li].tuple_variant_indices[ti];
-                local.tuple_struct_indices[ti] = module.routes[i].locals[li].tuple_struct_indices[ti];
+                local.tuple_types[ti] =
+                    module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Bool
+                        ? MirTypeKind::Bool
+                    : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::I32
+                        ? MirTypeKind::I32
+                    : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Str
+                        ? MirTypeKind::Str
+                    : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Variant
+                        ? MirTypeKind::Variant
+                    : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Struct
+                        ? MirTypeKind::Struct
+                        : MirTypeKind::Unknown;
+                local.tuple_variant_indices[ti] =
+                    module.routes[i].locals[li].tuple_variant_indices[ti];
+                local.tuple_struct_indices[ti] =
+                    module.routes[i].locals[li].tuple_struct_indices[ti];
             }
             local.error_struct_index = module.routes[i].locals[li].error_struct_index;
             local.error_variant_index = module.routes[i].locals[li].error_variant_index;
@@ -751,8 +785,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             out->span = term.span;
             out->status_code = term.status_code;
             out->upstream_index = term.upstream_index;
-            out->kind = term.kind == HirTerminatorKind::ReturnStatus ? MirTerminatorKind::ReturnStatus
-                                                                     : MirTerminatorKind::ForwardUpstream;
+            out->kind = term.kind == HirTerminatorKind::ReturnStatus
+                            ? MirTerminatorKind::ReturnStatus
+                            : MirTerminatorKind::ForwardUpstream;
             out->source_kind = term.source_kind == HirTerminatorSourceKind::LocalRef
                                    ? MirTerminatorSourceKind::LocalRef
                                    : MirTerminatorSourceKind::Literal;
@@ -987,13 +1022,15 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 u32 arm_then_index[HirControl::kMaxMatchArms]{};
                 u32 arm_else_index[HirControl::kMaxMatchArms]{};
                 u32 arm_guard_index[HirControl::kMaxMatchArms][HirMatchArm::kMaxPreludeGuards]{};
-                u32 arm_guard_fail_index[HirControl::kMaxMatchArms][HirMatchArm::kMaxPreludeGuards]{};
+                u32 arm_guard_fail_index[HirControl::kMaxMatchArms]
+                                        [HirMatchArm::kMaxPreludeGuards]{};
                 u32 next_index = guard_count + test_count;
                 for (u32 ai = 0; ai < arm_count; ai++) {
                     const auto& arm = module.routes[i].control.match_arms[ai];
                     arm_block_index[ai] = next_index++;
                     if (arm.guards.len != 0) {
-                        for (u32 gi = 1; gi < arm.guards.len; gi++) arm_guard_index[ai][gi] = next_index++;
+                        for (u32 gi = 1; gi < arm.guards.len; gi++)
+                            arm_guard_index[ai][gi] = next_index++;
                         arm_body_index[ai] = next_index++;
                         for (u32 gi = 0; gi < arm.guards.len; gi++) {
                             arm_guard_fail_index[ai][gi] = next_index;
@@ -1019,7 +1056,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 auto cond0 = mir_value(guard0.cond, module, &fn);
                 if (!cond0) return core::make_unexpected(cond0.error());
                 block.term.cond = cond0.value();
-                block.term.then_block = guard_count > 1 ? 1 : (test_count > 0 ? guard_count : arm_block_index[0]);
+                block.term.then_block =
+                    guard_count > 1 ? 1 : (test_count > 0 ? guard_count : arm_block_index[0]);
                 block.term.else_block = guard_fail_index[0];
                 if (!fn.blocks.push(block))
                     return frontend_error(FrontendError::TooManyItems, fn.span);
@@ -1034,7 +1072,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     if (!cond) return core::make_unexpected(cond.error());
                     guard_block.term.cond = cond.value();
                     guard_block.term.then_block =
-                        gi + 1 < guard_count ? gi + 1 : (test_count > 0 ? guard_count : arm_block_index[0]);
+                        gi + 1 < guard_count ? gi + 1
+                                             : (test_count > 0 ? guard_count : arm_block_index[0]);
                     guard_block.term.else_block = guard_fail_index[gi];
                     if (!fn.blocks.push(guard_block))
                         return frontend_error(FrontendError::TooManyItems, fn.span);
@@ -1094,8 +1133,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         guard_block.term.kind = MirTerminatorKind::Branch;
                         guard_block.term.span = arm.guards[gi].span;
                         guard_block.term.cond = cond.value();
-                        guard_block.term.then_block =
-                            gi + 1 < arm.guards.len ? arm_guard_index[ai][gi + 1] : arm_body_index[ai];
+                        guard_block.term.then_block = gi + 1 < arm.guards.len
+                                                          ? arm_guard_index[ai][gi + 1]
+                                                          : arm_body_index[ai];
                         guard_block.term.else_block = arm_guard_fail_index[ai][gi];
                         if (!fn.blocks.push(guard_block))
                             return frontend_error(FrontendError::TooManyItems, fn.span);
@@ -1150,8 +1190,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             block.term.cond = cond.value();
             block.term.then_block = 1;
             block.term.else_block = 2;
-            if (!fn.blocks.push(block))
-                return frontend_error(FrontendError::TooManyItems, fn.span);
+            if (!fn.blocks.push(block)) return frontend_error(FrontendError::TooManyItems, fn.span);
 
             MirBlock then_block{};
             then_block.label = then_label();
@@ -1178,7 +1217,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 const auto& arm = module.routes[i].control.match_arms[ai];
                 arm_block_index[ai] = next_index++;
                 if (arm.guards.len != 0) {
-                    for (u32 gi = 1; gi < arm.guards.len; gi++) arm_guard_index[ai][gi] = next_index++;
+                    for (u32 gi = 1; gi < arm.guards.len; gi++)
+                        arm_guard_index[ai][gi] = next_index++;
                     arm_body_index[ai] = next_index++;
                     for (u32 gi = 0; gi < arm.guards.len; gi++) {
                         arm_guard_fail_index[ai][gi] = next_index;
@@ -1280,7 +1320,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     test_block.term.lhs = subject.value();
                     test_block.term.rhs = arm_pattern.value();
                     test_block.term.then_block = arm_block_index[ai];
-                    test_block.term.else_block = ai + 1 < test_count ? ai + 1 : arm_block_index[test_count];
+                    test_block.term.else_block =
+                        ai + 1 < test_count ? ai + 1 : arm_block_index[test_count];
                     if (!fn.blocks.push(test_block))
                         return frontend_error(FrontendError::TooManyItems, fn.span);
                 }
@@ -1319,8 +1360,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         guard_block.term.kind = MirTerminatorKind::Branch;
                         guard_block.term.span = arm.guards[gi].span;
                         guard_block.term.cond = cond.value();
-                        guard_block.term.then_block =
-                            gi + 1 < arm.guards.len ? arm_guard_index[ai][gi + 1] : arm_body_index[ai];
+                        guard_block.term.then_block = gi + 1 < arm.guards.len
+                                                          ? arm_guard_index[ai][gi + 1]
+                                                          : arm_body_index[ai];
                         guard_block.term.else_block = arm_guard_fail_index[ai][gi];
                         if (!fn.blocks.push(guard_block))
                             return frontend_error(FrontendError::TooManyItems, fn.span);
@@ -1339,13 +1381,13 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         } else {
                             set_term_from_hir(&body_block.term, arm.direct_term);
                         }
-                    if (!fn.blocks.push(body_block))
-                        return frontend_error(FrontendError::TooManyItems, fn.span);
-                    for (u32 gi = 0; gi < arm.guards.len; gi++) {
-                        auto emitted = emit_guard_fail(arm.guards[gi]);
-                        if (!emitted) return core::make_unexpected(emitted.error());
+                        if (!fn.blocks.push(body_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                        for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                            auto emitted = emit_guard_fail(arm.guards[gi]);
+                            if (!emitted) return core::make_unexpected(emitted.error());
+                        }
                     }
-                }
                     if (arm.body_kind == HirMatchArm::BodyKind::If) {
                         MirBlock then_block{};
                         then_block.label = then_label();
@@ -1362,11 +1404,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             }
         } else {
             set_term_from_hir(&block.term, module.routes[i].control.direct_term);
-            if (!fn.blocks.push(block))
-                return frontend_error(FrontendError::TooManyItems, fn.span);
+            if (!fn.blocks.push(block)) return frontend_error(FrontendError::TooManyItems, fn.span);
         }
-        if (!mir->functions.push(fn))
-            return frontend_error(FrontendError::TooManyItems, fn.span);
+        if (!mir->functions.push(fn)) return frontend_error(FrontendError::TooManyItems, fn.span);
     }
 
     return mir;

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -267,8 +267,6 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         apply_expr_shape_if_available(module, expr, &v);
         return v;
     }
-    if (expr.kind == HirExprKind::TupleSlot)
-        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
     if (expr.kind == HirExprKind::VariantCase) {
         v.kind = MirValueKind::VariantCase;
         v.type = MirTypeKind::Variant;

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -1,0 +1,1369 @@
+#include "rut/compiler/mir_build.h"
+
+
+namespace rut {
+
+namespace {
+
+static Str entry_label() {
+    return {"entry", 5};
+}
+
+static Str then_label() {
+    return {"then", 4};
+}
+
+static Str else_label() {
+    return {"else", 4};
+}
+
+static Str cont_label() {
+    return {"cont", 4};
+}
+
+static Str fail_label() {
+    return {"fail", 4};
+}
+
+static Str match_test_label() {
+    return {"match_test", 10};
+}
+
+static Str match_case_label() {
+    return {"match_case", 10};
+}
+
+static Str match_default_label() {
+    return {"match_default", 13};
+}
+
+static MirTypeKind mir_type_kind(HirTypeKind kind) {
+    return kind == HirTypeKind::Bool    ? MirTypeKind::Bool
+           : kind == HirTypeKind::I32   ? MirTypeKind::I32
+           : kind == HirTypeKind::Str   ? MirTypeKind::Str
+           : kind == HirTypeKind::Variant ? MirTypeKind::Variant
+           : kind == HirTypeKind::Tuple ? MirTypeKind::Tuple
+           : kind == HirTypeKind::Struct ? MirTypeKind::Struct
+                                         : MirTypeKind::Unknown;
+}
+
+static bool expand_hir_flat_shape(const HirModule& module,
+                                  u32 shape_index,
+                                  MirTypeKind* type,
+                                  u32* variant_index,
+                                  u32* struct_index,
+                                  u32* tuple_len,
+                                  MirTypeKind* tuple_types,
+                                  u32* tuple_variant_indices,
+                                  u32* tuple_struct_indices) {
+    if (shape_index == 0xffffffffu || shape_index >= module.type_shapes.len) return false;
+    const auto& shape = module.type_shapes[shape_index];
+    *type = mir_type_kind(shape.type);
+    *variant_index = shape.variant_index;
+    *struct_index = shape.struct_index;
+    *tuple_len = shape.tuple_len;
+    if (shape.type != HirTypeKind::Tuple) return true;
+    for (u32 i = 0; i < shape.tuple_len; i++) {
+        const u32 elem_index = shape.tuple_elem_shape_indices[i];
+        if (elem_index >= module.type_shapes.len) return false;
+        const auto& elem = module.type_shapes[elem_index];
+        if (elem.type == HirTypeKind::Tuple) return false;
+        tuple_types[i] = mir_type_kind(elem.type);
+        tuple_variant_indices[i] = elem.variant_index;
+        tuple_struct_indices[i] = elem.struct_index;
+    }
+    return true;
+}
+
+static void apply_expr_shape_if_available(const HirModule& module, const HirExpr& expr, MirValue* out) {
+    expand_hir_flat_shape(module,
+                          expr.shape_index,
+                          &out->type,
+                          &out->variant_index,
+                          &out->struct_index,
+                          &out->tuple_len,
+                          out->tuple_types,
+                          out->tuple_variant_indices,
+                          out->tuple_struct_indices);
+}
+
+static bool shape_carrier_ready(const MirModule& mir,
+                                u32 shape_index,
+                                const bool* struct_ready,
+                                const bool* variant_ready) {
+    if (shape_index >= mir.type_shapes.len) return false;
+    const auto& shape = mir.type_shapes[shape_index];
+    if (!shape.is_concrete) return false;
+    if (shape.type == MirTypeKind::Bool || shape.type == MirTypeKind::I32 || shape.type == MirTypeKind::Str)
+        return true;
+    if (shape.type == MirTypeKind::Struct)
+        return shape.struct_index < mir.structs.len && struct_ready[shape.struct_index];
+    if (shape.type == MirTypeKind::Variant)
+        return shape.variant_index < mir.variants.len && variant_ready[shape.variant_index];
+    if (shape.type != MirTypeKind::Tuple) return false;
+    for (u32 i = 0; i < shape.tuple_len; i++) {
+        if (!shape_carrier_ready(mir, shape.tuple_elem_shape_indices[i], struct_ready, variant_ready))
+            return false;
+    }
+    return true;
+}
+
+static bool instance_arg_concrete(const MirModule& mir, MirTypeKind type, u32 shape_index) {
+    if (shape_index != 0xffffffffu) {
+        if (shape_index >= mir.type_shapes.len) return false;
+        return mir.type_shapes[shape_index].is_concrete;
+    }
+    return type != MirTypeKind::Unknown;
+}
+
+static bool instance_fully_concrete(const MirModule& mir,
+                                    u32 arg_count,
+                                    const MirTypeKind* arg_types,
+                                    const u32* shape_indices) {
+    for (u32 ai = 0; ai < arg_count; ai++) {
+        if (!instance_arg_concrete(mir, arg_types[ai], shape_indices[ai])) return false;
+    }
+    return true;
+}
+
+static bool is_open_generic_struct_decl(const MirStruct& st) {
+    return st.type_params.len != 0 && st.template_struct_index == 0xffffffffu;
+}
+
+static bool is_open_generic_variant_decl(const MirVariant& variant) {
+    return variant.type_params.len != 0 && variant.template_variant_index == 0xffffffffu;
+}
+
+static bool field_carrier_ready(const MirModule& mir,
+                                const MirStruct::FieldDecl& field,
+                                const bool* struct_ready,
+                                const bool* variant_ready) {
+    if (field.is_error_type) return true;
+    if (field.shape_index != 0xffffffffu)
+        return shape_carrier_ready(mir, field.shape_index, struct_ready, variant_ready);
+    if (field.type == MirTypeKind::Bool || field.type == MirTypeKind::I32 || field.type == MirTypeKind::Str)
+        return true;
+    if (field.type == MirTypeKind::Struct)
+        return field.struct_index < mir.structs.len && struct_ready[field.struct_index];
+    if (field.type == MirTypeKind::Variant)
+        return field.variant_index < mir.variants.len && variant_ready[field.variant_index];
+    return false;
+}
+
+static bool variant_payload_carrier_ready(const MirModule& mir,
+                                          const MirVariant::CaseDecl& c,
+                                          const bool* struct_ready,
+                                          const bool* variant_ready) {
+    if (!c.has_payload) return true;
+    if (c.payload_shape_index != 0xffffffffu)
+        return shape_carrier_ready(mir, c.payload_shape_index, struct_ready, variant_ready);
+    if (c.payload_type == MirTypeKind::Bool || c.payload_type == MirTypeKind::I32 || c.payload_type == MirTypeKind::Str)
+        return true;
+    if (c.payload_type == MirTypeKind::Struct)
+        return c.payload_struct_index < mir.structs.len && struct_ready[c.payload_struct_index];
+    if (c.payload_type == MirTypeKind::Variant)
+        return c.payload_variant_index < mir.variants.len && variant_ready[c.payload_variant_index];
+    return false;
+}
+
+static FrontendResult<MirValue> mir_value(const HirExpr& expr, const HirModule& module, MirFunction* fn) {
+    MirValue v{};
+    v.shape_index = expr.shape_index;
+    v.may_nil = expr.may_nil;
+    v.may_error = expr.may_error;
+    if (expr.kind == HirExprKind::BoolLit) {
+        v.kind = MirValueKind::BoolConst;
+        v.type = MirTypeKind::Bool;
+        v.bool_value = expr.bool_value;
+        return v;
+    }
+    if (expr.kind == HirExprKind::IntLit) {
+        v.kind = MirValueKind::IntConst;
+        v.type = MirTypeKind::I32;
+        v.int_value = expr.int_value;
+        return v;
+    }
+    if (expr.kind == HirExprKind::StrLit) {
+        v.kind = MirValueKind::StrConst;
+        v.type = MirTypeKind::Str;
+        v.str_value = expr.str_value;
+        return v;
+    }
+    if (expr.kind == HirExprKind::Tuple) {
+        v.kind = MirValueKind::Tuple;
+        v.type = MirTypeKind::Tuple;
+        v.tuple_len = expr.tuple_len;
+        for (u32 i = 0; i < expr.tuple_len; i++) {
+            v.tuple_types[i] = expr.tuple_types[i] == HirTypeKind::Bool    ? MirTypeKind::Bool
+                             : expr.tuple_types[i] == HirTypeKind::I32     ? MirTypeKind::I32
+                             : expr.tuple_types[i] == HirTypeKind::Str     ? MirTypeKind::Str
+                             : expr.tuple_types[i] == HirTypeKind::Variant ? MirTypeKind::Variant
+                             : expr.tuple_types[i] == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                                            : MirTypeKind::Unknown;
+            v.tuple_variant_indices[i] = expr.tuple_variant_indices[i];
+            v.tuple_struct_indices[i] = expr.tuple_struct_indices[i];
+        }
+        expand_hir_flat_shape(module,
+                              expr.shape_index,
+                              &v.type,
+                              &v.variant_index,
+                              &v.struct_index,
+                              &v.tuple_len,
+                              v.tuple_types,
+                              v.tuple_variant_indices,
+                              v.tuple_struct_indices);
+        for (u32 i = 0; i < expr.args.len; i++) {
+            auto elem = mir_value(*expr.args[i], module, fn);
+            if (!elem) return core::make_unexpected(elem.error());
+            if (!fn->values.push(elem.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            if (!v.args.push(&fn->values[fn->values.len - 1]))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+        }
+        return v;
+    }
+    if (expr.kind == HirExprKind::StructInit) {
+        v.kind = MirValueKind::StructInit;
+        v.type = MirTypeKind::Struct;
+        v.struct_index = expr.struct_index;
+        v.str_value = expr.str_value;
+        for (u32 i = 0; i < expr.field_inits.len; i++) {
+            auto field_value = mir_value(*expr.field_inits[i].value, module, fn);
+            if (!field_value) return core::make_unexpected(field_value.error());
+            if (!fn->values.push(field_value.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            MirValue::FieldInit field_init{};
+            field_init.name = expr.field_inits[i].name;
+            field_init.value = &fn->values[fn->values.len - 1];
+            if (!v.field_inits.push(field_init))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+        }
+        return v;
+    }
+    if (expr.kind == HirExprKind::TupleSlot) {
+        auto lhs = mir_value(*expr.lhs, module, fn);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        v.kind = MirValueKind::TupleSlot;
+        v.type = expr.type == HirTypeKind::Bool  ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32 ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str ? MirTypeKind::Str
+                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
+                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
+                                                    : MirTypeKind::Unknown;
+        v.variant_index = expr.variant_index;
+        v.struct_index = expr.struct_index;
+        v.int_value = expr.int_value;
+        v.lhs = &fn->values[fn->values.len - 1];
+        apply_expr_shape_if_available(module, expr, &v);
+        return v;
+    }
+    if (expr.kind == HirExprKind::TupleSlot)
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+    if (expr.kind == HirExprKind::VariantCase) {
+        v.kind = MirValueKind::VariantCase;
+        v.type = MirTypeKind::Variant;
+        v.variant_index = expr.variant_index;
+        v.case_index = expr.case_index;
+        v.error_variant_index = expr.error_variant_index;
+        v.error_case_index = expr.error_case_index;
+        v.int_value = expr.int_value;
+        if (expr.lhs != nullptr) {
+            auto payload = mir_value(*expr.lhs, module, fn);
+            if (!payload) return core::make_unexpected(payload.error());
+            if (!fn->values.push(payload.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            v.lhs = &fn->values[fn->values.len - 1];
+        }
+        return v;
+    }
+    if (expr.kind == HirExprKind::Field) {
+        auto lhs = mir_value(*expr.lhs, module, fn);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        v.kind = MirValueKind::Field;
+        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
+                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
+                                                    : MirTypeKind::Unknown;
+        v.str_value = expr.str_value;
+        v.lhs = &fn->values[fn->values.len - 1];
+        v.variant_index = expr.variant_index;
+        v.struct_index = expr.struct_index;
+        v.tuple_len = expr.tuple_len;
+        for (u32 i = 0; i < expr.tuple_len; i++) {
+            v.tuple_types[i] = expr.tuple_types[i] == HirTypeKind::Bool    ? MirTypeKind::Bool
+                             : expr.tuple_types[i] == HirTypeKind::I32     ? MirTypeKind::I32
+                             : expr.tuple_types[i] == HirTypeKind::Str     ? MirTypeKind::Str
+                             : expr.tuple_types[i] == HirTypeKind::Variant ? MirTypeKind::Variant
+                             : expr.tuple_types[i] == HirTypeKind::Struct  ? MirTypeKind::Struct
+                                                                            : MirTypeKind::Unknown;
+            v.tuple_variant_indices[i] = expr.tuple_variant_indices[i];
+            v.tuple_struct_indices[i] = expr.tuple_struct_indices[i];
+        }
+        v.error_struct_index = expr.error_struct_index;
+        v.error_variant_index = expr.error_variant_index;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqHeader) {
+        v.kind = MirValueKind::ReqHeader;
+        v.type = MirTypeKind::Str;
+        v.may_nil = true;
+        v.str_value = expr.str_value;
+        return v;
+    }
+    if (expr.kind == HirExprKind::Nil) {
+        v.kind = MirValueKind::Nil;
+        v.type = MirTypeKind::Unknown;
+        return v;
+    }
+    if (expr.kind == HirExprKind::Error) {
+        v.kind = MirValueKind::Error;
+        v.type = MirTypeKind::Unknown;
+        v.int_value = expr.int_value;
+        v.msg = expr.msg;
+        v.error_struct_index = expr.error_struct_index;
+        v.error_variant_index = expr.error_variant_index;
+        v.error_case_index = expr.error_case_index;
+        v.str_value = expr.str_value;
+        for (u32 i = 0; i < expr.field_inits.len; i++) {
+            auto field_value = mir_value(*expr.field_inits[i].value, module, fn);
+            if (!field_value) return core::make_unexpected(field_value.error());
+            if (!fn->values.push(field_value.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            MirValue::FieldInit field_init{};
+            field_init.name = expr.field_inits[i].name;
+            field_init.value = &fn->values[fn->values.len - 1];
+            if (!v.field_inits.push(field_init))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+        }
+        return v;
+    }
+    if (expr.kind == HirExprKind::Eq || expr.kind == HirExprKind::Lt || expr.kind == HirExprKind::Gt) {
+        auto lhs = mir_value(*expr.lhs, module, fn);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto rhs = mir_value(*expr.rhs, module, fn);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        MirValue* lhs_ptr = &fn->values[fn->values.len - 1];
+        if (!fn->values.push(rhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        MirValue* rhs_ptr = &fn->values[fn->values.len - 1];
+        v.kind = expr.kind == HirExprKind::Eq ? MirValueKind::Eq : (expr.kind == HirExprKind::Lt ? MirValueKind::Lt : MirValueKind::Gt);
+        v.type = MirTypeKind::Bool;
+        v.lhs = lhs_ptr;
+        v.rhs = rhs_ptr;
+        v.error_variant_index = expr.error_variant_index;
+        return v;
+    }
+    if (expr.kind == HirExprKind::IfElse) {
+        auto cond = mir_value(*expr.lhs, module, fn);
+        if (!cond) return core::make_unexpected(cond.error());
+        auto then_v = mir_value(*expr.rhs, module, fn);
+        if (!then_v) return core::make_unexpected(then_v.error());
+        auto else_v = mir_value(*expr.args[0], module, fn);
+        if (!else_v) return core::make_unexpected(else_v.error());
+        if (!fn->values.push(cond.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        MirValue* cond_ptr = &fn->values[fn->values.len - 1];
+        if (!fn->values.push(then_v.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        MirValue* then_ptr = &fn->values[fn->values.len - 1];
+        if (!fn->values.push(else_v.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        MirValue* else_ptr = &fn->values[fn->values.len - 1];
+        v.kind = MirValueKind::IfElse;
+        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
+                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
+                                                    : MirTypeKind::Unknown;
+        v.lhs = cond_ptr;
+        v.rhs = then_ptr;
+        if (!v.args.push(else_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        v.variant_index = expr.variant_index;
+        v.struct_index = expr.struct_index;
+        v.error_struct_index = expr.error_struct_index;
+        v.error_variant_index = expr.error_variant_index;
+        apply_expr_shape_if_available(module, expr, &v);
+        return v;
+    }
+    if (expr.kind == HirExprKind::Or) {
+        auto lhs = mir_value(*expr.lhs, module, fn);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto rhs = mir_value(*expr.rhs, module, fn);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        MirValue* lhs_ptr = &fn->values[fn->values.len - 1];
+        if (!fn->values.push(rhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        MirValue* rhs_ptr = &fn->values[fn->values.len - 1];
+        v.kind = MirValueKind::Or;
+        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
+                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
+                                                    : MirTypeKind::Unknown;
+        v.lhs = lhs_ptr;
+        v.rhs = rhs_ptr;
+        v.variant_index = expr.variant_index;
+        v.struct_index = expr.struct_index;
+        v.error_variant_index = expr.error_variant_index;
+        apply_expr_shape_if_available(module, expr, &v);
+        return v;
+    }
+    if (expr.kind == HirExprKind::NoError) {
+        auto lhs = mir_value(*expr.lhs, module, fn);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        v.kind = MirValueKind::NoError;
+        v.type = MirTypeKind::Bool;
+        v.lhs = &fn->values[fn->values.len - 1];
+        v.error_variant_index = expr.error_variant_index;
+        return v;
+    }
+    if (expr.kind == HirExprKind::HasValue) {
+        auto lhs = mir_value(*expr.lhs, module, fn);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        v.kind = MirValueKind::HasValue;
+        v.type = MirTypeKind::Bool;
+        v.lhs = &fn->values[fn->values.len - 1];
+        v.variant_index = expr.variant_index;
+        v.struct_index = expr.struct_index;
+        v.error_struct_index = expr.error_struct_index;
+        v.error_variant_index = expr.error_variant_index;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ValueOf) {
+        auto lhs = mir_value(*expr.lhs, module, fn);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        v.kind = MirValueKind::ValueOf;
+        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
+                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
+                                                    : MirTypeKind::Unknown;
+        v.variant_index = expr.variant_index;
+        v.struct_index = expr.struct_index;
+        v.error_struct_index = expr.error_struct_index;
+        v.error_variant_index = expr.error_variant_index;
+        v.lhs = &fn->values[fn->values.len - 1];
+        apply_expr_shape_if_available(module, expr, &v);
+        return v;
+    }
+    if (expr.kind == HirExprKind::MissingOf) {
+        auto lhs = mir_value(*expr.lhs, module, fn);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        v.kind = MirValueKind::MissingOf;
+        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
+                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
+                                                    : MirTypeKind::Unknown;
+        v.may_nil = expr.may_nil;
+        v.may_error = expr.may_error;
+        v.variant_index = expr.variant_index;
+        v.struct_index = expr.struct_index;
+        v.error_struct_index = expr.error_struct_index;
+        v.error_variant_index = expr.error_variant_index;
+        v.lhs = &fn->values[fn->values.len - 1];
+        apply_expr_shape_if_available(module, expr, &v);
+        return v;
+    }
+    if (expr.kind == HirExprKind::MatchPayload) {
+        auto lhs = mir_value(*expr.lhs, module, fn);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!fn->values.push(lhs.value())) return frontend_error(FrontendError::TooManyItems, expr.span);
+        v.kind = MirValueKind::MatchPayload;
+        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
+                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
+                                                    : MirTypeKind::Unknown;
+        v.variant_index = expr.variant_index;
+        v.struct_index = expr.struct_index;
+        v.case_index = expr.case_index;
+        v.lhs = &fn->values[fn->values.len - 1];
+        v.error_variant_index = expr.error_variant_index;
+        apply_expr_shape_if_available(module, expr, &v);
+        return v;
+    }
+    if (expr.kind == HirExprKind::LocalRef) {
+        v.kind = MirValueKind::LocalRef;
+        v.type = expr.type == HirTypeKind::Bool    ? MirTypeKind::Bool
+                 : expr.type == HirTypeKind::I32   ? MirTypeKind::I32
+                 : expr.type == HirTypeKind::Str   ? MirTypeKind::Str
+                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
+                 : expr.type == HirTypeKind::Tuple ? MirTypeKind::Tuple
+                 : expr.type == HirTypeKind::Struct ? MirTypeKind::Struct
+                                                    : MirTypeKind::Unknown;
+        v.variant_index = expr.variant_index;
+        v.struct_index = expr.struct_index;
+        v.local_index = expr.local_index;
+        v.error_struct_index = expr.error_struct_index;
+        v.error_variant_index = expr.error_variant_index;
+        apply_expr_shape_if_available(module, expr, &v);
+        return v;
+    }
+    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+}
+
+}  // namespace
+
+FrontendResult<MirModule*> build_mir(const HirModule& module) {
+    auto* mir = new MirModule{};
+
+    for (u32 i = 0; i < module.type_shapes.len; i++) {
+        MirTypeShape shape{};
+        shape.type = mir_type_kind(module.type_shapes[i].type);
+        shape.is_concrete = module.type_shapes[i].is_concrete;
+        shape.generic_index = module.type_shapes[i].generic_index;
+        shape.variant_index = module.type_shapes[i].variant_index;
+        shape.struct_index = module.type_shapes[i].struct_index;
+        shape.tuple_len = module.type_shapes[i].tuple_len;
+        for (u32 ti = 0; ti < shape.tuple_len; ti++) {
+            shape.tuple_elem_shape_indices[ti] = module.type_shapes[i].tuple_elem_shape_indices[ti];
+        }
+        if (!mir->type_shapes.push(shape))
+            return frontend_error(FrontendError::TooManyItems, {});
+    }
+    for (u32 i = 0; i < module.upstreams.len; i++) {
+        MirUpstream up{};
+        up.span = module.upstreams[i].span;
+        up.name = module.upstreams[i].name;
+        up.id = module.upstreams[i].id;
+        if (!mir->upstreams.push(up))
+            return frontend_error(FrontendError::TooManyItems, up.span);
+    }
+
+    for (u32 i = 0; i < module.structs.len; i++) {
+        MirStruct st{};
+        st.span = module.structs[i].span;
+        st.name = module.structs[i].name;
+        st.conforms_error = module.structs[i].conforms_error;
+        st.type_params = module.structs[i].type_params;
+        st.template_struct_index = module.structs[i].template_struct_index;
+        st.instance_type_arg_count = module.structs[i].instance_type_arg_count;
+        for (u32 ai = 0; ai < st.instance_type_arg_count; ai++) {
+            st.instance_type_args[ai] =
+                module.structs[i].instance_type_args[ai] == HirTypeKind::Bool    ? MirTypeKind::Bool
+                : module.structs[i].instance_type_args[ai] == HirTypeKind::I32   ? MirTypeKind::I32
+                : module.structs[i].instance_type_args[ai] == HirTypeKind::Str   ? MirTypeKind::Str
+                : module.structs[i].instance_type_args[ai] == HirTypeKind::Variant ? MirTypeKind::Variant
+                : module.structs[i].instance_type_args[ai] == HirTypeKind::Struct ? MirTypeKind::Struct
+                : module.structs[i].instance_type_args[ai] == HirTypeKind::Tuple ? MirTypeKind::Tuple
+                                                                                  : MirTypeKind::Unknown;
+            st.instance_generic_indices[ai] = module.structs[i].instance_generic_indices[ai];
+            st.instance_shape_indices[ai] = module.structs[i].instance_shape_indices[ai];
+        }
+        for (u32 fi = 0; fi < module.structs[i].fields.len; fi++) {
+            MirStruct::FieldDecl field{};
+            field.name = module.structs[i].fields[fi].name;
+            field.type_name = module.structs[i].fields[fi].type_name;
+            field.type = mir_type_kind(module.structs[i].fields[fi].type);
+            field.shape_index = module.structs[i].fields[fi].shape_index;
+            field.is_error_type = module.structs[i].fields[fi].is_error_type;
+            field.variant_index = module.structs[i].fields[fi].variant_index;
+            field.struct_index = module.structs[i].fields[fi].struct_index;
+            field.tuple_len = module.structs[i].fields[fi].tuple_len;
+            for (u32 ti = 0; ti < field.tuple_len; ti++) {
+                field.tuple_types[ti] = module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Bool
+                                            ? MirTypeKind::Bool
+                                        : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::I32
+                                            ? MirTypeKind::I32
+                                        : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Str
+                                            ? MirTypeKind::Str
+                                        : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Variant
+                                            ? MirTypeKind::Variant
+                                        : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Struct
+                                            ? MirTypeKind::Struct
+                                            : MirTypeKind::Unknown;
+                field.tuple_variant_indices[ti] = module.structs[i].fields[fi].tuple_variant_indices[ti];
+                field.tuple_struct_indices[ti] = module.structs[i].fields[fi].tuple_struct_indices[ti];
+            }
+            if (!st.fields.push(field))
+                return frontend_error(FrontendError::TooManyItems, st.span);
+        }
+        if (!mir->structs.push(st))
+            return frontend_error(FrontendError::TooManyItems, st.span);
+    }
+
+    for (u32 i = 0; i < module.variants.len; i++) {
+        MirVariant variant{};
+        variant.span = module.variants[i].span;
+        variant.name = module.variants[i].name;
+        variant.type_params = module.variants[i].type_params;
+        variant.template_variant_index = module.variants[i].template_variant_index;
+        variant.instance_type_arg_count = module.variants[i].instance_type_arg_count;
+        for (u32 ai = 0; ai < variant.instance_type_arg_count; ai++) {
+            variant.instance_type_args[ai] =
+                module.variants[i].instance_type_args[ai] == HirTypeKind::Bool    ? MirTypeKind::Bool
+                : module.variants[i].instance_type_args[ai] == HirTypeKind::I32   ? MirTypeKind::I32
+                : module.variants[i].instance_type_args[ai] == HirTypeKind::Str   ? MirTypeKind::Str
+                : module.variants[i].instance_type_args[ai] == HirTypeKind::Variant ? MirTypeKind::Variant
+                : module.variants[i].instance_type_args[ai] == HirTypeKind::Struct ? MirTypeKind::Struct
+                : module.variants[i].instance_type_args[ai] == HirTypeKind::Tuple ? MirTypeKind::Tuple
+                                                                                   : MirTypeKind::Unknown;
+            variant.instance_generic_indices[ai] = module.variants[i].instance_generic_indices[ai];
+            variant.instance_shape_indices[ai] = module.variants[i].instance_shape_indices[ai];
+        }
+        for (u32 ci = 0; ci < module.variants[i].cases.len; ci++) {
+            MirVariant::CaseDecl case_decl{};
+            case_decl.name = module.variants[i].cases[ci].name;
+            case_decl.has_payload = module.variants[i].cases[ci].has_payload;
+            case_decl.payload_type = mir_type_kind(module.variants[i].cases[ci].payload_type);
+            case_decl.payload_shape_index = module.variants[i].cases[ci].payload_shape_index;
+            case_decl.payload_variant_index = module.variants[i].cases[ci].payload_variant_index;
+            case_decl.payload_struct_index = module.variants[i].cases[ci].payload_struct_index;
+            case_decl.payload_tuple_len = module.variants[i].cases[ci].payload_tuple_len;
+            for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
+                case_decl.payload_tuple_types[ti] =
+                    module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Bool  ? MirTypeKind::Bool
+                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::I32 ? MirTypeKind::I32
+                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Str ? MirTypeKind::Str
+                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Variant
+                        ? MirTypeKind::Variant
+                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Struct
+                        ? MirTypeKind::Struct
+                        : MirTypeKind::Unknown;
+                case_decl.payload_tuple_variant_indices[ti] =
+                    module.variants[i].cases[ci].payload_tuple_variant_indices[ti];
+                case_decl.payload_tuple_struct_indices[ti] =
+                    module.variants[i].cases[ci].payload_tuple_struct_indices[ti];
+            }
+            if (!variant.cases.push(case_decl))
+                return frontend_error(FrontendError::TooManyItems, variant.span);
+        }
+        if (!mir->variants.push(variant))
+            return frontend_error(FrontendError::TooManyItems, variant.span);
+    }
+
+    bool struct_ready[MirModule::kMaxStructs]{};
+    bool variant_ready[MirModule::kMaxVariants]{};
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (u32 i = 0; i < mir->structs.len; i++) {
+            if (struct_ready[i]) continue;
+            const auto& st = mir->structs[i];
+            bool ready = true;
+            if (is_open_generic_struct_decl(st)) ready = false;
+            if (ready &&
+                !instance_fully_concrete(*mir,
+                                         st.instance_type_arg_count,
+                                         st.instance_type_args,
+                                         st.instance_shape_indices))
+                ready = false;
+            for (u32 fi = 0; ready && fi < st.fields.len; fi++) {
+                if (!field_carrier_ready(*mir, st.fields[fi], struct_ready, variant_ready)) ready = false;
+            }
+            if (ready) {
+                struct_ready[i] = true;
+                changed = true;
+            }
+        }
+        for (u32 i = 0; i < mir->variants.len; i++) {
+            if (variant_ready[i]) continue;
+            const auto& variant = mir->variants[i];
+            bool ready = true;
+            if (is_open_generic_variant_decl(variant)) ready = false;
+            if (ready &&
+                !instance_fully_concrete(*mir,
+                                         variant.instance_type_arg_count,
+                                         variant.instance_type_args,
+                                         variant.instance_shape_indices))
+                ready = false;
+            for (u32 ci = 0; ready && ci < variant.cases.len; ci++) {
+                if (!variant_payload_carrier_ready(*mir, variant.cases[ci], struct_ready, variant_ready)) ready = false;
+            }
+            if (ready) {
+                variant_ready[i] = true;
+                changed = true;
+            }
+        }
+    }
+    for (u32 i = 0; i < mir->type_shapes.len; i++) {
+        mir->type_shapes[i].carrier_ready = shape_carrier_ready(*mir, i, struct_ready, variant_ready);
+    }
+
+    for (u32 i = 0; i < module.routes.len; i++) {
+        MirFunction fn{};
+        fn.span = module.routes[i].span;
+        fn.method = module.routes[i].method;
+        fn.path = module.routes[i].path;
+        fn.name = {"route", 5};
+        fn.error_variant_index = module.routes[i].error_variant_index;
+
+        for (u32 li = 0; li < module.routes[i].locals.len; li++) {
+            if (module.routes[i].locals[li].type == HirTypeKind::Tuple)
+                continue;
+            MirLocal local{};
+            local.span = module.routes[i].locals[li].span;
+            local.name = module.routes[i].locals[li].name;
+            local.ref_index = module.routes[i].locals[li].ref_index;
+            local.type = mir_type_kind(module.routes[i].locals[li].type);
+            local.shape_index = module.routes[i].locals[li].shape_index;
+            local.may_nil = module.routes[i].locals[li].may_nil;
+            local.may_error = module.routes[i].locals[li].may_error;
+            local.variant_index = module.routes[i].locals[li].variant_index;
+            local.struct_index = module.routes[i].locals[li].struct_index;
+            local.tuple_len = module.routes[i].locals[li].tuple_len;
+            for (u32 ti = 0; ti < local.tuple_len; ti++) {
+                local.tuple_types[ti] = module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Bool
+                                            ? MirTypeKind::Bool
+                                            : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::I32
+                                                ? MirTypeKind::I32
+                                                : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Str
+                                                    ? MirTypeKind::Str
+                                                    : module.routes[i].locals[li].tuple_types[ti] ==
+                                                              HirTypeKind::Variant
+                                                          ? MirTypeKind::Variant
+                                                          : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Struct
+                                                          ? MirTypeKind::Struct
+                                                          : MirTypeKind::Unknown;
+                local.tuple_variant_indices[ti] = module.routes[i].locals[li].tuple_variant_indices[ti];
+                local.tuple_struct_indices[ti] = module.routes[i].locals[li].tuple_struct_indices[ti];
+            }
+            local.error_struct_index = module.routes[i].locals[li].error_struct_index;
+            local.error_variant_index = module.routes[i].locals[li].error_variant_index;
+            auto init = mir_value(module.routes[i].locals[li].init, module, &fn);
+            if (!init) return core::make_unexpected(init.error());
+            local.init = init.value();
+            if (!fn.locals.push(local))
+                return frontend_error(FrontendError::TooManyItems, local.span);
+        }
+
+        auto set_term_from_hir = [](MirTerminator* out, const HirTerminator& term) {
+            out->span = term.span;
+            out->status_code = term.status_code;
+            out->upstream_index = term.upstream_index;
+            out->kind = term.kind == HirTerminatorKind::ReturnStatus ? MirTerminatorKind::ReturnStatus
+                                                                     : MirTerminatorKind::ForwardUpstream;
+        };
+        auto guard_fail_block_count = [&](const HirGuard& guard) -> u32 {
+            if (guard.fail_kind == HirGuard::FailKind::Term) return 1;
+            u32 non_wildcard = 0;
+            for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
+                // one test block per non-wildcard arm, one case/default block per arm
+                // fail_match arms live in route storage to keep HirGuard compact
+                const auto& arm = module.guard_match_arms[guard.fail_match_start + ai];
+                if (!arm.is_wildcard) non_wildcard++;
+            }
+            return non_wildcard + guard.fail_match_count;
+        };
+        auto emit_guard_fail = [&](const HirGuard& guard) -> FrontendResult<void> {
+            if (guard.fail_kind == HirGuard::FailKind::Term) {
+                MirBlock fail_block{};
+                fail_block.label = fail_label();
+                set_term_from_hir(&fail_block.term, guard.fail_term);
+                if (!fn.blocks.push(fail_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+                return {};
+            }
+
+            if (guard.fail_kind == HirGuard::FailKind::Body) {
+                MirBlock fail_block{};
+                fail_block.label = fail_label();
+                if (guard.fail_body.body_kind == HirGuardBody::BodyKind::If) {
+                    fail_block.term.kind = MirTerminatorKind::Branch;
+                    fail_block.term.span = guard.fail_body.cond.span;
+                    auto cond = mir_value(guard.fail_body.cond, module, &fn);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    fail_block.term.cond = cond.value();
+                    const u32 then_index = fn.blocks.len + 1;
+                    const u32 else_index = fn.blocks.len + 2;
+                    fail_block.term.then_block = then_index;
+                    fail_block.term.else_block = else_index;
+                    if (!fn.blocks.push(fail_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                    MirBlock then_block{};
+                    then_block.label = then_label();
+                    set_term_from_hir(&then_block.term, guard.fail_body.then_term);
+                    if (!fn.blocks.push(then_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                    MirBlock else_block{};
+                    else_block.label = else_label();
+                    set_term_from_hir(&else_block.term, guard.fail_body.else_term);
+                    if (!fn.blocks.push(else_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                } else {
+                    set_term_from_hir(&fail_block.term, guard.fail_body.direct_term);
+                    if (!fn.blocks.push(fail_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                }
+                return {};
+            }
+
+            u32 test_index[HirGuard::kMaxFailMatchArms]{};
+            u32 case_index[HirGuard::kMaxFailMatchArms]{};
+            u32 cursor = fn.blocks.len;
+            u32 default_index = 0xffffffffu;
+            for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
+                const auto& arm = module.guard_match_arms[guard.fail_match_start + ai];
+                if (!arm.is_wildcard) test_index[ai] = cursor++;
+            }
+            for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
+                const auto& arm = module.guard_match_arms[guard.fail_match_start + ai];
+                case_index[ai] = cursor++;
+                if (arm.is_wildcard) default_index = case_index[ai];
+            }
+
+            auto subject = mir_value(guard.fail_match_expr, module, &fn);
+            if (!subject) return core::make_unexpected(subject.error());
+            for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
+                const auto& arm = module.guard_match_arms[guard.fail_match_start + ai];
+                if (arm.is_wildcard) continue;
+                MirBlock test_block{};
+                test_block.label = match_test_label();
+                auto arm_pattern = mir_value(arm.pattern, module, &fn);
+                if (!arm_pattern) return core::make_unexpected(arm_pattern.error());
+                test_block.term.kind = MirTerminatorKind::Branch;
+                test_block.term.use_cmp = true;
+                test_block.term.span = arm.span;
+                test_block.term.lhs = subject.value();
+                test_block.term.rhs = arm_pattern.value();
+                test_block.term.then_block = case_index[ai];
+                u32 next_test = default_index;
+                for (u32 next = ai + 1; next < guard.fail_match_count; next++) {
+                    if (!module.guard_match_arms[guard.fail_match_start + next].is_wildcard) {
+                        next_test = test_index[next];
+                        break;
+                    }
+                }
+                test_block.term.else_block = next_test;
+                if (!fn.blocks.push(test_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+            }
+
+            for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
+                const auto& arm = module.guard_match_arms[guard.fail_match_start + ai];
+                MirBlock case_block{};
+                case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
+                set_term_from_hir(&case_block.term, arm.direct_term);
+                if (!fn.blocks.push(case_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+            }
+            return {};
+        };
+
+        MirBlock block{};
+        block.label = entry_label();
+        if (module.routes[i].guards.len != 0) {
+            const u32 guard_count = module.routes[i].guards.len;
+
+            if (module.routes[i].control.kind == HirControlKind::Direct) {
+                const u32 body_index = guard_count;
+                u32 guard_fail_index[HirRoute::kMaxGuards]{};
+                u32 fail_cursor = body_index + 1;
+                for (u32 gi = 0; gi < guard_count; gi++) {
+                    guard_fail_index[gi] = fail_cursor;
+                    fail_cursor += guard_fail_block_count(module.routes[i].guards[gi]);
+                }
+                const auto& guard0 = module.routes[i].guards[0];
+                block.term.kind = MirTerminatorKind::Branch;
+                block.term.span = guard0.span;
+                auto cond0 = mir_value(guard0.cond, module, &fn);
+                if (!cond0) return core::make_unexpected(cond0.error());
+                block.term.cond = cond0.value();
+                block.term.then_block = guard_count > 1 ? 1 : body_index;
+                block.term.else_block = guard_fail_index[0];
+                if (!fn.blocks.push(block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                for (u32 gi = 1; gi < guard_count; gi++) {
+                    MirBlock guard_block{};
+                    guard_block.label = cont_label();
+                    const auto& guard = module.routes[i].guards[gi];
+                    guard_block.term.kind = MirTerminatorKind::Branch;
+                    guard_block.term.span = guard.span;
+                    auto cond = mir_value(guard.cond, module, &fn);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    guard_block.term.cond = cond.value();
+                    guard_block.term.then_block = gi + 1 < guard_count ? gi + 1 : body_index;
+                    guard_block.term.else_block = guard_fail_index[gi];
+                    if (!fn.blocks.push(guard_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                }
+
+                MirBlock cont_block{};
+                cont_block.label = cont_label();
+                set_term_from_hir(&cont_block.term, module.routes[i].control.direct_term);
+                if (!fn.blocks.push(cont_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                for (u32 gi = 0; gi < guard_count; gi++) {
+                    auto emitted = emit_guard_fail(module.routes[i].guards[gi]);
+                    if (!emitted) return core::make_unexpected(emitted.error());
+                }
+            } else if (module.routes[i].control.kind == HirControlKind::If) {
+                const u32 body_index = guard_count;
+                const u32 then_index = body_index + 1;
+                const u32 else_index = body_index + 2;
+                u32 guard_fail_index[HirRoute::kMaxGuards]{};
+                u32 fail_cursor = body_index + 3;
+                for (u32 gi = 0; gi < guard_count; gi++) {
+                    guard_fail_index[gi] = fail_cursor;
+                    fail_cursor += guard_fail_block_count(module.routes[i].guards[gi]);
+                }
+                const auto& guard0 = module.routes[i].guards[0];
+                block.term.kind = MirTerminatorKind::Branch;
+                block.term.span = guard0.span;
+                auto cond0 = mir_value(guard0.cond, module, &fn);
+                if (!cond0) return core::make_unexpected(cond0.error());
+                block.term.cond = cond0.value();
+                block.term.then_block = guard_count > 1 ? 1 : body_index;
+                block.term.else_block = guard_fail_index[0];
+                if (!fn.blocks.push(block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                for (u32 gi = 1; gi < guard_count; gi++) {
+                    MirBlock guard_block{};
+                    guard_block.label = cont_label();
+                    const auto& guard = module.routes[i].guards[gi];
+                    guard_block.term.kind = MirTerminatorKind::Branch;
+                    guard_block.term.span = guard.span;
+                    auto cond = mir_value(guard.cond, module, &fn);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    guard_block.term.cond = cond.value();
+                    guard_block.term.then_block = gi + 1 < guard_count ? gi + 1 : body_index;
+                    guard_block.term.else_block = guard_fail_index[gi];
+                    if (!fn.blocks.push(guard_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                }
+
+                MirBlock cont_block{};
+                cont_block.label = cont_label();
+                cont_block.term.kind = MirTerminatorKind::Branch;
+                cont_block.term.span = module.routes[i].control.cond.span;
+                auto if_cond = mir_value(module.routes[i].control.cond, module, &fn);
+                if (!if_cond) return core::make_unexpected(if_cond.error());
+                cont_block.term.cond = if_cond.value();
+                cont_block.term.then_block = then_index;
+                cont_block.term.else_block = else_index;
+                if (!fn.blocks.push(cont_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                MirBlock then_block{};
+                then_block.label = then_label();
+                set_term_from_hir(&then_block.term, module.routes[i].control.then_term);
+                if (!fn.blocks.push(then_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                MirBlock else_block{};
+                else_block.label = else_label();
+                set_term_from_hir(&else_block.term, module.routes[i].control.else_term);
+                if (!fn.blocks.push(else_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                for (u32 gi = 0; gi < guard_count; gi++) {
+                    auto emitted = emit_guard_fail(module.routes[i].guards[gi]);
+                    if (!emitted) return core::make_unexpected(emitted.error());
+                }
+            } else if (module.routes[i].control.kind == HirControlKind::Match) {
+                const u32 arm_count = module.routes[i].control.match_arms.len;
+                const u32 test_count = arm_count - 1;
+                u32 arm_block_index[HirControl::kMaxMatchArms]{};
+                u32 arm_body_index[HirControl::kMaxMatchArms]{};
+                u32 arm_then_index[HirControl::kMaxMatchArms]{};
+                u32 arm_else_index[HirControl::kMaxMatchArms]{};
+                u32 arm_guard_index[HirControl::kMaxMatchArms][HirMatchArm::kMaxPreludeGuards]{};
+                u32 arm_guard_fail_index[HirControl::kMaxMatchArms][HirMatchArm::kMaxPreludeGuards]{};
+                u32 next_index = guard_count + test_count;
+                for (u32 ai = 0; ai < arm_count; ai++) {
+                    const auto& arm = module.routes[i].control.match_arms[ai];
+                    arm_block_index[ai] = next_index++;
+                    if (arm.guards.len != 0) {
+                        for (u32 gi = 1; gi < arm.guards.len; gi++) arm_guard_index[ai][gi] = next_index++;
+                        arm_body_index[ai] = next_index++;
+                        for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                            arm_guard_fail_index[ai][gi] = next_index;
+                            next_index += guard_fail_block_count(arm.guards[gi]);
+                        }
+                    } else {
+                        arm_body_index[ai] = arm_block_index[ai];
+                    }
+                    if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                        arm_then_index[ai] = next_index++;
+                        arm_else_index[ai] = next_index++;
+                    }
+                }
+                u32 guard_fail_index[HirRoute::kMaxGuards]{};
+                u32 fail_cursor = next_index;
+                for (u32 gi = 0; gi < guard_count; gi++) {
+                    guard_fail_index[gi] = fail_cursor;
+                    fail_cursor += guard_fail_block_count(module.routes[i].guards[gi]);
+                }
+                const auto& guard0 = module.routes[i].guards[0];
+                block.term.kind = MirTerminatorKind::Branch;
+                block.term.span = guard0.span;
+                auto cond0 = mir_value(guard0.cond, module, &fn);
+                if (!cond0) return core::make_unexpected(cond0.error());
+                block.term.cond = cond0.value();
+                block.term.then_block = guard_count > 1 ? 1 : (test_count > 0 ? guard_count : arm_block_index[0]);
+                block.term.else_block = guard_fail_index[0];
+                if (!fn.blocks.push(block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                for (u32 gi = 1; gi < guard_count; gi++) {
+                    MirBlock guard_block{};
+                    guard_block.label = cont_label();
+                    const auto& guard = module.routes[i].guards[gi];
+                    guard_block.term.kind = MirTerminatorKind::Branch;
+                    guard_block.term.span = guard.span;
+                    auto cond = mir_value(guard.cond, module, &fn);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    guard_block.term.cond = cond.value();
+                    guard_block.term.then_block =
+                        gi + 1 < guard_count ? gi + 1 : (test_count > 0 ? guard_count : arm_block_index[0]);
+                    guard_block.term.else_block = guard_fail_index[gi];
+                    if (!fn.blocks.push(guard_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                }
+
+                auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
+                if (!subject) return core::make_unexpected(subject.error());
+                for (u32 ai = 0; ai < test_count; ai++) {
+                    MirBlock test_block{};
+                    test_block.label = ai == 0 ? cont_label() : match_test_label();
+                    const auto& arm = module.routes[i].control.match_arms[ai];
+                    auto arm_pattern = mir_value(arm.pattern, module, &fn);
+                    if (!arm_pattern) return core::make_unexpected(arm_pattern.error());
+                    test_block.term.kind = MirTerminatorKind::Branch;
+                    test_block.term.use_cmp = true;
+                    test_block.term.span = arm.span;
+                    test_block.term.lhs = subject.value();
+                    test_block.term.rhs = arm_pattern.value();
+                    test_block.term.then_block = arm_block_index[ai];
+                    test_block.term.else_block =
+                        ai + 1 < test_count ? (ai + 2) : arm_block_index[test_count];
+                    if (!fn.blocks.push(test_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                }
+
+                for (u32 ai = 0; ai < arm_count; ai++) {
+                    MirBlock case_block{};
+                    const auto& arm = module.routes[i].control.match_arms[ai];
+                    case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
+                    if (arm.guards.len != 0) {
+                        auto cond = mir_value(arm.guards[0].cond, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        case_block.term.kind = MirTerminatorKind::Branch;
+                        case_block.term.span = arm.guards[0].span;
+                        case_block.term.cond = cond.value();
+                        case_block.term.then_block =
+                            arm.guards.len > 1 ? arm_guard_index[ai][1] : arm_body_index[ai];
+                        case_block.term.else_block = arm_guard_fail_index[ai][0];
+                    } else if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                        case_block.term.kind = MirTerminatorKind::Branch;
+                        case_block.term.span = arm.cond.span;
+                        auto cond = mir_value(arm.cond, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        case_block.term.cond = cond.value();
+                        case_block.term.then_block = arm_then_index[ai];
+                        case_block.term.else_block = arm_else_index[ai];
+                    } else {
+                        set_term_from_hir(&case_block.term, arm.direct_term);
+                    }
+                    if (!fn.blocks.push(case_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                    for (u32 gi = 1; gi < arm.guards.len; gi++) {
+                        MirBlock guard_block{};
+                        guard_block.label = cont_label();
+                        auto cond = mir_value(arm.guards[gi].cond, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        guard_block.term.kind = MirTerminatorKind::Branch;
+                        guard_block.term.span = arm.guards[gi].span;
+                        guard_block.term.cond = cond.value();
+                        guard_block.term.then_block =
+                            gi + 1 < arm.guards.len ? arm_guard_index[ai][gi + 1] : arm_body_index[ai];
+                        guard_block.term.else_block = arm_guard_fail_index[ai][gi];
+                        if (!fn.blocks.push(guard_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                    }
+                    if (arm.guards.len != 0) {
+                        MirBlock body_block{};
+                        body_block.label = cont_label();
+                        if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                            body_block.term.kind = MirTerminatorKind::Branch;
+                            body_block.term.span = arm.cond.span;
+                            auto cond = mir_value(arm.cond, module, &fn);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            body_block.term.cond = cond.value();
+                            body_block.term.then_block = arm_then_index[ai];
+                            body_block.term.else_block = arm_else_index[ai];
+                        } else {
+                            set_term_from_hir(&body_block.term, arm.direct_term);
+                        }
+                        if (!fn.blocks.push(body_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                        for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                            auto emitted = emit_guard_fail(arm.guards[gi]);
+                            if (!emitted) return core::make_unexpected(emitted.error());
+                        }
+                    }
+                    if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                        MirBlock then_block{};
+                        then_block.label = then_label();
+                        set_term_from_hir(&then_block.term, arm.then_term);
+                        if (!fn.blocks.push(then_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                        MirBlock else_block{};
+                        else_block.label = else_label();
+                        set_term_from_hir(&else_block.term, arm.else_term);
+                        if (!fn.blocks.push(else_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                    }
+                }
+
+                for (u32 gi = 0; gi < guard_count; gi++) {
+                    auto emitted = emit_guard_fail(module.routes[i].guards[gi]);
+                    if (!emitted) return core::make_unexpected(emitted.error());
+                }
+            } else {
+                return frontend_error(FrontendError::UnsupportedSyntax, fn.span);
+            }
+        } else if (module.routes[i].control.kind == HirControlKind::If) {
+            block.term.kind = MirTerminatorKind::Branch;
+            block.term.span = module.routes[i].control.cond.span;
+            auto cond = mir_value(module.routes[i].control.cond, module, &fn);
+            if (!cond) return core::make_unexpected(cond.error());
+            block.term.cond = cond.value();
+            block.term.then_block = 1;
+            block.term.else_block = 2;
+            if (!fn.blocks.push(block))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+
+            MirBlock then_block{};
+            then_block.label = then_label();
+            set_term_from_hir(&then_block.term, module.routes[i].control.then_term);
+            if (!fn.blocks.push(then_block))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+
+            MirBlock else_block{};
+            else_block.label = else_label();
+            set_term_from_hir(&else_block.term, module.routes[i].control.else_term);
+            if (!fn.blocks.push(else_block))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+        } else if (module.routes[i].control.kind == HirControlKind::Match) {
+            const u32 arm_count = module.routes[i].control.match_arms.len;
+            const u32 test_count = arm_count - 1;
+            u32 arm_block_index[HirControl::kMaxMatchArms]{};
+            u32 arm_body_index[HirControl::kMaxMatchArms]{};
+            u32 arm_then_index[HirControl::kMaxMatchArms]{};
+            u32 arm_else_index[HirControl::kMaxMatchArms]{};
+            u32 arm_guard_index[HirControl::kMaxMatchArms][HirMatchArm::kMaxPreludeGuards]{};
+            u32 arm_guard_fail_index[HirControl::kMaxMatchArms][HirMatchArm::kMaxPreludeGuards]{};
+            u32 next_index = test_count;
+            for (u32 ai = 0; ai < arm_count; ai++) {
+                const auto& arm = module.routes[i].control.match_arms[ai];
+                arm_block_index[ai] = next_index++;
+                if (arm.guards.len != 0) {
+                    for (u32 gi = 1; gi < arm.guards.len; gi++) arm_guard_index[ai][gi] = next_index++;
+                    arm_body_index[ai] = next_index++;
+                    for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                        arm_guard_fail_index[ai][gi] = next_index;
+                        next_index += guard_fail_block_count(arm.guards[gi]);
+                    }
+                } else {
+                    arm_body_index[ai] = arm_block_index[ai];
+                }
+                if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                    arm_then_index[ai] = next_index++;
+                    arm_else_index[ai] = next_index++;
+                }
+            }
+            auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
+            if (!subject) return core::make_unexpected(subject.error());
+            if (test_count == 0) {
+                MirBlock case_block{};
+                const auto& arm = module.routes[i].control.match_arms[0];
+                case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
+                if (arm.guards.len != 0) {
+                    auto cond = mir_value(arm.guards[0].cond, module, &fn);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    case_block.term.kind = MirTerminatorKind::Branch;
+                    case_block.term.span = arm.guards[0].span;
+                    case_block.term.cond = cond.value();
+                    case_block.term.then_block =
+                        arm.guards.len > 1 ? arm_guard_index[0][1] : arm_body_index[0];
+                    case_block.term.else_block = arm_guard_fail_index[0][0];
+                } else if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                    case_block.term.kind = MirTerminatorKind::Branch;
+                    case_block.term.span = arm.cond.span;
+                    auto cond = mir_value(arm.cond, module, &fn);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    case_block.term.cond = cond.value();
+                    case_block.term.then_block = arm_then_index[0];
+                    case_block.term.else_block = arm_else_index[0];
+                } else {
+                    set_term_from_hir(&case_block.term, arm.direct_term);
+                }
+                if (!fn.blocks.push(case_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+                for (u32 gi = 1; gi < arm.guards.len; gi++) {
+                    MirBlock guard_block{};
+                    guard_block.label = cont_label();
+                    auto cond = mir_value(arm.guards[gi].cond, module, &fn);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    guard_block.term.kind = MirTerminatorKind::Branch;
+                    guard_block.term.span = arm.guards[gi].span;
+                    guard_block.term.cond = cond.value();
+                    guard_block.term.then_block =
+                        gi + 1 < arm.guards.len ? arm_guard_index[0][gi + 1] : arm_body_index[0];
+                    guard_block.term.else_block = arm_guard_fail_index[0][gi];
+                    if (!fn.blocks.push(guard_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                }
+                if (arm.guards.len != 0) {
+                    MirBlock body_block{};
+                    body_block.label = cont_label();
+                    if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                        body_block.term.kind = MirTerminatorKind::Branch;
+                        body_block.term.span = arm.cond.span;
+                        auto cond = mir_value(arm.cond, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        body_block.term.cond = cond.value();
+                        body_block.term.then_block = arm_then_index[0];
+                        body_block.term.else_block = arm_else_index[0];
+                    } else {
+                        set_term_from_hir(&body_block.term, arm.direct_term);
+                    }
+                    if (!fn.blocks.push(body_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                    for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                        auto emitted = emit_guard_fail(arm.guards[gi]);
+                        if (!emitted) return core::make_unexpected(emitted.error());
+                    }
+                }
+                if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                    MirBlock then_block{};
+                    then_block.label = then_label();
+                    set_term_from_hir(&then_block.term, arm.then_term);
+                    if (!fn.blocks.push(then_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                    MirBlock else_block{};
+                    else_block.label = else_label();
+                    set_term_from_hir(&else_block.term, arm.else_term);
+                    if (!fn.blocks.push(else_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                }
+            } else {
+                for (u32 ai = 0; ai < test_count; ai++) {
+                    MirBlock test_block{};
+                    test_block.label = match_test_label();
+                    const auto& arm = module.routes[i].control.match_arms[ai];
+                    auto arm_pattern = mir_value(arm.pattern, module, &fn);
+                    if (!arm_pattern) return core::make_unexpected(arm_pattern.error());
+                    test_block.term.kind = MirTerminatorKind::Branch;
+                    test_block.term.use_cmp = true;
+                    test_block.term.span = arm.span;
+                    test_block.term.lhs = subject.value();
+                    test_block.term.rhs = arm_pattern.value();
+                    test_block.term.then_block = arm_block_index[ai];
+                    test_block.term.else_block = ai + 1 < test_count ? ai + 1 : arm_block_index[test_count];
+                    if (!fn.blocks.push(test_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                }
+
+                for (u32 ai = 0; ai < arm_count; ai++) {
+                    MirBlock case_block{};
+                    const auto& arm = module.routes[i].control.match_arms[ai];
+                    case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
+                    if (arm.guards.len != 0) {
+                        auto cond = mir_value(arm.guards[0].cond, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        case_block.term.kind = MirTerminatorKind::Branch;
+                        case_block.term.span = arm.guards[0].span;
+                        case_block.term.cond = cond.value();
+                        case_block.term.then_block =
+                            arm.guards.len > 1 ? arm_guard_index[ai][1] : arm_body_index[ai];
+                        case_block.term.else_block = arm_guard_fail_index[ai][0];
+                    } else if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                        case_block.term.kind = MirTerminatorKind::Branch;
+                        case_block.term.span = arm.cond.span;
+                        auto cond = mir_value(arm.cond, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        case_block.term.cond = cond.value();
+                        case_block.term.then_block = arm_then_index[ai];
+                        case_block.term.else_block = arm_else_index[ai];
+                    } else {
+                        set_term_from_hir(&case_block.term, arm.direct_term);
+                    }
+                    if (!fn.blocks.push(case_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                    for (u32 gi = 1; gi < arm.guards.len; gi++) {
+                        MirBlock guard_block{};
+                        guard_block.label = cont_label();
+                        auto cond = mir_value(arm.guards[gi].cond, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        guard_block.term.kind = MirTerminatorKind::Branch;
+                        guard_block.term.span = arm.guards[gi].span;
+                        guard_block.term.cond = cond.value();
+                        guard_block.term.then_block =
+                            gi + 1 < arm.guards.len ? arm_guard_index[ai][gi + 1] : arm_body_index[ai];
+                        guard_block.term.else_block = arm_guard_fail_index[ai][gi];
+                        if (!fn.blocks.push(guard_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                    }
+                    if (arm.guards.len != 0) {
+                        MirBlock body_block{};
+                        body_block.label = cont_label();
+                        if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                            body_block.term.kind = MirTerminatorKind::Branch;
+                            body_block.term.span = arm.cond.span;
+                            auto cond = mir_value(arm.cond, module, &fn);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            body_block.term.cond = cond.value();
+                            body_block.term.then_block = arm_then_index[ai];
+                            body_block.term.else_block = arm_else_index[ai];
+                        } else {
+                            set_term_from_hir(&body_block.term, arm.direct_term);
+                        }
+                    if (!fn.blocks.push(body_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                    for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                        auto emitted = emit_guard_fail(arm.guards[gi]);
+                        if (!emitted) return core::make_unexpected(emitted.error());
+                    }
+                }
+                    if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                        MirBlock then_block{};
+                        then_block.label = then_label();
+                        set_term_from_hir(&then_block.term, arm.then_term);
+                        if (!fn.blocks.push(then_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                        MirBlock else_block{};
+                        else_block.label = else_label();
+                        set_term_from_hir(&else_block.term, arm.else_term);
+                        if (!fn.blocks.push(else_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                    }
+                }
+            }
+        } else {
+            set_term_from_hir(&block.term, module.routes[i].control.direct_term);
+            if (!fn.blocks.push(block))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+        }
+        if (!mir->functions.push(fn))
+            return frontend_error(FrontendError::TooManyItems, fn.span);
+    }
+
+    return mir;
+}
+
+}  // namespace rut

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1068,6 +1068,7 @@ struct Parser {
 
         if (!take(TokenType::RParen)) {
             while (true) {
+                const bool has_underscore = take(TokenType::Underscore) != nullptr;
                 auto param_name = expect(TokenType::Ident);
                 if (!param_name) return core::make_unexpected(param_name.error());
                 auto colon = expect(TokenType::Colon);
@@ -1077,6 +1078,7 @@ struct Parser {
                 AstFunctionDecl::ParamDecl param{};
                 param.name = param_name.value()->text;
                 param.type = type_ref.value();
+                param.has_underscore_label = has_underscore;
                 if (!item.func.params.push(param))
                     return frontend_error(FrontendError::TooManyItems, span_from(*param_name.value()));
                 if (take(TokenType::RParen)) break;
@@ -1185,6 +1187,7 @@ struct Parser {
             if (!lparen) return core::make_unexpected(lparen.error());
             if (!take(TokenType::RParen)) {
                 while (true) {
+                    const bool has_underscore = take(TokenType::Underscore) != nullptr;
                     auto param_name = expect(TokenType::Ident);
                     if (!param_name) return core::make_unexpected(param_name.error());
                     auto colon = expect(TokenType::Colon);
@@ -1194,6 +1197,7 @@ struct Parser {
                     AstProtocolDecl::MethodDecl::ParamDecl param{};
                     param.name = param_name.value()->text;
                     param.type = type_ref.value();
+                    param.has_underscore_label = has_underscore;
                     if (!method.params.push(param))
                         return frontend_error(FrontendError::TooManyItems, span_from(*param_name.value()));
                     if (take(TokenType::RParen)) break;
@@ -1397,27 +1401,39 @@ struct Parser {
         return item;
     }
 
-    FrontendResult<AstItem> parse_route() {
-        auto kw = expect(TokenType::KwRoute);
-        if (!kw) return core::make_unexpected(kw.error());
+    static bool is_method_keyword(TokenType t) {
+        return t == TokenType::KwGet || t == TokenType::KwPost || t == TokenType::KwPut ||
+               t == TokenType::KwDelete || t == TokenType::KwPatch || t == TokenType::KwHead ||
+               t == TokenType::KwOptions;
+    }
+
+    FrontendResult<AstDecorator> parse_decorator_atom() {
+        auto at = expect(TokenType::At);
+        if (!at) return core::make_unexpected(at.error());
+        auto name_tok = expect(TokenType::Ident);
+        if (!name_tok) return core::make_unexpected(name_tok.error());
+        AstDecorator d{};
+        d.name = name_tok.value()->text;
+        d.span = Span{at.value()->start, name_tok.value()->end, at.value()->line, at.value()->col};
+        return d;
+    }
+
+    static bool binding_matches(Str pattern, bool is_wildcard, Str path) {
+        if (is_wildcard) return true;
+        if (path.len < pattern.len) return false;
+        for (u32 i = 0; i < pattern.len; i++) {
+            if (path.ptr[i] != pattern.ptr[i]) return false;
+        }
+        return true;
+    }
+
+    FrontendResult<AstItem> parse_route_entry(const Token& kw_route) {
         AstItem item{};
         item.kind = AstItemKind::Route;
-
         const Token* method = nullptr;
-        switch (cur().type) {
-            case TokenType::KwGet:
-            case TokenType::KwPost:
-            case TokenType::KwPut:
-            case TokenType::KwDelete:
-            case TokenType::KwPatch:
-            case TokenType::KwHead:
-            case TokenType::KwOptions:
-                method = &toks->tokens[pos++];
-                break;
-            default:
-                return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
-        }
-
+        if (!is_method_keyword(cur().type))
+            return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
+        method = &toks->tokens[pos++];
         auto path = expect(TokenType::StringLit);
         if (!path) return core::make_unexpected(path.error());
         auto lbrace = expect(TokenType::LBrace);
@@ -1433,13 +1449,84 @@ struct Parser {
         if (!rbrace) return core::make_unexpected(rbrace.error());
         if (item.route.statements.len == 0)
             return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
-
-        item.span = Span{kw.value()->start, rbrace.value()->end, kw.value()->line, kw.value()->col};
+        item.span = Span{kw_route.start, rbrace.value()->end, kw_route.line, kw_route.col};
         item.route.span = item.span;
         item.route.body_span = Span{lbrace.value()->start, rbrace.value()->end, lbrace.value()->line, lbrace.value()->col};
         item.route.method = static_cast<u8>(method->type);
         item.route.path = path.value()->text;
         return item;
+    }
+
+    FrontendResult<AstItem> parse_route() {
+        auto kw = expect(TokenType::KwRoute);
+        if (!kw) return core::make_unexpected(kw.error());
+        return parse_route_entry(*kw.value());
+    }
+
+    // Block form: route { @binding "pattern"...  @entry-decorator method "path" { stmts } ... }
+    // Pushes one AstItem::Route per entry into file->items; bindings are matched against entry
+    // paths and merged into each entry's `decorators` list at parse time.
+    FrontendResult<u32> parse_route_block() {
+        auto kw = expect(TokenType::KwRoute);
+        if (!kw) return core::make_unexpected(kw.error());
+        auto lbrace = expect(TokenType::LBrace);
+        if (!lbrace) return core::make_unexpected(lbrace.error());
+
+        struct PendingBinding {
+            AstDecorator decorator{};
+            Str pattern{};
+            bool is_wildcard = false;
+        };
+        static constexpr u32 kMaxBindings = AstRouteDecl::kMaxDecorators;
+        FixedVec<PendingBinding, kMaxBindings> bindings;
+
+        // Phase 1: bindings — `@ident "pattern"` while next-after-@ident is StringLit.
+        while (cur().type == TokenType::At &&
+               peek().type == TokenType::Ident &&
+               peek(2).type == TokenType::StringLit) {
+            auto deco = parse_decorator_atom();
+            if (!deco) return core::make_unexpected(deco.error());
+            auto pat = expect(TokenType::StringLit);
+            if (!pat) return core::make_unexpected(pat.error());
+            PendingBinding pb{};
+            pb.decorator = deco.value();
+            pb.pattern = pat.value()->text;
+            pb.is_wildcard = pb.pattern.len == 1 && pb.pattern.ptr[0] == '*';
+            if (!bindings.push(pb))
+                return frontend_error(FrontendError::TooManyItems, deco->span);
+        }
+
+        // Phase 2: entries (with optional entry-prefix decorators).
+        u32 emitted = 0;
+        while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+            FixedVec<AstDecorator, AstRouteDecl::kMaxDecorators> entry_decorators;
+            while (cur().type == TokenType::At) {
+                auto deco = parse_decorator_atom();
+                if (!deco) return core::make_unexpected(deco.error());
+                if (!entry_decorators.push(deco.value()))
+                    return frontend_error(FrontendError::TooManyItems, deco->span);
+            }
+            auto entry = parse_route_entry(*kw.value());
+            if (!entry) return core::make_unexpected(entry.error());
+            for (u32 i = 0; i < bindings.len; i++) {
+                if (binding_matches(bindings[i].pattern, bindings[i].is_wildcard, entry->route.path)) {
+                    if (!entry->route.decorators.push(bindings[i].decorator))
+                        return frontend_error(FrontendError::TooManyItems, bindings[i].decorator.span);
+                }
+            }
+            for (u32 i = 0; i < entry_decorators.len; i++) {
+                if (!entry->route.decorators.push(entry_decorators[i]))
+                    return frontend_error(FrontendError::TooManyItems, entry_decorators[i].span);
+            }
+            if (!file->items.push(entry.value()))
+                return frontend_error(FrontendError::TooManyItems, entry->span);
+            emitted++;
+        }
+        auto rbrace = expect(TokenType::RBrace);
+        if (!rbrace) return core::make_unexpected(rbrace.error());
+        if (emitted == 0)
+            return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+        return emitted;
     }
 };
 
@@ -1484,6 +1571,11 @@ FrontendResult<AstFile*> parse_file(const LexedTokens& tokens) {
                 item = p.parse_variant();
                 break;
             case TokenType::KwRoute:
+                if (p.peek().type == TokenType::LBrace) {
+                    auto block = p.parse_route_block();
+                    if (!block) return core::make_unexpected(block.error());
+                    continue;
+                }
                 item = p.parse_route();
                 break;
             default:

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1299,10 +1299,7 @@ struct Parser {
         }
         auto rbrace = expect(TokenType::RBrace);
         if (!rbrace) return core::make_unexpected(rbrace.error());
-        item.span = Span{target.value().name.ptr != nullptr ? kw.value()->start : kw.value()->start,
-                         rbrace.value()->end,
-                         kw.value()->line,
-                         kw.value()->col};
+        item.span = Span{kw.value()->start, rbrace.value()->end, kw.value()->line, kw.value()->col};
         item.impl_decl.span = item.span;
         return item;
     }

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1,0 +1,1504 @@
+#include "rut/compiler/parser.h"
+
+#include <memory>
+
+namespace rut {
+
+namespace {
+
+struct Parser {
+    const LexedTokens* toks = nullptr;
+    AstFile* file = nullptr;
+    u32 pos = 0;
+
+    const Token& cur() const { return toks->tokens[pos]; }
+    const Token& prev() const { return toks->tokens[pos - 1]; }
+    const Token& peek(u32 offset = 1) const {
+        const u32 idx = pos + offset;
+        if (idx >= toks->tokens.len) return toks->tokens[toks->tokens.len - 1];
+        return toks->tokens[idx];
+    }
+
+    static Span span_from(const Token& tok) {
+        return Span{tok.start, tok.end, tok.line, tok.col};
+    }
+
+    const Token* take(TokenType type) {
+        if (cur().type != type) return nullptr;
+        return &toks->tokens[pos++];
+    }
+
+    FrontendResult<const Token*> expect(TokenType type) {
+        if (cur().type == type) return &toks->tokens[pos++];
+        if (cur().type == TokenType::Eof) return frontend_error(FrontendError::UnexpectedEof, span_from(cur()));
+        return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
+    }
+
+    FrontendResult<const Token*> expect_field_name() {
+        if (cur().type == TokenType::Ident || cur().type == TokenType::KwFunc) return &toks->tokens[pos++];
+        if (cur().type == TokenType::Eof) return frontend_error(FrontendError::UnexpectedEof, span_from(cur()));
+        return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
+    }
+
+    FrontendResult<AstExpr*> alloc_expr(const AstExpr& expr) {
+        if (!file->expr_pool.push(expr))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        return &file->expr_pool[file->expr_pool.len - 1];
+    }
+
+    FrontendResult<AstStatement*> alloc_stmt(const AstStatement& stmt) {
+        if (!file->stmt_pool.push(stmt))
+            return frontend_error(FrontendError::TooManyItems, stmt.span);
+        return &file->stmt_pool[file->stmt_pool.len - 1];
+    }
+
+    FrontendResult<AstTypeRef*> alloc_type(const AstTypeRef& type) {
+        if (!file->type_pool.push(type))
+            return frontend_error(FrontendError::TooManyItems, Span{});
+        return &file->type_pool[file->type_pool.len - 1];
+    }
+
+    FrontendResult<AstStatement> parse_braced_stmt_body(const Token& lbrace_tok) {
+        AstStatement block{};
+        block.kind = AstStmtKind::Block;
+        block.span = span_from(lbrace_tok);
+        while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+            auto inner = parse_stmt();
+            if (!inner) return core::make_unexpected(inner.error());
+            auto inner_ptr = alloc_stmt(inner.value());
+            if (!inner_ptr) return core::make_unexpected(inner_ptr.error());
+            if (!block.block_stmts.push(inner_ptr.value()))
+                return frontend_error(FrontendError::TooManyItems, inner->span);
+        }
+        auto rbrace = expect(TokenType::RBrace);
+        if (!rbrace) return core::make_unexpected(rbrace.error());
+        if (block.block_stmts.len == 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, span_from(*rbrace.value()));
+        block.span.end = rbrace.value()->end;
+        if (block.block_stmts.len == 1) return *block.block_stmts[0];
+        return block;
+    }
+
+    FrontendResult<AstStatement> parse_func_guard_stmt(const Token& guard_tok) {
+        AstStatement stmt{};
+        stmt.kind = AstStmtKind::Guard;
+        const bool is_match_guard = take(TokenType::KwMatch) != nullptr;
+        if (!is_match_guard && take(TokenType::KwLet)) {
+            auto name = expect(TokenType::Ident);
+            if (!name) return core::make_unexpected(name.error());
+            auto eq = expect(TokenType::Eq);
+            if (!eq) return core::make_unexpected(eq.error());
+            stmt.name = name.value()->text;
+            stmt.bind_value = true;
+        }
+        auto cond = parse_expr();
+        if (!cond) return core::make_unexpected(cond.error());
+        stmt.expr = cond.value();
+        auto kw_else = expect(TokenType::KwElse);
+        if (!kw_else) return core::make_unexpected(kw_else.error());
+        auto lbrace = expect(TokenType::LBrace);
+        if (!lbrace) return core::make_unexpected(lbrace.error());
+        if (is_match_guard) {
+            while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+                auto kw_case = expect(TokenType::KwCase);
+                if (!kw_case) return core::make_unexpected(kw_case.error());
+                AstStatement::MatchArm arm{};
+                arm.span = span_from(*kw_case.value());
+                if (take(TokenType::Underscore)) {
+                    arm.is_wildcard = true;
+                } else {
+                    auto pattern = parse_primary_expr();
+                    if (!pattern) return core::make_unexpected(pattern.error());
+                    arm.pattern = pattern.value();
+                }
+                auto arrow = expect(TokenType::Arrow);
+                if (!arrow) return core::make_unexpected(arrow.error());
+                auto arm_stmt = parse_func_body_stmt();
+                if (!arm_stmt) return core::make_unexpected(arm_stmt.error());
+                auto arm_ptr = alloc_stmt(arm_stmt.value());
+                if (!arm_ptr) return core::make_unexpected(arm_ptr.error());
+                arm.stmt = arm_ptr.value();
+                arm.span.end = arm_ptr.value()->span.end;
+                if (!stmt.match_arms.push(arm))
+                    return frontend_error(FrontendError::TooManyItems, arm.span);
+            }
+            auto rbrace = expect(TokenType::RBrace);
+            if (!rbrace) return core::make_unexpected(rbrace.error());
+            if (stmt.match_arms.len == 0)
+                return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+            stmt.span = Span{guard_tok.start, rbrace.value()->end, guard_tok.line, guard_tok.col};
+            return stmt;
+        }
+        auto else_stmt = parse_func_body_stmt();
+        if (!else_stmt) return core::make_unexpected(else_stmt.error());
+        auto rbrace = expect(TokenType::RBrace);
+        if (!rbrace) return core::make_unexpected(rbrace.error());
+        auto else_ptr = alloc_stmt(else_stmt.value());
+        if (!else_ptr) return core::make_unexpected(else_ptr.error());
+        stmt.else_stmt = else_ptr.value();
+        stmt.span = Span{guard_tok.start, rbrace.value()->end, guard_tok.line, guard_tok.col};
+        return stmt;
+    }
+
+    FrontendResult<AstExpr> parse_primary_atom() {
+        const Token start = cur();
+        AstExpr expr{};
+        if (take(TokenType::LParen)) {
+            auto first = parse_expr();
+            if (!first) return core::make_unexpected(first.error());
+            if (!take(TokenType::Comma)) {
+                auto rparen = expect(TokenType::RParen);
+                if (!rparen) return core::make_unexpected(rparen.error());
+                return first.value();
+            }
+
+            AstExpr tuple{};
+            tuple.kind = AstExprKind::Tuple;
+            auto first_ptr = alloc_expr(first.value());
+            if (!first_ptr) return core::make_unexpected(first_ptr.error());
+            if (!tuple.args.push(first_ptr.value()))
+                return frontend_error(FrontendError::TooManyItems, first->span);
+            while (true) {
+                auto elem = parse_expr();
+                if (!elem) return core::make_unexpected(elem.error());
+                auto elem_ptr = alloc_expr(elem.value());
+                if (!elem_ptr) return core::make_unexpected(elem_ptr.error());
+                if (!tuple.args.push(elem_ptr.value()))
+                    return frontend_error(FrontendError::TooManyItems, elem->span);
+                if (take(TokenType::RParen)) break;
+                auto comma = expect(TokenType::Comma);
+                if (!comma) return core::make_unexpected(comma.error());
+            }
+            tuple.span = Span{start.start, prev().end, start.line, start.col};
+            return tuple;
+        }
+        if (take(TokenType::Underscore)) {
+            expr.kind = AstExprKind::Placeholder;
+            expr.int_value = 1;
+            expr.span = span_from(prev());
+            return expr;
+        }
+        if (take(TokenType::Dot)) {
+            auto case_name = expect(TokenType::Ident);
+            if (!case_name) return core::make_unexpected(case_name.error());
+            expr.kind = AstExprKind::VariantCase;
+            expr.str_value = case_name.value()->text;
+            if (take(TokenType::LParen)) {
+                auto payload = parse_expr();
+                if (!payload) return core::make_unexpected(payload.error());
+                auto rparen = expect(TokenType::RParen);
+                if (!rparen) return core::make_unexpected(rparen.error());
+                auto payload_ptr = alloc_expr(payload.value());
+                if (!payload_ptr) return core::make_unexpected(payload_ptr.error());
+                expr.lhs = payload_ptr.value();
+                expr.span = Span{start.start, rparen.value()->end, start.line, start.col};
+                return expr;
+            }
+            expr.span = Span{start.start, case_name.value()->end, start.line, start.col};
+            return expr;
+        }
+        if (take(TokenType::KwOr)) {
+            auto lparen = expect(TokenType::LParen);
+            if (!lparen) return core::make_unexpected(lparen.error());
+            auto lhs = parse_expr();
+            if (!lhs) return core::make_unexpected(lhs.error());
+            auto comma = expect(TokenType::Comma);
+            if (!comma) return core::make_unexpected(comma.error());
+            auto rhs = parse_expr();
+            if (!rhs) return core::make_unexpected(rhs.error());
+            auto rparen = expect(TokenType::RParen);
+            if (!rparen) return core::make_unexpected(rparen.error());
+            auto lhs_ptr = alloc_expr(lhs.value());
+            if (!lhs_ptr) return core::make_unexpected(lhs_ptr.error());
+            auto rhs_ptr = alloc_expr(rhs.value());
+            if (!rhs_ptr) return core::make_unexpected(rhs_ptr.error());
+            expr.kind = AstExprKind::Or;
+            expr.lhs = lhs_ptr.value();
+            expr.rhs = rhs_ptr.value();
+            expr.span = Span{start.start, rparen.value()->end, start.line, start.col};
+            return expr;
+        }
+        if (take(TokenType::KwTrue)) {
+            expr.kind = AstExprKind::BoolLit;
+            expr.bool_value = true;
+            expr.span = span_from(prev());
+            return expr;
+        }
+        if (take(TokenType::KwFalse)) {
+            expr.kind = AstExprKind::BoolLit;
+            expr.bool_value = false;
+            expr.span = span_from(prev());
+            return expr;
+        }
+        if (take(TokenType::KwNil)) {
+            expr.kind = AstExprKind::Nil;
+            expr.span = span_from(prev());
+            return expr;
+        }
+        if (take(TokenType::KwError)) {
+            auto lparen = expect(TokenType::LParen);
+            if (!lparen) return core::make_unexpected(lparen.error());
+            if (cur().type == TokenType::Ident && peek().type == TokenType::Comma) {
+                auto type_name = expect(TokenType::Ident);
+                if (!type_name) return core::make_unexpected(type_name.error());
+                expr.name = type_name.value()->text;
+                auto comma = expect(TokenType::Comma);
+                if (!comma) return core::make_unexpected(comma.error());
+            }
+            auto arg = parse_expr();
+            if (!arg) return core::make_unexpected(arg.error());
+            Str msg{};
+            if (take(TokenType::Comma)) {
+                auto msg_expr = parse_expr();
+                if (!msg_expr) return core::make_unexpected(msg_expr.error());
+                if (msg_expr->kind != AstExprKind::StrLit)
+                    return frontend_error(FrontendError::UnsupportedSyntax, msg_expr->span);
+                msg = msg_expr->str_value;
+                while (take(TokenType::Comma)) {
+                    auto field_name = expect_field_name();
+                    if (!field_name) return core::make_unexpected(field_name.error());
+                    auto colon = expect(TokenType::Colon);
+                    if (!colon) return core::make_unexpected(colon.error());
+                    auto field_value = parse_expr();
+                    if (!field_value) return core::make_unexpected(field_value.error());
+                    auto field_value_ptr = alloc_expr(field_value.value());
+                    if (!field_value_ptr) return core::make_unexpected(field_value_ptr.error());
+                    AstExpr::FieldInit field_init{};
+                    field_init.name = field_name.value()->text;
+                    field_init.value = field_value_ptr.value();
+                    if (!expr.field_inits.push(field_init))
+                        return frontend_error(FrontendError::TooManyItems, field_value->span);
+                }
+            }
+            auto rparen = expect(TokenType::RParen);
+            if (!rparen) return core::make_unexpected(rparen.error());
+            auto arg_ptr = alloc_expr(arg.value());
+            if (!arg_ptr) return core::make_unexpected(arg_ptr.error());
+            expr.kind = AstExprKind::Error;
+            expr.lhs = arg_ptr.value();
+            expr.msg = msg;
+            expr.span = Span{start.start, rparen.value()->end, start.line, start.col};
+            return expr;
+        }
+        if (cur().type == TokenType::IntLit) {
+            const Token tok = cur();
+            pos++;
+            i32 value = 0;
+            for (u32 i = 0; i < tok.text.len; i++) {
+                const u32 digit = static_cast<u32>(tok.text.ptr[i] - '0');
+                if (value > (static_cast<i32>(0x7fffffff) - static_cast<i32>(digit)) / 10)
+                    return frontend_error(FrontendError::InvalidInteger, span_from(tok), tok.text);
+                value = value * 10 + static_cast<i32>(digit);
+            }
+            expr.kind = AstExprKind::IntLit;
+            expr.int_value = value;
+            expr.span = span_from(tok);
+            return expr;
+        }
+        if (cur().type == TokenType::StringLit) {
+            const Token tok = cur();
+            pos++;
+            expr.kind = AstExprKind::StrLit;
+            expr.str_value = tok.text;
+            expr.span = span_from(tok);
+            return expr;
+        }
+        if (cur().type == TokenType::Ident && cur().text.eq({"req", 3}) &&
+            peek().type == TokenType::Dot && peek(2).type == TokenType::Ident &&
+            peek(2).text.eq({"header", 6})) {
+            const Token start_tok = cur();
+            pos += 3;  // req . header
+            auto lparen = expect(TokenType::LParen);
+            if (!lparen) return core::make_unexpected(lparen.error());
+            auto name = expect(TokenType::StringLit);
+            if (!name) return core::make_unexpected(name.error());
+            auto rparen = expect(TokenType::RParen);
+            if (!rparen) return core::make_unexpected(rparen.error());
+            expr.kind = AstExprKind::ReqHeader;
+            expr.str_value = name.value()->text;
+            expr.span = Span{start_tok.start, rparen.value()->end, start_tok.line, start_tok.col};
+            return expr;
+        }
+        auto ident = expect(TokenType::Ident);
+        if (!ident) return core::make_unexpected(ident.error());
+        if (ident.value()->text.len >= 2 && ident.value()->text.ptr[0] == '_') {
+            bool all_digits = true;
+            i32 index = 0;
+            for (u32 i = 1; i < ident.value()->text.len; i++) {
+                const char ch = ident.value()->text.ptr[i];
+                if (ch < '0' || ch > '9') {
+                    all_digits = false;
+                    break;
+                }
+                index = index * 10 + static_cast<i32>(ch - '0');
+            }
+            if (all_digits && index > 0) {
+                if (index > 10)
+                    return frontend_error(FrontendError::UnsupportedSyntax, span_from(*ident.value()));
+                expr.kind = AstExprKind::Placeholder;
+                expr.int_value = index;
+                expr.span = span_from(*ident.value());
+                return expr;
+            }
+        }
+        expr.kind = AstExprKind::Ident;
+        expr.name = ident.value()->text;
+        expr.span = span_from(*ident.value());
+        return expr;
+    }
+
+    FrontendResult<AstExpr> parse_primary_expr() {
+        auto base = parse_primary_atom();
+        if (!base) return core::make_unexpected(base.error());
+        AstExpr expr = base.value();
+        while (true) {
+            if (expr.kind == AstExprKind::Ident && expr.type_args.len == 0 && cur().type == TokenType::Lt) {
+                const u32 saved_pos = pos;
+                pos++;
+                FixedVec<AstTypeRef, AstExpr::kMaxTypeArgs> parsed_type_args;
+                bool parsed_ok = false;
+                while (true) {
+                    auto type_arg = parse_func_type_ref();
+                    if (!type_arg) {
+                        pos = saved_pos;
+                        break;
+                    }
+                    if (!parsed_type_args.push(type_arg.value()))
+                        return frontend_error(FrontendError::TooManyItems, expr.span);
+                    if (take(TokenType::Gt)) {
+                        if (cur().type == TokenType::LParen || cur().type == TokenType::Dot) {
+                            expr.type_args = parsed_type_args;
+                            parsed_ok = true;
+                        } else {
+                            pos = saved_pos;
+                        }
+                        break;
+                    }
+                    if (!take(TokenType::Comma)) {
+                        pos = saved_pos;
+                        break;
+                    }
+                }
+                if (parsed_ok) continue;
+            }
+            if (take(TokenType::LParen)) {
+                if (expr.kind != AstExprKind::Ident)
+                    return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+                if (!take(TokenType::RParen) &&
+                    (cur().type == TokenType::Ident || cur().type == TokenType::KwFunc) &&
+                    peek().type == TokenType::Colon) {
+                    AstExpr init{};
+                    init.kind = AstExprKind::StructInit;
+                    init.name = expr.name;
+                    init.type_args = expr.type_args;
+                    init.span = expr.span;
+                    while (true) {
+                        auto field_name = expect_field_name();
+                        if (!field_name) return core::make_unexpected(field_name.error());
+                        auto colon = expect(TokenType::Colon);
+                        if (!colon) return core::make_unexpected(colon.error());
+                        auto field_value = parse_expr();
+                        if (!field_value) return core::make_unexpected(field_value.error());
+                        auto field_value_ptr = alloc_expr(field_value.value());
+                        if (!field_value_ptr) return core::make_unexpected(field_value_ptr.error());
+                        AstExpr::FieldInit field_init{};
+                        field_init.name = field_name.value()->text;
+                        field_init.value = field_value_ptr.value();
+                        if (!init.field_inits.push(field_init))
+                            return frontend_error(FrontendError::TooManyItems, field_value->span);
+                        if (take(TokenType::RParen)) break;
+                        auto comma = expect(TokenType::Comma);
+                        if (!comma) return core::make_unexpected(comma.error());
+                    }
+                    init.span.end = prev().end;
+                    expr = init;
+                } else {
+                    AstExpr call{};
+                    call.kind = AstExprKind::Call;
+                    call.name = expr.name;
+                    call.type_args = expr.type_args;
+                    call.span = expr.span;
+                    if (prev().type != TokenType::RParen) {
+                        while (true) {
+                            auto arg = parse_expr();
+                            if (!arg) return core::make_unexpected(arg.error());
+                            auto arg_ptr = alloc_expr(arg.value());
+                            if (!arg_ptr) return core::make_unexpected(arg_ptr.error());
+                            if (!call.args.push(arg_ptr.value()))
+                                return frontend_error(FrontendError::TooManyItems, arg->span);
+                            if (take(TokenType::RParen)) break;
+                            auto comma = expect(TokenType::Comma);
+                            if (!comma) return core::make_unexpected(comma.error());
+                        }
+                    }
+                    call.span.end = prev().end;
+                    expr = call;
+                }
+                continue;
+            }
+            if (!take(TokenType::Dot)) break;
+            const Token* field_name = nullptr;
+            if (cur().type == TokenType::Ident || cur().type == TokenType::KwFunc) {
+                field_name = &cur();
+                pos++;
+            } else {
+                auto expected = expect(TokenType::Ident);
+                if (!expected) return core::make_unexpected(expected.error());
+                field_name = expected.value();
+            }
+            auto lhs_ptr = alloc_expr(expr);
+            if (!lhs_ptr) return core::make_unexpected(lhs_ptr.error());
+            AstExpr field{};
+            field.kind = AstExprKind::Field;
+            field.lhs = lhs_ptr.value();
+            field.name = field_name->text;
+            field.span = Span{expr.span.start, field_name->end, expr.span.line, expr.span.col};
+            if (cur().type == TokenType::Lt) {
+                const u32 saved_pos = pos;
+                pos++;
+                FixedVec<AstTypeRef, AstExpr::kMaxTypeArgs> parsed_type_args;
+                bool parsed_ok = false;
+                while (true) {
+                    auto type_arg = parse_func_type_ref();
+                    if (!type_arg) {
+                        pos = saved_pos;
+                        break;
+                    }
+                    if (!parsed_type_args.push(type_arg.value()))
+                        return frontend_error(FrontendError::TooManyItems, field.span);
+                    if (take(TokenType::Gt)) {
+                        if (cur().type == TokenType::LParen || cur().type == TokenType::Dot) {
+                            field.type_args = parsed_type_args;
+                            parsed_ok = true;
+                        } else {
+                            pos = saved_pos;
+                        }
+                        break;
+                    }
+                    if (!take(TokenType::Comma)) {
+                        pos = saved_pos;
+                        break;
+                    }
+                }
+                if (parsed_ok) {
+                    field.span.end = prev().end;
+                }
+            }
+            if (take(TokenType::LParen)) {
+                const u32 after_lparen = pos;
+                const bool maybe_named_init = expr.kind == AstExprKind::Ident && cur().type != TokenType::RParen &&
+                                              (cur().type == TokenType::Ident || cur().type == TokenType::KwFunc) &&
+                                              peek().type == TokenType::Colon;
+                if (maybe_named_init) {
+                    AstExpr init{};
+                    init.kind = AstExprKind::StructInit;
+                    init.lhs = lhs_ptr.value();
+                    init.name = field.name;
+                    init.span = field.span;
+                    while (true) {
+                        auto field_name = expect_field_name();
+                        if (!field_name) return core::make_unexpected(field_name.error());
+                        auto colon = expect(TokenType::Colon);
+                        if (!colon) return core::make_unexpected(colon.error());
+                        auto field_value = parse_expr();
+                        if (!field_value) return core::make_unexpected(field_value.error());
+                        auto field_value_ptr = alloc_expr(field_value.value());
+                        if (!field_value_ptr) return core::make_unexpected(field_value_ptr.error());
+                        AstExpr::FieldInit field_init{};
+                        field_init.name = field_name.value()->text;
+                        field_init.value = field_value_ptr.value();
+                        if (!init.field_inits.push(field_init))
+                            return frontend_error(FrontendError::TooManyItems, field_value->span);
+                        if (take(TokenType::RParen)) break;
+                        auto comma = expect(TokenType::Comma);
+                        if (!comma) return core::make_unexpected(comma.error());
+                    }
+                    init.span.end = prev().end;
+                    expr = init;
+                } else {
+                    pos = after_lparen;
+                    AstExpr method{};
+                    method.kind = AstExprKind::MethodCall;
+                    method.lhs = lhs_ptr.value();
+                    method.name = field.name;
+                    method.span = field.span;
+                    if (!take(TokenType::RParen)) {
+                        while (true) {
+                            auto arg = parse_expr();
+                            if (!arg) return core::make_unexpected(arg.error());
+                            auto arg_ptr = alloc_expr(arg.value());
+                            if (!arg_ptr) return core::make_unexpected(arg_ptr.error());
+                            if (!method.args.push(arg_ptr.value()))
+                                return frontend_error(FrontendError::TooManyItems, arg->span);
+                            if (take(TokenType::RParen)) break;
+                            auto comma = expect(TokenType::Comma);
+                            if (!comma) return core::make_unexpected(comma.error());
+                        }
+                    }
+                    method.span.end = prev().end;
+                    expr = method;
+                }
+            } else {
+                expr = field;
+            }
+        }
+        return expr;
+    }
+
+    FrontendResult<AstExpr> parse_eq_expr() {
+        auto lhs = parse_primary_expr();
+        if (!lhs) return core::make_unexpected(lhs.error());
+        TokenType op = TokenType::Error;
+        if (take(TokenType::EqEq)) op = TokenType::EqEq;
+        else if (take(TokenType::Lt)) op = TokenType::Lt;
+        else if (take(TokenType::Gt)) op = TokenType::Gt;
+        else return lhs.value();
+        auto rhs = parse_primary_expr();
+        if (!rhs) return core::make_unexpected(rhs.error());
+        auto lhs_ptr = alloc_expr(lhs.value());
+        if (!lhs_ptr) return core::make_unexpected(lhs_ptr.error());
+        auto rhs_ptr = alloc_expr(rhs.value());
+        if (!rhs_ptr) return core::make_unexpected(rhs_ptr.error());
+        AstExpr expr{};
+        expr.kind = op == TokenType::EqEq ? AstExprKind::Eq : (op == TokenType::Lt ? AstExprKind::Lt : AstExprKind::Gt);
+        expr.lhs = lhs_ptr.value();
+        expr.rhs = rhs_ptr.value();
+        expr.span = Span{lhs->span.start, rhs->span.end, lhs->span.line, lhs->span.col};
+        return expr;
+    }
+
+    FrontendResult<AstExpr> parse_expr() {
+        auto lhs = parse_eq_expr();
+        if (!lhs) return core::make_unexpected(lhs.error());
+        while (take(TokenType::Pipe)) {
+            auto rhs = parse_eq_expr();
+            if (!rhs) return core::make_unexpected(rhs.error());
+            auto lhs_ptr = alloc_expr(lhs.value());
+            if (!lhs_ptr) return core::make_unexpected(lhs_ptr.error());
+            auto rhs_ptr = alloc_expr(rhs.value());
+            if (!rhs_ptr) return core::make_unexpected(rhs_ptr.error());
+            AstExpr expr{};
+            expr.kind = AstExprKind::Pipe;
+            expr.lhs = lhs_ptr.value();
+            expr.rhs = rhs_ptr.value();
+            expr.span = Span{lhs->span.start, rhs->span.end, lhs->span.line, lhs->span.col};
+            lhs = expr;
+        }
+        return lhs.value();
+    }
+
+    FrontendResult<AstStatement> parse_stmt() {
+        const Token start = cur();
+        if (take(TokenType::LBrace)) {
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::Block;
+            stmt.span = span_from(start);
+            while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+                auto inner = parse_stmt();
+                if (!inner) return core::make_unexpected(inner.error());
+                auto inner_ptr = alloc_stmt(inner.value());
+                if (!inner_ptr) return core::make_unexpected(inner_ptr.error());
+                if (!stmt.block_stmts.push(inner_ptr.value()))
+                    return frontend_error(FrontendError::TooManyItems, inner->span);
+            }
+            auto rbrace = expect(TokenType::RBrace);
+            if (!rbrace) return core::make_unexpected(rbrace.error());
+            if (stmt.block_stmts.len == 0)
+                return frontend_error(FrontendError::UnsupportedSyntax, span_from(*rbrace.value()));
+            stmt.span.end = rbrace.value()->end;
+            return stmt;
+        }
+        if (take(TokenType::KwLet)) {
+            auto name = expect(TokenType::Ident);
+            if (!name) return core::make_unexpected(name.error());
+            AstTypeRef type_ref{};
+            bool has_type = false;
+            if (take(TokenType::Colon)) {
+                auto parsed_type = parse_func_type_ref();
+                if (!parsed_type) return core::make_unexpected(parsed_type.error());
+                type_ref = parsed_type.value();
+                has_type = true;
+            }
+            auto eq = expect(TokenType::Eq);
+            if (!eq) return core::make_unexpected(eq.error());
+            auto init = parse_expr();
+            if (!init) return core::make_unexpected(init.error());
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::Let;
+            stmt.name = name.value()->text;
+            stmt.has_type = has_type;
+            stmt.type = type_ref;
+            stmt.expr = init.value();
+            stmt.span = Span{start.start, init->span.end, start.line, start.col};
+            return stmt;
+        }
+        if (take(TokenType::KwGuard)) {
+            const bool is_match_guard = take(TokenType::KwMatch) != nullptr;
+            Str bind_name{};
+            bool bind_value = false;
+            if (!is_match_guard && take(TokenType::KwLet)) {
+                auto name = expect(TokenType::Ident);
+                if (!name) return core::make_unexpected(name.error());
+                auto eq = expect(TokenType::Eq);
+                if (!eq) return core::make_unexpected(eq.error());
+                bind_name = name.value()->text;
+                bind_value = true;
+            }
+            auto cond = parse_expr();
+            if (!cond) return core::make_unexpected(cond.error());
+            auto kw_else = expect(TokenType::KwElse);
+            if (!kw_else) return core::make_unexpected(kw_else.error());
+            auto lbrace = expect(TokenType::LBrace);
+            if (!lbrace) return core::make_unexpected(lbrace.error());
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::Guard;
+            stmt.name = bind_name;
+            stmt.bind_value = bind_value;
+            stmt.expr = cond.value();
+            if (is_match_guard) {
+                while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+                    auto kw_case = expect(TokenType::KwCase);
+                    if (!kw_case) return core::make_unexpected(kw_case.error());
+                    AstStatement::MatchArm arm{};
+                    arm.span = span_from(*kw_case.value());
+                    if (take(TokenType::Underscore)) {
+                        arm.is_wildcard = true;
+                    } else {
+                        auto pattern = parse_primary_expr();
+                        if (!pattern) return core::make_unexpected(pattern.error());
+                        arm.pattern = pattern.value();
+                    }
+                    auto colon = expect(TokenType::Colon);
+                    if (!colon) return core::make_unexpected(colon.error());
+                    auto arm_stmt = parse_stmt();
+                    if (!arm_stmt) return core::make_unexpected(arm_stmt.error());
+                    if (arm_stmt->kind != AstStmtKind::ReturnStatus &&
+                        arm_stmt->kind != AstStmtKind::ForwardUpstream) {
+                        return frontend_error(FrontendError::UnsupportedSyntax, span_from(start));
+                    }
+                    auto arm_ptr = alloc_stmt(arm_stmt.value());
+                    if (!arm_ptr) return core::make_unexpected(arm_ptr.error());
+                    arm.stmt = arm_ptr.value();
+                    arm.span.end = arm_ptr.value()->span.end;
+                    if (!stmt.match_arms.push(arm))
+                        return frontend_error(FrontendError::TooManyItems, arm.span);
+                }
+                auto rbrace = expect(TokenType::RBrace);
+                if (!rbrace) return core::make_unexpected(rbrace.error());
+                if (stmt.match_arms.len == 0)
+                    return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+                stmt.span = Span{start.start, rbrace.value()->end, start.line, start.col};
+            } else {
+                auto else_stmt = parse_braced_stmt_body(*lbrace.value());
+                if (!else_stmt) return core::make_unexpected(else_stmt.error());
+                auto else_ptr = alloc_stmt(else_stmt.value());
+                if (!else_ptr) return core::make_unexpected(else_ptr.error());
+                stmt.else_stmt = else_ptr.value();
+                stmt.span = Span{start.start, else_stmt->span.end, start.line, start.col};
+            }
+            return stmt;
+        }
+        if (take(TokenType::KwReturn)) {
+            auto status = expect(TokenType::IntLit);
+            if (!status) return core::make_unexpected(status.error());
+            i32 value = 0;
+            for (u32 i = 0; i < status.value()->text.len; i++) {
+                const u32 digit = static_cast<u32>(status.value()->text.ptr[i] - '0');
+                if (value > (static_cast<i32>(0x7fffffff) - static_cast<i32>(digit)) / 10)
+                    return frontend_error(FrontendError::InvalidInteger,
+                                          span_from(*status.value()),
+                                          status.value()->text);
+                value = value * 10 + static_cast<i32>(digit);
+            }
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::ReturnStatus;
+            stmt.status_code = value;
+            stmt.span = Span{start.start, status.value()->end, start.line, start.col};
+            return stmt;
+        }
+        if (take(TokenType::KwIf)) {
+            const bool is_const = take(TokenType::KwConst) != nullptr;
+            auto cond = parse_expr();
+            if (!cond) return core::make_unexpected(cond.error());
+            auto lbrace = expect(TokenType::LBrace);
+            if (!lbrace) return core::make_unexpected(lbrace.error());
+            auto then_stmt = parse_braced_stmt_body(*lbrace.value());
+            if (!then_stmt) return core::make_unexpected(then_stmt.error());
+            auto kw_else = expect(TokenType::KwElse);
+            if (!kw_else) return core::make_unexpected(kw_else.error());
+            auto else_lbrace = expect(TokenType::LBrace);
+            if (!else_lbrace) return core::make_unexpected(else_lbrace.error());
+            auto else_stmt = parse_braced_stmt_body(*else_lbrace.value());
+            if (!else_stmt) return core::make_unexpected(else_stmt.error());
+            auto then_ptr = alloc_stmt(then_stmt.value());
+            if (!then_ptr) return core::make_unexpected(then_ptr.error());
+            auto else_ptr = alloc_stmt(else_stmt.value());
+            if (!else_ptr) return core::make_unexpected(else_ptr.error());
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::If;
+            stmt.is_const = is_const;
+            stmt.expr = cond.value();
+            stmt.then_stmt = then_ptr.value();
+            stmt.else_stmt = else_ptr.value();
+            stmt.span = Span{start.start, else_stmt->span.end, start.line, start.col};
+            return stmt;
+        }
+        if (take(TokenType::KwMatch)) {
+            const bool is_const = take(TokenType::KwConst) != nullptr;
+            auto subject = parse_expr();
+            if (!subject) return core::make_unexpected(subject.error());
+            auto lbrace = expect(TokenType::LBrace);
+            if (!lbrace) return core::make_unexpected(lbrace.error());
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::Match;
+            stmt.is_const = is_const;
+            stmt.expr = subject.value();
+            while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+                auto kw_case = expect(TokenType::KwCase);
+                if (!kw_case) return core::make_unexpected(kw_case.error());
+                AstStatement::MatchArm arm{};
+                arm.span = span_from(*kw_case.value());
+                if (take(TokenType::Underscore)) {
+                    arm.is_wildcard = true;
+                } else {
+                    auto pattern = parse_primary_expr();
+                    if (!pattern) return core::make_unexpected(pattern.error());
+                    arm.pattern = pattern.value();
+                }
+                auto colon = expect(TokenType::Colon);
+                if (!colon) return core::make_unexpected(colon.error());
+                auto arm_stmt = parse_stmt();
+                if (!arm_stmt) return core::make_unexpected(arm_stmt.error());
+                if (arm_stmt->kind == AstStmtKind::Let || arm_stmt->kind == AstStmtKind::Guard ||
+                    arm_stmt->kind == AstStmtKind::Match) {
+                    return frontend_error(FrontendError::UnsupportedSyntax, span_from(start));
+                }
+                auto arm_ptr = alloc_stmt(arm_stmt.value());
+                if (!arm_ptr) return core::make_unexpected(arm_ptr.error());
+                arm.stmt = arm_ptr.value();
+                arm.span.end = arm_ptr.value()->span.end;
+                if (!stmt.match_arms.push(arm))
+                    return frontend_error(FrontendError::TooManyItems, arm.span);
+            }
+            auto rbrace = expect(TokenType::RBrace);
+            if (!rbrace) return core::make_unexpected(rbrace.error());
+            if (stmt.match_arms.len == 0)
+                return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+            stmt.span = Span{start.start, rbrace.value()->end, start.line, start.col};
+            return stmt;
+        }
+        if (take(TokenType::KwForward)) {
+            auto name = expect(TokenType::Ident);
+            if (!name) return core::make_unexpected(name.error());
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::ForwardUpstream;
+            stmt.name = name.value()->text;
+            stmt.span = Span{start.start, name.value()->end, start.line, start.col};
+            return stmt;
+        }
+        if (cur().type == TokenType::Eof) return frontend_error(FrontendError::UnexpectedEof, span_from(cur()));
+        return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
+    }
+
+    FrontendResult<AstItem> parse_upstream() {
+        auto kw = expect(TokenType::KwUpstream);
+        if (!kw) return core::make_unexpected(kw.error());
+        auto name = expect(TokenType::Ident);
+        if (!name) return core::make_unexpected(name.error());
+        AstItem item{};
+        item.kind = AstItemKind::Upstream;
+        item.span = Span{kw.value()->start, name.value()->end, kw.value()->line, kw.value()->col};
+        item.upstream.span = item.span;
+        item.upstream.name = name.value()->text;
+        return item;
+    }
+
+    FrontendResult<AstStatement> parse_func_body_stmt() {
+        if (take(TokenType::KwGuard)) {
+            return parse_func_guard_stmt(prev());
+        }
+        if (take(TokenType::KwIf)) {
+            auto cond = parse_expr();
+            if (!cond) return core::make_unexpected(cond.error());
+            auto lbrace = expect(TokenType::LBrace);
+            if (!lbrace) return core::make_unexpected(lbrace.error());
+            auto then_stmt = parse_func_body_stmt();
+            if (!then_stmt) return core::make_unexpected(then_stmt.error());
+            auto rbrace = expect(TokenType::RBrace);
+            if (!rbrace) return core::make_unexpected(rbrace.error());
+            auto kw_else = expect(TokenType::KwElse);
+            if (!kw_else) return core::make_unexpected(kw_else.error());
+            auto else_lbrace = expect(TokenType::LBrace);
+            if (!else_lbrace) return core::make_unexpected(else_lbrace.error());
+            auto else_stmt = parse_func_body_stmt();
+            if (!else_stmt) return core::make_unexpected(else_stmt.error());
+            auto else_rbrace = expect(TokenType::RBrace);
+            if (!else_rbrace) return core::make_unexpected(else_rbrace.error());
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::If;
+            stmt.expr = cond.value();
+            auto then_ptr = alloc_stmt(then_stmt.value());
+            if (!then_ptr) return core::make_unexpected(then_ptr.error());
+            auto else_ptr = alloc_stmt(else_stmt.value());
+            if (!else_ptr) return core::make_unexpected(else_ptr.error());
+            stmt.then_stmt = then_ptr.value();
+            stmt.else_stmt = else_ptr.value();
+            stmt.span = Span{cond->span.start, else_rbrace.value()->end, cond->span.line, cond->span.col};
+            return stmt;
+        }
+        if (take(TokenType::KwMatch)) {
+            const bool is_const = take(TokenType::KwConst) != nullptr;
+            auto subject = parse_expr();
+            if (!subject) return core::make_unexpected(subject.error());
+            auto lbrace = expect(TokenType::LBrace);
+            if (!lbrace) return core::make_unexpected(lbrace.error());
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::Match;
+            stmt.is_const = is_const;
+            stmt.expr = subject.value();
+            while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+                auto kw_case = expect(TokenType::KwCase);
+                if (!kw_case) return core::make_unexpected(kw_case.error());
+                AstStatement::MatchArm arm{};
+                arm.span = span_from(*kw_case.value());
+                if (take(TokenType::Underscore)) {
+                    arm.is_wildcard = true;
+                } else {
+                    auto pattern = parse_primary_expr();
+                    if (!pattern) return core::make_unexpected(pattern.error());
+                    arm.pattern = pattern.value();
+                }
+                auto arrow = expect(TokenType::Arrow);
+                if (!arrow) return core::make_unexpected(arrow.error());
+                auto arm_stmt = parse_func_body_stmt();
+                if (!arm_stmt) return core::make_unexpected(arm_stmt.error());
+                auto arm_ptr = alloc_stmt(arm_stmt.value());
+                if (!arm_ptr) return core::make_unexpected(arm_ptr.error());
+                arm.stmt = arm_ptr.value();
+                arm.span.end = arm_ptr.value()->span.end;
+                if (!stmt.match_arms.push(arm))
+                    return frontend_error(FrontendError::TooManyItems, arm.span);
+            }
+            auto rbrace = expect(TokenType::RBrace);
+            if (!rbrace) return core::make_unexpected(rbrace.error());
+            if (stmt.match_arms.len == 0)
+                return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+            stmt.span = Span{subject->span.start, rbrace.value()->end, subject->span.line, subject->span.col};
+            return stmt;
+        }
+        if (cur().type == TokenType::LBrace) {
+            const Token start = cur();
+            pos++;
+            AstStatement block{};
+            block.kind = AstStmtKind::Block;
+            while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+                if (cur().type == TokenType::KwLet) {
+                    auto inner = parse_stmt();
+                    if (!inner) return core::make_unexpected(inner.error());
+                    auto inner_ptr = alloc_stmt(inner.value());
+                    if (!inner_ptr) return core::make_unexpected(inner_ptr.error());
+                    if (!block.block_stmts.push(inner_ptr.value()))
+                        return frontend_error(FrontendError::TooManyItems, inner->span);
+                    continue;
+                }
+                if (cur().type == TokenType::KwGuard) {
+                    take(TokenType::KwGuard);
+                    auto inner = parse_func_guard_stmt(prev());
+                    if (!inner) return core::make_unexpected(inner.error());
+                    auto inner_ptr = alloc_stmt(inner.value());
+                    if (!inner_ptr) return core::make_unexpected(inner_ptr.error());
+                    if (!block.block_stmts.push(inner_ptr.value()))
+                        return frontend_error(FrontendError::TooManyItems, inner->span);
+                    continue;
+                }
+                if (cur().type == TokenType::KwIf) {
+                    auto inner = parse_func_body_stmt();
+                    if (!inner) return core::make_unexpected(inner.error());
+                    auto inner_ptr = alloc_stmt(inner.value());
+                    if (!inner_ptr) return core::make_unexpected(inner_ptr.error());
+                    if (!block.block_stmts.push(inner_ptr.value()))
+                        return frontend_error(FrontendError::TooManyItems, inner->span);
+                    break;
+                }
+                if (cur().type == TokenType::KwMatch) {
+                    auto inner = parse_func_body_stmt();
+                    if (!inner) return core::make_unexpected(inner.error());
+                    auto inner_ptr = alloc_stmt(inner.value());
+                    if (!inner_ptr) return core::make_unexpected(inner_ptr.error());
+                    if (!block.block_stmts.push(inner_ptr.value()))
+                        return frontend_error(FrontendError::TooManyItems, inner->span);
+                    break;
+                }
+                auto expr = parse_expr();
+                if (!expr) return core::make_unexpected(expr.error());
+                AstStatement expr_stmt{};
+                expr_stmt.kind = AstStmtKind::Expr;
+                expr_stmt.expr = expr.value();
+                expr_stmt.span = expr->span;
+                auto expr_ptr = alloc_stmt(expr_stmt);
+                if (!expr_ptr) return core::make_unexpected(expr_ptr.error());
+                if (!block.block_stmts.push(expr_ptr.value()))
+                    return frontend_error(FrontendError::TooManyItems, expr->span);
+                break;
+            }
+            auto rbrace = expect(TokenType::RBrace);
+            if (!rbrace) return core::make_unexpected(rbrace.error());
+            if (block.block_stmts.len == 0)
+                return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+            block.span = Span{start.start, rbrace.value()->end, start.line, start.col};
+            return block;
+        }
+        auto expr = parse_expr();
+        if (!expr) return core::make_unexpected(expr.error());
+        AstStatement expr_stmt{};
+        expr_stmt.kind = AstStmtKind::Expr;
+        expr_stmt.expr = expr.value();
+        expr_stmt.span = expr->span;
+        return expr_stmt;
+    }
+
+    FrontendResult<AstTypeRef> parse_func_type_ref() {
+        AstTypeRef out{};
+        if (take(TokenType::LParen)) {
+            out.is_tuple = true;
+            while (true) {
+                auto elem = parse_func_type_ref();
+                if (!elem) return core::make_unexpected(elem.error());
+                if (!elem->is_tuple && elem->type_args.len == 0 && elem->name.len != 0) {
+                    if (!out.tuple_elem_names.push(elem->name))
+                        return frontend_error(FrontendError::TooManyItems, Span{});
+                } else {
+                    if (!out.tuple_elem_names.push({}))
+                        return frontend_error(FrontendError::TooManyItems, Span{});
+                }
+                auto elem_ptr = alloc_type(elem.value());
+                if (!elem_ptr) return core::make_unexpected(elem_ptr.error());
+                if (!out.tuple_elem_types.push(elem_ptr.value()))
+                    return frontend_error(FrontendError::TooManyItems, Span{});
+                if (take(TokenType::RParen)) break;
+                auto comma = expect(TokenType::Comma);
+                if (!comma) return core::make_unexpected(comma.error());
+            }
+            if (out.tuple_elem_types.len < 2)
+                return frontend_error(FrontendError::UnsupportedSyntax, span_from(prev()));
+            return out;
+        }
+        auto type_name = expect(TokenType::Ident);
+        if (!type_name) return core::make_unexpected(type_name.error());
+        out.name = type_name.value()->text;
+        if (take(TokenType::Dot)) {
+            out.namespace_name = out.name;
+            auto member_name = expect(TokenType::Ident);
+            if (!member_name) return core::make_unexpected(member_name.error());
+            out.name = member_name.value()->text;
+        }
+        if (take(TokenType::Lt)) {
+            while (true) {
+                auto type_arg = parse_func_type_ref();
+                if (!type_arg) return core::make_unexpected(type_arg.error());
+                if (!out.type_arg_namespaces.push(type_arg->namespace_name))
+                    return frontend_error(FrontendError::TooManyItems, span_from(*type_name.value()));
+                if (!out.type_arg_names.push(type_arg->name))
+                    return frontend_error(FrontendError::TooManyItems, span_from(*type_name.value()));
+                auto type_arg_ptr = alloc_type(type_arg.value());
+                if (!type_arg_ptr) return core::make_unexpected(type_arg_ptr.error());
+                if (!out.type_args.push(type_arg_ptr.value()))
+                    return frontend_error(FrontendError::TooManyItems, span_from(*type_name.value()));
+                if (take(TokenType::Gt)) break;
+                auto comma = expect(TokenType::Comma);
+                if (!comma) return core::make_unexpected(comma.error());
+            }
+        }
+        return out;
+    }
+
+    FrontendResult<AstItem> parse_func() {
+        auto kw = expect(TokenType::KwFunc);
+        if (!kw) return core::make_unexpected(kw.error());
+        auto name = expect(TokenType::Ident);
+        if (!name) return core::make_unexpected(name.error());
+
+        AstItem item{};
+        item.kind = AstItemKind::Func;
+        item.func.name = name.value()->text;
+        item.func.span = span_from(*kw.value());
+
+        if (take(TokenType::Lt)) {
+            while (true) {
+                auto type_param = expect(TokenType::Ident);
+                if (!type_param) return core::make_unexpected(type_param.error());
+                AstFunctionDecl::TypeParamDecl decl{};
+                decl.name = type_param.value()->text;
+                if (take(TokenType::Colon)) {
+                    while (true) {
+                        auto constraint = expect(TokenType::Ident);
+                        if (!constraint) return core::make_unexpected(constraint.error());
+                        Str constraint_namespace{};
+                        Str constraint_name = constraint.value()->text;
+                        if (take(TokenType::Dot)) {
+                            constraint_namespace = constraint_name;
+                            auto member = expect(TokenType::Ident);
+                            if (!member) return core::make_unexpected(member.error());
+                            constraint_name = member.value()->text;
+                        }
+                        decl.has_constraint = true;
+                        if (decl.constraints.len == 0) {
+                            decl.constraint_namespace = constraint_namespace;
+                            decl.constraint = constraint_name;
+                        }
+                        if (!decl.constraint_namespaces.push(constraint_namespace))
+                            return frontend_error(FrontendError::TooManyItems, span_from(*constraint.value()));
+                        if (!decl.constraints.push(constraint_name))
+                            return frontend_error(FrontendError::TooManyItems, span_from(*constraint.value()));
+                        if (cur().type != TokenType::Comma || peek(1).type == TokenType::Gt) break;
+                        auto comma = expect(TokenType::Comma);
+                        if (!comma) return core::make_unexpected(comma.error());
+                    }
+                }
+                if (!item.func.type_params.push(decl))
+                    return frontend_error(FrontendError::TooManyItems, span_from(*type_param.value()));
+                if (take(TokenType::Gt)) break;
+                auto comma = expect(TokenType::Comma);
+                if (!comma) return core::make_unexpected(comma.error());
+            }
+        }
+
+        auto lparen = expect(TokenType::LParen);
+        if (!lparen) return core::make_unexpected(lparen.error());
+
+        if (!take(TokenType::RParen)) {
+            while (true) {
+                auto param_name = expect(TokenType::Ident);
+                if (!param_name) return core::make_unexpected(param_name.error());
+                auto colon = expect(TokenType::Colon);
+                if (!colon) return core::make_unexpected(colon.error());
+                auto type_ref = parse_func_type_ref();
+                if (!type_ref) return core::make_unexpected(type_ref.error());
+                AstFunctionDecl::ParamDecl param{};
+                param.name = param_name.value()->text;
+                param.type = type_ref.value();
+                if (!item.func.params.push(param))
+                    return frontend_error(FrontendError::TooManyItems, span_from(*param_name.value()));
+                if (take(TokenType::RParen)) break;
+                auto comma = expect(TokenType::Comma);
+                if (!comma) return core::make_unexpected(comma.error());
+            }
+        }
+
+        if (take(TokenType::ThinArrow)) {
+            auto ret_type = parse_func_type_ref();
+            if (!ret_type) return core::make_unexpected(ret_type.error());
+            item.func.has_return_type = true;
+            item.func.return_type = ret_type.value();
+        }
+        AstStatement body_stmt{};
+        if (take(TokenType::Arrow)) {
+            auto body = parse_expr();
+            if (!body) return core::make_unexpected(body.error());
+            body_stmt.kind = AstStmtKind::Expr;
+            body_stmt.expr = body.value();
+            body_stmt.span = body->span;
+        } else {
+            auto body = parse_func_body_stmt();
+            if (!body) return core::make_unexpected(body.error());
+            body_stmt = body.value();
+        }
+        auto body_ptr = alloc_stmt(body_stmt);
+        if (!body_ptr) return core::make_unexpected(body_ptr.error());
+
+        item.func.body = body_ptr.value();
+        item.span = Span{kw.value()->start, body_ptr.value()->span.end, kw.value()->line, kw.value()->col};
+        item.func.span = item.span;
+        return item;
+    }
+
+    FrontendResult<AstItem> parse_variant() {
+        auto kw = expect(TokenType::KwVariant);
+        if (!kw) return core::make_unexpected(kw.error());
+        auto name = expect(TokenType::Ident);
+        if (!name) return core::make_unexpected(name.error());
+
+        AstItem item{};
+        item.kind = AstItemKind::Variant;
+        item.variant.name = name.value()->text;
+        item.variant.span = Span{kw.value()->start, kw.value()->end, kw.value()->line, kw.value()->col};
+
+        if (take(TokenType::Lt)) {
+            while (true) {
+                auto type_param = expect(TokenType::Ident);
+                if (!type_param) return core::make_unexpected(type_param.error());
+                if (!item.variant.type_params.push(type_param.value()->text))
+                    return frontend_error(FrontendError::TooManyItems, span_from(*type_param.value()));
+                if (take(TokenType::Gt)) break;
+                auto comma = expect(TokenType::Comma);
+                if (!comma) return core::make_unexpected(comma.error());
+            }
+        }
+
+        auto lbrace = expect(TokenType::LBrace);
+        if (!lbrace) return core::make_unexpected(lbrace.error());
+
+        while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+            auto case_name = expect(TokenType::Ident);
+            if (!case_name) return core::make_unexpected(case_name.error());
+            AstVariantDecl::CaseDecl case_decl{};
+            case_decl.name = case_name.value()->text;
+            if (take(TokenType::LParen)) {
+                auto payload_type = parse_func_type_ref();
+                if (!payload_type) return core::make_unexpected(payload_type.error());
+                case_decl.has_payload = true;
+                case_decl.payload_type = payload_type.value();
+                auto rparen = expect(TokenType::RParen);
+                if (!rparen) return core::make_unexpected(rparen.error());
+            }
+            if (!item.variant.cases.push(case_decl))
+                return frontend_error(FrontendError::TooManyItems, span_from(*case_name.value()));
+            take(TokenType::Comma);
+        }
+        auto rbrace = expect(TokenType::RBrace);
+        if (!rbrace) return core::make_unexpected(rbrace.error());
+        if (item.variant.cases.len == 0)
+            return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+        item.span = Span{kw.value()->start, rbrace.value()->end, kw.value()->line, kw.value()->col};
+        item.variant.span = item.span;
+        return item;
+    }
+
+    FrontendResult<AstItem> parse_protocol() {
+        auto kw = expect(TokenType::KwProtocol);
+        if (!kw) return core::make_unexpected(kw.error());
+        auto name = expect(TokenType::Ident);
+        if (!name) return core::make_unexpected(name.error());
+        AstItem item{};
+        item.kind = AstItemKind::Protocol;
+        item.protocol.name = name.value()->text;
+        auto lbrace = expect(TokenType::LBrace);
+        if (!lbrace) return core::make_unexpected(lbrace.error());
+        while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+            auto func_kw = expect(TokenType::KwFunc);
+            if (!func_kw) return core::make_unexpected(func_kw.error());
+            auto method_name = expect(TokenType::Ident);
+            if (!method_name) return core::make_unexpected(method_name.error());
+            AstProtocolDecl::MethodDecl method{};
+            method.name = method_name.value()->text;
+            auto lparen = expect(TokenType::LParen);
+            if (!lparen) return core::make_unexpected(lparen.error());
+            if (!take(TokenType::RParen)) {
+                while (true) {
+                    auto param_name = expect(TokenType::Ident);
+                    if (!param_name) return core::make_unexpected(param_name.error());
+                    auto colon = expect(TokenType::Colon);
+                    if (!colon) return core::make_unexpected(colon.error());
+                    auto type_ref = parse_func_type_ref();
+                    if (!type_ref) return core::make_unexpected(type_ref.error());
+                    AstProtocolDecl::MethodDecl::ParamDecl param{};
+                    param.name = param_name.value()->text;
+                    param.type = type_ref.value();
+                    if (!method.params.push(param))
+                        return frontend_error(FrontendError::TooManyItems, span_from(*param_name.value()));
+                    if (take(TokenType::RParen)) break;
+                    auto comma = expect(TokenType::Comma);
+                    if (!comma) return core::make_unexpected(comma.error());
+                }
+            }
+            if (take(TokenType::ThinArrow)) {
+                auto ret_type = parse_func_type_ref();
+                if (!ret_type) return core::make_unexpected(ret_type.error());
+                method.has_return_type = true;
+                method.return_type = ret_type.value();
+            }
+            if (take(TokenType::Arrow)) {
+                auto body = parse_expr();
+                if (!body) return core::make_unexpected(body.error());
+                AstStatement body_stmt{};
+                body_stmt.kind = AstStmtKind::Expr;
+                body_stmt.expr = body.value();
+                body_stmt.span = body->span;
+                auto body_ptr = alloc_stmt(body_stmt);
+                if (!body_ptr) return core::make_unexpected(body_ptr.error());
+                method.default_body = body_ptr.value();
+            } else if (cur().type == TokenType::LBrace) {
+                auto body = parse_func_body_stmt();
+                if (!body) return core::make_unexpected(body.error());
+                auto body_ptr = alloc_stmt(body.value());
+                if (!body_ptr) return core::make_unexpected(body_ptr.error());
+                method.default_body = body_ptr.value();
+            }
+            if (!item.protocol.methods.push(method))
+                return frontend_error(FrontendError::TooManyItems, span_from(*method_name.value()));
+        }
+        auto rbrace = expect(TokenType::RBrace);
+        if (!rbrace) return core::make_unexpected(rbrace.error());
+        item.span = Span{kw.value()->start, rbrace.value()->end, kw.value()->line, kw.value()->col};
+        item.protocol.span = item.span;
+        return item;
+    }
+
+    FrontendResult<AstItem> parse_impl() {
+        auto target = parse_func_type_ref();
+        if (!target) return core::make_unexpected(target.error());
+        auto kw = expect(TokenType::KwImpl);
+        if (!kw) return core::make_unexpected(kw.error());
+        AstItem item{};
+        item.kind = AstItemKind::Impl;
+        item.impl_decl.target = target.value();
+        while (true) {
+            auto proto = expect(TokenType::Ident);
+            if (!proto) return core::make_unexpected(proto.error());
+            Str proto_namespace{};
+            Str proto_name = proto.value()->text;
+            if (take(TokenType::Dot)) {
+                proto_namespace = proto_name;
+                auto member = expect(TokenType::Ident);
+                if (!member) return core::make_unexpected(member.error());
+                proto_name = member.value()->text;
+            }
+            if (!item.impl_decl.protocol_namespaces.push(proto_namespace))
+                return frontend_error(FrontendError::TooManyItems, span_from(*proto.value()));
+            if (!item.impl_decl.protocols.push(proto_name))
+                return frontend_error(FrontendError::TooManyItems, span_from(*proto.value()));
+            if (!take(TokenType::Comma)) break;
+        }
+        auto lbrace = expect(TokenType::LBrace);
+        if (!lbrace) return core::make_unexpected(lbrace.error());
+        while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+            auto method = parse_func();
+            if (!method) return core::make_unexpected(method.error());
+            if (method->kind != AstItemKind::Func)
+                return frontend_error(FrontendError::UnsupportedSyntax, item.span);
+            if (!item.impl_decl.methods.push(method->func))
+                return frontend_error(FrontendError::TooManyItems, span_from(*kw.value()));
+        }
+        auto rbrace = expect(TokenType::RBrace);
+        if (!rbrace) return core::make_unexpected(rbrace.error());
+        item.span = Span{target.value().name.ptr != nullptr ? kw.value()->start : kw.value()->start, rbrace.value()->end, kw.value()->line, kw.value()->col};
+        item.impl_decl.span = item.span;
+        return item;
+    }
+
+    FrontendResult<AstItem> parse_import() {
+        auto kw = expect(TokenType::KwImport);
+        if (!kw) return core::make_unexpected(kw.error());
+        AstItem item{};
+        item.kind = AstItemKind::Import;
+        if (take(TokenType::LBrace)) {
+            item.import_decl.selective = true;
+            while (true) {
+                auto name = expect(TokenType::Ident);
+                if (!name) return core::make_unexpected(name.error());
+                AstImportDecl::SelectedName selected{};
+                selected.name = name.value()->text;
+                if (take(TokenType::KwAs)) {
+                    auto alias = expect(TokenType::Ident);
+                    if (!alias) return core::make_unexpected(alias.error());
+                    selected.has_alias = true;
+                    selected.alias = alias.value()->text;
+                }
+                if (!item.import_decl.selected_names.push(selected))
+                    return frontend_error(FrontendError::TooManyItems, span_from(*name.value()));
+                if (take(TokenType::RBrace)) break;
+                auto comma = expect(TokenType::Comma);
+                if (!comma) return core::make_unexpected(comma.error());
+            }
+            auto from_kw = expect(TokenType::Ident);
+            if (!from_kw) return core::make_unexpected(from_kw.error());
+            if (!from_kw.value()->text.eq({"from", 4}))
+                return frontend_error(FrontendError::UnexpectedToken, span_from(*from_kw.value()), from_kw.value()->text);
+        } else if (take(TokenType::Star)) {
+            auto as_kw = expect(TokenType::KwAs);
+            if (!as_kw) return core::make_unexpected(as_kw.error());
+            auto alias = expect(TokenType::Ident);
+            if (!alias) return core::make_unexpected(alias.error());
+            item.import_decl.has_namespace_alias = true;
+            item.import_decl.namespace_alias = alias.value()->text;
+            auto from_kw = expect(TokenType::Ident);
+            if (!from_kw) return core::make_unexpected(from_kw.error());
+            if (!from_kw.value()->text.eq({"from", 4}))
+                return frontend_error(FrontendError::UnexpectedToken, span_from(*from_kw.value()), from_kw.value()->text);
+        }
+        auto path = expect(TokenType::StringLit);
+        if (!path) return core::make_unexpected(path.error());
+        item.import_decl.path = path.value()->text;
+        item.span = Span{kw.value()->start, path.value()->end, kw.value()->line, kw.value()->col};
+        item.import_decl.span = item.span;
+        return item;
+    }
+
+    FrontendResult<AstItem> parse_using() {
+        auto kw = expect(TokenType::KwUsing);
+        if (!kw) return core::make_unexpected(kw.error());
+        auto name = expect(TokenType::Ident);
+        if (!name) return core::make_unexpected(name.error());
+        auto eq = expect(TokenType::Eq);
+        if (!eq) return core::make_unexpected(eq.error());
+        auto first = expect(TokenType::Ident);
+        if (!first) return core::make_unexpected(first.error());
+        AstItem item{};
+        item.kind = AstItemKind::Using;
+        item.using_decl.name = name.value()->text;
+        if (!item.using_decl.target_parts.push(first.value()->text))
+            return frontend_error(FrontendError::TooManyItems, span_from(*first.value()));
+        while (take(TokenType::Dot)) {
+            auto part = expect(TokenType::Ident);
+            if (!part) return core::make_unexpected(part.error());
+            if (!item.using_decl.target_parts.push(part.value()->text))
+                return frontend_error(FrontendError::TooManyItems, span_from(*part.value()));
+        }
+        if (item.using_decl.target_parts.len < 2)
+            return frontend_error(FrontendError::UnsupportedSyntax, Span{kw.value()->start, cur().start, kw.value()->line, kw.value()->col});
+        item.span = Span{kw.value()->start, toks->tokens[pos - 1].end, kw.value()->line, kw.value()->col};
+        item.using_decl.span = item.span;
+        return item;
+    }
+
+    FrontendResult<AstItem> parse_struct() {
+        auto kw = expect(TokenType::KwStruct);
+        if (!kw) return core::make_unexpected(kw.error());
+        auto name = expect(TokenType::Ident);
+        if (!name) return core::make_unexpected(name.error());
+        AstItem item{};
+        item.kind = AstItemKind::Struct;
+        item.struct_decl.name = name.value()->text;
+        item.struct_decl.span = Span{kw.value()->start, kw.value()->end, kw.value()->line, kw.value()->col};
+        if (take(TokenType::Lt)) {
+            while (true) {
+                auto type_param = expect(TokenType::Ident);
+                if (!type_param) return core::make_unexpected(type_param.error());
+                if (!item.struct_decl.type_params.push(type_param.value()->text))
+                    return frontend_error(FrontendError::TooManyItems, span_from(*type_param.value()));
+                if (take(TokenType::Gt)) break;
+                auto comma = expect(TokenType::Comma);
+                if (!comma) return core::make_unexpected(comma.error());
+            }
+        }
+        auto lbrace = expect(TokenType::LBrace);
+        if (!lbrace) return core::make_unexpected(lbrace.error());
+
+        while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+            auto field_name = expect_field_name();
+            if (!field_name) return core::make_unexpected(field_name.error());
+            auto colon = expect(TokenType::Colon);
+            if (!colon) return core::make_unexpected(colon.error());
+            auto field_type = parse_func_type_ref();
+            if (!field_type) return core::make_unexpected(field_type.error());
+            AstStructDecl::FieldDecl field{};
+            field.name = field_name.value()->text;
+            field.type = field_type.value();
+            if (!item.struct_decl.fields.push(field))
+                return frontend_error(FrontendError::TooManyItems, span_from(*field_name.value()));
+            take(TokenType::Comma);
+        }
+        auto rbrace = expect(TokenType::RBrace);
+        if (!rbrace) return core::make_unexpected(rbrace.error());
+        if (item.struct_decl.fields.len == 0)
+            return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+        item.span = Span{kw.value()->start, rbrace.value()->end, kw.value()->line, kw.value()->col};
+        item.struct_decl.span = item.span;
+        return item;
+    }
+
+    FrontendResult<AstItem> parse_route() {
+        auto kw = expect(TokenType::KwRoute);
+        if (!kw) return core::make_unexpected(kw.error());
+        AstItem item{};
+        item.kind = AstItemKind::Route;
+
+        const Token* method = nullptr;
+        switch (cur().type) {
+            case TokenType::KwGet:
+            case TokenType::KwPost:
+            case TokenType::KwPut:
+            case TokenType::KwDelete:
+            case TokenType::KwPatch:
+            case TokenType::KwHead:
+            case TokenType::KwOptions:
+                method = &toks->tokens[pos++];
+                break;
+            default:
+                return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
+        }
+
+        auto path = expect(TokenType::StringLit);
+        if (!path) return core::make_unexpected(path.error());
+        auto lbrace = expect(TokenType::LBrace);
+        if (!lbrace) return core::make_unexpected(lbrace.error());
+        while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+            auto stmt = parse_stmt();
+            if (!stmt) return core::make_unexpected(stmt.error());
+            if (!item.route.statements.push(stmt.value()))
+                return frontend_error(FrontendError::TooManyItems, stmt.value().span);
+            if (stmt->kind != AstStmtKind::Let && stmt->kind != AstStmtKind::Guard) break;
+        }
+        auto rbrace = expect(TokenType::RBrace);
+        if (!rbrace) return core::make_unexpected(rbrace.error());
+        if (item.route.statements.len == 0)
+            return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+
+        item.span = Span{kw.value()->start, rbrace.value()->end, kw.value()->line, kw.value()->col};
+        item.route.span = item.span;
+        item.route.body_span = Span{lbrace.value()->start, rbrace.value()->end, lbrace.value()->line, lbrace.value()->col};
+        item.route.method = static_cast<u8>(method->type);
+        item.route.path = path.value()->text;
+        return item;
+    }
+};
+
+}  // namespace
+
+FrontendResult<AstFile*> parse_file(const LexedTokens& tokens) {
+    auto file = std::make_unique<AstFile>();
+    Parser p{};
+    p.toks = &tokens;
+    p.file = file.get();
+    if (p.cur().type == TokenType::KwPackage) {
+        auto kw = p.expect(TokenType::KwPackage);
+        if (!kw) return core::make_unexpected(kw.error());
+        auto name = p.expect(TokenType::Ident);
+        if (!name) return core::make_unexpected(name.error());
+        file->has_package_decl = true;
+        file->package_name = name.value()->text;
+        file->package_span = Span{kw.value()->start, name.value()->end, kw.value()->line, kw.value()->col};
+    }
+    while (p.cur().type != TokenType::Eof) {
+        FrontendResult<AstItem> item = frontend_error(FrontendError::UnexpectedToken, Parser::span_from(p.cur()), p.cur().text);
+        switch (p.cur().type) {
+            case TokenType::KwUpstream:
+                item = p.parse_upstream();
+                break;
+            case TokenType::KwFunc:
+                item = p.parse_func();
+                break;
+            case TokenType::KwStruct:
+                item = p.parse_struct();
+                break;
+            case TokenType::KwProtocol:
+                item = p.parse_protocol();
+                break;
+            case TokenType::KwImport:
+                item = p.parse_import();
+                break;
+            case TokenType::KwUsing:
+                item = p.parse_using();
+                break;
+            case TokenType::KwVariant:
+                item = p.parse_variant();
+                break;
+            case TokenType::KwRoute:
+                item = p.parse_route();
+                break;
+            default:
+                if (p.cur().type == TokenType::Ident || p.cur().type == TokenType::LParen) {
+                    item = p.parse_impl();
+                    break;
+                }
+                if (p.cur().type == TokenType::Eof)
+                    return frontend_error(FrontendError::UnexpectedEof, Parser::span_from(p.cur()));
+                return frontend_error(FrontendError::UnexpectedToken, Parser::span_from(p.cur()), p.cur().text);
+        }
+        if (!item) return core::make_unexpected(item.error());
+        if (!file->items.push(item.value())) return frontend_error(FrontendError::TooManyItems, item.value().span);
+    }
+    return file.release();
+}
+
+}  // namespace rut

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -19,9 +19,7 @@ struct Parser {
         return toks->tokens[idx];
     }
 
-    static Span span_from(const Token& tok) {
-        return Span{tok.start, tok.end, tok.line, tok.col};
-    }
+    static Span span_from(const Token& tok) { return Span{tok.start, tok.end, tok.line, tok.col}; }
 
     const Token* take(TokenType type) {
         if (cur().type != type) return nullptr;
@@ -30,13 +28,16 @@ struct Parser {
 
     FrontendResult<const Token*> expect(TokenType type) {
         if (cur().type == type) return &toks->tokens[pos++];
-        if (cur().type == TokenType::Eof) return frontend_error(FrontendError::UnexpectedEof, span_from(cur()));
+        if (cur().type == TokenType::Eof)
+            return frontend_error(FrontendError::UnexpectedEof, span_from(cur()));
         return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
     }
 
     FrontendResult<const Token*> expect_field_name() {
-        if (cur().type == TokenType::Ident || cur().type == TokenType::KwFunc) return &toks->tokens[pos++];
-        if (cur().type == TokenType::Eof) return frontend_error(FrontendError::UnexpectedEof, span_from(cur()));
+        if (cur().type == TokenType::Ident || cur().type == TokenType::KwFunc)
+            return &toks->tokens[pos++];
+        if (cur().type == TokenType::Eof)
+            return frontend_error(FrontendError::UnexpectedEof, span_from(cur()));
         return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
     }
 
@@ -53,8 +54,7 @@ struct Parser {
     }
 
     FrontendResult<AstTypeRef*> alloc_type(const AstTypeRef& type) {
-        if (!file->type_pool.push(type))
-            return frontend_error(FrontendError::TooManyItems, Span{});
+        if (!file->type_pool.push(type)) return frontend_error(FrontendError::TooManyItems, Span{});
         return &file->type_pool[file->type_pool.len - 1];
     }
 
@@ -334,7 +334,8 @@ struct Parser {
             }
             if (all_digits && index > 0) {
                 if (index > 10)
-                    return frontend_error(FrontendError::UnsupportedSyntax, span_from(*ident.value()));
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          span_from(*ident.value()));
                 expr.kind = AstExprKind::Placeholder;
                 expr.int_value = index;
                 expr.span = span_from(*ident.value());
@@ -352,7 +353,8 @@ struct Parser {
         if (!base) return core::make_unexpected(base.error());
         AstExpr expr = base.value();
         while (true) {
-            if (expr.kind == AstExprKind::Ident && expr.type_args.len == 0 && cur().type == TokenType::Lt) {
+            if (expr.kind == AstExprKind::Ident && expr.type_args.len == 0 &&
+                cur().type == TokenType::Lt) {
                 const u32 saved_pos = pos;
                 pos++;
                 FixedVec<AstTypeRef, AstExpr::kMaxTypeArgs> parsed_type_args;
@@ -486,9 +488,10 @@ struct Parser {
             }
             if (take(TokenType::LParen)) {
                 const u32 after_lparen = pos;
-                const bool maybe_named_init = expr.kind == AstExprKind::Ident && cur().type != TokenType::RParen &&
-                                              (cur().type == TokenType::Ident || cur().type == TokenType::KwFunc) &&
-                                              peek().type == TokenType::Colon;
+                const bool maybe_named_init =
+                    expr.kind == AstExprKind::Ident && cur().type != TokenType::RParen &&
+                    (cur().type == TokenType::Ident || cur().type == TokenType::KwFunc) &&
+                    peek().type == TokenType::Colon;
                 if (maybe_named_init) {
                     AstExpr init{};
                     init.kind = AstExprKind::StructInit;
@@ -549,10 +552,14 @@ struct Parser {
         auto lhs = parse_primary_expr();
         if (!lhs) return core::make_unexpected(lhs.error());
         TokenType op = TokenType::Error;
-        if (take(TokenType::EqEq)) op = TokenType::EqEq;
-        else if (take(TokenType::Lt)) op = TokenType::Lt;
-        else if (take(TokenType::Gt)) op = TokenType::Gt;
-        else return lhs.value();
+        if (take(TokenType::EqEq))
+            op = TokenType::EqEq;
+        else if (take(TokenType::Lt))
+            op = TokenType::Lt;
+        else if (take(TokenType::Gt))
+            op = TokenType::Gt;
+        else
+            return lhs.value();
         auto rhs = parse_primary_expr();
         if (!rhs) return core::make_unexpected(rhs.error());
         auto lhs_ptr = alloc_expr(lhs.value());
@@ -560,7 +567,9 @@ struct Parser {
         auto rhs_ptr = alloc_expr(rhs.value());
         if (!rhs_ptr) return core::make_unexpected(rhs_ptr.error());
         AstExpr expr{};
-        expr.kind = op == TokenType::EqEq ? AstExprKind::Eq : (op == TokenType::Lt ? AstExprKind::Lt : AstExprKind::Gt);
+        expr.kind = op == TokenType::EqEq
+                        ? AstExprKind::Eq
+                        : (op == TokenType::Lt ? AstExprKind::Lt : AstExprKind::Gt);
         expr.lhs = lhs_ptr.value();
         expr.rhs = rhs_ptr.value();
         expr.span = Span{lhs->span.start, rhs->span.end, lhs->span.line, lhs->span.col};
@@ -686,7 +695,8 @@ struct Parser {
                 auto rbrace = expect(TokenType::RBrace);
                 if (!rbrace) return core::make_unexpected(rbrace.error());
                 if (stmt.match_arms.len == 0)
-                    return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+                    return frontend_error(FrontendError::UnexpectedToken,
+                                          span_from(*rbrace.value()));
                 stmt.span = Span{start.start, rbrace.value()->end, start.line, start.col};
             } else {
                 auto else_stmt = parse_braced_stmt_body(*lbrace.value());
@@ -796,7 +806,8 @@ struct Parser {
             stmt.span = Span{start.start, name.value()->end, start.line, start.col};
             return stmt;
         }
-        if (cur().type == TokenType::Eof) return frontend_error(FrontendError::UnexpectedEof, span_from(cur()));
+        if (cur().type == TokenType::Eof)
+            return frontend_error(FrontendError::UnexpectedEof, span_from(cur()));
         return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
     }
 
@@ -843,7 +854,8 @@ struct Parser {
             if (!else_ptr) return core::make_unexpected(else_ptr.error());
             stmt.then_stmt = then_ptr.value();
             stmt.else_stmt = else_ptr.value();
-            stmt.span = Span{cond->span.start, else_rbrace.value()->end, cond->span.line, cond->span.col};
+            stmt.span =
+                Span{cond->span.start, else_rbrace.value()->end, cond->span.line, cond->span.col};
             return stmt;
         }
         if (take(TokenType::KwMatch)) {
@@ -883,7 +895,8 @@ struct Parser {
             if (!rbrace) return core::make_unexpected(rbrace.error());
             if (stmt.match_arms.len == 0)
                 return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
-            stmt.span = Span{subject->span.start, rbrace.value()->end, subject->span.line, subject->span.col};
+            stmt.span = Span{
+                subject->span.start, rbrace.value()->end, subject->span.line, subject->span.col};
             return stmt;
         }
         if (cur().type == TokenType::LBrace) {
@@ -997,13 +1010,16 @@ struct Parser {
                 auto type_arg = parse_func_type_ref();
                 if (!type_arg) return core::make_unexpected(type_arg.error());
                 if (!out.type_arg_namespaces.push(type_arg->namespace_name))
-                    return frontend_error(FrontendError::TooManyItems, span_from(*type_name.value()));
+                    return frontend_error(FrontendError::TooManyItems,
+                                          span_from(*type_name.value()));
                 if (!out.type_arg_names.push(type_arg->name))
-                    return frontend_error(FrontendError::TooManyItems, span_from(*type_name.value()));
+                    return frontend_error(FrontendError::TooManyItems,
+                                          span_from(*type_name.value()));
                 auto type_arg_ptr = alloc_type(type_arg.value());
                 if (!type_arg_ptr) return core::make_unexpected(type_arg_ptr.error());
                 if (!out.type_args.push(type_arg_ptr.value()))
-                    return frontend_error(FrontendError::TooManyItems, span_from(*type_name.value()));
+                    return frontend_error(FrontendError::TooManyItems,
+                                          span_from(*type_name.value()));
                 if (take(TokenType::Gt)) break;
                 auto comma = expect(TokenType::Comma);
                 if (!comma) return core::make_unexpected(comma.error());
@@ -1047,16 +1063,19 @@ struct Parser {
                             decl.constraint = constraint_name;
                         }
                         if (!decl.constraint_namespaces.push(constraint_namespace))
-                            return frontend_error(FrontendError::TooManyItems, span_from(*constraint.value()));
+                            return frontend_error(FrontendError::TooManyItems,
+                                                  span_from(*constraint.value()));
                         if (!decl.constraints.push(constraint_name))
-                            return frontend_error(FrontendError::TooManyItems, span_from(*constraint.value()));
+                            return frontend_error(FrontendError::TooManyItems,
+                                                  span_from(*constraint.value()));
                         if (cur().type != TokenType::Comma || peek(1).type == TokenType::Gt) break;
                         auto comma = expect(TokenType::Comma);
                         if (!comma) return core::make_unexpected(comma.error());
                     }
                 }
                 if (!item.func.type_params.push(decl))
-                    return frontend_error(FrontendError::TooManyItems, span_from(*type_param.value()));
+                    return frontend_error(FrontendError::TooManyItems,
+                                          span_from(*type_param.value()));
                 if (take(TokenType::Gt)) break;
                 auto comma = expect(TokenType::Comma);
                 if (!comma) return core::make_unexpected(comma.error());
@@ -1080,7 +1099,8 @@ struct Parser {
                 param.type = type_ref.value();
                 param.has_underscore_label = has_underscore;
                 if (!item.func.params.push(param))
-                    return frontend_error(FrontendError::TooManyItems, span_from(*param_name.value()));
+                    return frontend_error(FrontendError::TooManyItems,
+                                          span_from(*param_name.value()));
                 if (take(TokenType::RParen)) break;
                 auto comma = expect(TokenType::Comma);
                 if (!comma) return core::make_unexpected(comma.error());
@@ -1109,7 +1129,8 @@ struct Parser {
         if (!body_ptr) return core::make_unexpected(body_ptr.error());
 
         item.func.body = body_ptr.value();
-        item.span = Span{kw.value()->start, body_ptr.value()->span.end, kw.value()->line, kw.value()->col};
+        item.span =
+            Span{kw.value()->start, body_ptr.value()->span.end, kw.value()->line, kw.value()->col};
         item.func.span = item.span;
         return item;
     }
@@ -1123,14 +1144,16 @@ struct Parser {
         AstItem item{};
         item.kind = AstItemKind::Variant;
         item.variant.name = name.value()->text;
-        item.variant.span = Span{kw.value()->start, kw.value()->end, kw.value()->line, kw.value()->col};
+        item.variant.span =
+            Span{kw.value()->start, kw.value()->end, kw.value()->line, kw.value()->col};
 
         if (take(TokenType::Lt)) {
             while (true) {
                 auto type_param = expect(TokenType::Ident);
                 if (!type_param) return core::make_unexpected(type_param.error());
                 if (!item.variant.type_params.push(type_param.value()->text))
-                    return frontend_error(FrontendError::TooManyItems, span_from(*type_param.value()));
+                    return frontend_error(FrontendError::TooManyItems,
+                                          span_from(*type_param.value()));
                 if (take(TokenType::Gt)) break;
                 auto comma = expect(TokenType::Comma);
                 if (!comma) return core::make_unexpected(comma.error());
@@ -1199,7 +1222,8 @@ struct Parser {
                     param.type = type_ref.value();
                     param.has_underscore_label = has_underscore;
                     if (!method.params.push(param))
-                        return frontend_error(FrontendError::TooManyItems, span_from(*param_name.value()));
+                        return frontend_error(FrontendError::TooManyItems,
+                                              span_from(*param_name.value()));
                     if (take(TokenType::RParen)) break;
                     auto comma = expect(TokenType::Comma);
                     if (!comma) return core::make_unexpected(comma.error());
@@ -1275,7 +1299,10 @@ struct Parser {
         }
         auto rbrace = expect(TokenType::RBrace);
         if (!rbrace) return core::make_unexpected(rbrace.error());
-        item.span = Span{target.value().name.ptr != nullptr ? kw.value()->start : kw.value()->start, rbrace.value()->end, kw.value()->line, kw.value()->col};
+        item.span = Span{target.value().name.ptr != nullptr ? kw.value()->start : kw.value()->start,
+                         rbrace.value()->end,
+                         kw.value()->line,
+                         kw.value()->col};
         item.impl_decl.span = item.span;
         return item;
     }
@@ -1307,7 +1334,9 @@ struct Parser {
             auto from_kw = expect(TokenType::Ident);
             if (!from_kw) return core::make_unexpected(from_kw.error());
             if (!from_kw.value()->text.eq({"from", 4}))
-                return frontend_error(FrontendError::UnexpectedToken, span_from(*from_kw.value()), from_kw.value()->text);
+                return frontend_error(FrontendError::UnexpectedToken,
+                                      span_from(*from_kw.value()),
+                                      from_kw.value()->text);
         } else if (take(TokenType::Star)) {
             auto as_kw = expect(TokenType::KwAs);
             if (!as_kw) return core::make_unexpected(as_kw.error());
@@ -1318,7 +1347,9 @@ struct Parser {
             auto from_kw = expect(TokenType::Ident);
             if (!from_kw) return core::make_unexpected(from_kw.error());
             if (!from_kw.value()->text.eq({"from", 4}))
-                return frontend_error(FrontendError::UnexpectedToken, span_from(*from_kw.value()), from_kw.value()->text);
+                return frontend_error(FrontendError::UnexpectedToken,
+                                      span_from(*from_kw.value()),
+                                      from_kw.value()->text);
         }
         auto path = expect(TokenType::StringLit);
         if (!path) return core::make_unexpected(path.error());
@@ -1349,8 +1380,11 @@ struct Parser {
                 return frontend_error(FrontendError::TooManyItems, span_from(*part.value()));
         }
         if (item.using_decl.target_parts.len < 2)
-            return frontend_error(FrontendError::UnsupportedSyntax, Span{kw.value()->start, cur().start, kw.value()->line, kw.value()->col});
-        item.span = Span{kw.value()->start, toks->tokens[pos - 1].end, kw.value()->line, kw.value()->col};
+            return frontend_error(
+                FrontendError::UnsupportedSyntax,
+                Span{kw.value()->start, cur().start, kw.value()->line, kw.value()->col});
+        item.span =
+            Span{kw.value()->start, toks->tokens[pos - 1].end, kw.value()->line, kw.value()->col};
         item.using_decl.span = item.span;
         return item;
     }
@@ -1363,13 +1397,15 @@ struct Parser {
         AstItem item{};
         item.kind = AstItemKind::Struct;
         item.struct_decl.name = name.value()->text;
-        item.struct_decl.span = Span{kw.value()->start, kw.value()->end, kw.value()->line, kw.value()->col};
+        item.struct_decl.span =
+            Span{kw.value()->start, kw.value()->end, kw.value()->line, kw.value()->col};
         if (take(TokenType::Lt)) {
             while (true) {
                 auto type_param = expect(TokenType::Ident);
                 if (!type_param) return core::make_unexpected(type_param.error());
                 if (!item.struct_decl.type_params.push(type_param.value()->text))
-                    return frontend_error(FrontendError::TooManyItems, span_from(*type_param.value()));
+                    return frontend_error(FrontendError::TooManyItems,
+                                          span_from(*type_param.value()));
                 if (take(TokenType::Gt)) break;
                 auto comma = expect(TokenType::Comma);
                 if (!comma) return core::make_unexpected(comma.error());
@@ -1451,7 +1487,8 @@ struct Parser {
             return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
         item.span = Span{kw_route.start, rbrace.value()->end, kw_route.line, kw_route.col};
         item.route.span = item.span;
-        item.route.body_span = Span{lbrace.value()->start, rbrace.value()->end, lbrace.value()->line, lbrace.value()->col};
+        item.route.body_span = Span{
+            lbrace.value()->start, rbrace.value()->end, lbrace.value()->line, lbrace.value()->col};
         item.route.method = static_cast<u8>(method->type);
         item.route.path = path.value()->text;
         return item;
@@ -1481,8 +1518,7 @@ struct Parser {
         FixedVec<PendingBinding, kMaxBindings> bindings;
 
         // Phase 1: bindings — `@ident "pattern"` while next-after-@ident is StringLit.
-        while (cur().type == TokenType::At &&
-               peek().type == TokenType::Ident &&
+        while (cur().type == TokenType::At && peek().type == TokenType::Ident &&
                peek(2).type == TokenType::StringLit) {
             auto deco = parse_decorator_atom();
             if (!deco) return core::make_unexpected(deco.error());
@@ -1492,8 +1528,7 @@ struct Parser {
             pb.decorator = deco.value();
             pb.pattern = pat.value()->text;
             pb.is_wildcard = pb.pattern.len == 1 && pb.pattern.ptr[0] == '*';
-            if (!bindings.push(pb))
-                return frontend_error(FrontendError::TooManyItems, deco->span);
+            if (!bindings.push(pb)) return frontend_error(FrontendError::TooManyItems, deco->span);
         }
 
         // Phase 2: entries (with optional entry-prefix decorators).
@@ -1509,9 +1544,11 @@ struct Parser {
             auto entry = parse_route_entry(*kw.value());
             if (!entry) return core::make_unexpected(entry.error());
             for (u32 i = 0; i < bindings.len; i++) {
-                if (binding_matches(bindings[i].pattern, bindings[i].is_wildcard, entry->route.path)) {
+                if (binding_matches(
+                        bindings[i].pattern, bindings[i].is_wildcard, entry->route.path)) {
                     if (!entry->route.decorators.push(bindings[i].decorator))
-                        return frontend_error(FrontendError::TooManyItems, bindings[i].decorator.span);
+                        return frontend_error(FrontendError::TooManyItems,
+                                              bindings[i].decorator.span);
                 }
             }
             for (u32 i = 0; i < entry_decorators.len; i++) {
@@ -1544,10 +1581,12 @@ FrontendResult<AstFile*> parse_file(const LexedTokens& tokens) {
         if (!name) return core::make_unexpected(name.error());
         file->has_package_decl = true;
         file->package_name = name.value()->text;
-        file->package_span = Span{kw.value()->start, name.value()->end, kw.value()->line, kw.value()->col};
+        file->package_span =
+            Span{kw.value()->start, name.value()->end, kw.value()->line, kw.value()->col};
     }
     while (p.cur().type != TokenType::Eof) {
-        FrontendResult<AstItem> item = frontend_error(FrontendError::UnexpectedToken, Parser::span_from(p.cur()), p.cur().text);
+        FrontendResult<AstItem> item = frontend_error(
+            FrontendError::UnexpectedToken, Parser::span_from(p.cur()), p.cur().text);
         switch (p.cur().type) {
             case TokenType::KwUpstream:
                 item = p.parse_upstream();
@@ -1585,10 +1624,12 @@ FrontendResult<AstFile*> parse_file(const LexedTokens& tokens) {
                 }
                 if (p.cur().type == TokenType::Eof)
                     return frontend_error(FrontendError::UnexpectedEof, Parser::span_from(p.cur()));
-                return frontend_error(FrontendError::UnexpectedToken, Parser::span_from(p.cur()), p.cur().text);
+                return frontend_error(
+                    FrontendError::UnexpectedToken, Parser::span_from(p.cur()), p.cur().text);
         }
         if (!item) return core::make_unexpected(item.error());
-        if (!file->items.push(item.value())) return frontend_error(FrontendError::TooManyItems, item.value().span);
+        if (!file->items.push(item.value()))
+            return frontend_error(FrontendError::TooManyItems, item.value().span);
     }
     return file.release();
 }

--- a/src/compiler/rir_printer.cc
+++ b/src/compiler/rir_printer.cc
@@ -576,7 +576,11 @@ void print_instruction(PrintBuf& buf, const Instruction& inst, const Function& f
             break;
         case Opcode::RetStatus:
             buf.put(' ');
-            buf.put_i32(inst.imm.i32_val);
+            if (inst.operand_count > 0) {
+                print_value_ref(buf, inst.operands[0]);
+            } else {
+                buf.put_i32(inst.imm.i32_val);
+            }
             break;
         case Opcode::RetForward:
             buf.put(' ');

--- a/src/compiler/rir_printer.cc
+++ b/src/compiler/rir_printer.cc
@@ -220,6 +220,12 @@ void print_opcode(PrintBuf& buf, Opcode op) {
         case Opcode::BodyParse:
             buf.put_cstr("body.parse");
             break;
+        case Opcode::OptNil:
+            buf.put_cstr("opt.nil");
+            break;
+        case Opcode::OptWrap:
+            buf.put_cstr("opt.wrap");
+            break;
         case Opcode::ArrayLen:
             buf.put_cstr("array.len");
             break;
@@ -231,6 +237,9 @@ void print_opcode(PrintBuf& buf, Opcode op) {
             break;
         case Opcode::OptUnwrap:
             buf.put_cstr("opt.unwrap");
+            break;
+        case Opcode::Select:
+            buf.put_cstr("select");
             break;
         case Opcode::TraceFuncEnter:
             buf.put_cstr("trace.func_enter");
@@ -499,11 +508,20 @@ void print_instruction(PrintBuf& buf, const Instruction& inst, const Function& f
             buf.put_cstr(", ");
             print_quoted_str(buf, inst.imm.str_val);
             break;
+        case Opcode::OptWrap:
         case Opcode::OptIsNil:
         case Opcode::OptUnwrap:
         case Opcode::BytesHex:
             buf.put(' ');
             print_value_ref(buf, inst.operands[0]);
+            break;
+        case Opcode::Select:
+            buf.put(' ');
+            print_value_ref(buf, inst.operands[0]);
+            buf.put_cstr(", ");
+            print_value_ref(buf, inst.operands[1]);
+            buf.put_cstr(", ");
+            print_value_ref(buf, inst.operands[2]);
             break;
         case Opcode::StructCreate:
             buf.put(' ');

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -56,6 +56,9 @@ struct Ctx {
     // Optional(Str): {i8, ptr, i32} — has_value byte + ptr + len
     LLVMTypeRef opt_str_ty;
 
+    // Optional(I32): {i8, i32}
+    LLVMTypeRef opt_i32_ty;
+
     // HandlerResult: i64 (packed 8-byte struct, passed as integer)
     LLVMTypeRef result_ty;
 
@@ -78,6 +81,8 @@ struct Ctx {
     LLVMValueRef fn_req_header;
     LLVMValueRef fn_req_remote_addr;
     LLVMValueRef fn_str_has_prefix;
+    LLVMValueRef fn_str_eq;
+    LLVMValueRef fn_str_cmp;
     LLVMValueRef fn_str_trim_prefix;
 
     void init_types() {
@@ -96,6 +101,10 @@ struct Ctx {
         // Optional(Str): {i8, ptr, i32}
         LLVMTypeRef opt_str_fields[] = {i8_ty, ptr_ty, i32_ty};
         opt_str_ty = LLVMStructTypeInContext(llvm_ctx, opt_str_fields, 3, 0);
+
+        // Optional(I32): {i8, i32}
+        LLVMTypeRef opt_i32_fields[] = {i8_ty, i32_ty};
+        opt_i32_ty = LLVMStructTypeInContext(llvm_ctx, opt_i32_fields, 2, 0);
 
         // HandlerResult is returned as i64 (8-byte packed struct)
         result_ty = i64_ty;
@@ -155,6 +164,26 @@ struct Ctx {
             fn_str_has_prefix = LLVMAddFunction(llvm_mod, "rut_helper_str_has_prefix", ft);
         }
         return fn_str_has_prefix;
+    }
+
+    // u8 rut_helper_str_eq(ptr, i32, ptr, i32)
+    LLVMValueRef get_str_eq() {
+        if (!fn_str_eq) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, i32_ty};
+            LLVMTypeRef ft = LLVMFunctionType(i8_ty, params, 4, 0);
+            fn_str_eq = LLVMAddFunction(llvm_mod, "rut_helper_str_eq", ft);
+        }
+        return fn_str_eq;
+    }
+
+    // i32 rut_helper_str_cmp(ptr, i32, ptr, i32)
+    LLVMValueRef get_str_cmp() {
+        if (!fn_str_cmp) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, i32_ty};
+            LLVMTypeRef ft = LLVMFunctionType(i32_ty, params, 4, 0);
+            fn_str_cmp = LLVMAddFunction(llvm_mod, "rut_helper_str_cmp", ft);
+        }
+        return fn_str_cmp;
     }
 
     // void rut_helper_str_trim_prefix(ptr, i32, ptr, i32, ptr, ptr)
@@ -275,7 +304,23 @@ struct Ctx {
             case rir::TypeKind::Method:
                 return i8_ty;
             case rir::TypeKind::Optional:
-                return opt_str_ty;  // TODO: generic optional
+                if (ty->inner && ty->inner->kind == rir::TypeKind::I32) return opt_i32_ty;
+                if (ty->inner && ty->inner->kind == rir::TypeKind::Str) return opt_str_ty;
+                {
+                    LLVMTypeRef payload = map_type(ty->inner);
+                    LLVMTypeRef fields[] = {i8_ty, payload};
+                    return LLVMStructTypeInContext(llvm_ctx, fields, 2, 0);
+                }
+            case rir::TypeKind::Struct:
+                if (ty->struct_def) {
+                    auto* sd = ty->struct_def;
+                    LLVMTypeRef fields[16]{};
+                    for (u32 i = 0; i < sd->field_count; i++) {
+                        fields[i] = map_type(sd->fields()[i].type);
+                    }
+                    return LLVMStructTypeInContext(llvm_ctx, fields, sd->field_count, 0);
+                }
+                return ptr_ty;
             default:
                 return ptr_ty;
         }
@@ -450,6 +495,52 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
         case rir::Opcode::CmpGe: {
             LLVMValueRef a = c.get_value(inst.operands[0]);
             LLVMValueRef b = c.get_value(inst.operands[1]);
+            const rir::Type* lhs_ty =
+                c.cur_fn && inst.operands[0].id < c.cur_fn->value_cap ? c.cur_fn->values[inst.operands[0].id].type
+                                                                      : nullptr;
+            if (lhs_ty && lhs_ty->kind == rir::TypeKind::Str) {
+                LLVMValueRef a_ptr = LLVMBuildExtractValue(c.builder, a, 0, "cmp.s.a.ptr");
+                LLVMValueRef a_len = LLVMBuildExtractValue(c.builder, a, 1, "cmp.s.a.len");
+                LLVMValueRef b_ptr = LLVMBuildExtractValue(c.builder, b, 0, "cmp.s.b.ptr");
+                LLVMValueRef b_len = LLVMBuildExtractValue(c.builder, b, 1, "cmp.s.b.len");
+                LLVMValueRef args[] = {a_ptr, a_len, b_ptr, b_len};
+                if (inst.op == rir::Opcode::CmpEq || inst.op == rir::Opcode::CmpNe) {
+                    LLVMValueRef eq = LLVMBuildCall2(c.builder,
+                                                     LLVMGlobalGetValueType(c.get_str_eq()),
+                                                     c.get_str_eq(),
+                                                     args,
+                                                     4,
+                                                     "str.eq");
+                    LLVMValueRef as_bool = LLVMBuildICmp(c.builder,
+                                                         LLVMIntNE,
+                                                         eq,
+                                                         LLVMConstInt(c.i8_ty, 0, 0),
+                                                         "str.eq.bool");
+                    if (inst.op == rir::Opcode::CmpNe) {
+                        as_bool = LLVMBuildNot(c.builder, as_bool, "str.ne.bool");
+                    }
+                    c.set_value(inst.result, as_bool);
+                    break;
+                }
+                LLVMValueRef cmp = LLVMBuildCall2(c.builder,
+                                                  LLVMGlobalGetValueType(c.get_str_cmp()),
+                                                  c.get_str_cmp(),
+                                                  args,
+                                                  4,
+                                                  "str.cmp");
+                LLVMIntPredicate pred;
+                switch (inst.op) {
+                    case rir::Opcode::CmpLt: pred = LLVMIntSLT; break;
+                    case rir::Opcode::CmpGt: pred = LLVMIntSGT; break;
+                    case rir::Opcode::CmpLe: pred = LLVMIntSLE; break;
+                    case rir::Opcode::CmpGe: pred = LLVMIntSGE; break;
+                    default: pred = LLVMIntEQ; break;
+                }
+                LLVMValueRef as_bool =
+                    LLVMBuildICmp(c.builder, pred, cmp, LLVMConstInt(c.i32_ty, 0, 0), "str.ord.bool");
+                c.set_value(inst.result, as_bool);
+                break;
+            }
             // Eq/Ne are sign-agnostic. For ordered comparisons, pick
             // signed vs unsigned predicates based on the RIR operand type.
             bool uns = c.is_unsigned_operand(inst.operands[0]);
@@ -483,6 +574,40 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
         }
 
         // ── Optional operations ──
+        case rir::Opcode::OptNil: {
+            LLVMTypeRef out_ty = c.map_type(c.cur_fn->values[inst.result.id].type);
+            LLVMValueRef opt = LLVMGetUndef(out_ty);
+            opt = LLVMBuildInsertValue(c.builder, opt, LLVMConstInt(c.i8_ty, 0, 0), 0, "opt.nil.has");
+            if (out_ty == c.opt_i32_ty) {
+                opt = LLVMBuildInsertValue(c.builder, opt, LLVMConstInt(c.i32_ty, 0, 0), 1, "opt.nil.i32");
+            } else if (out_ty == c.opt_str_ty) {
+                opt = LLVMBuildInsertValue(c.builder, opt, LLVMConstNull(c.ptr_ty), 1, "opt.nil.ptr");
+                opt = LLVMBuildInsertValue(c.builder, opt, LLVMConstInt(c.i32_ty, 0, 0), 2, "opt.nil.len");
+            } else {
+                LLVMTypeRef payload_ty = LLVMStructGetTypeAtIndex(out_ty, 1);
+                opt = LLVMBuildInsertValue(c.builder, opt, LLVMGetUndef(payload_ty), 1, "opt.nil.payload");
+            }
+            c.set_value(inst.result, opt);
+            break;
+        }
+        case rir::Opcode::OptWrap: {
+            LLVMValueRef val = c.get_value(inst.operands[0]);
+            LLVMTypeRef out_ty = c.map_type(c.cur_fn->values[inst.result.id].type);
+            LLVMValueRef opt = LLVMGetUndef(out_ty);
+            opt = LLVMBuildInsertValue(c.builder, opt, LLVMConstInt(c.i8_ty, 1, 0), 0, "opt.wrap.has");
+            if (out_ty == c.opt_i32_ty) {
+                opt = LLVMBuildInsertValue(c.builder, opt, val, 1, "opt.wrap.i32");
+            } else if (out_ty == c.opt_str_ty) {
+                LLVMValueRef p = LLVMBuildExtractValue(c.builder, val, 0, "opt.wrap.ptr");
+                LLVMValueRef l = LLVMBuildExtractValue(c.builder, val, 1, "opt.wrap.len");
+                opt = LLVMBuildInsertValue(c.builder, opt, p, 1, "opt.wrap.ptr.set");
+                opt = LLVMBuildInsertValue(c.builder, opt, l, 2, "opt.wrap.len.set");
+            } else {
+                opt = LLVMBuildInsertValue(c.builder, opt, val, 1, "opt.wrap.payload");
+            }
+            c.set_value(inst.result, opt);
+            break;
+        }
         case rir::Opcode::OptIsNil: {
             LLVMValueRef opt = c.get_value(inst.operands[0]);
             LLVMValueRef has = LLVMBuildExtractValue(c.builder, opt, 0, "opt.has");
@@ -492,14 +617,55 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             break;
         }
         case rir::Opcode::OptUnwrap: {
-            // Extract the value fields (ptr, len) from Optional(Str).
             LLVMValueRef opt = c.get_value(inst.operands[0]);
-            LLVMValueRef p = LLVMBuildExtractValue(c.builder, opt, 1, "uw.ptr");
-            LLVMValueRef l = LLVMBuildExtractValue(c.builder, opt, 2, "uw.len");
-            LLVMValueRef strval = LLVMGetUndef(c.str_ty);
-            strval = LLVMBuildInsertValue(c.builder, strval, p, 0, "uw.s.ptr");
-            strval = LLVMBuildInsertValue(c.builder, strval, l, 1, "uw.s.len");
-            c.set_value(inst.result, strval);
+            LLVMTypeRef out_ty = c.map_type(c.cur_fn->values[inst.result.id].type);
+            if (out_ty == c.i32_ty) {
+                LLVMValueRef v = LLVMBuildExtractValue(c.builder, opt, 1, "uw.i32");
+                c.set_value(inst.result, v);
+            } else if (out_ty == c.str_ty) {
+                LLVMValueRef p = LLVMBuildExtractValue(c.builder, opt, 1, "uw.ptr");
+                LLVMValueRef l = LLVMBuildExtractValue(c.builder, opt, 2, "uw.len");
+                LLVMValueRef strval = LLVMGetUndef(c.str_ty);
+                strval = LLVMBuildInsertValue(c.builder, strval, p, 0, "uw.s.ptr");
+                strval = LLVMBuildInsertValue(c.builder, strval, l, 1, "uw.s.len");
+                c.set_value(inst.result, strval);
+            } else {
+                LLVMValueRef v = LLVMBuildExtractValue(c.builder, opt, 1, "uw.payload");
+                c.set_value(inst.result, v);
+            }
+            break;
+        }
+        case rir::Opcode::Select: {
+            LLVMValueRef cond = c.get_value(inst.operands[0]);
+            LLVMValueRef then_v = c.get_value(inst.operands[1]);
+            LLVMValueRef else_v = c.get_value(inst.operands[2]);
+            LLVMValueRef v = LLVMBuildSelect(c.builder, cond, then_v, else_v, "sel");
+            c.set_value(inst.result, v);
+            break;
+        }
+        case rir::Opcode::StructCreate: {
+            LLVMTypeRef out_ty = c.map_type(c.cur_fn->values[inst.result.id].type);
+            LLVMValueRef s = LLVMGetUndef(out_ty);
+            for (u32 i = 0; i < inst.operand_count; i++) {
+                s = LLVMBuildInsertValue(c.builder, s, c.get_value(inst.operand(i)), i, "st.ins");
+            }
+            c.set_value(inst.result, s);
+            break;
+        }
+        case rir::Opcode::StructField: {
+            LLVMValueRef s = c.get_value(inst.operands[0]);
+            auto* struct_ty = c.cur_fn->values[inst.operands[0].id].type;
+            u32 field_index = struct_ty && struct_ty->struct_def ? struct_ty->struct_def->field_count : 0;
+            if (struct_ty && struct_ty->struct_def) {
+                for (u32 i = 0; i < struct_ty->struct_def->field_count; i++) {
+                    if (struct_ty->struct_def->fields()[i].name.eq(inst.imm.struct_ref.name)) {
+                        field_index = i;
+                        break;
+                    }
+                }
+            }
+            LLVMValueRef v = LLVMBuildExtractValue(c.builder, s, field_index, "st.field");
+            c.set_value(inst.result, v);
             break;
         }
 
@@ -652,6 +818,7 @@ CodegenResult codegen(const rir::Module& rir_mod) {
     c.fn_req_header = nullptr;
     c.fn_req_remote_addr = nullptr;
     c.fn_str_has_prefix = nullptr;
+    c.fn_str_eq = nullptr;
     c.fn_str_trim_prefix = nullptr;
     c.cur_fn = nullptr;
 

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -314,7 +314,13 @@ struct Ctx {
             case rir::TypeKind::Struct:
                 if (ty->struct_def) {
                     auto* sd = ty->struct_def;
-                    LLVMTypeRef fields[16]{};
+                    // Stack buffer capped at 16 to avoid heap/arena plumbing in
+                    // the type mapper. MirStruct::kMaxFields is 8 upstream, so
+                    // 16 is 2x headroom; if frontend capacity ever grows, raise
+                    // this in lockstep. Trap instead of silently truncating.
+                    static constexpr u32 kMaxStructFields = 16;
+                    if (sd->field_count > kMaxStructFields) __builtin_trap();
+                    LLVMTypeRef fields[kMaxStructFields]{};
                     for (u32 i = 0; i < sd->field_count; i++) {
                         fields[i] = map_type(sd->fields()[i].type);
                     }
@@ -833,6 +839,7 @@ CodegenResult codegen(const rir::Module& rir_mod) {
     c.fn_req_remote_addr = nullptr;
     c.fn_str_has_prefix = nullptr;
     c.fn_str_eq = nullptr;
+    c.fn_str_cmp = nullptr;
     c.fn_str_trim_prefix = nullptr;
     c.cur_fn = nullptr;
 

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -495,9 +495,9 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
         case rir::Opcode::CmpGe: {
             LLVMValueRef a = c.get_value(inst.operands[0]);
             LLVMValueRef b = c.get_value(inst.operands[1]);
-            const rir::Type* lhs_ty =
-                c.cur_fn && inst.operands[0].id < c.cur_fn->value_cap ? c.cur_fn->values[inst.operands[0].id].type
-                                                                      : nullptr;
+            const rir::Type* lhs_ty = c.cur_fn && inst.operands[0].id < c.cur_fn->value_cap
+                                          ? c.cur_fn->values[inst.operands[0].id].type
+                                          : nullptr;
             if (lhs_ty && lhs_ty->kind == rir::TypeKind::Str) {
                 LLVMValueRef a_ptr = LLVMBuildExtractValue(c.builder, a, 0, "cmp.s.a.ptr");
                 LLVMValueRef a_len = LLVMBuildExtractValue(c.builder, a, 1, "cmp.s.a.len");
@@ -511,11 +511,8 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
                                                      args,
                                                      4,
                                                      "str.eq");
-                    LLVMValueRef as_bool = LLVMBuildICmp(c.builder,
-                                                         LLVMIntNE,
-                                                         eq,
-                                                         LLVMConstInt(c.i8_ty, 0, 0),
-                                                         "str.eq.bool");
+                    LLVMValueRef as_bool = LLVMBuildICmp(
+                        c.builder, LLVMIntNE, eq, LLVMConstInt(c.i8_ty, 0, 0), "str.eq.bool");
                     if (inst.op == rir::Opcode::CmpNe) {
                         as_bool = LLVMBuildNot(c.builder, as_bool, "str.ne.bool");
                     }
@@ -530,14 +527,24 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
                                                   "str.cmp");
                 LLVMIntPredicate pred;
                 switch (inst.op) {
-                    case rir::Opcode::CmpLt: pred = LLVMIntSLT; break;
-                    case rir::Opcode::CmpGt: pred = LLVMIntSGT; break;
-                    case rir::Opcode::CmpLe: pred = LLVMIntSLE; break;
-                    case rir::Opcode::CmpGe: pred = LLVMIntSGE; break;
-                    default: pred = LLVMIntEQ; break;
+                    case rir::Opcode::CmpLt:
+                        pred = LLVMIntSLT;
+                        break;
+                    case rir::Opcode::CmpGt:
+                        pred = LLVMIntSGT;
+                        break;
+                    case rir::Opcode::CmpLe:
+                        pred = LLVMIntSLE;
+                        break;
+                    case rir::Opcode::CmpGe:
+                        pred = LLVMIntSGE;
+                        break;
+                    default:
+                        pred = LLVMIntEQ;
+                        break;
                 }
-                LLVMValueRef as_bool =
-                    LLVMBuildICmp(c.builder, pred, cmp, LLVMConstInt(c.i32_ty, 0, 0), "str.ord.bool");
+                LLVMValueRef as_bool = LLVMBuildICmp(
+                    c.builder, pred, cmp, LLVMConstInt(c.i32_ty, 0, 0), "str.ord.bool");
                 c.set_value(inst.result, as_bool);
                 break;
             }
@@ -577,15 +584,20 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
         case rir::Opcode::OptNil: {
             LLVMTypeRef out_ty = c.map_type(c.cur_fn->values[inst.result.id].type);
             LLVMValueRef opt = LLVMGetUndef(out_ty);
-            opt = LLVMBuildInsertValue(c.builder, opt, LLVMConstInt(c.i8_ty, 0, 0), 0, "opt.nil.has");
+            opt =
+                LLVMBuildInsertValue(c.builder, opt, LLVMConstInt(c.i8_ty, 0, 0), 0, "opt.nil.has");
             if (out_ty == c.opt_i32_ty) {
-                opt = LLVMBuildInsertValue(c.builder, opt, LLVMConstInt(c.i32_ty, 0, 0), 1, "opt.nil.i32");
+                opt = LLVMBuildInsertValue(
+                    c.builder, opt, LLVMConstInt(c.i32_ty, 0, 0), 1, "opt.nil.i32");
             } else if (out_ty == c.opt_str_ty) {
-                opt = LLVMBuildInsertValue(c.builder, opt, LLVMConstNull(c.ptr_ty), 1, "opt.nil.ptr");
-                opt = LLVMBuildInsertValue(c.builder, opt, LLVMConstInt(c.i32_ty, 0, 0), 2, "opt.nil.len");
+                opt =
+                    LLVMBuildInsertValue(c.builder, opt, LLVMConstNull(c.ptr_ty), 1, "opt.nil.ptr");
+                opt = LLVMBuildInsertValue(
+                    c.builder, opt, LLVMConstInt(c.i32_ty, 0, 0), 2, "opt.nil.len");
             } else {
                 LLVMTypeRef payload_ty = LLVMStructGetTypeAtIndex(out_ty, 1);
-                opt = LLVMBuildInsertValue(c.builder, opt, LLVMGetUndef(payload_ty), 1, "opt.nil.payload");
+                opt = LLVMBuildInsertValue(
+                    c.builder, opt, LLVMGetUndef(payload_ty), 1, "opt.nil.payload");
             }
             c.set_value(inst.result, opt);
             break;
@@ -594,7 +606,8 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             LLVMValueRef val = c.get_value(inst.operands[0]);
             LLVMTypeRef out_ty = c.map_type(c.cur_fn->values[inst.result.id].type);
             LLVMValueRef opt = LLVMGetUndef(out_ty);
-            opt = LLVMBuildInsertValue(c.builder, opt, LLVMConstInt(c.i8_ty, 1, 0), 0, "opt.wrap.has");
+            opt = LLVMBuildInsertValue(
+                c.builder, opt, LLVMConstInt(c.i8_ty, 1, 0), 0, "opt.wrap.has");
             if (out_ty == c.opt_i32_ty) {
                 opt = LLVMBuildInsertValue(c.builder, opt, val, 1, "opt.wrap.i32");
             } else if (out_ty == c.opt_str_ty) {
@@ -655,7 +668,8 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
         case rir::Opcode::StructField: {
             LLVMValueRef s = c.get_value(inst.operands[0]);
             auto* struct_ty = c.cur_fn->values[inst.operands[0].id].type;
-            u32 field_index = struct_ty && struct_ty->struct_def ? struct_ty->struct_def->field_count : 0;
+            u32 field_index =
+                struct_ty && struct_ty->struct_def ? struct_ty->struct_def->field_count : 0;
             if (struct_ty && struct_ty->struct_def) {
                 for (u32 i = 0; i < struct_ty->struct_def->field_count; i++) {
                     if (struct_ty->struct_def->fields()[i].name.eq(inst.imm.struct_ref.name)) {

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -85,6 +85,20 @@ struct Ctx {
     LLVMValueRef fn_str_cmp;
     LLVMValueRef fn_str_trim_prefix;
 
+    // Cache for map_type: LLVM literal structs (Optional<composite>, Struct
+    // with a StructDef) are identity-compared, so emitting a fresh
+    // LLVMStructTypeInContext call per lookup produces *different* LLVM types
+    // for the same RIR type — breaking PHIs, selects, and other operations
+    // that require exact type equality. Key by the rir::Type pointer, which
+    // is arena-allocated and stable for the module's lifetime.
+    static constexpr u32 kMaxCachedTypes = 256;
+    struct TypeCacheEntry {
+        const rir::Type* key;
+        LLVMTypeRef value;
+    };
+    TypeCacheEntry type_cache[kMaxCachedTypes];
+    u32 type_cache_count;
+
     void init_types() {
         i1_ty = LLVMInt1TypeInContext(llvm_ctx);
         i8_ty = LLVMInt8TypeInContext(llvm_ctx);
@@ -275,8 +289,18 @@ struct Ctx {
 
     // ── Type mapping ───────────────────────────────────────────────
 
+    LLVMTypeRef cache_type(const rir::Type* ty, LLVMTypeRef t) {
+        if (type_cache_count < kMaxCachedTypes) {
+            type_cache[type_cache_count++] = {ty, t};
+        }
+        return t;
+    }
+
     LLVMTypeRef map_type(const rir::Type* ty) {
         if (!ty) return void_ty;
+        for (u32 i = 0; i < type_cache_count; i++) {
+            if (type_cache[i].key == ty) return type_cache[i].value;
+        }
         switch (ty->kind) {
             case rir::TypeKind::Void:
                 return void_ty;
@@ -309,7 +333,7 @@ struct Ctx {
                 {
                     LLVMTypeRef payload = map_type(ty->inner);
                     LLVMTypeRef fields[] = {i8_ty, payload};
-                    return LLVMStructTypeInContext(llvm_ctx, fields, 2, 0);
+                    return cache_type(ty, LLVMStructTypeInContext(llvm_ctx, fields, 2, 0));
                 }
             case rir::TypeKind::Struct:
                 if (ty->struct_def) {
@@ -324,7 +348,8 @@ struct Ctx {
                     for (u32 i = 0; i < sd->field_count; i++) {
                         fields[i] = map_type(sd->fields()[i].type);
                     }
-                    return LLVMStructTypeInContext(llvm_ctx, fields, sd->field_count, 0);
+                    return cache_type(
+                        ty, LLVMStructTypeInContext(llvm_ctx, fields, sd->field_count, 0));
                 }
                 return ptr_ty;
             default:
@@ -842,6 +867,7 @@ CodegenResult codegen(const rir::Module& rir_mod) {
     c.fn_str_cmp = nullptr;
     c.fn_str_trim_prefix = nullptr;
     c.cur_fn = nullptr;
+    c.type_cache_count = 0;
 
     c.init_types();
 

--- a/src/jit/jit_engine.cc
+++ b/src/jit/jit_engine.cc
@@ -140,19 +140,26 @@ bool JitEngine::compile(LLVMModuleRef mod, LLVMContextRef ctx) {
     LLVMOrcThreadSafeModuleRef tsm = LLVMOrcCreateNewThreadSafeModule(mod, tsctx);
     LLVMOrcDisposeThreadSafeContext(tsctx);
 
-    // Track the orphaned context for cleanup.
-    if (ctx_count < kMaxContexts) {
-        contexts[ctx_count++] = ctx;
-    }
-
     // Submit to the main JITDylib. On success, LLJIT owns tsm.
+    // We defer tracking `ctx` until *after* the module is accepted: on failure
+    // we dispose ctx here rather than letting a failed compile consume a slot
+    // in `contexts[]` (and eventually exhaust kMaxContexts).
     LLVMOrcJITDylibRef main_jd = LLVMOrcLLJITGetMainJITDylib(lljit);
     LLVMErrorRef err = LLVMOrcLLJITAddLLVMIRModule(lljit, main_jd, tsm);
     if (err) {
         log_error("jit: module compilation failed", err);
-        // On failure, ownership of tsm stays with us.
+        // On failure, ownership of tsm stays with us; disposing tsm also
+        // disposes the inner module. We still own `ctx` (module's original
+        // context) — dispose it here to match the verification-failure path.
         LLVMOrcDisposeThreadSafeModule(tsm);
+        LLVMContextDispose(ctx);
         return false;
+    }
+
+    // Track the orphaned context for cleanup in shutdown(), after LLJIT
+    // has accepted the module.
+    if (ctx_count < kMaxContexts) {
+        contexts[ctx_count++] = ctx;
     }
 
     return true;

--- a/src/jit/jit_engine.cc
+++ b/src/jit/jit_engine.cc
@@ -3,6 +3,7 @@
 #include "rut/jit/runtime_helpers.h"
 
 #include <llvm-c/Core.h>
+#include <llvm-c/Analysis.h>
 #include <llvm-c/Error.h>
 #include <llvm-c/LLJIT.h>
 #include <llvm-c/Orc.h>
@@ -41,6 +42,8 @@ static const HelperEntry kHelpers[] = {
     {"rut_helper_req_header", reinterpret_cast<void*>(&rut_helper_req_header)},
     {"rut_helper_req_remote_addr", reinterpret_cast<void*>(&rut_helper_req_remote_addr)},
     {"rut_helper_str_has_prefix", reinterpret_cast<void*>(&rut_helper_str_has_prefix)},
+    {"rut_helper_str_eq", reinterpret_cast<void*>(&rut_helper_str_eq)},
+    {"rut_helper_str_cmp", reinterpret_cast<void*>(&rut_helper_str_cmp)},
     {"rut_helper_str_trim_prefix", reinterpret_cast<void*>(&rut_helper_str_trim_prefix)},
     {nullptr, nullptr},
 };
@@ -104,6 +107,24 @@ bool JitEngine::compile(LLVMModuleRef mod, LLVMContextRef ctx) {
     if (dl) LLVMSetDataLayout(mod, dl);
     const char* triple = LLVMOrcLLJITGetTripleString(lljit);
     if (triple) LLVMSetTarget(mod, triple);
+
+    char* verify_msg = nullptr;
+    if (LLVMVerifyModule(mod, LLVMReturnStatusAction, &verify_msg)) {
+        if (verify_msg) {
+            auto write_str = [](const char* s) {
+                int len = 0;
+                while (s[len]) len++;
+                (void)::write(2, s, len);
+            };
+            write_str("jit: module verification failed: ");
+            write_str(verify_msg);
+            write_str("\n");
+            LLVMDisposeMessage(verify_msg);
+        }
+        LLVMDisposeModule(mod);
+        LLVMContextDispose(ctx);
+        return false;
+    }
 
     // Wrap module into a ThreadSafeModule for submission to LLJIT.
     // We create a fresh ThreadSafeContext as the lock wrapper. Its internal

--- a/src/jit/jit_engine.cc
+++ b/src/jit/jit_engine.cc
@@ -15,17 +15,19 @@ namespace rut::jit {
 // ── Error logging (no stdlib) ──────────────────────────────────────
 
 static void log_error(const char* prefix, LLVMErrorRef err) {
-    char* msg = LLVMGetErrorMessage(err);
     auto write_str = [](const char* s) {
         int len = 0;
         while (s[len]) len++;
         (void)::write(2, s, len);
     };
     write_str(prefix);
-    write_str(": ");
-    write_str(msg);
+    if (err) {
+        char* msg = LLVMGetErrorMessage(err);
+        write_str(": ");
+        write_str(msg);
+        LLVMDisposeErrorMessage(msg);
+    }
     write_str("\n");
-    LLVMDisposeErrorMessage(msg);
 }
 
 // ── Runtime Helper Symbol Table ────────────────────────────────────
@@ -70,9 +72,18 @@ bool JitEngine::init() {
     // Fixed stack buffer; raise kMaxHelpers in lockstep when kHelpers grows.
     // Without the clamp on `count` the loop below can leave tail pairs
     // uninitialized yet still hand them to LLVMOrcAbsoluteSymbols.
+    // If kHelpers ever grows past kMaxHelpers, fail loudly instead of
+    // silently skipping helpers (which would produce opaque JIT link
+    // failures at runtime).
     static constexpr u32 kMaxHelpers = 16;
     u32 count = 0;
-    for (const auto* h = kHelpers; h->name && count < kMaxHelpers; h++) count++;
+    for (const auto* h = kHelpers; h->name; h++) count++;
+    if (count > kMaxHelpers) {
+        log_error("jit: helper table exceeds kMaxHelpers — raise the cap", nullptr);
+        LLVMOrcDisposeLLJIT(lljit);
+        lljit = nullptr;
+        return false;
+    }
 
     LLVMOrcCSymbolMapPair pairs[kMaxHelpers];
     for (u32 i = 0; i < count; i++) {

--- a/src/jit/jit_engine.cc
+++ b/src/jit/jit_engine.cc
@@ -2,8 +2,8 @@
 
 #include "rut/jit/runtime_helpers.h"
 
-#include <llvm-c/Core.h>
 #include <llvm-c/Analysis.h>
+#include <llvm-c/Core.h>
 #include <llvm-c/Error.h>
 #include <llvm-c/LLJIT.h>
 #include <llvm-c/Orc.h>

--- a/src/jit/jit_engine.cc
+++ b/src/jit/jit_engine.cc
@@ -67,11 +67,15 @@ bool JitEngine::init() {
     // MangleAndIntern produces correctly mangled names for the target.
     LLVMOrcJITDylibRef main_jd = LLVMOrcLLJITGetMainJITDylib(lljit);
 
+    // Fixed stack buffer; raise kMaxHelpers in lockstep when kHelpers grows.
+    // Without the clamp on `count` the loop below can leave tail pairs
+    // uninitialized yet still hand them to LLVMOrcAbsoluteSymbols.
+    static constexpr u32 kMaxHelpers = 16;
     u32 count = 0;
-    for (const auto* h = kHelpers; h->name; h++) count++;
+    for (const auto* h = kHelpers; h->name && count < kMaxHelpers; h++) count++;
 
-    LLVMOrcCSymbolMapPair pairs[16];
-    for (u32 i = 0; i < count && i < 16; i++) {
+    LLVMOrcCSymbolMapPair pairs[kMaxHelpers];
+    for (u32 i = 0; i < count; i++) {
         pairs[i].Name = LLVMOrcLLJITMangleAndIntern(lljit, kHelpers[i].name);
         pairs[i].Sym.Address = reinterpret_cast<LLVMOrcExecutorAddress>(kHelpers[i].addr);
         pairs[i].Sym.Flags.GenericFlags = LLVMJITSymbolGenericFlagsExported;

--- a/src/jit/runtime_helpers.cc
+++ b/src/jit/runtime_helpers.cc
@@ -104,6 +104,27 @@ u8 rut_helper_str_has_prefix(const char* s, u32 s_len, const char* pfx, u32 pfx_
     return 1;
 }
 
+u8 rut_helper_str_eq(const char* a, u32 a_len, const char* b, u32 b_len) {
+    if (a_len != b_len) return 0;
+    for (u32 i = 0; i < a_len; i++) {
+        if (a[i] != b[i]) return 0;
+    }
+    return 1;
+}
+
+i32 rut_helper_str_cmp(const char* a, u32 a_len, const char* b, u32 b_len) {
+    u32 n = a_len < b_len ? a_len : b_len;
+    for (u32 i = 0; i < n; i++) {
+        unsigned char ac = static_cast<unsigned char>(a[i]);
+        unsigned char bc = static_cast<unsigned char>(b[i]);
+        if (ac < bc) return -1;
+        if (ac > bc) return 1;
+    }
+    if (a_len < b_len) return -1;
+    if (a_len > b_len) return 1;
+    return 0;
+}
+
 void rut_helper_str_trim_prefix(
     const char* s, u32 s_len, const char* pfx, u32 pfx_len, const char** out_ptr, u32* out_len) {
     if (pfx_len <= s_len) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,6 +118,15 @@ target_include_directories(test_rir PRIVATE
 add_test(NAME test_rir COMMAND test_rir)
 set_tests_properties(test_rir PROPERTIES LABELS "unit")
 
+add_executable(test_frontend test_frontend.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
+target_link_libraries(test_frontend rut_compiler)
+target_include_directories(test_frontend PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+)
+add_test(NAME test_frontend COMMAND test_frontend)
+set_tests_properties(test_frontend PROPERTIES LABELS "unit;compiler")
+
 add_executable(test_drain test_drain.cc)
 target_link_libraries(test_drain rut_runtime)
 target_include_directories(test_drain PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -232,6 +232,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_buffer>
     COMMAND $<TARGET_FILE:test_types>
     COMMAND $<TARGET_FILE:test_rir>
+    COMMAND $<TARGET_FILE:test_frontend>
     COMMAND $<TARGET_FILE:test_drain>
     COMMAND $<TARGET_FILE:test_access_log>
     COMMAND $<TARGET_FILE:test_metrics>
@@ -242,6 +243,6 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_traffic_replay>
     COMMAND $<TARGET_FILE:test_sim>
     COMMAND $<TARGET_FILE:test_simulate_engine>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine
     COMMENT "Running all tests..."
 )

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -74,6 +74,147 @@ TEST(frontend, lex_parse_return_route) {
     CHECK_EQ(ast->items[1].route.statements[0].status_code, 200);
 }
 
+TEST(frontend, lex_emits_at_token_for_decorator_prefix) {
+    const char* src = "@auth";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    REQUIRE_EQ(lexed->tokens.len, 3u);  // @, auth, EOF
+    CHECK_EQ(static_cast<u8>(lexed->tokens[0].type), static_cast<u8>(TokenType::At));
+    CHECK_EQ(static_cast<u8>(lexed->tokens[1].type), static_cast<u8>(TokenType::Ident));
+    CHECK(lexed->tokens[1].text.eq(lit("auth")));
+}
+
+TEST(frontend, lex_recognizes_lowercase_http_methods) {
+    const char* src = "get post put delete patch head options";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    REQUIRE_EQ(lexed->tokens.len, 8u);  // 7 methods + EOF
+    CHECK_EQ(static_cast<u8>(lexed->tokens[0].type), static_cast<u8>(TokenType::KwGet));
+    CHECK_EQ(static_cast<u8>(lexed->tokens[1].type), static_cast<u8>(TokenType::KwPost));
+    CHECK_EQ(static_cast<u8>(lexed->tokens[2].type), static_cast<u8>(TokenType::KwPut));
+    CHECK_EQ(static_cast<u8>(lexed->tokens[3].type), static_cast<u8>(TokenType::KwDelete));
+    CHECK_EQ(static_cast<u8>(lexed->tokens[4].type), static_cast<u8>(TokenType::KwPatch));
+    CHECK_EQ(static_cast<u8>(lexed->tokens[5].type), static_cast<u8>(TokenType::KwHead));
+    CHECK_EQ(static_cast<u8>(lexed->tokens[6].type), static_cast<u8>(TokenType::KwOptions));
+}
+
+TEST(frontend, parse_route_block_single_entry_no_decorators) {
+    const char* src = "route { GET \"/users\" { return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].kind), static_cast<u8>(AstItemKind::Route));
+    CHECK(ast->items[0].route.path.eq(lit("/users")));
+    CHECK_EQ(ast->items[0].route.decorators.len, 0u);
+}
+
+TEST(frontend, parse_route_block_multiple_entries) {
+    const char* src = "route {\n  GET \"/users\" { return 200 }\n  POST \"/orders\" { return 201 }\n}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    CHECK(ast->items[0].route.path.eq(lit("/users")));
+    CHECK(ast->items[1].route.path.eq(lit("/orders")));
+}
+
+TEST(frontend, parse_route_block_wildcard_binding_applies_to_all_entries) {
+    const char* src = "route {\n  @auth \"*\"\n  GET \"/users\" { return 200 }\n  POST \"/orders\" { return 201 }\n}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    REQUIRE_EQ(ast->items[0].route.decorators.len, 1u);
+    CHECK(ast->items[0].route.decorators[0].name.eq(lit("auth")));
+    REQUIRE_EQ(ast->items[1].route.decorators.len, 1u);
+    CHECK(ast->items[1].route.decorators[0].name.eq(lit("auth")));
+}
+
+TEST(frontend, parse_route_block_prefix_binding_applies_only_to_matching_entries) {
+    const char* src = "route {\n  @auth \"/admin\"\n  GET \"/admin/users\" { return 200 }\n  GET \"/public/health\" { return 200 }\n}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    REQUIRE_EQ(ast->items[0].route.decorators.len, 1u);
+    CHECK(ast->items[0].route.decorators[0].name.eq(lit("auth")));
+    CHECK_EQ(ast->items[1].route.decorators.len, 0u);
+}
+
+TEST(frontend, parse_route_block_entry_decorator_only_attached_to_its_entry) {
+    const char* src = "route {\n  @logResp\n  GET \"/users\" { return 200 }\n  GET \"/health\" { return 200 }\n}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    REQUIRE_EQ(ast->items[0].route.decorators.len, 1u);
+    CHECK(ast->items[0].route.decorators[0].name.eq(lit("logResp")));
+    CHECK_EQ(ast->items[1].route.decorators.len, 0u);
+}
+
+TEST(frontend, parse_route_block_binding_and_entry_decorators_are_merged) {
+    const char* src = "route {\n  @requestId \"*\"\n  @auth \"/admin\"\n  @maxBody\n  POST \"/admin/upload\" { return 200 }\n}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    REQUIRE_EQ(ast->items[0].route.decorators.len, 3u);
+    // Order: matching bindings first (in declaration order), then entry-prefix decorators
+    CHECK(ast->items[0].route.decorators[0].name.eq(lit("requestId")));
+    CHECK(ast->items[0].route.decorators[1].name.eq(lit("auth")));
+    CHECK(ast->items[0].route.decorators[2].name.eq(lit("maxBody")));
+}
+
+TEST(frontend, parse_route_block_lowercase_methods_are_accepted) {
+    const char* src = "route {\n  get \"/users\" { return 200 }\n  post \"/orders\" { return 201 }\n}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+}
+
+TEST(frontend, parse_route_block_legacy_form_still_works) {
+    const char* src = "route GET \"/users\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    CHECK(ast->items[0].route.path.eq(lit("/users")));
+    CHECK_EQ(ast->items[0].route.decorators.len, 0u);
+}
+
+TEST(frontend, parse_func_param_accepts_underscore_label) {
+    const char* src = "func auth(_ req: i32) -> i32 => 0\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    REQUIRE_EQ(ast->items[0].func.params.len, 1u);
+    CHECK(ast->items[0].func.params[0].has_underscore_label);
+    CHECK(ast->items[0].func.params[0].name.eq(lit("req")));
+}
+
+TEST(frontend, parse_func_param_without_underscore_label) {
+    const char* src = "func plain(req: i32) -> i32 => 0\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    REQUIRE_EQ(ast->items[0].func.params.len, 1u);
+    CHECK(!ast->items[0].func.params[0].has_underscore_label);
+}
+
 TEST(frontend, parse_file_header_package_decl_is_recorded) {
     const char* src = "package auth\nfunc jwtAuth() -> i32 => 200\n";
     auto lexed = lex(lit(src));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1,0 +1,8108 @@
+#include "rut/compiler/analyze.h"
+#include "rut/compiler/lexer.h"
+#include "rut/compiler/lower_rir.h"
+#include "rut/compiler/mir_build.h"
+#include "rut/compiler/parser.h"
+#include "test.h"
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+using namespace rut;
+static Str lit(const char* s) {
+    u32 n = 0;
+    while (s[n]) n++;
+    return {s, n};
+}
+static bool block_has_op(const rir::Block& block, rir::Opcode op) {
+    for (u32 i = 0; i < block.inst_count; i++) {
+        if (block.insts[i].op == op) return true;
+    }
+    return false;
+}
+static u32 block_op_count(const rir::Block& block, rir::Opcode op) {
+    u32 count = 0;
+    for (u32 i = 0; i < block.inst_count; i++) {
+        if (block.insts[i].op == op) count++;
+    }
+    return count;
+}
+template <typename T>
+struct HeapFrontendResult {
+    FrontendResult<T*> inner;
+    bool has_value() const { return inner.has_value(); }
+    explicit operator bool() const { return static_cast<bool>(inner); }
+    T* operator->() { return inner.value(); }
+    const T* operator->() const { return inner.value(); }
+    T& value() { return *inner.value(); }
+    const T& value() const { return *inner.value(); }
+    Diagnostic& error() { return inner.error(); }
+    const Diagnostic& error() const { return inner.error(); }
+};
+static HeapFrontendResult<AstFile> parse_file_heap(const LexedTokens& tokens) {
+    auto ast = parse_file(tokens);
+    if (!ast) return {core::make_unexpected(ast.error())};
+    return {ast.value()};
+}
+static HeapFrontendResult<HirModule> analyze_file_heap(const AstFile& file) {
+    auto hir = analyze_file(file);
+    if (!hir) return {core::make_unexpected(hir.error())};
+    return {hir.value()};
+}
+static HeapFrontendResult<HirModule> analyze_file_heap_with_path(const AstFile& file, const std::string& source_path) {
+    Str path{source_path.c_str(), static_cast<u32>(source_path.size())};
+    auto hir = analyze_file(file, path);
+    if (!hir) return {core::make_unexpected(hir.error())};
+    return {hir.value()};
+}
+static HeapFrontendResult<MirModule> build_mir_heap(const HirModule& module) {
+    auto mir = build_mir(module);
+    if (!mir) return {core::make_unexpected(mir.error())};
+    return {mir.value()};
+}
+TEST(frontend, lex_parse_return_route) {
+    const char* src = "upstream api\nroute GET \"/users\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    CHECK(lexed->tokens.len > 0);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].kind), static_cast<u8>(AstItemKind::Upstream));
+    CHECK_EQ(static_cast<u8>(ast->items[1].kind), static_cast<u8>(AstItemKind::Route));
+    CHECK(ast->items[1].route.path.eq(lit("/users")));
+    REQUIRE_EQ(ast->items[1].route.statements.len, 1u);
+    CHECK_EQ(ast->items[1].route.statements[0].status_code, 200);
+}
+
+TEST(frontend, parse_file_header_package_decl_is_recorded) {
+    const char* src = "package auth\nfunc jwtAuth() -> i32 => 200\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    CHECK(ast->has_package_decl);
+    CHECK(ast->package_name.eq(lit("auth")));
+    REQUIRE_EQ(ast->items.len, 1u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].kind), static_cast<u8>(AstItemKind::Func));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->has_package_decl);
+    CHECK(hir->package_name.eq(lit("auth")));
+}
+
+TEST(frontend, parse_rejects_package_decl_after_top_level_item) {
+    const char* src = "func jwtAuth() -> i32 => 200\npackage auth\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+TEST(frontend, import_relative_file_merges_imported_function_symbols) {
+    const std::string dir = "/tmp/rut_import_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route GET "/users" {
+    if jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    if (!hir) {
+        std::fprintf(stderr,
+                     "hir error code=%d detail=%.*s span=(%u,%u)\n",
+                     static_cast<int>(hir.error().code),
+                     static_cast<int>(hir.error().detail.len),
+                     hir.error().detail.ptr,
+                     hir.error().span.line,
+                     hir.error().span.col);
+    }
+    REQUIRE(hir);
+    CHECK(hir->functions.len >= 1u);
+}
+
+TEST(frontend, import_relative_file_with_package_decl_merges_imported_function_symbols) {
+    const std::string dir = "/tmp/rut_import_packaged_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "package auth\nfunc jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route GET "/users" {
+    if jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    CHECK(hir->functions.len >= 1u);
+}
+
+TEST(frontend, import_relative_file_records_imported_package_metadata_in_hir) {
+    const std::string dir = "/tmp/rut_import_package_metadata_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "package auth\nfunc jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route GET "/users" {
+    if jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->imports.len, 1u);
+    CHECK(hir->imports[0].has_package_decl);
+    CHECK(hir->imports[0].package_name.eq(lit("auth")));
+    CHECK(!hir->imports[0].same_package);
+}
+
+TEST(frontend, import_relative_file_in_same_package_marks_hir_import_as_same_package) {
+    const std::string dir = "/tmp/rut_import_same_package_metadata_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "package auth\nfunc jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+package auth
+import "auth.rut"
+route GET "/users" {
+    if jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->imports.len, 1u);
+    CHECK(hir->imports[0].has_package_decl);
+    CHECK(hir->imports[0].package_name.eq(lit("auth")));
+    CHECK(hir->imports[0].same_package);
+}
+
+TEST(frontend, import_relative_file_in_different_package_keeps_hir_import_outside_same_package) {
+    const std::string dir = "/tmp/rut_import_different_package_metadata_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "package auth\nfunc jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+package gateway
+import "auth.rut"
+route GET "/users" {
+    if jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->imports.len, 1u);
+    CHECK(hir->imports[0].has_package_decl);
+    CHECK(hir->imports[0].package_name.eq(lit("auth")));
+    CHECK(!hir->imports[0].same_package);
+}
+
+TEST(frontend, selective_import_in_same_package_marks_hir_import_as_same_package) {
+    const std::string dir = "/tmp/rut_selective_import_same_package_metadata_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "package auth\nfunc jwtAuth() -> i32 => 200\n";
+        out << "func basicAuth() -> i32 => 500\n";
+    }
+    const auto src = R"rut(
+package auth
+import { jwtAuth } from "auth.rut"
+route GET "/users" {
+    if jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->imports.len, 1u);
+    CHECK(hir->imports[0].selective);
+    CHECK(hir->imports[0].has_package_decl);
+    CHECK(hir->imports[0].package_name.eq(lit("auth")));
+    CHECK(hir->imports[0].same_package);
+}
+
+TEST(frontend, namespace_alias_import_in_same_package_marks_hir_import_as_same_package) {
+    const std::string dir = "/tmp/rut_namespace_import_same_package_metadata_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "package auth\nfunc jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+package auth
+import * as authV1 from "auth.rut"
+route GET "/users" {
+    if authV1.jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->imports.len, 1u);
+    CHECK(hir->imports[0].has_namespace_alias);
+    CHECK(hir->imports[0].namespace_alias.eq(lit("authV1")));
+    CHECK(hir->imports[0].has_package_decl);
+    CHECK(hir->imports[0].package_name.eq(lit("auth")));
+    CHECK(hir->imports[0].same_package);
+}
+
+TEST(frontend, import_namespace_function_call_is_supported_for_file_with_package_decl) {
+    const std::string dir = "/tmp/rut_import_namespace_packaged_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "package auth\nfunc jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route GET "/users" {
+    if auth.jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, same_package_multiple_files_do_not_create_package_namespace) {
+    const std::string dir = "/tmp/rut_import_same_package_no_package_namespace_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/jwt.rut", std::ios::binary);
+        out << "package auth\nfunc jwtAuth() -> i32 => 200\n";
+    }
+    {
+        std::ofstream out(dir + "/basic.rut", std::ios::binary);
+        out << "package auth\nfunc basicAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "jwt.rut"
+import "basic.rut"
+route GET "/users" {
+    if auth.jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, same_package_multiple_files_still_use_file_namespaces) {
+    const std::string dir = "/tmp/rut_import_same_package_file_namespaces_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/jwt.rut", std::ios::binary);
+        out << "package auth\nfunc jwtAuth() -> i32 => 200\n";
+    }
+    {
+        std::ofstream out(dir + "/basic.rut", std::ios::binary);
+        out << "package auth\nfunc basicAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "jwt.rut"
+import "basic.rut"
+route GET "/users" {
+    if jwt.jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_struct_symbol) {
+    const std::string dir = "/tmp/rut_import_struct_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/types.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import "types.rut"
+route GET "/users" {
+    let b = Box(value: 200)
+    if b.value == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_variant_symbol) {
+    const std::string dir = "/tmp/rut_import_variant_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/types.rut", std::ios::binary);
+        out << "variant AuthState { ok, err }\n";
+    }
+    const auto src = R"rut(
+import "types.rut"
+route GET "/users" {
+    let state = AuthState.ok
+    match state { case .ok: return 200 case _: return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_variant_tuple_of_struct_payload_symbol) {
+    const std::string dir = "/tmp/rut_import_variant_tuple_of_struct_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/types.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "variant Result { ok((Box, i32)), err }\n";
+    }
+    const auto src = R"rut(
+import "types.rut"
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE(hir->variants.len >= 1u);
+    const auto& ok = hir->variants[0].cases[0];
+    CHECK(ok.has_payload);
+    CHECK(ok.payload_type == HirTypeKind::Tuple);
+    REQUIRE_EQ(ok.payload_tuple_len, 2u);
+    CHECK(ok.payload_tuple_types[0] == HirTypeKind::Struct);
+    CHECK(ok.payload_tuple_struct_indices[0] == 0u);
+}
+TEST(frontend, import_relative_file_merges_imported_protocol_symbol) {
+    const std::string dir = "/tmp/rut_import_protocol_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 1)) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_impl_symbol) {
+    const std::string dir = "/tmp/rut_import_impl_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 1)) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_local_impl_overlapping_imported_impl_for_same_protocol_and_type) {
+    const std::string dir = "/tmp/rut_import_impl_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+Box impl Hashable {
+    func hash(self: Box) -> i32 => 0
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_local_concrete_impl_overlapping_imported_generic_impl) {
+    const std::string dir = "/tmp/rut_import_impl_overlap_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 1\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+Box<i32> impl Hashable {
+    func hash(self: Box<i32>) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_imported_impl_conflict_across_files_for_same_protocol_and_type) {
+    const std::string dir = "/tmp/rut_import_impl_imported_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/a.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => 1\n";
+        out << "}\n";
+    }
+    {
+        std::ofstream out(dir + "/b.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => 2\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "a.rut"
+import "b.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, import_relative_file_merges_imported_empty_impl_for_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_default_impl_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, selective_import_relative_file_merges_selected_function_symbol) {
+    const std::string dir = "/tmp/rut_selective_import_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+        out << "func basicAuth() -> i32 => 500\n";
+    }
+    const auto src = R"rut(
+import { jwtAuth } from "auth.rut"
+route GET "/users" { if jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, selective_import_relative_file_merges_selected_protocol_and_struct_with_impl) {
+    const std::string dir = "/tmp/rut_selective_import_impl_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import { Hashable, Box } from "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 1)) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, selective_import_relative_file_aliases_selected_function_symbol) {
+    const std::string dir = "/tmp/rut_selective_import_alias_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+        out << "func basicAuth() -> i32 => 500\n";
+    }
+    const auto src = R"rut(
+import { jwtAuth as authV1 } from "auth.rut"
+route GET "/users" { if authV1() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_namespace_function_call_is_supported) {
+    const std::string dir = "/tmp/rut_import_namespace_function_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route GET "/users" { if auth.jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_namespace_type_ref_is_supported) {
+    const std::string dir = "/tmp/rut_import_namespace_type_ref_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func read(x: proto.Box) -> i32 => x.value
+route GET "/users" { if read(proto.Box(value: 1)) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_import_namespace_type_ref_binding_to_local_same_name_type) {
+    const std::string dir = "/tmp/rut_import_namespace_type_ref_same_name_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+struct Box { value: str }
+func read(x: proto.Box) -> i32 => x.value
+route GET "/users" { if read(Box(value: "x")) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, import_namespace_protocol_constraint_is_supported) {
+    const std::string dir = "/tmp/rut_import_namespace_protocol_constraint_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+proto.Box impl proto.Hashable {
+    func hash(self: proto.Box) -> i32 => self.value
+}
+func run<T: proto.Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(proto.Box(value: 1)) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_import_namespace_protocol_constraint_for_local_same_name_type_without_impl) {
+    const std::string dir = "/tmp/rut_import_namespace_protocol_constraint_same_name_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+struct Box { value: str }
+func run<T: proto.Hashable>(x: T) -> i32 => 200
+route GET "/users" {
+    if run(Box(value: "x")) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_import_namespace_generic_receiver_dispatch_with_local_same_name_protocol) {
+    const std::string dir = "/tmp/rut_import_namespace_protocol_dispatch_same_name_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 1 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+protocol Hashable {}
+struct Box { value: str }
+func run<T: proto.Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: "x")) == 1 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_import_namespace_concrete_generic_receiver_dispatch_with_local_same_name_type) {
+    const std::string dir = "/tmp/rut_import_namespace_concrete_generic_receiver_dispatch_same_name_type_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 1 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<i32> impl Hashable {\n";
+        out << "    func hash(self: Box<i32>) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+struct Box<T> { value: T }
+func run<T: proto.Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: "x")) == 1 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, import_namespace_generic_type_ref_is_supported) {
+    const std::string dir = "/tmp/rut_import_namespace_generic_type_ref_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result<T> { ok(T), err }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func pick(x: proto.Result<i32>) -> i32 {
+    match x {
+    case .ok(v) => v
+    case .err => 0
+    }
+}
+route GET "/users" { if pick(proto.Result<i32>.ok(1)) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_namespace_nested_generic_payload_lowering_path_is_supported) {
+    const std::string dir = "/tmp/rut_import_namespace_nested_generic_type_arg_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box<T> { value: T }\n";
+        out << "variant Result<T> { ok(T), err }\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+func wrap(x: proto.Result<proto.Box<proto.Result<i32>>>) -> proto.Result<proto.Box<proto.Result<i32>>> => x
+route GET "/users" { let state = wrap(proto.Result<proto.Box<proto.Result<i32>>>.ok(proto.Box<proto.Result<i32>>(value: proto.Result<i32>.ok(1)))) match state { case .ok(v): return 200 case .err: return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_namespace_nested_generic_payload_shape_is_carrier_ready_in_mir) {
+    const std::string dir = "/tmp/rut_import_namespace_nested_generic_payload_shape_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box<T> { value: T }\n";
+        out << "variant Result<T> { ok(T), err }\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+func wrap(x: proto.Result<proto.Box<proto.Result<i32>>>) -> proto.Result<proto.Box<proto.Result<i32>>> => x
+route GET "/users" { let state = wrap(proto.Result<proto.Box<proto.Result<i32>>>.ok(proto.Box<proto.Result<i32>>(value: proto.Result<i32>.ok(1)))) match state { case .ok(v): return 200 case .err: return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    bool found = false;
+    for (u32 vi = 0; vi < mir->variants.len; vi++) {
+        const auto& variant = mir->variants[vi];
+        if (variant.template_variant_index == 0xffffffffu) continue;
+        bool variant_fully_instantiated = variant.instance_type_arg_count != 0;
+        for (u32 ai = 0; variant_fully_instantiated && ai < variant.instance_type_arg_count; ai++) {
+            if (variant.instance_shape_indices[ai] == 0xffffffffu) variant_fully_instantiated = false;
+        }
+        if (!variant_fully_instantiated) continue;
+        if (variant.cases.len == 0) continue;
+        const auto& c = variant.cases[0];
+        if (!c.has_payload) continue;
+        if (c.payload_type != MirTypeKind::Struct) continue;
+        if (c.payload_struct_index >= mir->structs.len) continue;
+        const auto& payload_struct = mir->structs[c.payload_struct_index];
+        if (payload_struct.template_struct_index == 0xffffffffu) continue;
+        bool payload_fully_instantiated = payload_struct.instance_type_arg_count != 0;
+        for (u32 ai = 0; payload_fully_instantiated && ai < payload_struct.instance_type_arg_count; ai++) {
+            if (payload_struct.instance_shape_indices[ai] == 0xffffffffu) payload_fully_instantiated = false;
+        }
+        if (!payload_fully_instantiated) continue;
+        if (c.payload_shape_index == 0xffffffffu) continue;
+        REQUIRE(c.payload_shape_index < mir->type_shapes.len);
+        const auto& shape = mir->type_shapes[c.payload_shape_index];
+        CHECK(shape.is_concrete);
+        CHECK(shape.carrier_ready);
+        found = true;
+        break;
+    }
+    CHECK(found);
+}
+
+TEST(frontend, generic_variant_instance_payload_shape_survives_refresh_in_mir) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+variant Result<T> { ok(T), err }
+func wrap(x: Result<Box<Result<i32>>>) -> Result<Box<Result<i32>>> => x
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    bool found = false;
+    for (u32 vi = 0; vi < mir->variants.len; vi++) {
+        const auto& variant = mir->variants[vi];
+        if (variant.template_variant_index == 0xffffffffu) continue;
+        if (variant.cases.len == 0) continue;
+        const auto& c = variant.cases[0];
+        if (!c.has_payload) continue;
+        if (c.payload_shape_index == 0xffffffffu) continue;
+        REQUIRE(c.payload_shape_index < mir->type_shapes.len);
+        const auto& shape = mir->type_shapes[c.payload_shape_index];
+        CHECK(shape.is_concrete);
+        CHECK(shape.carrier_ready);
+        found = true;
+        break;
+    }
+    CHECK(found);
+}
+
+TEST(frontend, generic_struct_instance_field_shape_survives_refresh_in_mir) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+struct Holder<T> { inner: Box<T> }
+struct Wrap<U> { holder: Holder<U> }
+func wrap(x: Wrap<i32>) -> Wrap<i32> => x
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    bool found = false;
+    for (u32 si = 0; si < mir->structs.len; si++) {
+        const auto& st = mir->structs[si];
+        if (st.template_struct_index == 0xffffffffu) continue;
+        if (st.fields.len == 0) continue;
+        const auto& field = st.fields[0];
+        if (field.shape_index == 0xffffffffu) continue;
+        REQUIRE(field.shape_index < mir->type_shapes.len);
+        const auto& shape = mir->type_shapes[field.shape_index];
+        if (!shape.is_concrete) continue;
+        if (!shape.carrier_ready) continue;
+        found = true;
+    }
+    CHECK(found);
+}
+
+TEST(frontend, generic_function_instantiated_return_shape_is_carrier_ready_in_mir) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: Result<T> }
+func unwrap<T>(x: Holder<T>) -> Result<T> => x.state
+route GET "/users" {
+    let state = unwrap(Holder(state: Result.ok(200)))
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    const auto& local = mir->functions[0].locals[0];
+    REQUIRE(local.shape_index < mir->type_shapes.len);
+    const auto& shape = mir->type_shapes[local.shape_index];
+    CHECK(shape.is_concrete);
+    CHECK(shape.carrier_ready);
+}
+
+TEST(frontend, import_namespace_struct_init_is_supported) {
+    const std::string dir = "/tmp/rut_import_namespace_struct_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" { if proto.Box(value: 1).value == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_namespace_variant_constructor_is_supported) {
+    const std::string dir = "/tmp/rut_import_namespace_variant_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result { ok(i32), err }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    match proto.Result.ok(200) {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_namespace_payloadless_variant_case_is_supported) {
+    const std::string dir = "/tmp/rut_import_namespace_payloadless_variant_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Token { ready, wait }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    match proto.Token.ready {
+    case .ready: return 200
+    case .wait: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, analyze_rejects_import_namespace_reference_after_selective_import_only) {
+    const std::string dir = "/tmp/rut_import_namespace_selective_only_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import { jwtAuth } from "auth.rut"
+route GET "/users" { if auth.jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_import_namespace_reference_to_missing_function_member) {
+    const std::string dir = "/tmp/rut_import_namespace_missing_member_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route GET "/users" { if auth.basicAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_import_namespace_conflict_across_files_with_same_stem) {
+    const std::string dir = "/tmp/rut_import_namespace_conflict_frontend";
+    std::filesystem::create_directories(dir + "/a");
+    std::filesystem::create_directories(dir + "/b");
+    {
+        std::ofstream out(dir + "/a/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    {
+        std::ofstream out(dir + "/b/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 500\n";
+    }
+    const auto src = R"rut(
+import "a/auth.rut"
+import "b/auth.rut"
+route GET "/users" { if auth.jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+}
+
+TEST(frontend, import_namespace_alias_resolves_same_stem_conflict) {
+    const std::string dir = "/tmp/rut_import_namespace_alias_conflict_frontend";
+    std::filesystem::create_directories(dir + "/a");
+    std::filesystem::create_directories(dir + "/b");
+    {
+        std::ofstream out(dir + "/a/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    {
+        std::ofstream out(dir + "/b/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 500\n";
+    }
+    const auto src = R"rut(
+import * as authA from "a/auth.rut"
+import * as authB from "b/auth.rut"
+route GET "/users" { if authA.jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, analyze_rejects_import_namespace_alias_conflicting_with_local_function_name) {
+    const std::string dir = "/tmp/rut_import_namespace_alias_local_fn_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import * as auth from "auth.rut"
+func auth() -> i32 => 200
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_import_namespace_alias_conflicting_with_local_protocol_name) {
+    const std::string dir = "/tmp/rut_import_namespace_alias_local_protocol_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import * as auth from "auth.rut"
+protocol auth {}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_import_namespace_alias_conflicting_with_local_using_alias) {
+    const std::string dir = "/tmp/rut_import_namespace_alias_local_using_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import * as auth from "auth.rut"
+using auth = v1.jwtAuth
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_import_namespace_alias_conflicting_with_local_struct_name) {
+    const std::string dir = "/tmp/rut_import_namespace_alias_local_struct_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import * as auth from "auth.rut"
+struct auth { value: i32 }
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_import_namespace_alias_conflicting_with_local_variant_name) {
+    const std::string dir = "/tmp/rut_import_namespace_alias_local_variant_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import * as auth from "auth.rut"
+variant auth { ok, err }
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_import_namespace_alias_conflicting_with_selective_import_alias) {
+    const std::string dir = "/tmp/rut_import_namespace_alias_selective_alias_conflict_frontend";
+    std::filesystem::create_directories(dir + "/a");
+    std::filesystem::create_directories(dir + "/b");
+    {
+        std::ofstream out(dir + "/a/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    {
+        std::ofstream out(dir + "/b/api.rut", std::ios::binary);
+        out << "func login() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import * as auth from "a/auth.rut"
+import { login as auth } from "b/api.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_import_namespace_alias_conflicting_with_imported_function_name) {
+    const std::string dir = "/tmp/rut_import_namespace_alias_imported_function_conflict_frontend";
+    std::filesystem::create_directories(dir + "/a");
+    std::filesystem::create_directories(dir + "/b");
+    {
+        std::ofstream out(dir + "/a/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    {
+        std::ofstream out(dir + "/b/core.rut", std::ios::binary);
+        out << "func auth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import * as auth from "a/auth.rut"
+import "b/core.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
+}
+TEST(frontend, selective_import_relative_file_aliases_selected_struct_symbol) {
+    const std::string dir = "/tmp/rut_selective_import_alias_struct_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import { Box as AuthBox } from "proto.rut"
+route GET "/users" { if AuthBox(value: 1).value == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_selective_import_struct_alias_binding_to_local_same_name_type_ref) {
+    const std::string dir = "/tmp/rut_selective_import_alias_struct_same_name_type_ref_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import { Box as AuthBox } from "proto.rut"
+struct AuthBox { value: str }
+func read(x: AuthBox) -> i32 => x.value
+route GET "/users" { if read(AuthBox(value: "x")) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, selective_import_relative_file_aliases_selected_protocol_and_struct_with_impl) {
+    const std::string dir = "/tmp/rut_selective_import_alias_impl_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import { Hashable as Digestible, Box as AuthBox } from "proto.rut"
+func run<T: Digestible>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(AuthBox(value: 1)) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_selective_import_alias_combined_same_name_type_and_protocol_drift) {
+    const std::string dir = "/tmp/rut_selective_import_alias_combined_same_name_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import { Hashable as Digestible, Box as AuthBox } from "proto.rut"
+protocol Digestible { func hash() -> i32 => 200 }
+struct AuthBox { value: str }
+AuthBox impl Digestible {}
+func run<T: Digestible>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(AuthBox(value: "x")) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_selective_import_struct_alias_impl_target_with_local_same_name_receiver_type) {
+    const std::string dir = "/tmp/rut_selective_import_alias_struct_same_name_impl_target_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import { Hashable as Digestible, Box as AuthBox } from "proto.rut"
+struct AuthBox { value: str }
+AuthBox impl Digestible {
+    func hash(self: AuthBox) -> i32 => 200
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_selective_import_protocol_alias_constraint_for_local_same_name_type_without_impl) {
+    const std::string dir = "/tmp/rut_selective_import_alias_protocol_same_name_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import { Hashable as Digestible, Box as ImportedBox } from "proto.rut"
+protocol Digestible {}
+struct Box { value: str }
+func run<T: Digestible>(x: T) -> i32 => 200
+route GET "/users" {
+    if run(Box(value: "x")) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_selective_import_concrete_generic_receiver_dispatch_with_local_same_name_type) {
+    const std::string dir = "/tmp/rut_selective_import_alias_concrete_generic_receiver_dispatch_same_name_type_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 1 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<i32> impl Hashable {\n";
+        out << "    func hash(self: Box<i32>) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import { Hashable as Digestible, Box as AuthBox } from "proto.rut"
+struct AuthBox<T> { value: T }
+func run<T: Digestible>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(AuthBox(value: "x")) == 1 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_selective_import_protocol_alias_impl_binding_to_local_same_name_protocol) {
+    const std::string dir = "/tmp/rut_selective_import_alias_protocol_impl_same_name_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import { Hashable as Digestible, Box as AuthBox } from "proto.rut"
+protocol Digestible {}
+AuthBox impl Digestible {}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_selective_import_protocol_alias_empty_impl_binding_to_local_same_name_protocol) {
+    const std::string dir = "/tmp/rut_selective_import_alias_protocol_empty_impl_same_name_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Producer { func make() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import { Producer as Buildable, Box as ImportedBox } from "proto.rut"
+protocol Buildable {}
+struct Box { value: str }
+ImportedBox impl Buildable {}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_selective_import_impl_method_with_mismatched_concrete_generic_return_type) {
+    const std::string dir = "/tmp/rut_selective_import_alias_protocol_concrete_generic_return_mismatch_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box<T> { value: T }\n";
+        out << "protocol Producer { func make() -> Box<i32> }\n";
+    }
+    const auto src = R"rut(
+import { Producer as Buildable, Box as AuthBox } from "proto.rut"
+struct Holder { value: i32 }
+struct AuthBox<T> { value: T }
+Holder impl Buildable {
+    func make(self: Holder) -> AuthBox<str> => AuthBox(value: "x")
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_selective_import_impl_method_with_mismatched_concrete_generic_parameter_type) {
+    const std::string dir = "/tmp/rut_selective_import_alias_protocol_concrete_generic_parameter_mismatch_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box<T> { value: T }\n";
+        out << "protocol Consumer { func take(x: Box<i32>) -> i32 }\n";
+    }
+    const auto src = R"rut(
+import { Consumer as Takeable, Box as AuthBox } from "proto.rut"
+struct Holder { value: i32 }
+struct AuthBox<T> { value: T }
+Holder impl Takeable {
+    func take(self: Holder, x: AuthBox<str>) -> i32 => 200
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_selective_import_alias_leaking_original_function_name) {
+    const std::string dir = "/tmp/rut_selective_import_alias_hidden_original_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import { jwtAuth as authV1 } from "auth.rut"
+route GET "/users" { if jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_selective_import_reference_to_non_selected_function) {
+    const std::string dir = "/tmp/rut_selective_import_hidden_name_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+        out << "func basicAuth() -> i32 => 500\n";
+    }
+    const auto src = R"rut(
+import { jwtAuth } from "auth.rut"
+route GET "/users" { if basicAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_selective_import_of_missing_symbol) {
+    const std::string dir = "/tmp/rut_selective_import_missing_symbol_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import { basicAuth } from "auth.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_cyclic_relative_imports) {
+    const std::string dir = "/tmp/rut_import_cycle_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/a.rut", std::ios::binary);
+        out << "import \"b.rut\"\nfunc fa() -> i32 => 1\n";
+    }
+    {
+        std::ofstream out(dir + "/b.rut", std::ios::binary);
+        out << "import \"a.rut\"\nfunc fb() -> i32 => 2\n";
+    }
+    const auto src = R"rut(
+import "a.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_imported_function_name_conflict_across_files) {
+    const std::string dir = "/tmp/rut_import_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/a.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 1\n";
+    }
+    {
+        std::ofstream out(dir + "/b.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 2\n";
+    }
+    const auto src = R"rut(
+import "a.rut"
+import "b.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_imported_struct_name_conflict_across_files) {
+    const std::string dir = "/tmp/rut_import_struct_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/a.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+    }
+    {
+        std::ofstream out(dir + "/b.rut", std::ios::binary);
+        out << "struct Box { code: i32 }\n";
+    }
+    const auto src = R"rut(
+import "a.rut"
+import "b.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_imported_variant_name_conflict_across_files) {
+    const std::string dir = "/tmp/rut_import_variant_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/a.rut", std::ios::binary);
+        out << "variant AuthState { ok }\n";
+    }
+    {
+        std::ofstream out(dir + "/b.rut", std::ios::binary);
+        out << "variant AuthState { err }\n";
+    }
+    const auto src = R"rut(
+import "a.rut"
+import "b.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_imported_protocol_name_conflict_across_files) {
+    const std::string dir = "/tmp/rut_import_protocol_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/a.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+    }
+    {
+        std::ofstream out(dir + "/b.rut", std::ios::binary);
+        out << "protocol Hashable { func code() -> i32 }\n";
+    }
+    const auto src = R"rut(
+import "a.rut"
+import "b.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_imported_struct_name_conflict_with_local_declaration) {
+    const std::string dir = "/tmp/rut_import_local_struct_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/types.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import "types.rut"
+struct Box { code: i32 }
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+TEST(frontend, import_declaration_is_recorded_in_hir) {
+    const auto src = R"rut(
+import "middleware/auth.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].kind), static_cast<u8>(AstItemKind::Import));
+    CHECK(ast->items[0].import_decl.path.eq(lit("middleware/auth.rut")));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->imports.len, 1u);
+    CHECK(hir->imports[0].path.eq(lit("middleware/auth.rut")));
+}
+TEST(frontend, duplicate_import_is_deduplicated_in_hir) {
+    const auto src = R"rut(
+import "middleware/auth.rut"
+import "middleware/auth.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->imports.len, 1u);
+}
+TEST(frontend, duplicate_relative_import_does_not_reanalyze_same_file) {
+    const std::string dir = "/tmp/rut_import_dedup_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+import "auth.rut"
+route GET "/users" {
+    if jwtAuth() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    reset_import_analysis_counter();
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    CHECK_EQ(get_import_analysis_counter(), 1u);
+}
+TEST(frontend, using_alias_declaration_is_recorded_in_hir) {
+    const auto src = R"rut(
+using authV1 = v1.jwtAuth
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].kind), static_cast<u8>(AstItemKind::Using));
+    CHECK(ast->items[0].using_decl.name.eq(lit("authV1")));
+    REQUIRE_EQ(ast->items[0].using_decl.target_parts.len, 2u);
+    CHECK(ast->items[0].using_decl.target_parts[0].eq(lit("v1")));
+    CHECK(ast->items[0].using_decl.target_parts[1].eq(lit("jwtAuth")));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->aliases.len, 1u);
+    CHECK(hir->aliases[0].name.eq(lit("authV1")));
+    REQUIRE_EQ(hir->aliases[0].target_parts.len, 2u);
+    CHECK(hir->aliases[0].target_parts[0].eq(lit("v1")));
+    CHECK(hir->aliases[0].target_parts[1].eq(lit("jwtAuth")));
+}
+TEST(frontend, analyze_resolves_using_alias_in_function_call) {
+    const auto src = R"rut(
+using authV1 = v1.jwtAuth
+func jwtAuth() -> i32 => 200
+route GET "/users" {
+    if authV1() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->aliases.len, 1u);
+    REQUIRE_EQ(hir->functions.len, 1u);
+}
+TEST(frontend, analyze_rejects_using_alias_to_unknown_function_symbol_on_call) {
+    const auto src = R"rut(
+using authV1 = v1.jwtAuth
+route GET "/users" {
+    if authV1() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_duplicate_using_alias_name) {
+    const auto src = R"rut(
+using authV1 = v1.jwtAuth
+using authV1 = v2.jwtAuth
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, parse_rejects_old_using_as_protocol_syntax) {
+    const auto src = R"rut(
+using Box as Hashable
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK(ast.error().code == FrontendError::UnexpectedToken || ast.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, variant_match_lowers_to_tag_compare) {
+    const char* src =
+        "variant AuthState { timeout, forbidden }\n"
+        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return 200 case _: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].kind), static_cast<u8>(AstItemKind::Variant));
+    REQUIRE_EQ(ast->items[0].variant.cases.len, 2u);
+    CHECK(ast->items[0].variant.name.eq(lit("AuthState")));
+    CHECK(ast->items[0].variant.cases[0].name.eq(lit("timeout")));
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir) {
+        rut::test::out("analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+        REQUIRE(hir);
+    }
+    REQUIRE_EQ(hir->variants.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Variant));
+    CHECK_EQ(hir->routes[0].locals[0].variant_index, 0u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::VariantCase));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].pattern.kind),
+             static_cast<u8>(HirExprKind::VariantCase));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].type), static_cast<u8>(MirTypeKind::Variant));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::VariantCase));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::StructField));
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::CmpEq));
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::Br));
+    rir.destroy();
+}
+TEST(frontend, variant_match_all_cases_without_wildcard_is_exhaustive) {
+    const char* src =
+        "variant AuthState { timeout, forbidden }\n"
+        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return 200 case .forbidden: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir) {
+        rut::test::out("plain struct analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+    }
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, variant_single_payload_case_parses_and_lowers) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): return 200 case .err: return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    REQUIRE_EQ(ast->items[0].variant.cases.len, 2u);
+    CHECK(ast->items[0].variant.cases[0].name.eq(lit("ok")));
+    CHECK(ast->items[0].variant.cases[0].has_payload);
+    CHECK(!ast->items[0].variant.cases[0].payload_type.is_tuple);
+    CHECK(ast->items[0].variant.cases[0].payload_type.name.eq(lit("i32")));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 1u);
+    REQUIRE_EQ(hir->variants[0].cases.len, 2u);
+    CHECK(hir->variants[0].cases[0].has_payload);
+    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[0].payload_type), static_cast<u8>(HirTypeKind::I32));
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::VariantCase));
+    CHECK_EQ(hir->routes[0].locals[0].init.case_index, 0u);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].pattern.kind),
+             static_cast<u8>(HirExprKind::VariantCase));
+    CHECK_EQ(hir->routes[0].control.match_arms[0].pattern.case_index, 0u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::VariantCase));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, variant_payload_binding_flows_into_match_arm_if) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): if x == 200 { return 200 } else { return 500 } case .err: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir) {
+        rut::test::out("analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+    }
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK(hir->routes[0].control.match_arms[0].bind_payload);
+    CHECK(hir->routes[0].control.match_arms[0].bind_name.eq(lit("x")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].body_kind),
+             static_cast<u8>(HirMatchArm::BodyKind::If));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].cond.kind),
+             static_cast<u8>(HirExprKind::Eq));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, variant_payload_binding_flows_into_match_arm_block) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let y = x if y == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir) {
+        rut::test::out("analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+        REQUIRE(hir);
+    }
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[1].name.eq(lit("y")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].type), static_cast<u8>(HirTypeKind::I32));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].body_kind),
+             static_cast<u8>(HirMatchArm::BodyKind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, variant_payload_binding_flows_into_match_arm_block_with_guard) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed = error(7) guard failed else { return 401 } if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir) {
+        rut::test::out("analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+        REQUIRE(hir);
+    }
+    REQUIRE_EQ(hir->routes[0].control.match_arms[0].guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].guards[0].cond.kind),
+             static_cast<u8>(HirExprKind::BoolLit));
+    CHECK_EQ(hir->routes[0].control.match_arms[0].guards[0].cond.bool_value, false);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, variant_payload_binding_flows_into_match_arm_block_with_guard_match) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed = error(.timeout) guard match failed else { case .timeout: return 401 case _: return 402 } if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir) {
+        rut::test::out("analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+    }
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms[0].guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].guards[0].fail_kind),
+             static_cast<u8>(HirGuard::FailKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms[0].guards[0].fail_match_count, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, variant_mixed_payload_cases_lower) {
+    const char* src =
+        "variant Mixed { count(i32), ready(bool), label(str), none }\n"
+        "route GET \"/users\" { let state = Mixed.ready(true) match state { case .count(x): return 200 case .ready(flag): if flag == true { return 201 } else { return 202 } case .label(name): return 203 case .none: return 204 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir) {
+        rut::test::out("analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+    }
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 1u);
+    REQUIRE_EQ(hir->variants[0].cases.len, 4u);
+    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[0].payload_type), static_cast<u8>(HirTypeKind::I32));
+    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[1].payload_type), static_cast<u8>(HirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[2].payload_type), static_cast<u8>(HirTypeKind::Str));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, variant_tuple_payload_binding_flows_into_pipe_multi_slot) {
+    const char* src =
+        "variant Result { ok((i32, i32)), err }\n"
+        "func second(a: i32, b: i32) -> i32 => b\n"
+        "route GET \"/users\" { let state = Result.ok((200, 500)) match state { case .ok(pair): { let code = pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].variant.cases.len, 2u);
+    CHECK(ast->items[0].variant.cases[0].has_payload);
+    CHECK(ast->items[0].variant.cases[0].payload_type.is_tuple);
+    REQUIRE_EQ(ast->items[0].variant.cases[0].payload_type.tuple_elem_names.len, 2u);
+    CHECK(ast->items[0].variant.cases[0].payload_type.tuple_elem_names[0].eq(lit("i32")));
+    CHECK(ast->items[0].variant.cases[0].payload_type.tuple_elem_names[1].eq(lit("i32")));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(hir->variants[0].cases[0].payload_type, HirTypeKind::Tuple);
+    CHECK_EQ(hir->variants[0].cases[0].payload_tuple_len, 2u);
+    CHECK_EQ(hir->routes[0].control.match_arms[0].bind_type, HirTypeKind::Tuple);
+    CHECK_EQ(hir->routes[0].control.match_arms[0].bind_tuple_len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, route_match_struct_payload_binding_preserves_shape) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "variant Result { ok(Box), err }\n"
+        "func boxCode(x: Box) -> i32 => x.value\n"
+        "route GET \"/users\" { let state = Result.ok(Box(value: 200)) match state { case .ok(box): { let code = box | boxCode(_) if code == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK(hir->routes[0].control.match_arms[0].bind_payload);
+    CHECK_EQ(hir->routes[0].control.match_arms[0].bind_type, HirTypeKind::Struct);
+    CHECK_EQ(hir->routes[0].control.match_arms[0].bind_struct_index, 0u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].body_kind),
+             static_cast<u8>(HirMatchArm::BodyKind::If));
+}
+
+TEST(frontend, route_guard_bound_struct_preserves_shape_index) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "func maybeBox(ok: bool) -> Box { if ok { Box(value: 200) } else { nil } }\n"
+        "route GET \"/users\" { guard let picked = maybeBox(true) else { return 401 } if picked.value == 200 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(hir->routes[0].locals[0].type, HirTypeKind::Struct);
+    CHECK_EQ(hir->routes[0].locals[0].struct_index, 0u);
+    CHECK_NE(hir->routes[0].locals[0].shape_index, 0xffffffffu);
+}
+
+TEST(frontend, route_guard_bound_runtime_error_struct_preserves_init_shape) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "func maybeBox(ok: bool) -> Box { if ok { Box(value: 200) } else { error(.timeout) } }\n"
+        "route GET \"/users\" { guard let picked = maybeBox(true) else { return 401 } if picked.value == 200 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    const auto& picked = hir->routes[0].locals[0];
+    CHECK_EQ(picked.type, HirTypeKind::Struct);
+    CHECK_EQ(picked.struct_index, 0u);
+    CHECK_NE(picked.shape_index, 0xffffffffu);
+    CHECK_EQ(static_cast<u8>(picked.init.kind), static_cast<u8>(HirExprKind::ValueOf));
+    CHECK_EQ(picked.init.type, HirTypeKind::Struct);
+    CHECK_EQ(picked.init.struct_index, 0u);
+    CHECK_NE(picked.init.shape_index, 0xffffffffu);
+}
+
+TEST(frontend, match_arm_guard_bound_struct_preserves_shape_index) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "variant Result { ok, err }\n"
+        "func maybeBox(ok: bool) -> Box { if ok { Box(value: 200) } else { nil } }\n"
+        "route GET \"/users\" { let state = Result.ok match state { case .ok: { guard let picked = maybeBox(true) else { return 401 } if picked.value == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(hir->routes[0].locals[1].type, HirTypeKind::Struct);
+    CHECK_EQ(hir->routes[0].locals[1].struct_index, 0u);
+    CHECK_NE(hir->routes[0].locals[1].shape_index, 0xffffffffu);
+}
+
+TEST(frontend, generic_variant_constructor_and_match_are_supported) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+route GET "/users" {
+    let state = Result<i32>.ok(200)
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].variant.type_params.len, 1u);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->variants.len >= 2u);
+    CHECK_EQ(hir->variants[0].type_params.len, 1u);
+    CHECK_EQ(hir->variants[1].template_variant_index, 0u);
+    CHECK_EQ(hir->routes[0].locals[0].variant_index, 1u);
+}
+TEST(frontend, explicit_generic_variant_constructor_records_instance_shape_index) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+variant Wrap<T> { some(T), none }
+route GET "/users" {
+    let state = Wrap<Box<i32>>.some(Box<i32>(value: 200))
+    match state {
+    case .some(v): return 200
+    case .none: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->variants.len >= 2u);
+    const auto& inst = hir->variants[1];
+    CHECK_EQ(inst.template_variant_index, 0u);
+    CHECK_EQ(inst.instance_type_arg_count, 1u);
+    CHECK_EQ(inst.instance_type_args[0], HirTypeKind::Struct);
+    CHECK_NE(inst.instance_shape_indices[0], 0xffffffffu);
+}
+TEST(frontend, generic_variant_constructor_infers_type_argument_from_single_payload_case) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+route GET "/users" {
+    let state = Result.ok(200)
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir) {
+        rut::test::out("analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+    }
+    REQUIRE(hir);
+    REQUIRE(hir->variants.len >= 2u);
+    CHECK_EQ(hir->variants[0].type_params.len, 1u);
+    CHECK_EQ(hir->variants[1].template_variant_index, 0u);
+    CHECK_EQ(hir->variants[1].instance_type_arg_count, 1u);
+    CHECK_EQ(hir->variants[1].instance_type_args[0], HirTypeKind::I32);
+    CHECK_EQ(hir->routes[0].locals[0].variant_index, 1u);
+}
+TEST(frontend, generic_variant_instance_records_shape_for_tuple_of_struct_type_arg) {
+    const auto src = R"rut(
+struct Item { value: i32 }
+variant Result<T> { ok(T), err }
+route GET "/users" {
+    let state = Result.ok((Item(value: 7), 9))
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->variants.len >= 2u);
+    CHECK_EQ(hir->variants[1].template_variant_index, 0u);
+    CHECK_EQ(hir->variants[1].instance_type_arg_count, 1u);
+    CHECK_EQ(hir->variants[1].instance_type_args[0], HirTypeKind::Tuple);
+    CHECK_EQ(hir->variants[1].instance_tuple_lens[0], 2u);
+    CHECK_EQ(hir->variants[1].instance_tuple_types[0][0], HirTypeKind::Struct);
+    CHECK_EQ(hir->variants[1].instance_tuple_struct_indices[0][0], 0u);
+    CHECK_NE(hir->variants[1].instance_shape_indices[0], 0xffffffffu);
+    CHECK_EQ(hir->routes[0].locals[0].variant_index, 1u);
+}
+TEST(frontend, generic_variant_tuple_of_struct_payload_preserves_struct_slots_after_instantiation) {
+    const auto src = R"rut(
+struct Item { value: i32 }
+variant Result<T> { ok(T), err }
+route GET "/users" {
+    let state = Result.ok((Item(value: 7), 9))
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->variants.len >= 2u);
+    const auto& inst = hir->variants[1];
+    CHECK_EQ(inst.template_variant_index, 0u);
+    REQUIRE(inst.cases.len >= 1u);
+    CHECK_EQ(inst.cases[0].payload_type, HirTypeKind::Tuple);
+    CHECK_EQ(inst.cases[0].payload_tuple_len, 2u);
+    CHECK_EQ(inst.cases[0].payload_tuple_types[0], HirTypeKind::Struct);
+    CHECK_EQ(inst.cases[0].payload_tuple_struct_indices[0], 0u);
+}
+TEST(frontend, mir_build_preserves_variant_instance_shape_for_tuple_of_struct_type_arg) {
+    const auto src = R"rut(
+struct Item { value: i32 }
+variant Result<T> { ok(T), err }
+route GET "/users" {
+    let state = Result.ok((Item(value: 7), 9))
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE(mir->variants.len >= 2u);
+    CHECK_EQ(mir->variants[1].template_variant_index, 0u);
+    CHECK_EQ(mir->variants[1].instance_type_arg_count, 1u);
+    CHECK_EQ(mir->variants[1].instance_type_args[0], MirTypeKind::Tuple);
+    CHECK_NE(mir->variants[1].instance_shape_indices[0], 0xffffffffu);
+    REQUIRE(mir->variants[1].instance_shape_indices[0] < mir->type_shapes.len);
+    CHECK(mir->type_shapes[mir->variants[1].instance_shape_indices[0]].is_concrete);
+    CHECK(mir->type_shapes[mir->variants[1].instance_shape_indices[0]].carrier_ready);
+}
+TEST(frontend, named_errors_aggregate_into_hidden_error_variant) {
+    const char* src =
+        "route GET \"/users\" { let timeout = error(.timeout) let denied = error(.forbidden) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 1u);
+    CHECK(hir->variants[0].name.eq(lit("__error_route")));
+    REQUIRE_EQ(hir->variants[0].cases.len, 2u);
+    CHECK(hir->variants[0].cases[0].name.eq(lit("timeout")));
+    CHECK(hir->variants[0].cases[1].name.eq(lit("forbidden")));
+    CHECK_EQ(hir->routes[0].error_variant_index, 0u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(hir->routes[0].locals[0].error_variant_index, 0u);
+    CHECK_EQ(hir->routes[0].locals[0].init.error_variant_index, 0u);
+    CHECK_EQ(hir->routes[0].locals[0].init.error_case_index, 0u);
+    CHECK_EQ(hir->routes[0].locals[1].error_variant_index, 0u);
+    CHECK_EQ(hir->routes[0].locals[1].init.error_variant_index, 0u);
+    CHECK_EQ(hir->routes[0].locals[1].init.error_case_index, 1u);
+}
+TEST(frontend, error_message_is_preserved_for_named_error) {
+    const char* src =
+        "route GET \"/users\" { let timeout = error(.timeout, \"request timed out\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 2u);
+    CHECK(ast->items[0].route.statements[0].expr.msg.eq(lit("request timed out")));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].init.msg.eq(lit("request timed out")));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK(mir->functions[0].locals[0].init.msg.eq(lit("request timed out")));
+}
+TEST(frontend, custom_error_struct_can_be_used_in_error_constructor) {
+    const char* src =
+        "struct AuthError { err: Error }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].kind), static_cast<u8>(AstItemKind::Struct));
+    REQUIRE_EQ(ast->items[0].struct_decl.fields.len, 1u);
+    CHECK(ast->items[0].struct_decl.fields[0].name.eq(lit("err")));
+    CHECK(!ast->items[0].struct_decl.fields[0].type.is_tuple);
+    CHECK(ast->items[0].struct_decl.fields[0].type.name.eq(lit("Error")));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->structs.len, 1u);
+    CHECK(hir->structs[0].name.eq(lit("AuthError")));
+    CHECK(hir->structs[0].conforms_error);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind), static_cast<u8>(HirExprKind::Error));
+    CHECK_EQ(hir->routes[0].locals[0].init.error_struct_index, 0u);
+    CHECK(hir->routes[0].locals[0].init.msg.eq(lit("timed out")));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(mir->functions[0].locals[0].init.error_struct_index, 0u);
+}
+TEST(frontend, custom_error_struct_with_extra_fields_lowers_to_rir_struct) {
+    const char* src =
+        "struct AuthError { err: Error, token: str, retry: i32 }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir.has_value()) {
+        rut::test::out("analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+    }
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->structs.len, 1u);
+    REQUIRE_EQ(hir->structs[0].fields.len, 3u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->structs.len, 1u);
+    REQUIRE_EQ(mir->structs[0].fields.len, 3u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    bool found_auth_error = false;
+    for (u32 i = 0; i < rir.module.struct_count; i++) {
+        auto* sd = rir.module.struct_defs[i];
+        if (!sd->name.eq(lit("AuthError"))) continue;
+        found_auth_error = true;
+        REQUIRE_EQ(sd->field_count, 3u);
+        CHECK(sd->fields()[0].name.eq(lit("err")));
+        CHECK(sd->fields()[1].name.eq(lit("token")));
+        CHECK(sd->fields()[2].name.eq(lit("retry")));
+        break;
+    }
+    CHECK(found_auth_error);
+    rir.destroy();
+}
+TEST(frontend, custom_error_struct_constructor_preserves_extra_field_inits) {
+    const char* src =
+        "struct AuthError { err: Error, token: str, retry: i32 }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[1].route.statements[0].expr.field_inits.len, 2u);
+    CHECK(ast->items[1].route.statements[0].expr.field_inits[0].name.eq(lit("token")));
+    CHECK(ast->items[1].route.statements[0].expr.field_inits[1].name.eq(lit("retry")));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals[0].init.field_inits.len, 2u);
+    CHECK(hir->routes[0].locals[0].init.field_inits[0].name.eq(lit("token")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.field_inits[0].value->type),
+             static_cast<u8>(HirTypeKind::Str));
+    CHECK(hir->routes[0].locals[0].init.field_inits[1].name.eq(lit("retry")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.field_inits[1].value->type),
+             static_cast<u8>(HirTypeKind::I32));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals[0].init.field_inits.len, 2u);
+    CHECK(mir->functions[0].locals[0].init.field_inits[0].name.eq(lit("token")));
+    CHECK(mir->functions[0].locals[0].init.field_inits[1].name.eq(lit("retry")));
+}
+TEST(frontend, custom_error_struct_with_tuple_field_lowers_to_rir_struct) {
+    const char* src =
+        "struct AuthError { err: Error, pair: (i32, i32) }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, 500)) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE(ast->items[0].struct_decl.fields[1].type.is_tuple);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->structs.len, 1u);
+    CHECK_EQ(hir->structs[0].fields[1].type, HirTypeKind::Tuple);
+    CHECK_EQ(hir->structs[0].fields[1].tuple_len, 2u);
+    REQUIRE_EQ(hir->routes[0].locals[0].init.field_inits.len, 1u);
+    CHECK_EQ(hir->routes[0].locals[0].init.field_inits[0].value->type, HirTypeKind::Tuple);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    CHECK_EQ(mir->structs[0].fields[1].type, MirTypeKind::Tuple);
+    CHECK_EQ(mir->structs[0].fields[1].tuple_len, 2u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    bool found_auth_error = false;
+    for (u32 i = 0; i < rir.module.struct_count; i++) {
+        auto* sd = rir.module.struct_defs[i];
+        if (!sd->name.eq(lit("AuthError"))) continue;
+        found_auth_error = true;
+        REQUIRE_EQ(sd->field_count, 2u);
+        CHECK(sd->fields()[0].name.eq(lit("err")));
+        CHECK(sd->fields()[1].name.eq(lit("pair")));
+        break;
+    }
+    CHECK(found_auth_error);
+    rir.destroy();
+}
+TEST(frontend, analyze_rejects_non_error_struct_in_error_constructor) {
+    const char* src =
+        "struct Foo { code: i32 }\n"
+        "route GET \"/users\" { let failed = error(Foo, .timeout, \"timed out\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_custom_error_constructor_missing_extra_fields) {
+    const char* src =
+        "struct AuthError { err: Error, token: str, retry: i32 }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_custom_error_constructor_unknown_extra_field) {
+    const char* src =
+        "struct AuthError { err: Error, token: str }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", retry: 3) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_custom_error_constructor_wrong_extra_field_type) {
+    const char* src =
+        "struct AuthError { err: Error, retry: i32 }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", retry: \"soon\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_user_declared_struct_error) {
+    const char* src =
+        "struct Error { code: i32 }\n"
+        "route GET \"/users\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_duplicate_struct_field_names) {
+    const char* src =
+        "struct AuthError { err: Error, err: Error }\n"
+        "route GET \"/users\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, explicit_error_variant_is_not_wrapped_again) {
+    const char* src =
+        "variant AuthError { timeout, forbidden }\n"
+        "route GET \"/users\" { let failed = error(AuthError.timeout) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 1u);
+    CHECK_EQ(hir->routes[0].error_variant_index, 0xffffffffu);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(hir->routes[0].locals[0].error_variant_index, 0u);
+    CHECK_EQ(hir->routes[0].locals[0].init.error_variant_index, 0u);
+    CHECK_EQ(hir->routes[0].locals[0].init.error_case_index, 0u);
+}
+TEST(frontend, error_message_is_preserved_for_explicit_error_variant) {
+    const char* src =
+        "variant AuthError { timeout, forbidden }\n"
+        "route GET \"/users\" { let failed = error(AuthError.timeout, \"timed out\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    CHECK(ast->items[1].route.statements[0].expr.msg.eq(lit("timed out")));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].init.msg.eq(lit("timed out")));
+    CHECK_EQ(hir->routes[0].locals[0].init.error_variant_index, 0u);
+    CHECK_EQ(hir->routes[0].locals[0].init.error_case_index, 0u);
+}
+TEST(frontend, lower_to_rir_emits_standard_error_struct) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = or(failed, 200) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    bool found_error = false;
+    for (u32 i = 0; i < rir.module.struct_count; i++) {
+        auto* sd = rir.module.struct_defs[i];
+        if (!sd->name.eq(lit("Error"))) continue;
+        found_error = true;
+        REQUIRE_EQ(sd->field_count, 5u);
+        CHECK(sd->fields()[0].name.eq(lit("code")));
+        CHECK(sd->fields()[1].name.eq(lit("msg")));
+        CHECK(sd->fields()[2].name.eq(lit("file")));
+        CHECK(sd->fields()[3].name.eq(lit("func")));
+        CHECK(sd->fields()[4].name.eq(lit("line")));
+        break;
+    }
+    CHECK(found_error);
+    rir.destroy();
+}
+TEST(frontend, lower_to_rir_uses_module_name_for_error_file_field) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = or(failed, 200) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    rir.source_name = lit("custom_frontend.rut");
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    bool saw_custom_file = false;
+    for (u32 bi = 0; bi < rir.module.functions[0].block_count; bi++) {
+        const auto& block = rir.module.functions[0].blocks[bi];
+        for (u32 ii = 0; ii < block.inst_count; ii++) {
+            const auto& inst = block.insts[ii];
+            if (inst.op != rir::Opcode::ConstStr) continue;
+            if (inst.imm.str_val.eq(lit("custom_frontend.rut"))) {
+                saw_custom_file = true;
+                break;
+            }
+        }
+        if (saw_custom_file) break;
+    }
+    CHECK(saw_custom_file);
+    rir.destroy();
+}
+TEST(frontend, custom_error_struct_lowers_with_standard_error_metadata) {
+    const char* src =
+        "struct AuthError { err: Error }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\") let code = or(failed, 200) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    rir.source_name = lit("custom_auth_error.rut");
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    bool saw_error_struct = false;
+    bool saw_msg = false;
+    bool saw_file = false;
+    bool saw_func = false;
+    for (u32 i = 0; i < rir.module.struct_count; i++) {
+        auto* sd = rir.module.struct_defs[i];
+        if (!sd->name.eq(lit("Error"))) continue;
+        saw_error_struct = true;
+        break;
+    }
+    for (u32 bi = 0; bi < rir.module.functions[0].block_count; bi++) {
+        const auto& block = rir.module.functions[0].blocks[bi];
+        for (u32 ii = 0; ii < block.inst_count; ii++) {
+            const auto& inst = block.insts[ii];
+            if (inst.op != rir::Opcode::ConstStr) continue;
+            saw_msg = saw_msg || inst.imm.str_val.eq(lit("timed out"));
+            saw_file = saw_file || inst.imm.str_val.eq(lit("custom_auth_error.rut"));
+            saw_func = saw_func || inst.imm.str_val.eq(lit("route"));
+        }
+    }
+    CHECK(saw_error_struct);
+    CHECK(saw_msg);
+    CHECK(saw_file);
+    CHECK(saw_func);
+    rir.destroy();
+}
+TEST(frontend, custom_error_struct_extra_fields_enter_runtime_lowering) {
+    const char* src =
+        "struct AuthError { err: Error, token: str, retry: i32 }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) let code = or(failed, 200) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    bool saw_auth_error_create = false;
+    bool saw_retry = false;
+    bool saw_token = false;
+    for (u32 bi = 0; bi < rir.module.functions[0].block_count; bi++) {
+        const auto& block = rir.module.functions[0].blocks[bi];
+        for (u32 ii = 0; ii < block.inst_count; ii++) {
+            const auto& inst = block.insts[ii];
+            if (inst.op == rir::Opcode::StructCreate && inst.imm.struct_ref.name.eq(lit("AuthError")))
+                saw_auth_error_create = true;
+            if (inst.op == rir::Opcode::ConstI32 && inst.imm.i32_val == 3)
+                saw_retry = true;
+            if (inst.op == rir::Opcode::ConstStr && inst.imm.str_val.eq(lit("abc")))
+                saw_token = true;
+        }
+    }
+    CHECK(saw_auth_error_create);
+    CHECK(saw_retry);
+    CHECK(saw_token);
+    rir.destroy();
+}
+TEST(frontend, custom_error_struct_fields_can_be_projected_from_known_error_local) {
+    const char* src =
+        "struct AuthError { err: Error, token: str, retry: i32 }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) let token = failed.token let retry = failed.retry if retry == 3 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir.value().routes[0].locals.len, 3u);
+    CHECK_EQ(hir.value().routes[0].locals[1].type, HirTypeKind::Str);
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::StrLit));
+    CHECK(hir.value().routes[0].locals[1].init.str_value.eq(lit("abc")));
+    CHECK_EQ(hir.value().routes[0].locals[2].type, HirTypeKind::I32);
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[2].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(hir.value().routes[0].locals[2].init.int_value, 3);
+}
+TEST(frontend, custom_error_struct_tuple_field_can_flow_into_pipe_slots) {
+    const char* src =
+        "struct AuthError { err: Error, pair: (i32, i32) }\n"
+        "func second(a: i32, b: i32) -> i32 => b\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, 500)) let code = failed.pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir.value().routes[0].locals.len, 2u);
+    CHECK_EQ(hir.value().routes[0].locals[1].type, HirTypeKind::I32);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, plain_struct_constructor_and_field_projection_are_supported) {
+    constexpr auto src =
+        "struct Foo { code: i32, msg: str }\n"
+        "route GET \"/users\" { let foo = Foo(code: 200, msg: \"ok\") let code = foo.code let msg = foo.msg if code == 200 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK_EQ(hir->routes[0].locals[0].type, HirTypeKind::Struct);
+    CHECK_EQ(hir->routes[0].locals[1].init.kind, HirExprKind::Field);
+    CHECK_EQ(hir->routes[0].locals[1].type, HirTypeKind::I32);
+    CHECK_EQ(hir->routes[0].locals[2].init.kind, HirExprKind::Field);
+    CHECK_EQ(hir->routes[0].locals[2].type, HirTypeKind::Str);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, generic_struct_constructor_and_field_projection_are_supported) {
+    const char* src =
+        "struct Box<T> { value: T }\n"
+        "route GET \"/users\" { let box = Box<i32>(value: 200) if box.value == 200 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].struct_decl.type_params.len, 1u);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    CHECK_EQ(hir->structs[0].type_params.len, 1u);
+    CHECK_EQ(hir->structs[1].template_struct_index, 0u);
+    CHECK_EQ(hir->structs[1].instance_type_arg_count, 1u);
+    CHECK_EQ(hir->structs[1].instance_type_args[0], HirTypeKind::I32);
+    CHECK_EQ(hir->routes[0].locals[0].struct_index, 1u);
+}
+TEST(frontend, generic_struct_constructor_infers_type_argument_from_field_shape) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+route GET "/users" {
+    let box = Box(value: 200)
+    if box.value == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    CHECK_EQ(hir->structs[1].template_struct_index, 0u);
+    CHECK_EQ(hir->structs[1].instance_type_arg_count, 1u);
+    CHECK_EQ(hir->structs[1].instance_type_args[0], HirTypeKind::I32);
+    CHECK_EQ(hir->routes[0].locals[0].struct_index, 1u);
+}
+TEST(frontend, generic_struct_instance_records_shape_for_tuple_of_struct_type_arg) {
+    const auto src = R"rut(
+struct Item { value: i32 }
+struct Box<T> { value: T }
+route GET "/users" {
+    let box = Box(value: (Item(value: 7), 9))
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 3u);
+    CHECK_EQ(hir->structs[2].template_struct_index, 1u);
+    CHECK_EQ(hir->structs[2].instance_type_arg_count, 1u);
+    CHECK_EQ(hir->structs[2].instance_type_args[0], HirTypeKind::Tuple);
+    CHECK_EQ(hir->structs[2].instance_tuple_lens[0], 2u);
+    CHECK_EQ(hir->structs[2].instance_tuple_types[0][0], HirTypeKind::Struct);
+    CHECK_EQ(hir->structs[2].instance_tuple_struct_indices[0][0], 0u);
+    CHECK_NE(hir->structs[2].instance_shape_indices[0], 0xffffffffu);
+    CHECK_EQ(hir->routes[0].locals[0].struct_index, 2u);
+}
+TEST(frontend, generic_struct_field_tuple_of_struct_preserves_struct_slots_after_instantiation) {
+    const auto src = R"rut(
+struct Item { value: i32 }
+struct Wrap<T> { payload: T }
+func boxCode(x: Item) -> i32 => x.value
+func read(x: Wrap<(Item, i32)>) -> i32 => x.payload | boxCode(_1)
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 3u);
+    const auto& wrap_inst = hir->structs[2];
+    CHECK_EQ(wrap_inst.template_struct_index, 1u);
+    REQUIRE_EQ(wrap_inst.fields.len, 1u);
+    const auto& payload = wrap_inst.fields[0];
+    CHECK_EQ(payload.type, HirTypeKind::Tuple);
+    REQUIRE_EQ(payload.tuple_len, 2u);
+    CHECK_EQ(payload.tuple_types[0], HirTypeKind::Struct);
+    CHECK_EQ(payload.tuple_struct_indices[0], 0u);
+}
+TEST(frontend, mir_build_preserves_struct_instance_shape_for_tuple_of_struct_type_arg) {
+    const auto src = R"rut(
+struct Item { value: i32 }
+struct Box<T> { value: T }
+route GET "/users" {
+    let box = Box(value: (Item(value: 7), 9))
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE(mir->structs.len >= 3u);
+    CHECK_EQ(mir->structs[2].template_struct_index, 1u);
+    CHECK_EQ(mir->structs[2].instance_type_arg_count, 1u);
+    CHECK_EQ(mir->structs[2].instance_type_args[0], MirTypeKind::Tuple);
+    CHECK_NE(mir->structs[2].instance_shape_indices[0], 0xffffffffu);
+    REQUIRE(mir->structs[2].instance_shape_indices[0] < mir->type_shapes.len);
+    CHECK(mir->type_shapes[mir->structs[2].instance_shape_indices[0]].is_concrete);
+    CHECK(mir->type_shapes[mir->structs[2].instance_shape_indices[0]].carrier_ready);
+}
+TEST(frontend, concrete_generic_type_refs_are_supported_in_let_types) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+route GET "/users" {
+    let state: Result<i32> = Result.ok(200)
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->variants.len >= 2u);
+    CHECK_EQ(hir->routes[0].locals[0].type, HirTypeKind::Variant);
+    CHECK_EQ(hir->routes[0].locals[0].variant_index, 1u);
+}
+TEST(frontend, concrete_generic_type_refs_are_supported_in_function_signatures) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+func wrap(x: Result<i32>) -> Result<i32> => x
+route GET "/users" {
+    let state = wrap(Result.ok(200))
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(hir->functions[0].params[0].type, HirTypeKind::Variant);
+    CHECK_EQ(hir->functions[0].params[0].variant_index, 1u);
+    CHECK_EQ(hir->functions[0].return_type, HirTypeKind::Variant);
+    CHECK_EQ(hir->functions[0].return_variant_index, 1u);
+}
+TEST(frontend, concrete_generic_struct_type_refs_are_supported_in_function_signatures) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+func wrap(x: Box<i32>) -> Box<i32> => x
+route GET "/users" {
+    let box = wrap(Box(value: 200))
+    if box.value == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(hir->functions[0].params[0].type, HirTypeKind::Struct);
+    CHECK_EQ(hir->functions[0].params[0].struct_index, 1u);
+    CHECK_EQ(hir->functions[0].return_type, HirTypeKind::Struct);
+    CHECK_EQ(hir->functions[0].return_struct_index, 1u);
+}
+TEST(frontend, concrete_generic_type_refs_are_supported_in_struct_fields) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder { state: Result<i32> }
+route GET "/users" {
+    let holder = Holder(state: Result.ok(200))
+    match holder.state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 1u);
+    CHECK_EQ(hir->structs[0].fields[0].type, HirTypeKind::Variant);
+    CHECK_EQ(hir->structs[0].fields[0].variant_index, 1u);
+}
+TEST(frontend, concrete_generic_type_refs_are_supported_in_variant_payloads) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+variant Outer { wrap(Result<i32>), bad }
+func isOk(x: Result<i32>) -> bool {
+    match x {
+    case .ok => true
+    case .err => false
+    }
+}
+route GET "/users" {
+    let state = Outer.wrap(Result.ok(200))
+    match state {
+    case .wrap(inner): {
+        let ok = isOk(inner)
+        if ok { return 200 } else { return 500 }
+    }
+    case .bad:
+        return 404
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->variants.len >= 3u);
+    CHECK_EQ(hir->variants[1].cases[0].payload_type, HirTypeKind::Variant);
+    CHECK_EQ(hir->variants[1].cases[0].payload_variant_index, 2u);
+}
+TEST(frontend, concrete_generic_struct_type_refs_are_supported_in_variant_payloads) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+variant Outer { wrap(Box<i32>), bad }
+func is200(x: Box<i32>) -> bool => x.value == 200
+route GET "/users" {
+    let state = Outer.wrap(Box(value: 200))
+    match state {
+    case .wrap(inner): {
+        let ok = is200(inner)
+        if ok { return 200 } else { return 500 }
+    }
+    case .bad:
+        return 404
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    CHECK_EQ(hir->variants[0].cases[0].payload_type, HirTypeKind::Struct);
+    CHECK_EQ(hir->variants[0].cases[0].payload_struct_index, 1u);
+}
+TEST(frontend, generic_struct_can_reference_generic_variant_with_same_type_arg) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: Result<T> }
+route GET "/users" {
+    let holder = Holder<i32>(state: Result.ok(200))
+    match holder.state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    REQUIRE(hir->variants.len >= 2u);
+    CHECK_EQ(hir->structs[1].template_struct_index, 0u);
+    CHECK_EQ(hir->structs[1].fields[0].type, HirTypeKind::Variant);
+    REQUIRE(hir->structs[1].fields[0].variant_index < hir->variants.len);
+    CHECK_EQ(hir->variants[hir->structs[1].fields[0].variant_index].template_variant_index, 0u);
+}
+TEST(frontend, generic_variant_can_reference_generic_struct_with_same_type_arg) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+variant Wrap<T> { some(Box<T>), none }
+route GET "/users" {
+    let state = Wrap<i32>.some(Box(value: 200))
+    match state {
+    case .some(box): {
+        if box.value == 200 { return 200 } else { return 500 }
+    }
+    case .none:
+        return 404
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    REQUIRE(hir->variants.len >= 2u);
+    CHECK_EQ(hir->variants[1].template_variant_index, 0u);
+    CHECK_EQ(hir->variants[1].cases[0].payload_type, HirTypeKind::Struct);
+    REQUIRE(hir->variants[1].cases[0].payload_struct_index < hir->structs.len);
+    CHECK_EQ(hir->structs[hir->variants[1].cases[0].payload_struct_index].template_struct_index, 0u);
+}
+TEST(frontend, concrete_nested_generic_struct_type_refs_are_supported_in_function_signatures) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: Result<T> }
+func unwrap(x: Holder<i32>) -> Result<i32> => x.state
+route GET "/users" {
+    let state = unwrap(Holder<i32>(state: Result.ok(200)))
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    REQUIRE(hir->variants.len >= 2u);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(hir->functions[0].params[0].type, HirTypeKind::Struct);
+    CHECK_EQ(hir->functions[0].params[0].struct_index, 1u);
+    CHECK_NE(hir->functions[0].params[0].type_args[0].shape_index, 0xffffffffu);
+    CHECK_EQ(hir->functions[0].return_type, HirTypeKind::Variant);
+    REQUIRE(hir->functions[0].return_variant_index < hir->variants.len);
+    CHECK_EQ(hir->variants[hir->functions[0].return_variant_index].template_variant_index, 0u);
+    CHECK_NE(hir->functions[0].return_type_args[0].shape_index, 0xffffffffu);
+}
+TEST(frontend, concrete_nested_generic_struct_type_ref_records_instance_shape_index) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: T }
+func unwrap(x: Holder<Result<i32>>) -> Result<i32> => x.state
+route GET "/users" {
+    let state = unwrap(Holder<Result<i32>>(state: Result.ok(200)))
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(hir->functions[0].params[0].type, HirTypeKind::Struct);
+    REQUIRE(hir->functions[0].params[0].struct_index < hir->structs.len);
+    const auto& holder_inst = hir->structs[hir->functions[0].params[0].struct_index];
+    CHECK_EQ(holder_inst.template_struct_index, 0u);
+    CHECK_EQ(holder_inst.instance_type_arg_count, 1u);
+    CHECK_EQ(holder_inst.instance_type_args[0], HirTypeKind::Variant);
+    CHECK_NE(holder_inst.instance_shape_indices[0], 0xffffffffu);
+    CHECK_NE(hir->functions[0].params[0].type_args[0].shape_index, 0xffffffffu);
+}
+TEST(frontend, explicit_generic_struct_init_records_instance_shape_index) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: T }
+route GET "/users" {
+    let holder = Holder<Result<i32>>(state: Result<i32>.ok(200))
+    match holder.state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    const auto& inst = hir->structs[1];
+    CHECK_EQ(inst.template_struct_index, 0u);
+    CHECK_EQ(inst.instance_type_arg_count, 1u);
+    CHECK_EQ(inst.instance_type_args[0], HirTypeKind::Variant);
+    CHECK_NE(inst.instance_shape_indices[0], 0xffffffffu);
+}
+TEST(frontend, concrete_nested_generic_variant_type_ref_records_instance_shape_index) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+variant Wrap<T> { some(T), none }
+func unwrap(x: Wrap<Box<i32>>) -> Box<i32> {
+    match x {
+    case .some(v) => v
+    case .none => Box<i32>(value: 0)
+    }
+}
+route GET "/users" {
+    let box = unwrap(Wrap<Box<i32>>.some(Box<i32>(value: 200)))
+    if box.value == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->variants.len >= 2u);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(hir->functions[0].params[0].type, HirTypeKind::Variant);
+    REQUIRE(hir->functions[0].params[0].variant_index < hir->variants.len);
+    const auto& wrap_inst = hir->variants[hir->functions[0].params[0].variant_index];
+    CHECK_EQ(wrap_inst.template_variant_index, 0u);
+    CHECK_EQ(wrap_inst.instance_type_arg_count, 1u);
+    CHECK_EQ(wrap_inst.instance_type_args[0], HirTypeKind::Struct);
+    CHECK_NE(wrap_inst.instance_shape_indices[0], 0xffffffffu);
+    CHECK_NE(hir->functions[0].params[0].type_args[0].shape_index, 0xffffffffu);
+}
+TEST(frontend, concrete_nested_generic_variant_type_refs_are_supported_in_function_signatures) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+variant Wrap<T> { some(Box<T>), none }
+func is200(x: Wrap<i32>) -> bool {
+    match x {
+    case .some(box) => box.value == 200
+    case .none => false
+    }
+}
+route GET "/users" {
+    let ok = is200(Wrap<i32>.some(Box(value: 200)))
+    if ok { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    REQUIRE(hir->variants.len >= 2u);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(hir->functions[0].params[0].type, HirTypeKind::Variant);
+    CHECK_EQ(hir->functions[0].params[0].variant_index, 1u);
+    CHECK_NE(hir->functions[0].params[0].type_args[0].shape_index, 0xffffffffu);
+    CHECK_EQ(hir->functions[0].return_type, HirTypeKind::Bool);
+}
+TEST(frontend, tuple_literal_with_struct_element_can_flow_into_pipe) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+func boxCode(b: Box) -> i32 => b.value
+route GET "/users" {
+    let pair = (Box(value: 200), 1)
+    let code = pair | boxCode(_1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, variant_tuple_of_struct_payload_records_struct_slots) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+variant Result { ok((Box, i32)), err }
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 1u);
+    REQUIRE_EQ(hir->variants[0].cases.len, 2u);
+    const auto& ok = hir->variants[0].cases[0];
+    CHECK(ok.has_payload);
+    CHECK(ok.payload_type == HirTypeKind::Tuple);
+    REQUIRE_EQ(ok.payload_tuple_len, 2u);
+    CHECK(ok.payload_tuple_types[0] == HirTypeKind::Struct);
+    CHECK(ok.payload_tuple_struct_indices[0] == 0u);
+}
+
+TEST(frontend, generic_function_tuple_of_struct_binding_preserves_struct_slots) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+func id<T>(x: T) -> T => x
+func boxCode(b: Box) -> i32 => b.value
+route GET "/users" {
+    let pair = id((Box(value: 200), 1))
+    let code = pair | boxCode(_1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
+TEST(frontend, generic_function_explicit_tuple_of_struct_type_arg_preserves_struct_slots) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+func id<T>(x: T) -> T => x
+func boxCode(b: Box) -> i32 => b.value
+route GET "/users" {
+    let pair = id<(Box, i32)>((Box(value: 200), 1))
+    let code = pair | boxCode(_1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
+TEST(frontend, plain_struct_tuple_field_can_flow_into_pipe_slots) {
+    const char* src =
+        "struct Foo { pair: (i32, i32) }\n"
+        "func second(a: i32, b: i32) -> i32 => b\n"
+        "route GET \"/users\" { let foo = Foo(pair: (200, 500)) let code = foo.pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(hir->routes[0].locals[0].type, HirTypeKind::Struct);
+    CHECK_EQ(hir->routes[0].locals[1].type, HirTypeKind::I32);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    CHECK(block_has_op(rir.module.functions[0].blocks[0], rir::Opcode::StructField));
+    rir.destroy();
+}
+TEST(frontend, plain_struct_tuple_of_struct_field_projection_preserves_struct_slots) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "struct Foo { pair: (Box, i32) }\n"
+        "route GET \"/users\" { let foo = Foo(pair: (Box(value: 200), 500)) let pair = foo.pair return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(hir->routes[0].locals[1].type, HirTypeKind::Tuple);
+    REQUIRE_EQ(hir->routes[0].locals[1].tuple_len, 2u);
+    CHECK_EQ(hir->routes[0].locals[1].tuple_types[0], HirTypeKind::Struct);
+    CHECK_EQ(hir->routes[0].locals[1].tuple_struct_indices[0], 0u);
+}
+TEST(frontend, plain_struct_variant_field_can_flow_into_match) {
+    const char* src =
+        "variant AuthState { timeout, forbidden }\n"
+        "struct Foo { state: AuthState }\n"
+        "route GET \"/users\" { let foo = Foo(state: AuthState.timeout) match foo.state { case .timeout: return 200 case _: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(hir->routes[0].locals[0].type, HirTypeKind::Struct);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    CHECK(block_has_op(rir.module.functions[0].blocks[0], rir::Opcode::StructField));
+    rir.destroy();
+}
+TEST(frontend, source_error_standard_fields_are_accessible) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = failed.code let msg = failed.msg if code == 0 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir.value().routes[0].locals.len, 3u);
+    CHECK_EQ(hir.value().routes[0].locals[1].type, HirTypeKind::I32);
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(hir.value().routes[0].locals[2].type, HirTypeKind::Str);
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[2].init.kind), static_cast<u8>(HirExprKind::StrLit));
+    CHECK(hir.value().routes[0].locals[2].init.str_value.eq(lit("timed out")));
+}
+TEST(frontend, source_error_line_field_is_accessible) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let line = failed.line if line == 1 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir.value().routes[0].locals.len, 2u);
+    CHECK_EQ(hir.value().routes[0].locals[1].type, HirTypeKind::I32);
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(hir.value().routes[0].locals[1].init.int_value, 1);
+}
+TEST(frontend, source_error_file_and_func_fields_are_accessible) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let file_name = failed.file let fn_name = failed.func return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir.value().routes[0].locals.len, 3u);
+    CHECK_EQ(hir.value().routes[0].locals[1].type, HirTypeKind::Str);
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Field));
+    CHECK(hir.value().routes[0].locals[1].init.str_value.eq(lit("file")));
+    CHECK_EQ(hir.value().routes[0].locals[2].type, HirTypeKind::Str);
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[2].init.kind), static_cast<u8>(HirExprKind::Field));
+    CHECK(hir.value().routes[0].locals[2].init.str_value.eq(lit("func")));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    CHECK(block_has_op(rir.module.functions[0].blocks[0], rir::Opcode::StructField));
+    rir.destroy();
+}
+TEST(frontend, known_named_error_match_selects_error_case) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) match failed { case .timeout: return 503 case _: return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Direct));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.direct_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(hir->routes[0].control.direct_term.status_code, 503);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, if_const_selects_then_without_checking_else) {
+    const char* src =
+        "route GET \"/users\" { if const true { return 200 } else { forward missing } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Direct));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.direct_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(hir->routes[0].control.direct_term.status_code, 200);
+}
+TEST(frontend, if_const_rejects_runtime_condition) {
+    const char* src =
+        "route GET \"/users\" { if const req.header(\"Host\") { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, match_const_selects_variant_case_without_checking_other_arms) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match const state { case .ok(x): if x == 200 { return 200 } else { return 500 } case .err: forward missing } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, function_match_const_preserves_outer_payload_binding) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "func pick(x: Result) -> i32 {\n"
+        "  match x {\n"
+        "    case .ok(v) => {\n"
+        "      match const true {\n"
+        "        case true => v\n"
+        "        case false => 500\n"
+        "      }\n"
+        "    }\n"
+        "    case .err => 404\n"
+        "  }\n"
+        "}\n"
+        "route GET \"/users\" { let code = pick(Result.ok(200)) if code == 200 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(hir->functions[0].return_type, HirTypeKind::I32);
+}
+TEST(frontend, match_const_rejects_runtime_subject) {
+    const char* src =
+        "variant AuthState { timeout, forbidden }\n"
+        "route GET \"/users\" { match const req.header(\"Host\") { case .timeout: return 200 case _: return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_variant_payload_type_mismatch) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(\"x\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_generic_variant_constructor_when_not_all_type_arguments_can_be_inferred) {
+    const auto src = R"rut(
+variant Pair<T, U> { one(T), two(U) }
+route GET "/users" {
+    let state = Pair.one(200)
+    match state {
+    case .one(v): return 200
+    case .two(v): return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_generic_struct_constructor_when_not_all_type_arguments_can_be_inferred) {
+    const auto src = R"rut(
+struct Holder<T, U> { value: T, tag: i32 }
+route GET "/users" {
+    let box = Holder(value: 200, tag: 1)
+    if box.tag == 1 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_missing_variant_payload) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_payload_on_payloadless_variant_case) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.err(1) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_variant_match_missing_case_without_wildcard) {
+    const char* src =
+        "variant AuthState { timeout, forbidden }\n"
+        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_duplicate_variant_match_case) {
+    const char* src =
+        "variant AuthState { timeout, forbidden }\n"
+        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return 200 case .timeout: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, lower_forward_route_to_rir) {
+    const char* src = "upstream api\nroute GET \"/users\" { forward api }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->upstreams.len, 1u);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    CHECK_EQ(hir->upstreams[0].id, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.direct_term.kind),
+             static_cast<u8>(HirTerminatorKind::ForwardUpstream));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ForwardUpstream));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.func_count, 1u);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_EQ(fn.block_count, 1u);
+    REQUIRE_EQ(fn.blocks[0].inst_count, 2u);
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ConstI32));
+    CHECK_EQ(fn.blocks[0].insts[0].imm.i32_val, 1);
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[1].op),
+             static_cast<u8>(rir::Opcode::RetForward));
+    rir.destroy();
+}
+TEST(frontend, let_if_lowers_to_branching_rir) {
+    const char* src =
+        "upstream api\n"
+        "route GET \"/users\" { let ok = true if ok { return 200 } else { forward api } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[1].route.statements.len, 2u);
+    CHECK_EQ(static_cast<u8>(ast->items[1].route.statements[0].kind),
+             static_cast<u8>(AstStmtKind::Let));
+    CHECK_EQ(static_cast<u8>(ast->items[1].route.statements[1].kind),
+             static_cast<u8>(AstStmtKind::If));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.func_count, 1u);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_EQ(fn.block_count, 3u);
+    CHECK_EQ(fn.blocks[0].inst_count, 2u);
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ConstBool));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[1].op), static_cast<u8>(rir::Opcode::Br));
+    CHECK_EQ(static_cast<u8>(fn.blocks[1].insts[0].op), static_cast<u8>(rir::Opcode::RetStatus));
+    CHECK_EQ(static_cast<u8>(fn.blocks[2].insts[1].op), static_cast<u8>(rir::Opcode::RetForward));
+    rir.destroy();
+}
+TEST(frontend, route_if_branch_block_with_let_lowers_via_match_shape) {
+    const char* src =
+        "route GET \"/users\" { let ok = true if ok { let code = 200 if code == 200 { return 200 } else { return 500 } } else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].body_kind),
+             static_cast<u8>(HirMatchArm::BodyKind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE(mir->functions[0].blocks.len >= 5u);
+}
+TEST(frontend, route_if_branch_block_with_guard_is_supported) {
+    const char* src =
+        "route GET \"/users\" { let ok = true if ok { let failed = error(7) guard failed else { return 401 } return 200 } else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    REQUIRE_EQ(hir->routes[0].control.match_arms[0].guards.len, 1u);
+}
+TEST(frontend, guard_lowers_to_fail_and_continue_blocks) {
+    const char* src =
+        "upstream api\n"
+        "route GET \"/users\" { let failed = error(7) guard failed else { return 401 } forward api }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[1].route.statements.len, 3u);
+    CHECK_EQ(static_cast<u8>(ast->items[1].route.statements[1].kind),
+             static_cast<u8>(AstStmtKind::Guard));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Direct));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_FALSE(mir->functions[0].blocks[0].term.cond.bool_value);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.kind),
+             static_cast<u8>(MirTerminatorKind::ForwardUpstream));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_EQ(fn.block_count, 3u);
+    REQUIRE(fn.blocks[0].inst_count > 0);
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[fn.blocks[0].inst_count - 1].op),
+             static_cast<u8>(rir::Opcode::Br));
+    CHECK_EQ(static_cast<u8>(fn.blocks[1].insts[1].op), static_cast<u8>(rir::Opcode::RetForward));
+    CHECK_EQ(fn.blocks[2].insts[0].imm.i32_val, 401);
+    rir.destroy();
+}
+TEST(frontend, guard_else_block_with_let_is_supported) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(7) guard failed else { let code = 401 if code == 401 { return 401 } else { return 500 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].fail_kind), static_cast<u8>(HirGuard::FailKind::Body));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].fail_body.body_kind),
+             static_cast<u8>(HirGuardBody::BodyKind::If));
+}
+TEST(frontend, guard_let_binds_success_value) {
+    const char* src =
+        "route GET \"/users\" { guard let code = 200 else { return 401 } if code == 200 { return 200 } else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 2u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].route.statements[0].kind),
+             static_cast<u8>(AstStmtKind::Guard));
+    CHECK(ast->items[0].route.statements[0].bind_value);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].name.eq(lit("code")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::I32));
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+}
+TEST(frontend, guard_let_does_not_unwrap_nil) {
+    const char* src =
+        "route GET \"/users\" { guard let maybe = nil else { return 401 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].name.eq(lit("maybe")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Unknown));
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].cond.kind), static_cast<u8>(HirExprKind::BoolLit));
+    CHECK(hir->routes[0].guards[0].cond.bool_value);
+}
+TEST(frontend, equality_expression_lowers_to_cmp_eq) {
+    const char* src =
+        "upstream api\n"
+        "route GET \"/users\" { let code = 200 if code == 200 { forward api } else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::I32));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].type), static_cast<u8>(MirTypeKind::I32));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_EQ(fn.block_count, 3u);
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ConstI32));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[fn.blocks[0].inst_count - 1].op),
+             static_cast<u8>(rir::Opcode::Br));
+    rir.destroy();
+}
+TEST(frontend, or_builtin_falls_back_from_nil) {
+    const char* src =
+        "route GET \"/users\" { let code = or(nil, 200) if code == 200 { return 200 } else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 2u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].route.statements[0].kind),
+             static_cast<u8>(AstStmtKind::Let));
+    CHECK_EQ(static_cast<u8>(ast->items[0].route.statements[0].expr.kind),
+             static_cast<u8>(AstExprKind::Or));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::I32));
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(hir->routes[0].locals[0].init.int_value, 200);
+}
+TEST(frontend, req_header_flows_as_optional_str) {
+    const char* src =
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"fallback\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 3u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].route.statements[0].expr.kind),
+             static_cast<u8>(AstExprKind::ReqHeader));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqHeader));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqHeader));
+    REQUIRE(mir->functions[0].locals[1].init.lhs != nullptr);
+    REQUIRE(mir->functions[0].locals[1].init.rhs != nullptr);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[1].init.kind),
+             static_cast<u8>(MirValueKind::Or));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[1].init.lhs->kind),
+             static_cast<u8>(MirValueKind::LocalRef));
+    CHECK_EQ(mir->functions[0].locals[1].init.lhs->local_index, 0u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[1].init.rhs->kind),
+             static_cast<u8>(MirValueKind::StrConst));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ReqHeader));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[1].op), static_cast<u8>(rir::Opcode::ConstStr));
+    rir.destroy();
+}
+TEST(frontend, req_header_alias_flows_as_optional_str) {
+    const char* src =
+        "route GET \"/users\" { let host = req.header(\"Host\") let alias = host let value = or(alias, \"fallback\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].may_nil);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(hir->routes[0].locals[1].init.local_index, 0u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[2].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK_FALSE(hir->routes[0].locals[2].may_nil);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 3u);
+    REQUIRE(mir->functions[0].locals[2].init.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[2].init.kind),
+             static_cast<u8>(MirValueKind::Or));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[2].init.lhs->kind),
+             static_cast<u8>(MirValueKind::LocalRef));
+    CHECK_EQ(mir->functions[0].locals[2].init.lhs->local_index, 1u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ReqHeader));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[1].op), static_cast<u8>(rir::Opcode::ConstStr));
+    rir.destroy();
+}
+TEST(frontend, or_builtin_falls_back_from_nil_local) {
+    const char* src =
+        "route GET \"/users\" { let maybe = nil let code = or(maybe, 200) if code == 200 { return 200 } else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 3u);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Unknown));
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind), static_cast<u8>(HirExprKind::Nil));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].type), static_cast<u8>(HirTypeKind::I32));
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(hir->routes[0].locals[1].init.int_value, 200);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 2u);
+}
+TEST(frontend, or_builtin_falls_back_from_error_local) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(7) let code = or(failed, 200) if code == 200 { return 200 } else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 3u);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind), static_cast<u8>(HirExprKind::Error));
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].type), static_cast<u8>(HirTypeKind::I32));
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(hir->routes[0].locals[1].init.int_value, 200);
+}
+TEST(frontend, or_builtin_falls_back_from_error_alias) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(7) let alias = failed let code = or(alias, 200) if code == 200 { return 200 } else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[2].type), static_cast<u8>(HirTypeKind::I32));
+    CHECK_FALSE(hir->routes[0].locals[2].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[2].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[2].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(hir->routes[0].locals[2].init.int_value, 200);
+}
+TEST(frontend, analyze_rejects_unknown_upstream) {
+    const char* src = "route GET \"/users\" { forward api }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnknownUpstream));
+}
+TEST(frontend, match_lowers_to_cmp_eq_chain) {
+    const char* src =
+        "upstream api\n"
+        "route GET \"/users\" { let code = 200 match code { case 200: forward api case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[1].route.statements.len, 2u);
+    CHECK_EQ(static_cast<u8>(ast->items[1].route.statements[1].kind),
+             static_cast<u8>(AstStmtKind::Match));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_EQ(fn.block_count, 3u);
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[2].op), static_cast<u8>(rir::Opcode::CmpEq));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[3].op), static_cast<u8>(rir::Opcode::Br));
+    CHECK_EQ(static_cast<u8>(fn.blocks[1].insts[1].op), static_cast<u8>(rir::Opcode::RetForward));
+    CHECK_EQ(static_cast<u8>(fn.blocks[2].insts[0].op), static_cast<u8>(rir::Opcode::RetStatus));
+    rir.destroy();
+}
+TEST(frontend, guard_then_match_lowers_to_guard_and_match_blocks) {
+    const char* src =
+        "upstream api\n"
+        "route GET \"/users\" { let failed = error(7) let code = 200 guard code else { return 401 } match code { case 200: forward api case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.functions[0].block_count, 5u);
+    rir.destroy();
+}
+TEST(frontend, multiple_top_level_guards_are_allowed) {
+    const char* src =
+        "route GET \"/users\" { let ok = 200 guard ok else { return 401 } let failed = error(7) guard failed else { return 402 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].guards.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.functions[0].block_count, 5u);
+    rir.destroy();
+}
+TEST(frontend, guard_match_lowers_to_fail_side_match_arms) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].guards.len, 1u);
+    REQUIRE_EQ(hir->guard_match_arms.len, 2u);
+    const auto& guard = hir->routes[0].guards[0];
+    CHECK_EQ(static_cast<u8>(guard.fail_kind), static_cast<u8>(HirGuard::FailKind::Match));
+    REQUIRE_EQ(guard.fail_match_count, 2u);
+    CHECK_EQ(guard.fail_match_start, 0u);
+    CHECK(!hir->guard_match_arms[0].is_wildcard);
+    CHECK(hir->guard_match_arms[1].is_wildcard);
+    CHECK_EQ(hir->guard_match_arms[0].direct_term.status_code, 503);
+    CHECK_EQ(hir->guard_match_arms[1].direct_term.status_code, 500);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    CHECK(mir->functions[0].blocks.len >= 5u);
+}
+TEST(frontend, analyze_rejects_guard_match_without_wildcard) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case .timeout: return 503 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_guard_match_wildcard_before_last) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case _: return 500 case .timeout: return 503 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_guard_match_duplicate_case) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case .timeout: return 503 case .timeout: return 504 case _: return 500 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_guard_match_pattern_type_mismatch) {
+    const char* src =
+        "variant AuthError { timeout, forbidden }\n"
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case AuthError.timeout: return 503 case _: return 500 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_match_arm_block_guard_match_on_non_error_value) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { guard match x else { case .timeout: return 401 case _: return 402 } if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_match_without_wildcard) {
+    const char* src =
+        "route GET \"/users\" { let code = 200 match code { case 200: return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, guard_lowers_from_error_alias) {
+    const char* src =
+        "upstream api\n"
+        "route GET \"/users\" { let failed = error(7) let alias = failed guard alias else { return 401 } forward api }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].guards.len, 1u);
+    CHECK_FALSE(hir->routes[0].guards[0].cond.bool_value);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+}
+TEST(frontend, analyze_rejects_match_wildcard_before_last) {
+    const char* src =
+        "route GET \"/users\" { let code = 200 match code { case _: return 404 case 200: return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_match_pattern_type_mismatch) {
+    const char* src =
+        "route GET \"/users\" { let ok = true match ok { case 200: return 200 case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_or_with_mismatched_types) {
+    const char* src =
+        "route GET \"/users\" { let code = 200 let fallback = or(code, true) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_or_with_fallible_fallback) {
+    const char* src =
+        "route GET \"/users\" { let code = or(nil, error(7)) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_guard_let_binding_error_value) {
+    const char* src =
+        "route GET \"/users\" { guard let code = error(7) else { return 401 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_guard_let_binding_error_alias) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(7) let alias = failed guard let code = alias else { return 401 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, build_mir_preserves_runtime_or_value) {
+    auto* hir = new HirModule{};
+    HirRoute route{};
+    route.span = {1, 1, 1, 1};
+    route.method = 'G';
+    route.path = lit("/users");
+    HirLocal maybe{};
+    maybe.span = {1, 1, 1, 1};
+    maybe.name = lit("maybe");
+    maybe.type = HirTypeKind::I32;
+    maybe.may_nil = true;
+    maybe.init.kind = HirExprKind::IntLit;
+    maybe.init.type = HirTypeKind::I32;
+    maybe.init.int_value = 123;
+    REQUIRE(route.locals.push(maybe));
+    HirLocal code{};
+    code.span = {1, 1, 1, 1};
+    code.name = lit("code");
+    code.type = HirTypeKind::I32;
+    code.init.kind = HirExprKind::Or;
+    code.init.type = HirTypeKind::I32;
+    HirExpr lhs{};
+    lhs.kind = HirExprKind::LocalRef;
+    lhs.type = HirTypeKind::I32;
+    lhs.may_nil = true;
+    lhs.may_error = false;
+    lhs.local_index = 0;
+    REQUIRE(route.exprs.push(lhs));
+    HirExpr rhs{};
+    rhs.kind = HirExprKind::IntLit;
+    rhs.type = HirTypeKind::I32;
+    rhs.int_value = 200;
+    REQUIRE(route.exprs.push(rhs));
+    code.init.lhs = &route.exprs[0];
+    code.init.rhs = &route.exprs[1];
+    REQUIRE(route.locals.push(code));
+    route.control.kind = HirControlKind::Direct;
+    route.control.direct_term.kind = HirTerminatorKind::ReturnStatus;
+    route.control.direct_term.status_code = 200;
+    REQUIRE(hir->routes.push(route));
+    auto mir = build_mir(*hir);
+    REQUIRE(mir);
+    REQUIRE_EQ(mir.value()->functions.len, 1u);
+    REQUIRE_EQ(mir.value()->functions[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(mir.value()->functions[0].locals[1].init.kind),
+             static_cast<u8>(MirValueKind::Or));
+    REQUIRE_NE(mir.value()->functions[0].locals[1].init.lhs, nullptr);
+    REQUIRE_NE(mir.value()->functions[0].locals[1].init.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(mir.value()->functions[0].locals[1].init.lhs->kind),
+             static_cast<u8>(MirValueKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(mir.value()->functions[0].locals[1].init.rhs->kind),
+             static_cast<u8>(MirValueKind::IntConst));
+}
+TEST(frontend, build_mir_preserves_runtime_no_error_guard) {
+    auto* hir = new HirModule{};
+    HirRoute route{};
+    route.span = {1, 1, 1, 1};
+    route.method = 'G';
+    route.path = lit("/users");
+    HirLocal value{};
+    value.span = {1, 1, 1, 1};
+    value.name = lit("value");
+    value.type = HirTypeKind::I32;
+    value.may_error = true;
+    value.init.kind = HirExprKind::IntLit;
+    value.init.type = HirTypeKind::I32;
+    value.init.int_value = 7;
+    REQUIRE(route.locals.push(value));
+    HirGuard guard{};
+    guard.span = {1, 1, 1, 1};
+    guard.cond.kind = HirExprKind::NoError;
+    guard.cond.type = HirTypeKind::Bool;
+    HirExpr ref{};
+    ref.kind = HirExprKind::LocalRef;
+    ref.type = HirTypeKind::I32;
+    ref.may_error = true;
+    ref.local_index = 0;
+    REQUIRE(route.exprs.push(ref));
+    guard.cond.lhs = &route.exprs[0];
+    guard.fail_term.kind = HirTerminatorKind::ReturnStatus;
+    guard.fail_term.status_code = 401;
+    REQUIRE(route.guards.push(guard));
+    route.control.kind = HirControlKind::Direct;
+    route.control.direct_term.kind = HirTerminatorKind::ReturnStatus;
+    route.control.direct_term.status_code = 200;
+    REQUIRE(hir->routes.push(route));
+    auto mir = build_mir(*hir);
+    REQUIRE(mir);
+    REQUIRE_EQ(mir.value()->functions.len, 1u);
+    REQUIRE_EQ(mir.value()->functions[0].blocks.len, 3u);
+    CHECK_EQ(static_cast<u8>(mir.value()->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(static_cast<u8>(mir.value()->functions[0].blocks[0].term.cond.kind),
+             static_cast<u8>(MirValueKind::NoError));
+    REQUIRE_NE(mir.value()->functions[0].blocks[0].term.cond.lhs, nullptr);
+    CHECK_EQ(static_cast<u8>(mir.value()->functions[0].blocks[0].term.cond.lhs->kind),
+             static_cast<u8>(MirValueKind::LocalRef));
+}
+TEST(frontend, lower_to_rir_supports_runtime_optional_or_value) {
+    auto* hir = new HirModule{};
+    HirRoute route{};
+    route.span = {1, 1, 1, 1};
+    route.method = 'G';
+    route.path = lit("/users");
+    HirLocal maybe{};
+    maybe.span = {1, 1, 1, 1};
+    maybe.name = lit("maybe");
+    maybe.type = HirTypeKind::I32;
+    maybe.may_nil = true;
+    maybe.init.kind = HirExprKind::IntLit;
+    maybe.init.type = HirTypeKind::I32;
+    maybe.init.int_value = 123;
+    REQUIRE(route.locals.push(maybe));
+    HirLocal code{};
+    code.span = {1, 1, 1, 1};
+    code.name = lit("code");
+    code.type = HirTypeKind::I32;
+    code.init.kind = HirExprKind::Or;
+    code.init.type = HirTypeKind::I32;
+    HirExpr lhs{};
+    lhs.kind = HirExprKind::LocalRef;
+    lhs.type = HirTypeKind::I32;
+    lhs.may_nil = true;
+    lhs.may_error = false;
+    lhs.local_index = 0;
+    REQUIRE(route.exprs.push(lhs));
+    HirExpr rhs{};
+    rhs.kind = HirExprKind::IntLit;
+    rhs.type = HirTypeKind::I32;
+    rhs.int_value = 200;
+    REQUIRE(route.exprs.push(rhs));
+    code.init.lhs = &route.exprs[0];
+    code.init.rhs = &route.exprs[1];
+    REQUIRE(route.locals.push(code));
+    route.control.kind = HirControlKind::Direct;
+    route.control.direct_term.kind = HirTerminatorKind::ReturnStatus;
+    route.control.direct_term.status_code = 200;
+    REQUIRE(hir->routes.push(route));
+    auto mir = build_mir(*hir);
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.func_count, 1u);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_EQ(fn.block_count, 1u);
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ConstI32));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[1].op), static_cast<u8>(rir::Opcode::OptWrap));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[2].op), static_cast<u8>(rir::Opcode::ConstI32));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[3].op), static_cast<u8>(rir::Opcode::OptIsNil));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[4].op), static_cast<u8>(rir::Opcode::OptUnwrap));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[5].op), static_cast<u8>(rir::Opcode::Select));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[6].op), static_cast<u8>(rir::Opcode::RetStatus));
+    rir.destroy();
+}
+TEST(frontend, lower_to_rir_supports_runtime_error_or_value) {
+    auto* mir = new MirModule{};
+    MirFunction fn{};
+    fn.span = Span{0, 0, 1, 1};
+    fn.method = 'G';
+    fn.path = lit("/users");
+    fn.name = lit("route");
+    MirLocal failed{};
+    failed.span = fn.span;
+    failed.name = lit("failed");
+    failed.type = MirTypeKind::I32;
+    failed.may_error = true;
+    failed.init.kind = MirValueKind::Error;
+    failed.init.type = MirTypeKind::Unknown;
+    failed.init.may_error = true;
+    failed.init.int_value = 7;
+    REQUIRE(fn.locals.push(failed));
+    MirValue lhs{};
+    lhs.kind = MirValueKind::LocalRef;
+    lhs.type = MirTypeKind::I32;
+    lhs.may_error = true;
+    lhs.local_index = 0;
+    MirValue rhs{};
+    rhs.kind = MirValueKind::IntConst;
+    rhs.type = MirTypeKind::I32;
+    rhs.int_value = 200;
+    MirValue orv{};
+    orv.kind = MirValueKind::Or;
+    orv.type = MirTypeKind::I32;
+    orv.may_error = true;
+    orv.lhs = &lhs;
+    orv.rhs = &rhs;
+    REQUIRE(fn.values.push(lhs));
+    REQUIRE(fn.values.push(rhs));
+    REQUIRE(fn.values.push(orv));
+    MirLocal code{};
+    code.span = fn.span;
+    code.name = lit("code");
+    code.type = MirTypeKind::I32;
+    code.init = fn.values[2];
+    REQUIRE(fn.locals.push(code));
+    MirBlock entry{};
+    entry.label = lit("entry");
+    entry.term.kind = MirTerminatorKind::ReturnStatus;
+    entry.term.span = fn.span;
+    entry.term.status_code = 200;
+    REQUIRE(fn.blocks.push(entry));
+    REQUIRE(mir->functions.push(fn));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir, rir);
+    REQUIRE(lowered);
+    const auto& out_fn = rir.module.functions[0];
+    REQUIRE_EQ(out_fn.block_count, 1u);
+    CHECK(block_has_op(out_fn.blocks[0], rir::Opcode::StructCreate));
+    CHECK(block_has_op(out_fn.blocks[0], rir::Opcode::StructField));
+    CHECK(block_has_op(out_fn.blocks[0], rir::Opcode::OptIsNil));
+    CHECK(block_has_op(out_fn.blocks[0], rir::Opcode::OptUnwrap));
+    CHECK(block_has_op(out_fn.blocks[0], rir::Opcode::Select));
+    REQUIRE(out_fn.blocks[0].inst_count > 0);
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[out_fn.blocks[0].inst_count - 1].op),
+             static_cast<u8>(rir::Opcode::RetStatus));
+    rir.destroy();
+}
+TEST(frontend, lower_to_rir_supports_runtime_optional_error_or_value) {
+    auto* mir = new MirModule{};
+    MirFunction fn{};
+    fn.span = Span{0, 0, 1, 1};
+    fn.method = 'G';
+    fn.path = lit("/users");
+    fn.name = lit("route");
+    MirLocal maybe_failed{};
+    maybe_failed.span = fn.span;
+    maybe_failed.name = lit("maybe_failed");
+    maybe_failed.type = MirTypeKind::I32;
+    maybe_failed.may_nil = true;
+    maybe_failed.may_error = true;
+    maybe_failed.init.kind = MirValueKind::Nil;
+    maybe_failed.init.type = MirTypeKind::Unknown;
+    maybe_failed.init.may_nil = true;
+    REQUIRE(fn.locals.push(maybe_failed));
+    MirValue lhs{};
+    lhs.kind = MirValueKind::LocalRef;
+    lhs.type = MirTypeKind::I32;
+    lhs.may_nil = true;
+    lhs.may_error = true;
+    lhs.local_index = 0;
+    MirValue rhs{};
+    rhs.kind = MirValueKind::IntConst;
+    rhs.type = MirTypeKind::I32;
+    rhs.int_value = 200;
+    MirValue orv{};
+    orv.kind = MirValueKind::Or;
+    orv.type = MirTypeKind::I32;
+    orv.may_nil = true;
+    orv.may_error = true;
+    orv.lhs = &lhs;
+    orv.rhs = &rhs;
+    REQUIRE(fn.values.push(lhs));
+    REQUIRE(fn.values.push(rhs));
+    REQUIRE(fn.values.push(orv));
+    MirLocal code{};
+    code.span = fn.span;
+    code.name = lit("code");
+    code.type = MirTypeKind::I32;
+    code.init = fn.values[2];
+    REQUIRE(fn.locals.push(code));
+    MirBlock entry{};
+    entry.label = lit("entry");
+    entry.term.kind = MirTerminatorKind::ReturnStatus;
+    entry.term.span = fn.span;
+    entry.term.status_code = 200;
+    REQUIRE(fn.blocks.push(entry));
+    REQUIRE(mir->functions.push(fn));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir, rir);
+    REQUIRE(lowered);
+    const auto& out_fn = rir.module.functions[0];
+    REQUIRE_EQ(out_fn.block_count, 1u);
+    CHECK(block_has_op(out_fn.blocks[0], rir::Opcode::StructCreate));
+    CHECK(block_op_count(out_fn.blocks[0], rir::Opcode::OptIsNil) >= 2u);
+    CHECK(block_has_op(out_fn.blocks[0], rir::Opcode::OptUnwrap));
+    CHECK(block_op_count(out_fn.blocks[0], rir::Opcode::Select) >= 2u);
+    REQUIRE(out_fn.blocks[0].inst_count > 0);
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[out_fn.blocks[0].inst_count - 1].op),
+             static_cast<u8>(rir::Opcode::RetStatus));
+    rir.destroy();
+}
+TEST(frontend, lower_to_rir_supports_runtime_optional_str_or_value) {
+    auto* mir = new MirModule{};
+    MirFunction fn{};
+    fn.span = Span{0, 0, 1, 1};
+    fn.method = 'G';
+    fn.path = lit("/users");
+    fn.name = lit("route");
+    MirLocal maybe{};
+    maybe.span = fn.span;
+    maybe.name = lit("maybe");
+    maybe.type = MirTypeKind::Str;
+    maybe.may_nil = true;
+    maybe.init.kind = MirValueKind::StrConst;
+    maybe.init.type = MirTypeKind::Str;
+    maybe.init.str_value = lit("api");
+    REQUIRE(fn.locals.push(maybe));
+    MirBlock entry{};
+    entry.label = lit("entry");
+    entry.term.kind = MirTerminatorKind::ReturnStatus;
+    entry.term.span = fn.span;
+    entry.term.status_code = 200;
+    REQUIRE(fn.blocks.push(entry));
+    MirValue lhs{};
+    lhs.kind = MirValueKind::LocalRef;
+    lhs.type = MirTypeKind::Str;
+    lhs.may_nil = true;
+    lhs.local_index = 0;
+    MirValue rhs{};
+    rhs.kind = MirValueKind::StrConst;
+    rhs.type = MirTypeKind::Str;
+    rhs.str_value = lit("fallback");
+    MirValue orv{};
+    orv.kind = MirValueKind::Or;
+    orv.type = MirTypeKind::Str;
+    orv.may_nil = false;
+    orv.lhs = &lhs;
+    orv.rhs = &rhs;
+    REQUIRE(fn.values.push(lhs));
+    REQUIRE(fn.values.push(rhs));
+    REQUIRE(fn.values.push(orv));
+    MirLocal code{};
+    code.span = fn.span;
+    code.name = lit("code");
+    code.type = MirTypeKind::Str;
+    code.init = fn.values[2];
+    REQUIRE(fn.locals.push(code));
+    REQUIRE(mir->functions.push(fn));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir, rir);
+    REQUIRE(lowered);
+    const auto& out_fn = rir.module.functions[0];
+    REQUIRE_EQ(out_fn.block_count, 1u);
+    REQUIRE_EQ(out_fn.blocks[0].inst_count, 7u);
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ConstStr));
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[1].op), static_cast<u8>(rir::Opcode::OptWrap));
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[2].op), static_cast<u8>(rir::Opcode::ConstStr));
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[3].op), static_cast<u8>(rir::Opcode::OptIsNil));
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[4].op), static_cast<u8>(rir::Opcode::OptUnwrap));
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[5].op), static_cast<u8>(rir::Opcode::Select));
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[6].op), static_cast<u8>(rir::Opcode::RetStatus));
+    rir.destroy();
+}
+TEST(frontend, lower_to_rir_supports_runtime_no_error_guard) {
+    auto* hir = new HirModule{};
+    HirRoute route{};
+    route.span = {1, 1, 1, 1};
+    route.method = 'G';
+    route.path = lit("/users");
+    HirLocal value{};
+    value.span = {1, 1, 1, 1};
+    value.name = lit("value");
+    value.type = HirTypeKind::I32;
+    value.may_error = true;
+    value.init.kind = HirExprKind::IntLit;
+    value.init.type = HirTypeKind::I32;
+    value.init.int_value = 7;
+    REQUIRE(route.locals.push(value));
+    HirGuard guard{};
+    guard.span = {1, 1, 1, 1};
+    guard.cond.kind = HirExprKind::NoError;
+    guard.cond.type = HirTypeKind::Bool;
+    HirExpr ref{};
+    ref.kind = HirExprKind::LocalRef;
+    ref.type = HirTypeKind::I32;
+    ref.may_error = true;
+    ref.local_index = 0;
+    REQUIRE(route.exprs.push(ref));
+    guard.cond.lhs = &route.exprs[0];
+    guard.fail_term.kind = HirTerminatorKind::ReturnStatus;
+    guard.fail_term.status_code = 401;
+    REQUIRE(route.guards.push(guard));
+    route.control.kind = HirControlKind::Direct;
+    route.control.direct_term.kind = HirTerminatorKind::ReturnStatus;
+    route.control.direct_term.status_code = 200;
+    REQUIRE(hir->routes.push(route));
+    auto mir = build_mir(*hir);
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.func_count, 1u);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_EQ(fn.block_count, 3u);
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::StructCreate));
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::StructField));
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::OptIsNil));
+    REQUIRE(fn.blocks[0].inst_count > 0);
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[fn.blocks[0].inst_count - 1].op),
+             static_cast<u8>(rir::Opcode::Br));
+    rir.destroy();
+}
+TEST(frontend, lower_to_rir_supports_runtime_no_error_guard_on_optional_error) {
+    auto* hir = new HirModule{};
+    HirRoute route{};
+    route.span = {1, 1, 1, 1};
+    route.method = 'G';
+    route.path = lit("/users");
+    HirLocal maybe_failed{};
+    maybe_failed.span = route.span;
+    maybe_failed.name = lit("maybe_failed");
+    maybe_failed.type = HirTypeKind::I32;
+    maybe_failed.may_nil = true;
+    maybe_failed.may_error = true;
+    maybe_failed.init.kind = HirExprKind::Nil;
+    maybe_failed.init.type = HirTypeKind::Unknown;
+    maybe_failed.init.may_nil = true;
+    REQUIRE(route.locals.push(maybe_failed));
+    HirExpr subject{};
+    subject.kind = HirExprKind::LocalRef;
+    subject.type = HirTypeKind::I32;
+    subject.may_nil = true;
+    subject.may_error = true;
+    subject.local_index = 0;
+    REQUIRE(route.exprs.push(subject));
+    HirGuard guard{};
+    guard.span = route.span;
+    guard.cond.kind = HirExprKind::NoError;
+    guard.cond.type = HirTypeKind::Bool;
+    guard.cond.lhs = &route.exprs[0];
+    guard.fail_term.kind = HirTerminatorKind::ReturnStatus;
+    guard.fail_term.status_code = 401;
+    REQUIRE(route.guards.push(guard));
+    route.control.kind = HirControlKind::Direct;
+    route.control.direct_term.kind = HirTerminatorKind::ReturnStatus;
+    route.control.direct_term.status_code = 200;
+    REQUIRE(hir->routes.push(route));
+    auto mir = build_mir(*hir);
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_EQ(fn.block_count, 3u);
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::StructCreate));
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::StructField));
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::OptIsNil));
+    REQUIRE(fn.blocks[0].inst_count > 0);
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[fn.blocks[0].inst_count - 1].op),
+             static_cast<u8>(rir::Opcode::Br));
+    rir.destroy();
+}
+TEST(frontend, lower_to_rir_supports_runtime_error_code_field) {
+    auto* hir = new HirModule{};
+    HirRoute route{};
+    route.span = {1, 1, 1, 1};
+    route.method = 'G';
+    route.path = lit("/users");
+    HirLocal failed{};
+    failed.span = route.span;
+    failed.name = lit("failed");
+    failed.type = HirTypeKind::I32;
+    failed.may_error = true;
+    failed.init.kind = HirExprKind::Error;
+    failed.init.type = HirTypeKind::Unknown;
+    failed.init.may_error = true;
+    failed.init.int_value = 7;
+    failed.init.msg = lit("boom");
+    REQUIRE(route.locals.push(failed));
+    HirExpr failed_ref{};
+    failed_ref.kind = HirExprKind::LocalRef;
+    failed_ref.type = HirTypeKind::I32;
+    failed_ref.may_error = true;
+    failed_ref.local_index = 0;
+    REQUIRE(route.exprs.push(failed_ref));
+    HirLocal code{};
+    code.span = route.span;
+    code.name = lit("code");
+    code.type = HirTypeKind::I32;
+    code.init.kind = HirExprKind::Field;
+    code.init.type = HirTypeKind::I32;
+    code.init.lhs = &route.exprs[0];
+    code.init.str_value = lit("code");
+    REQUIRE(route.locals.push(code));
+    route.control.kind = HirControlKind::Direct;
+    route.control.direct_term.kind = HirTerminatorKind::ReturnStatus;
+    route.control.direct_term.status_code = 200;
+    REQUIRE(hir->routes.push(route));
+    auto mir = build_mir(*hir);
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::StructField));
+    CHECK(block_has_op(fn.blocks[0], rir::Opcode::OptUnwrap));
+    rir.destroy();
+}
+TEST(frontend, lower_to_rir_supports_runtime_error_kind_match) {
+    auto* mir = new MirModule{};
+    MirVariant err_variant{};
+    err_variant.span = {1, 1, 1, 1};
+    err_variant.name = lit("AuthError");
+    MirVariant::CaseDecl timeout{};
+    timeout.name = lit("timeout");
+    MirVariant::CaseDecl forbidden{};
+    forbidden.name = lit("forbidden");
+    REQUIRE(err_variant.cases.push(timeout));
+    REQUIRE(err_variant.cases.push(forbidden));
+    REQUIRE(mir->variants.push(err_variant));
+    MirFunction fn{};
+    fn.span = Span{1, 1, 1, 1};
+    fn.method = 'G';
+    fn.path = lit("/users");
+    fn.name = lit("route");
+    MirLocal failed{};
+    failed.span = fn.span;
+    failed.name = lit("failed");
+    failed.type = MirTypeKind::I32;
+    failed.may_error = true;
+    failed.error_variant_index = 0;
+    failed.init.kind = MirValueKind::Error;
+    failed.init.type = MirTypeKind::Unknown;
+    failed.init.may_error = true;
+    failed.init.error_variant_index = 0;
+    failed.init.error_case_index = 1;
+    REQUIRE(fn.locals.push(failed));
+    MirValue subject{};
+    subject.kind = MirValueKind::LocalRef;
+    subject.type = MirTypeKind::I32;
+    subject.may_error = true;
+    subject.local_index = 0;
+    subject.error_variant_index = 0;
+    REQUIRE(fn.values.push(subject));
+    fn.blocks.len = 0;
+    MirBlock test{};
+    test.label = lit("match_test");
+    test.term.kind = MirTerminatorKind::Branch;
+    test.term.use_cmp = true;
+    test.term.span = fn.span;
+    test.term.lhs = fn.values[0];
+    MirValue timeout_pat{};
+    timeout_pat.kind = MirValueKind::VariantCase;
+    timeout_pat.type = MirTypeKind::Variant;
+    timeout_pat.variant_index = 0;
+    timeout_pat.case_index = 0;
+    timeout_pat.int_value = 0;
+    REQUIRE(fn.values.push(timeout_pat));
+    test.term.rhs = fn.values[1];
+    test.term.then_block = 1;
+    test.term.else_block = 2;
+    REQUIRE(fn.blocks.push(test));
+    MirBlock then_block{};
+    then_block.label = lit("then");
+    then_block.term.kind = MirTerminatorKind::ReturnStatus;
+    then_block.term.span = fn.span;
+    then_block.term.status_code = 503;
+    REQUIRE(fn.blocks.push(then_block));
+    MirBlock else_block{};
+    else_block.label = lit("else");
+    else_block.term.kind = MirTerminatorKind::ReturnStatus;
+    else_block.term.span = fn.span;
+    else_block.term.status_code = 403;
+    REQUIRE(fn.blocks.push(else_block));
+    REQUIRE(mir->functions.push(fn));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir, rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.func_count, 1u);
+    const auto& out_fn = rir.module.functions[0];
+    REQUIRE_EQ(out_fn.block_count, 3u);
+    bool saw_struct_create = false;
+    bool saw_struct_field = false;
+    bool saw_opt_unwrap = false;
+    for (u32 bi = 0; bi < out_fn.block_count; bi++) {
+        for (u32 ii = 0; ii < out_fn.blocks[bi].inst_count; ii++) {
+            saw_struct_create |= out_fn.blocks[bi].insts[ii].op == rir::Opcode::StructCreate;
+            saw_struct_field |= out_fn.blocks[bi].insts[ii].op == rir::Opcode::StructField;
+            saw_opt_unwrap |= out_fn.blocks[bi].insts[ii].op == rir::Opcode::OptUnwrap;
+        }
+    }
+    CHECK(saw_struct_create);
+    CHECK(saw_struct_field);
+    CHECK(saw_opt_unwrap);
+    rir.destroy();
+}
+TEST(frontend, source_function_call_inlines_i32_expression_body) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = id(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+}
+TEST(frontend, source_function_call_inlines_i32_expression_body_without_return_annotation) {
+    const auto src = R"(
+func id(x: i32) => x
+route GET "/users" {
+    let code = id(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::I32);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+}
+TEST(frontend, source_generic_function_inlines_i32_expression_body) {
+    const auto src = R"rut(
+func id<T>(x: T) -> T => x
+route GET "/users" {
+    let code = id(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(hir->functions[0].type_params.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::Generic);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_generic_function_reuses_same_type_parameter_shape) {
+    const auto src = R"rut(
+func first<T>(x: T, y: T) -> T => x
+route GET "/users" {
+    let code = first(200, 500)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_generic_function_accepts_explicit_type_arguments) {
+    const auto src = R"rut(
+func id<T>(x: T) -> T => x
+route GET "/users" {
+    let code = id<i32>(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_generic_function_supports_nested_generic_param_and_return_shapes) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: Result<T> }
+func unwrap<T>(x: Holder<T>) -> Result<T> => x.state
+route GET "/users" {
+    let state = unwrap(Holder(state: Result.ok(200)))
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir) {
+        rut::test::out("analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+    }
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(hir->functions[0].type_params.len, 1u);
+    CHECK_EQ(hir->functions[0].params[0].type, HirTypeKind::Struct);
+    CHECK_EQ(hir->functions[0].return_type, HirTypeKind::Variant);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(hir->routes[0].locals[0].type, HirTypeKind::Variant);
+}
+TEST(frontend, protocol_method_requirements_are_recorded_in_hir) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->protocols.len, 4u);
+    REQUIRE_EQ(hir->protocols[3].methods.len, 1u);
+    CHECK(hir->protocols[3].methods[0].name.eq(lit("hash")));
+    CHECK_EQ(hir->protocols[3].methods[0].params.len, 0u);
+    CHECK(hir->protocols[3].methods[0].return_type_name.eq(lit("i32")));
+}
+TEST(frontend, protocol_method_requirement_shapes_are_recorded_in_hir) {
+    const auto src = R"rut(
+protocol Boxed {
+    func wrap(x: i32) -> i32
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE(hir->protocols.len >= 1u);
+    const auto& proto = hir->protocols[hir->protocols.len - 1];
+    CHECK(proto.name.eq(lit("Boxed")));
+    REQUIRE_EQ(proto.methods.len, 1u);
+    const auto& method = proto.methods[0];
+    REQUIRE_EQ(method.params.len, 1u);
+    CHECK_EQ(method.params[0].type, HirTypeKind::I32);
+    CHECK(method.params[0].shape_index != 0xffffffffu);
+    CHECK_EQ(method.return_type, HirTypeKind::I32);
+    CHECK(method.return_shape_index != 0xffffffffu);
+}
+TEST(frontend, generic_protocol_constraint_survives_if_merge_in_hir) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+func pick<T: Hashable>(x: T, ok: bool) -> T {
+    if ok { x } else { x }
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    const auto& body = hir->functions[0].body;
+    CHECK_EQ(static_cast<u8>(body.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK_EQ(body.type, HirTypeKind::Generic);
+    CHECK_EQ(body.generic_protocol_count, 1u);
+    CHECK_NE(body.generic_protocol_indices[0], 0xffffffffu);
+}
+TEST(frontend, concretized_generic_call_result_clears_protocol_constraint_metadata) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+i32 impl Hashable {
+    func hash(self: i32) -> i32 => self
+}
+func id<T: Hashable>(x: T) -> T { x }
+route GET "/users" {
+    let x = id(200)
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    const auto& local = hir->routes[0].locals[0];
+    CHECK_EQ(local.type, HirTypeKind::I32);
+    CHECK_EQ(local.generic_index, 0xffffffffu);
+    CHECK_FALSE(local.generic_has_error_constraint);
+    CHECK_FALSE(local.generic_has_eq_constraint);
+    CHECK_FALSE(local.generic_has_ord_constraint);
+    CHECK_EQ(local.generic_protocol_index, 0xffffffffu);
+    CHECK_EQ(local.generic_protocol_count, 0u);
+}
+TEST(frontend, analyze_rejects_duplicate_protocol_method_requirement) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+    func hash() -> i32
+}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, protocol_declaration_is_recorded_in_hir) {
+    const auto src = R"rut(
+protocol Hashable {}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].kind, AstItemKind::Protocol);
+    CHECK(ast->items[0].protocol.name.eq({"Hashable", 8}));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->protocols.len, 4u);
+    CHECK(hir->protocols[3].name.eq({"Hashable", 8}));
+    CHECK(hir->protocols[3].kind == HirProtocolKind::Custom);
+}
+TEST(frontend, analyze_rejects_duplicate_custom_protocol_declaration) {
+    const auto src = R"rut(
+protocol Hashable {}
+protocol Hashable {}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_custom_protocol_declaration_using_builtin_name) {
+    const auto src = R"rut(
+protocol Eq {}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, generic_function_call_accepts_custom_protocol_constraint_for_builtin_conformance) {
+    const auto src = R"rut(
+protocol Hashable {}
+i32 impl Hashable {}
+func hash<T: Hashable>(x: T) -> i32 => 200
+route GET "/users" {
+    if hash(200) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->conformances.len, 1u);
+    CHECK(hir->conformances[0].type == HirTypeKind::I32);
+}
+TEST(frontend, generic_function_call_accepts_custom_protocol_constraint_for_struct_conformance) {
+    const auto src = R"rut(
+protocol Hashable {}
+struct Box { value: i32 }
+Box impl Hashable {}
+func hash<T: Hashable>(x: T) -> i32 => 200
+route GET "/users" {
+    if hash(Box(value: 200)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->conformances.len, 1u);
+    CHECK(hir->conformances[0].type == HirTypeKind::Struct);
+}
+TEST(frontend, analyze_rejects_duplicate_custom_protocol_conformance) {
+    const auto src = R"rut(
+protocol Hashable {}
+i32 impl Hashable {}
+i32 impl Hashable {}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_conformance_to_unknown_protocol) {
+    const auto src = R"rut(
+i32 impl Hashable {}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_generic_struct_custom_protocol_conformance) {
+    const auto src = R"rut(
+protocol Hashable {}
+struct Box<T> { value: T }
+Box impl Hashable {}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, generic_struct_instance_custom_protocol_conformance_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box<T> { value: T }
+Box<i32> impl Hashable {}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_generic_function_call_with_custom_protocol_constraint_without_impls) {
+    const auto src = R"rut(
+protocol Hashable {}
+func hash<T: Hashable>(x: T) -> i32 => 200
+route GET "/users" {
+    if hash(200) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, source_generic_function_accepts_error_constraint_and_standard_field_access) {
+    const auto src = R"rut(
+struct AuthError { err: Error, retry: i32 }
+func codeOf<E: Error>(x: E) -> i32 => x.code
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(hir->functions[0].type_params.len, 1u);
+    CHECK(hir->functions[0].type_params[0].has_error_constraint);
+    CHECK(hir->functions[0].body.kind == HirExprKind::Field);
+    CHECK(hir->functions[0].body.type == HirTypeKind::I32);
+}
+TEST(frontend, source_generic_function_accepts_eq_constraint_and_ne_method) {
+    const auto src = R"rut(
+func diff<T: Eq>(x: T, y: T) -> bool => x.ne(y)
+route GET "/users" {
+    if diff(200, 300) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].body.kind == HirExprKind::Eq);
+}
+TEST(frontend, source_generic_function_accepts_ord_constraint_and_le_ge_methods) {
+    const auto src = R"rut(
+func clampOk<T: Ord>(x: T, lo: T, hi: T) -> bool => x.ge(lo).eq(x.le(hi))
+route GET "/users" {
+    if clampOk(5, 1, 9) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_error_standard_fields_are_accessible_via_methods) {
+    const auto src = R"rut(
+route GET "/users" {
+    let failed = error(.timeout, "timed out")
+    let code = failed.code()
+    let line = failed.line()
+    if code == line { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+}
+TEST(frontend, source_generic_function_accepts_eq_constraint_and_eq_method) {
+    const auto src = R"rut(
+func same<T: Eq>(x: T, y: T) -> bool => x.eq(y)
+route GET "/users" {
+    if same(200, 200) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].body.kind == HirExprKind::Eq);
+}
+TEST(frontend, source_generic_function_accepts_ord_constraint_and_lt_method) {
+    const auto src = R"rut(
+func min<T: Ord>(x: T, y: T) -> T {
+    if x.lt(y) { x } else { y }
+}
+route GET "/users" {
+    if min(200, 300) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_concrete_custom_protocol_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 200).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_duplicate_impl_for_same_protocol_and_type) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable { func hash(self: Box) -> i32 => self.value }
+Box impl Hashable { func hash(self: Box) -> i32 => self.value }
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, source_concrete_generic_struct_impl_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box<T> { value: T }
+Box<i32> impl Hashable {
+    func hash(self: Box<i32>) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 200).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_struct_impl_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box<T> { value: T }
+Box<T> impl Hashable {
+    func hash(self: Box<T>) -> i32 => 200
+}
+route GET "/users" {
+    if Box(value: 123).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_custom_protocol_method_dispatch_with_generic_impl_target_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box<T> { value: T }
+Box<T> impl Hashable {
+    func hash(self: Box<T>) -> i32 => 200
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 123)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_custom_protocol_method_dispatch_with_generic_impl_target_tuple_of_struct_arg_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Item { value: i32 }
+struct Box<T> { value: T }
+Box<T> impl Hashable {
+    func hash(self: Box<T>) -> i32 => 200
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: (Item(value: 7), 9))) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_impl_target_accepts_renamed_placeholder) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box<T> { value: T }
+Box<U> impl Hashable {
+    func hash(self: Box<U>) -> i32 => 200
+}
+route GET "/users" {
+    if Box(value: 7).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_impl_target_accepts_multiple_type_params) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Pair<T, U> { left: T, right: U }
+Pair<A, B> impl Hashable {
+    func hash(self: Pair<A, B>) -> i32 => 200
+}
+route GET "/users" {
+    if Pair(left: 7, right: "x").hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_generic_impl_target_with_duplicate_placeholder_name) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Pair<T, U> { left: T, right: U }
+Pair<A, A> impl Hashable {
+    func hash(self: Pair<A, A>) -> i32 => 200
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+}
+TEST(frontend, analyze_rejects_overlapping_generic_and_concrete_impl_for_same_protocol) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box<T> { value: T }
+Box<T> impl Hashable {
+    func hash(self: Box<T>) -> i32 => 200
+}
+Box<i32> impl Hashable {
+    func hash(self: Box<i32>) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_impl_method_with_mismatched_receiver_type) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: i32) -> i32 => self
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, source_generic_receiver_custom_protocol_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 200)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_concrete_custom_protocol_method_dispatch_with_parameter_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash(x: i32) -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box, x: i32) -> i32 => x
+}
+route GET "/users" {
+    if Box(value: 200).hash(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_impl_method_with_mismatched_requirement_parameter_type) {
+    const auto src = R"rut(
+protocol Hashable { func hash(x: i32) -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box, x: str) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_impl_method_with_mismatched_requirement_return_type) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) }
+struct Box { value: i32 }
+Box impl Pairable {
+    func pair(self: Box) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_impl_method_with_mismatched_imported_namespace_same_name_parameter_type) {
+    const std::string dir = "/tmp/rut_import_namespace_protocol_requirement_mismatch_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "protocol Consumer { func take(x: Box) -> i32 }\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+struct Box { value: str }
+struct Holder { value: i32 }
+Holder impl proto.Consumer {
+    func take(self: Holder, x: Box) -> i32 => 200
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_impl_method_with_mismatched_imported_namespace_same_name_return_type) {
+    const std::string dir = "/tmp/rut_import_namespace_protocol_requirement_return_mismatch_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "protocol Producer { func make() -> Box }\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+struct Box { value: str }
+struct Holder { value: i32 }
+Holder impl proto.Producer {
+    func make(self: Holder) -> Box => Box(value: "x")
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_impl_method_with_mismatched_concrete_generic_requirement_parameter_type) {
+    const auto src = R"rut(
+protocol Consumer { func take(x: Box<i32>) -> i32 }
+struct Box<T> { value: T }
+struct Holder { value: i32 }
+Holder impl Consumer {
+    func take(self: Holder, x: Box<str>) -> i32 => 200
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_impl_method_with_mismatched_imported_namespace_concrete_generic_return_type) {
+    const std::string dir = "/tmp/rut_import_namespace_protocol_requirement_generic_return_mismatch_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box<T> { value: T }\n";
+        out << "protocol Producer { func make() -> Box<i32> }\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+struct Holder { value: i32 }
+Holder impl proto.Producer {
+    func make(self: Holder) -> proto.Box<str> => proto.Box(value: "x")
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_impl_method_with_mismatched_imported_namespace_concrete_generic_parameter_type) {
+    const std::string dir = "/tmp/rut_import_namespace_protocol_requirement_generic_param_mismatch_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box<T> { value: T }\n";
+        out << "protocol Consumer { func take(x: Box<i32>) -> i32 }\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+struct Box<T> { value: T }
+struct Holder { value: i32 }
+Holder impl proto.Consumer {
+    func take(self: Holder, x: Box<str>) -> i32 => 200
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_import_namespace_impl_target_with_local_same_name_receiver_type) {
+    const std::string dir = "/tmp/rut_import_namespace_impl_target_same_name_receiver_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+struct Box { value: str }
+proto.Box impl proto.Hashable {
+    func hash(self: Box) -> i32 => 200
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, source_multi_protocol_impl_block_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+protocol Adder { func add(x: i32) -> i32 }
+struct Box { value: i32 }
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+    func add(self: Box, x: i32) -> i32 => x
+}
+route GET "/users" {
+    if Box(value: 7).hash() == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_concrete_custom_protocol_default_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box { value: i32 }
+Box impl Hashable {}
+route GET "/users" {
+    if Box(value: 7).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_custom_protocol_default_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box { value: i32 }
+Box impl Hashable {}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_concrete_custom_protocol_default_method_dispatch_with_parameter_is_supported) {
+    const auto src = R"rut(
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Adder {}
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_custom_protocol_default_method_dispatch_with_parameter_is_supported) {
+    const auto src = R"rut(
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Adder {}
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" {
+    if run(Box(value: 7)) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_empty_impl_when_protocol_method_has_no_default_body) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {}
+route GET "/users" {
+    if Box(value: 7).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_generic_receiver_custom_protocol_default_method_dispatch_without_conformance) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box { value: i32 }
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_concrete_custom_protocol_default_method_dispatch_without_conformance) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box { value: i32 }
+route GET "/users" {
+    if Box(value: 7).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, source_custom_protocol_default_method_supports_tuple_return) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = Box(value: 7).pair() | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_custom_protocol_default_method_supports_optional_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => nil }
+struct Box { value: i32 }
+Box impl MaybeCode {}
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_custom_protocol_default_method_supports_error_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => error(.timeout) }
+struct Box { value: i32 }
+Box impl MaybeCode {}
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_custom_protocol_default_method_supports_block_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code() -> i32 {
+        let x = 200
+        x
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+route GET "/users" {
+    if Box(value: 7).code() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_custom_protocol_default_method_supports_guard_prefix) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        let y = maybefail(ok)
+        guard y else { 401 }
+        200
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+func maybefail(ok: bool) -> i32 { if ok { 200 } else { error(.timeout) } }
+route GET "/users" {
+    if Box(value: 7).code(true) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_custom_protocol_default_method_supports_guard_match_prefix) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        let y = maybefail(ok)
+        guard match y else { case .timeout => 401 case _ => 500 }
+        200
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+func maybefail(ok: bool) -> i32 { if ok { 200 } else { error(.timeout) } }
+route GET "/users" {
+    if Box(value: 7).code(false) == 401 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_protocol_default_method_guard_match_without_wildcard) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        let y = maybefail(ok)
+        guard match y else { case .timeout => 401 }
+        200
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+func maybefail(ok: bool) -> i32 { if ok { 200 } else { error(.timeout) } }
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_protocol_default_method_guard_match_on_non_error_value) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code() -> i32 {
+        let y = 200
+        guard match y else { case _ => 401 }
+        200
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, source_impl_overrides_protocol_default_method_with_optional_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => nil }
+struct Box { value: i32 }
+Box impl MaybeCode { func code(self: Box) -> i32 => self.value }
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box<T> { value: T }
+Box<T> impl Hashable { func hash(self: Box<T>) -> i32 => 7 }
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_multi_protocol_default_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Hashable {}
+Box impl Adder {}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_generic_receiver_method_dispatch_when_multiple_protocol_constraints_define_same_name) {
+    const auto src = R"rut(
+protocol A { func hash() -> i32 => 1 }
+protocol B { func hash() -> i32 => 2 }
+struct Box { value: i32 }
+Box impl A {}
+Box impl B {}
+func run<T: A, B>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_selective_import_protocol_alias_generic_receiver_dispatch_with_local_same_name_protocol) {
+    const std::string dir = "/tmp/rut_selective_import_alias_protocol_dispatch_same_name_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 1 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import { Hashable as Digestible, Box as ImportedBox } from "proto.rut"
+protocol Digestible {}
+func run<T: Digestible>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_concrete_receiver_method_dispatch_when_multiple_protocol_impls_define_same_name) {
+    const auto src = R"rut(
+protocol A { func hash() -> i32 => 1 }
+protocol B { func hash() -> i32 => 2 }
+struct Box { value: i32 }
+Box impl A {}
+Box impl B {}
+route GET "/users" {
+    if Box(value: 7).hash() == 1 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, source_impl_takes_precedence_over_protocol_default_method) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box { value: i32 }
+Box impl Hashable { func hash(self: Box) -> i32 => self.value }
+route GET "/users" {
+    if Box(value: 7).hash() == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_impl_may_omit_protocol_method_with_default_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+    func add(x: i32) -> i32 => x
+}
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_impl_missing_required_protocol_method_without_default_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+    func add(x: i32) -> i32
+}
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, source_multi_protocol_impl_may_omit_methods_with_default_bodies) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+    func add(x: i32) -> i32 => x
+}
+protocol Adder {
+    func mul(x: i32) -> i32 => x
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_multi_protocol_impl_may_omit_methods_with_default_bodies) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(x: i32) -> i32 => x
+}
+struct Box<T> { value: T }
+Box<T> impl Hashable, Adder {
+    func hash(self: Box<T>) -> i32 => 7
+}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_multi_protocol_impl_missing_required_method_without_default_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+    func add(x: i32) -> i32 => x
+}
+protocol Adder {
+    func mul(x: i32) -> i32
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_generic_multi_protocol_impl_missing_required_method_without_default_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(x: i32) -> i32
+}
+struct Box<T> { value: T }
+Box<T> impl Hashable, Adder {
+    func hash(self: Box<T>) -> i32 => 7
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_multi_protocol_impl_block_with_conflicting_default_method_names) {
+    const auto src = R"rut(
+protocol P1 { func hash() -> i32 => 1 }
+protocol P2 { func hash() -> i32 => 2 }
+struct Box { value: i32 }
+Box impl P1, P2 {}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_multi_protocol_impl_block_with_ambiguous_method_name) {
+    const auto src = R"rut(
+protocol P1 { func hash() -> i32 }
+protocol P2 { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl P1, P2 {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_multi_protocol_impl_block_with_duplicate_protocol_name) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable, Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_duplicate_impl_for_same_protocol_and_type_via_empty_impl) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {}
+Box impl Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_overlapping_empty_impl_and_multi_protocol_impl) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+protocol Adder { func add(x: i32) -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {}
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+    func add(self: Box, x: i32) -> i32 => x
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_impl_block_with_unknown_protocol_name) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+Box impl Missing {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, source_generic_function_accepts_eq_constraint_and_equality) {
+    const auto src = R"rut(
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    if same("a", "a") { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].type_params[0].has_eq_constraint);
+    CHECK(hir->functions[0].body.kind == HirExprKind::Eq);
+    CHECK(hir->functions[0].body.type == HirTypeKind::Bool);
+}
+TEST(frontend, source_generic_function_accepts_eq_constraint_for_tuple) {
+    const auto src = R"rut(
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    if same((200, 500), (200, 500)) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].type_params[0].has_eq_constraint);
+    CHECK(hir->functions[0].body.kind == HirExprKind::Eq);
+}
+TEST(frontend, source_generic_function_accepts_eq_constraint_for_tuple_of_struct) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    if same((Box(value: 200), 500), (Box(value: 200), 500)) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].type_params[0].has_eq_constraint);
+    CHECK(hir->functions[0].body.kind == HirExprKind::Eq);
+}
+TEST(frontend, source_generic_function_accepts_eq_constraint_for_struct) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    if same(Box(value: 200), Box(value: 200)) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].type_params[0].has_eq_constraint);
+    CHECK(hir->functions[0].body.kind == HirExprKind::Eq);
+}
+TEST(frontend, source_generic_function_accepts_eq_constraint_for_variant_payload) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    if same(Result.ok(200), Result.ok(500)) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].type_params[0].has_eq_constraint);
+    CHECK(hir->functions[0].body.kind == HirExprKind::Eq);
+}
+TEST(frontend, source_generic_function_accepts_ord_constraint_and_lt) {
+    const auto src = R"rut(
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min(200, 500) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].type_params[0].has_ord_constraint);
+    CHECK(hir->functions[0].body.kind == HirExprKind::IfElse);
+    REQUIRE(hir->functions[0].body.lhs != nullptr);
+    CHECK(hir->functions[0].body.lhs->kind == HirExprKind::Lt);
+}
+TEST(frontend, analyze_rejects_generic_function_lt_without_ord_constraint) {
+    const auto src = R"rut(
+func min<T>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, source_generic_function_accepts_ord_constraint_and_lt_for_str) {
+    const auto src = R"rut(
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min("alpha", "beta") == "alpha" { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].type_params[0].has_ord_constraint);
+    CHECK(hir->functions[0].body.kind == HirExprKind::IfElse);
+    REQUIRE(hir->functions[0].body.lhs != nullptr);
+    CHECK(hir->functions[0].body.lhs->kind == HirExprKind::Lt);
+}
+TEST(frontend, source_generic_function_accepts_ord_constraint_for_tuple) {
+    const auto src = R"rut(
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min((200, 500), (200, 600)) == (200, 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].type_params[0].has_ord_constraint);
+    REQUIRE(hir->functions[0].body.lhs != nullptr);
+    CHECK(hir->functions[0].body.lhs->kind == HirExprKind::Lt);
+}
+TEST(frontend, source_generic_function_accepts_ord_constraint_for_tuple_of_struct) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min((Box(value: 200), 500), (Box(value: 200), 600)) == (Box(value: 200), 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].type_params[0].has_ord_constraint);
+    REQUIRE(hir->functions[0].body.lhs != nullptr);
+    CHECK(hir->functions[0].body.lhs->kind == HirExprKind::Lt);
+}
+TEST(frontend, source_generic_function_accepts_ord_constraint_for_struct) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min(Box(value: 200), Box(value: 500)) == Box(value: 200) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].type_params[0].has_ord_constraint);
+    REQUIRE(hir->functions[0].body.lhs != nullptr);
+    CHECK(hir->functions[0].body.lhs->kind == HirExprKind::Lt);
+}
+TEST(frontend, source_generic_function_accepts_ord_constraint_for_variant) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min(Result<i32>.ok(200), Result<i32>.ok(500)) == Result<i32>.ok(200) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].type_params[0].has_ord_constraint);
+    REQUIRE(hir->functions[0].body.lhs != nullptr);
+    CHECK(hir->functions[0].body.lhs->kind == HirExprKind::Lt);
+}
+TEST(frontend, analyze_rejects_generic_function_lt_for_str_without_ord_constraint) {
+    const auto src = R"rut(
+func min<T>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min("alpha", "beta") == "alpha" { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_generic_function_equality_without_eq_constraint) {
+    const auto src = R"rut(
+func same<T>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_generic_function_call_with_inconsistent_type_binding) {
+    const auto src = R"rut(
+func first<T>(x: T, y: T) -> T => x
+route GET "/users" {
+    let code = first(200, "oops")
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+TEST(frontend, analyze_rejects_generic_function_call_violating_error_constraint) {
+    const auto src = R"rut(
+func codeOf<E: Error>(x: E) -> i32 => x.code
+route GET "/users" {
+    let code = codeOf(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+}
+TEST(frontend, analyze_rejects_generic_function_call_with_wrong_type_arg_count) {
+    const auto src = R"rut(
+func id<T>(x: T) -> T => x
+route GET "/users" {
+    let code = id<i32, i32>(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+TEST(frontend, source_function_call_inlines_variant_expression_body) {
+    const auto src = R"(
+variant AuthState { ok, err }
+func success() -> AuthState => AuthState.ok
+route GET "/users" {
+    match success() {
+    case .ok: return 200
+    case _: return 500
+    }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    if (!hir) {
+        rut::test::out("analyze err code=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+        REQUIRE(hir);
+    }
+    REQUIRE_EQ(hir->functions.len, 1u);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    CHECK(hir->routes[0].control.kind == HirControlKind::Match);
+    CHECK(hir->routes[0].control.match_expr.type == HirTypeKind::Variant);
+}
+TEST(frontend, source_function_call_inlines_variant_expression_body_without_return_annotation) {
+    const auto src = R"(
+variant AuthState { ok, err }
+func success() => AuthState.ok
+route GET "/users" {
+    match success() {
+    case .ok: return 200
+    case _: return 500
+    }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::Variant);
+    CHECK(hir->functions[0].return_variant_index != 0xffffffffu);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    CHECK(hir->routes[0].control.kind == HirControlKind::Match);
+    CHECK(hir->routes[0].control.match_expr.type == HirTypeKind::Variant);
+}
+TEST(frontend, source_function_supports_explicit_tuple_return_type) {
+    const auto src = R"(
+func pair() -> (i32, i32) { (200, 500) }
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = pair() | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[0].return_type == HirTypeKind::Tuple);
+    CHECK_EQ(hir->functions[0].return_tuple_len, 2u);
+    CHECK(hir->functions[0].return_tuple_types[0] == HirTypeKind::I32);
+    CHECK(hir->functions[0].return_tuple_types[1] == HirTypeKind::I32);
+}
+TEST(frontend, source_function_supports_explicit_tuple_param_type) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+func pick(pair: (i32, i32)) -> i32 => pair | second(_2, _1)
+route GET "/users" {
+    let code = pick((200, 500))
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[1].params[0].type == HirTypeKind::Tuple);
+    CHECK_EQ(hir->functions[1].params[0].tuple_len, 2u);
+}
+TEST(frontend, source_function_tuple_return_tracks_struct_slots_separately) {
+    const auto src = R"(
+struct Box { value: i32 }
+func make() -> (Box, i32) => (Box(value: 200), 1)
+route GET "/users" { return 200 }
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::Tuple);
+    CHECK_EQ(hir->functions[0].return_tuple_len, 2u);
+    CHECK(hir->functions[0].return_tuple_types[0] == HirTypeKind::Struct);
+    CHECK(hir->functions[0].return_tuple_struct_indices[0] != 0xffffffffu);
+}
+
+TEST(frontend, function_param_local_ref_preserves_shape_index) {
+    const auto src = R"(
+struct Box { value: i32 }
+func id(x: (Box, i32)) -> (Box, i32) => x
+route GET "/users" { return 200 }
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    const auto& body = hir->functions[0].body;
+    CHECK_EQ(static_cast<u8>(body.kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(body.type, HirTypeKind::Tuple);
+    CHECK(body.shape_index != 0xffffffffu);
+    REQUIRE_EQ(body.tuple_len, 2u);
+    CHECK_EQ(body.tuple_types[0], HirTypeKind::Struct);
+    CHECK_EQ(body.tuple_struct_indices[0], 0u);
+}
+
+TEST(frontend, source_route_let_supports_explicit_tuple_type) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let pair: (i32, i32) = (200, 500)
+    let code = pair | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Tuple);
+    CHECK_EQ(hir->routes[0].locals[0].tuple_len, 2u);
+}
+TEST(frontend, source_function_block_let_supports_explicit_tuple_type) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+func pick() -> i32 {
+    let pair: (i32, i32) = (200, 500)
+    pair | second(_2, _1)
+}
+route GET "/users" {
+    let code = pick()
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK(hir->functions[1].return_type == HirTypeKind::I32);
+    CHECK(hir->functions[1].body.type == HirTypeKind::I32);
+}
+TEST(frontend, analyze_rejects_function_without_return_annotation_when_base_type_is_unknown) {
+    const auto src = R"(
+func maybe() => nil
+route GET "/users" { return 200 }
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+TEST(frontend, source_function_call_propagates_optional_value_flow) {
+    const auto src = R"(
+func maybe() -> i32 => nil
+route GET "/users" {
+    let code = or(maybe(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+}
+TEST(frontend, source_function_block_body_allows_pure_nil_with_explicit_return_type) {
+    const auto src = R"(
+func maybe() -> i32 {
+    nil
+}
+route GET "/users" {
+    let code = or(maybe(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::I32);
+    CHECK(hir->functions[0].body.shape_index != 0xffffffffu);
+    CHECK(hir->functions[0].body.may_nil);
+    CHECK_FALSE(hir->functions[0].body.may_error);
+}
+TEST(frontend, source_function_infers_optional_return_from_if_without_annotation) {
+    const auto src = R"(
+func maybe(ok: bool) {
+    if ok { 200 } else { nil }
+}
+route GET "/users" {
+    let code = or(maybe(true), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::I32);
+    CHECK(hir->functions[0].body.may_nil);
+    CHECK_FALSE(hir->functions[0].body.may_error);
+}
+TEST(frontend, source_function_call_propagates_error_value_flow) {
+    const auto src = R"(
+func fail() -> i32 => error(.timeout)
+route GET "/users" {
+    let code = or(fail(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+}
+TEST(frontend, source_function_block_body_allows_pure_error_with_explicit_return_type) {
+    const auto src = R"(
+func fail() -> i32 {
+    error(.timeout)
+}
+route GET "/users" {
+    let code = or(fail(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::I32);
+    CHECK(hir->functions[0].body.shape_index != 0xffffffffu);
+    CHECK_FALSE(hir->functions[0].body.may_nil);
+    CHECK(hir->functions[0].body.may_error);
+}
+TEST(frontend, source_function_infers_error_return_from_if_without_annotation) {
+    const auto src = R"(
+func maybefail(ok: bool) {
+    if ok { 200 } else { error(.timeout) }
+}
+route GET "/users" {
+    let code = or(maybefail(true), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::I32);
+    CHECK_FALSE(hir->functions[0].body.may_nil);
+    CHECK(hir->functions[0].body.may_error);
+}
+TEST(frontend, source_function_allows_pure_nil_if_with_explicit_return_type) {
+    const auto src = R"(
+func maybe(ok: bool) -> i32 {
+    if ok { nil } else { nil }
+}
+route GET "/users" {
+    let code = or(maybe(true), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::I32);
+    CHECK(hir->functions[0].body.shape_index != 0xffffffffu);
+    CHECK(hir->functions[0].body.may_nil);
+    CHECK_FALSE(hir->functions[0].body.may_error);
+}
+TEST(frontend, source_function_block_body_with_let_prefix_inlines) {
+    const auto src = R"(
+func wrap(x: i32) -> i32 {
+    let y = x
+    y
+}
+route GET "/users" {
+    let code = wrap(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+}
+TEST(frontend, source_function_block_body_with_guard_prefix_inlines) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func wrap(ok: bool) -> i32 {
+    let y = maybefail(ok)
+    guard y else { 401 }
+    200
+}
+route GET "/users" {
+    let code = wrap(false)
+    if code == 401 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->functions[1].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK_FALSE(hir->functions[1].body.may_nil);
+    CHECK_FALSE(hir->functions[1].body.may_error);
+}
+TEST(frontend, source_function_block_body_with_guard_let_prefix_binds_value) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func wrap(ok: bool) -> i32 {
+    guard let y = maybefail(ok) else { 401 }
+    y
+}
+route GET "/users" {
+    let code = wrap(true)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->functions[1].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK_FALSE(hir->functions[1].body.may_nil);
+    CHECK_FALSE(hir->functions[1].body.may_error);
+}
+TEST(frontend, source_function_block_body_with_guard_match_prefix_inlines) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func wrap(ok: bool) -> i32 {
+    let y = maybefail(ok)
+    guard match y else { case .timeout => 401 case _ => 500 }
+    200
+}
+route GET "/users" {
+    let code = wrap(false)
+    if code == 401 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->functions[1].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK_FALSE(hir->functions[1].body.may_nil);
+    CHECK_FALSE(hir->functions[1].body.may_error);
+}
+TEST(frontend, analyze_rejects_function_block_guard_match_without_wildcard) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func wrap(ok: bool) -> i32 {
+    let y = maybefail(ok)
+    guard match y else { case .timeout => 401 }
+    200
+}
+route GET "/users" { return 200 }
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+TEST(frontend, analyze_rejects_function_block_guard_match_on_non_error_value) {
+    const auto src = R"(
+func wrap(x: i32) -> i32 {
+    guard match x else { case .timeout => 401 case _ => 500 }
+    200
+}
+route GET "/users" { return 200 }
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+TEST(frontend, source_function_block_body_with_final_if_inlines) {
+    const auto src = R"(
+func wrap(x: i32) -> i32 {
+    let y = x
+    if y == 200 { 200 } else { 500 }
+}
+route GET "/users" {
+    let code = wrap(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+}
+
+TEST(frontend, source_function_if_merging_tuple_of_struct_preserves_struct_slots) {
+    const auto src = R"(
+struct Box { value: i32 }
+func pick(flag: bool) -> (Box, i32) {
+    if flag { (Box(value: 200), 1) } else { (Box(value: 500), 2) }
+}
+route GET "/users" {
+    let pair = pick(true)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    const auto& body = hir->functions[0].body;
+    CHECK_EQ(static_cast<u8>(body.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK_EQ(body.type, HirTypeKind::Tuple);
+    REQUIRE_EQ(body.tuple_len, 2u);
+    CHECK_EQ(body.tuple_types[0], HirTypeKind::Struct);
+    CHECK_EQ(body.tuple_struct_indices[0], 0u);
+}
+
+TEST(frontend, source_function_guard_merging_tuple_of_struct_preserves_struct_slots) {
+    const auto src = R"(
+struct Box { value: i32 }
+func pick(flag: bool) -> (Box, i32) {
+    guard flag else { (Box(value: 500), 2) }
+    (Box(value: 200), 1)
+}
+route GET "/users" {
+    let pair = pick(true)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    const auto& body = hir->functions[0].body;
+    CHECK_EQ(static_cast<u8>(body.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK_EQ(body.type, HirTypeKind::Tuple);
+    REQUIRE_EQ(body.tuple_len, 2u);
+    CHECK_EQ(body.tuple_types[0], HirTypeKind::Struct);
+    CHECK_EQ(body.tuple_struct_indices[0], 0u);
+}
+TEST(frontend, source_pipe_unwrapped_tuple_of_struct_preserves_param_shape) {
+    const auto src = R"(
+struct Box { value: i32 }
+func code(x: (Box, i32)) -> i32 => 200
+func load(ok: bool) -> (Box, i32) {
+    if ok { (Box(value: 200), 1) } else { error(.timeout) }
+}
+route GET "/users" {
+    let code = load(true) | code(_)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    const auto& code = hir->routes[0].locals[0];
+    CHECK_EQ(code.type, HirTypeKind::I32);
+    CHECK_FALSE(code.may_nil);
+    CHECK_TRUE(code.may_error);
+}
+
+TEST(frontend, source_function_block_body_with_final_match_inlines) {
+    const auto src = R"(
+variant Result { ok, err }
+func pick(x: Result) -> i32 {
+    let y = x
+    match y {
+        case .ok => 200
+        case .err => 500
+    }
+}
+route GET "/users" {
+    let code = pick(Result.ok)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+}
+TEST(frontend, source_function_match_arm_block_with_let_inlines) {
+    const auto src = R"(
+variant Result { ok, err }
+func pick(x: Result) -> i32 {
+    match x {
+        case .ok => { let y = 200 y }
+        case .err => { let z = 500 z }
+    }
+}
+route GET "/users" {
+    let code = pick(Result.ok)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_function_infers_optional_return_from_match_without_annotation) {
+    const auto src = R"(
+variant Result { ok, err }
+func pick(x: Result) {
+    match x {
+        case .ok => 200
+        case .err => nil
+    }
+}
+route GET "/users" {
+    let code = or(pick(Result.ok), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::I32);
+    CHECK(hir->functions[0].body.may_nil);
+    CHECK_FALSE(hir->functions[0].body.may_error);
+}
+TEST(frontend, source_function_infers_error_return_from_match_without_annotation) {
+    const auto src = R"(
+variant Result { ok, err }
+func pick(x: Result) {
+    match x {
+        case .ok => 200
+        case .err => error(.timeout)
+    }
+}
+route GET "/users" {
+    let code = or(pick(Result.ok), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::I32);
+    CHECK_FALSE(hir->functions[0].body.may_nil);
+    CHECK(hir->functions[0].body.may_error);
+}
+TEST(frontend, source_function_allows_pure_error_match_with_explicit_return_type) {
+    const auto src = R"(
+variant Result { ok, err }
+func pick(x: Result) -> i32 {
+    match x {
+        case .ok => error(.timeout)
+        case .err => error(.timeout)
+    }
+}
+route GET "/users" {
+    let code = or(pick(Result.ok), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK(hir->functions[0].return_type == HirTypeKind::I32);
+    CHECK_FALSE(hir->functions[0].body.may_nil);
+    CHECK(hir->functions[0].body.may_error);
+}
+TEST(frontend, source_pipe_single_stage_inlines_call) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(_)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+}
+TEST(frontend, source_pipe_chains_multiple_stages) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(_) | id(_)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_pipe_respects_placeholder_position) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = 200 | second(500, _)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_pipe_accepts_placeholder_slot_one_alias) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = 200 | second(500, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_pipe_accepts_tuple_literal_multi_slot_placeholders) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = (200, 500) | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_pipe_accepts_tuple_returning_function_multi_slot_placeholders) {
+    const auto src = R"(
+func pair() { (200, 500) }
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = pair() | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_pipe_accepts_tuple_local_alias_multi_slot_placeholders) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let pair = (200, 500)
+    let code = pair | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+}
+TEST(frontend, source_pipe_chains_tuple_returning_stage_multi_slot_placeholders) {
+    const auto src = R"(
+func swap(a: i32, b: i32) { (b, a) }
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = (200, 500) | swap(_1, _2) | second(_1, _2)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_pipe_propagates_known_nil_as_optional_value_flow) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = nil | id(_)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[0].shape_index != 0xffffffffu);
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_propagates_known_error_as_error_value_flow) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let failed = error(.timeout)
+    let code = failed | id(_)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[1].shape_index != 0xffffffffu);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK(hir->routes[0].locals[1].may_error);
+    CHECK(hir->routes[0].locals[2].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[2].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[2].may_error);
+}
+TEST(frontend, analyze_rejects_pipe_without_placeholder) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(200)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_pipe_with_non_stage_rhs) {
+    const auto src = R"(
+route GET "/users" {
+    let code = 200 | 404
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_pipe_with_placeholder_slot_two) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(_2)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_pipe_runtime_fallible_lhs_with_placeholder_slot_two) {
+    const auto src = R"(
+func id(x: str) -> str => x
+route GET "/users" {
+    let code = req.header("Host") | id(_2)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, parse_rejects_pipe_with_placeholder_slot_eleven) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(_11)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE_FALSE(ast.has_value());
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, source_pipe_runtime_optional_lhs_flows_via_or) {
+    const auto src = R"(
+func id(x: str) -> str => x
+route GET "/users" {
+    let host = req.header("Host") | id(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Str);
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Str);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_runtime_error_lhs_flows_via_or) {
+    const auto src = R"(
+func fail() -> i32 => error(.timeout)
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = fail() | id(_)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_runtime_optional_error_lhs_flows_via_or) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { nil } else { error(.timeout) }
+}
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = maybefail(true) | id(_)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_runtime_optional_lhs_flows_into_optional_stage_via_or) {
+    const auto src = R"(
+func drop(x: str) -> str { nil }
+route GET "/users" {
+    let host = req.header("Host") | drop(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Str);
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Str);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_runtime_optional_lhs_flows_into_error_stage_via_or) {
+    const auto src = R"(
+func failstage(x: str) -> str => error(.timeout)
+route GET "/users" {
+    let host = req.header("Host") | failstage(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Str);
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Str);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_runtime_error_lhs_flows_into_optional_stage_via_or) {
+    const auto src = R"(
+func fail() -> str => error(.timeout)
+func drop(x: str) -> str { nil }
+route GET "/users" {
+    let host = fail() | drop(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Str);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Str);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_runtime_error_lhs_flows_into_error_stage_via_or) {
+    const auto src = R"(
+func fail() -> str => error(.timeout)
+func failstage(x: str) -> str => error(.timeout)
+route GET "/users" {
+    let host = fail() | failstage(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Str);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Str);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_runtime_optional_lhs_flows_into_optional_error_stage_via_or) {
+    const auto src = R"(
+func tri(x: str) -> str {
+    if x == "host" { nil } else { error(.timeout) }
+}
+route GET "/users" {
+    let host = req.header("Host") | tri(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Str);
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Str);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_runtime_error_lhs_flows_into_optional_error_stage_via_or) {
+    const auto src = R"(
+func fail() -> str => error(.timeout)
+func tri(x: str) -> str {
+    if x == "host" { nil } else { error(.timeout) }
+}
+route GET "/users" {
+    let host = fail() | tri(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Str);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Str);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, lower_to_rir_supports_source_pipe_runtime_optional_error_value_flow) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { nil } else { error(.timeout) }
+}
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = maybefail(true) | id(_)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, lower_to_rir_supports_source_runtime_optional_error_value_flow) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { nil } else { error(.timeout) }
+}
+route GET "/users" {
+    let code = maybefail(true)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_type_shapes_track_carrier_readiness_via_type_decls) {
+    const auto src = R"(
+struct Box { value: i32 }
+func keep(x: (i32, bool), y: (Box, i32)) -> (i32, bool) => x
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    const auto scalar_tuple_shape = hir->functions[0].params[0].shape_index;
+    const auto struct_tuple_shape = hir->functions[0].params[1].shape_index;
+    REQUIRE(scalar_tuple_shape < mir->type_shapes.len);
+    REQUIRE(struct_tuple_shape < mir->type_shapes.len);
+    CHECK(mir->type_shapes[scalar_tuple_shape].is_concrete);
+    CHECK(mir->type_shapes[scalar_tuple_shape].carrier_ready);
+    CHECK(mir->type_shapes[struct_tuple_shape].is_concrete);
+    CHECK(mir->type_shapes[struct_tuple_shape].carrier_ready);
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -215,6 +215,93 @@ TEST(frontend, parse_func_param_without_underscore_label) {
     CHECK(!ast->items[0].func.params[0].has_underscore_label);
 }
 
+TEST(frontend, analyze_resolves_route_decorator_to_function_index) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].decorators.len, 1u);
+    CHECK(hir->routes[0].decorators[0].name.eq(lit("auth")));
+    CHECK_EQ(hir->routes[0].decorators[0].function_index, 0u);  // auth is the only func
+}
+
+TEST(frontend, analyze_rejects_unknown_route_decorator) {
+    const char* src = R"rut(
+route {
+    @doesNotExist "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, analyze_rejects_decorator_function_with_zero_params) {
+    const char* src = R"rut(
+func auth() -> i32 => 0
+route {
+    @auth "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, analyze_rejects_decorator_function_missing_underscore_first_param) {
+    const char* src = R"rut(
+func auth(req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, analyze_rejects_decorator_function_with_non_i32_return_type) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> bool => true
+route {
+    @auth "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
 TEST(frontend, parse_file_header_package_decl_is_recorded) {
     const char* src = "package auth\nfunc jwtAuth() -> i32 => 200\n";
     auto lexed = lex(lit(src));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -147,6 +147,15 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    if (!hir) {
+        std::fprintf(stderr,
+                     "hir error code=%d detail=%.*s span=(%u,%u)\n",
+                     static_cast<int>(hir.error().code),
+                     static_cast<int>(hir.error().detail.len),
+                     hir.error().detail.ptr,
+                     hir.error().span.line,
+                     hir.error().span.col);
+    }
     REQUIRE(hir);
     CHECK(hir->functions.len >= 1u);
 }
@@ -302,6 +311,15 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    if (!hir) {
+        rut::test::out("import_namespace_default_method_struct_return err=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+    }
     REQUIRE(hir);
 }
 
@@ -355,6 +373,15 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    if (!hir) {
+        rut::test::out("import_namespace_default_method_struct_return err=");
+        rut::test::out_int(static_cast<int>(hir.error().code));
+        rut::test::out(" line=");
+        rut::test::out_int(static_cast<int>(hir.error().span.line));
+        rut::test::out(" col=");
+        rut::test::out_int(static_cast<int>(hir.error().span.col));
+        rut::test::out("\n");
+    }
     REQUIRE(hir);
 }
 TEST(frontend, import_relative_file_merges_imported_struct_symbol) {
@@ -376,8 +403,74 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    if (!hir) std::fprintf(stderr,
+                           "import_namespace_default_method_struct_return err=%d line=%u col=%u\n",
+                           static_cast<int>(hir.error().code),
+                           hir.error().span.line,
+                           hir.error().span.col);
     REQUIRE(hir);
 }
+
+TEST(frontend, import_relative_file_merges_imported_struct_tuple_of_struct_field_symbol) {
+    const std::string dir = "/tmp/rut_import_struct_tuple_of_struct_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/types.rut", std::ios::binary);
+        out << "struct Item { value: i32 }\n";
+        out << "struct Wrap { pair: (Item, i32) }\n";
+    }
+    const auto src = R"rut(
+import "types.rut"
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 2u);
+    const auto& wrap = hir->structs[1];
+    REQUIRE_EQ(wrap.fields.len, 1u);
+    const auto& pair = wrap.fields[0];
+    CHECK(pair.type == HirTypeKind::Tuple);
+    REQUIRE_EQ(pair.tuple_len, 2u);
+    CHECK(pair.tuple_types[0] == HirTypeKind::Struct);
+    CHECK(pair.tuple_struct_indices[0] == 0u);
+}
+
+TEST(frontend, import_relative_file_merges_imported_struct_tuple_of_variant_field_symbol) {
+    const std::string dir = "/tmp/rut_import_struct_tuple_of_variant_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/types.rut", std::ios::binary);
+        out << "variant State { ok, err }\n";
+        out << "struct Wrap { pair: (State, i32) }\n";
+    }
+    const auto src = R"rut(
+import "types.rut"
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE(hir->structs.len >= 1u);
+    const auto& wrap = hir->structs[0];
+    REQUIRE_EQ(wrap.fields.len, 1u);
+    const auto& pair = wrap.fields[0];
+    CHECK(pair.type == HirTypeKind::Tuple);
+    REQUIRE_EQ(pair.tuple_len, 2u);
+    CHECK(pair.tuple_types[0] == HirTypeKind::Variant);
+    CHECK(pair.tuple_variant_indices[0] == 0u);
+}
+
 TEST(frontend, import_relative_file_merges_imported_variant_symbol) {
     const std::string dir = "/tmp/rut_import_variant_frontend";
     std::filesystem::create_directories(dir);
@@ -397,6 +490,15 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    if (!hir) {
+        std::fprintf(stderr,
+                     "hir error code=%d detail=%.*s span=(%u,%u)\n",
+                     static_cast<int>(hir.error().code),
+                     static_cast<int>(hir.error().detail.len),
+                     hir.error().detail.ptr,
+                     hir.error().span.line,
+                     hir.error().span.col);
+    }
     REQUIRE(hir);
 }
 TEST(frontend, import_relative_file_merges_imported_variant_tuple_of_struct_payload_symbol) {
@@ -448,6 +550,15 @@ route GET "/users" { if run(Box(value: 1)) == 1 { return 200 } else { return 500
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    if (!hir) {
+        std::fprintf(stderr,
+                     "hir error code=%d detail=%.*s span=(%u,%u)\n",
+                     static_cast<int>(hir.error().code),
+                     static_cast<int>(hir.error().detail.len),
+                     hir.error().detail.ptr,
+                     hir.error().span.line,
+                     hir.error().span.col);
+    }
     REQUIRE(hir);
 }
 TEST(frontend, import_relative_file_merges_imported_impl_symbol) {
@@ -472,6 +583,81 @@ route GET "/users" { if run(Box(value: 1)) == 1 { return 200 } else { return 500
     REQUIRE(ast);
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_impl_symbol) {
+    const std::string dir = "/tmp/rut_import_generic_impl_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 200\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 123)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_remaps_imported_concrete_generic_impl_target) {
+    const std::string dir = "/tmp/rut_import_concrete_generic_impl_target_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<i32> impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+
+    const u32 protocol_index = [&]() {
+        for (u32 i = 0; i < hir->protocols.len; i++) {
+            if (hir->protocols[i].name.eq(lit("Hashable"))) return i;
+        }
+        return hir->protocols.len;
+    }();
+    REQUIRE(protocol_index < hir->protocols.len);
+    const HirImpl* imported_impl = nullptr;
+    for (u32 i = 0; i < hir->impls.len; i++) {
+        const auto& impl = hir->impls[i];
+        if (impl.protocol_index != protocol_index || impl.is_generic_template || impl.type != HirTypeKind::Struct)
+            continue;
+        if (impl.struct_index >= hir->structs.len) continue;
+        const auto& st = hir->structs[impl.struct_index];
+        if (!st.name.eq(lit("Box")) || st.template_struct_index == 0xffffffffu) continue;
+        imported_impl = &impl;
+        break;
+    }
+    REQUIRE(imported_impl != nullptr);
+    REQUIRE(imported_impl->struct_index < hir->structs.len);
+    const auto& concrete = hir->structs[imported_impl->struct_index];
+    REQUIRE(concrete.template_struct_index < hir->structs.len);
+    REQUIRE(concrete.instance_type_arg_count == 1);
+    CHECK(concrete.instance_type_args[0] == HirTypeKind::I32);
+    CHECK(concrete.instance_shape_indices[0] != 0xffffffffu);
+    CHECK(hir->type_shapes[concrete.instance_shape_indices[0]].type == HirTypeKind::I32);
 }
 TEST(frontend, analyze_rejects_local_impl_overlapping_imported_impl_for_same_protocol_and_type) {
     const std::string dir = "/tmp/rut_import_impl_conflict_frontend";
@@ -498,6 +684,120 @@ route GET "/users" { return 200 }
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     CHECK(!hir);
 }
+TEST(frontend, analyze_rejects_local_impl_overlapping_imported_concrete_generic_impl) {
+    const std::string dir = "/tmp/rut_import_concrete_generic_impl_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<i32> impl Hashable {\n";
+        out << "    func hash(self: Box<i32>) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+Box<i32> impl Hashable {
+    func hash(self: Box<i32>) -> i32 => 0
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+
+TEST(frontend, import_relative_file_allows_distinct_local_concrete_generic_impl) {
+    const std::string dir = "/tmp/rut_import_concrete_generic_impl_distinct_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<i32> impl Hashable {\n";
+        out << "    func hash(self: Box<i32>) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+Box<str> impl Hashable {
+    func hash(self: Box<str>) -> i32 => 200
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: "ok")) == 200 { return 200 } else { return 500 }
+}
+    )rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_dispatches_distinct_concrete_generic_impls) {
+    const std::string dir = "/tmp/rut_import_concrete_generic_impl_dual_dispatch_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<i32> impl Hashable {\n";
+        out << "    func hash(self: Box<i32>) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+Box<str> impl Hashable {
+    func hash(self: Box<str>) -> i32 => 200
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 7)) == 7 {
+        if run(Box(value: "ok")) == 200 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, analyze_rejects_imported_concrete_generic_impl_for_distinct_local_instance) {
+    const std::string dir = "/tmp/rut_import_concrete_generic_impl_distinct_instance_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<i32> impl Hashable {\n";
+        out << "    func hash(self: Box<i32>) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: "ok")) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+
 TEST(frontend, analyze_rejects_local_concrete_impl_overlapping_imported_generic_impl) {
     const std::string dir = "/tmp/rut_import_impl_overlap_frontend";
     std::filesystem::create_directories(dir);
@@ -523,6 +823,57 @@ route GET "/users" { return 200 }
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     CHECK(!hir);
 }
+
+TEST(frontend, analyze_rejects_local_generic_impl_overlapping_imported_generic_impl) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overlap_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 1\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+Box<U> impl Hashable {
+    func hash(self: Box<U>) -> i32 => 200
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_rejects_local_concrete_impl_overlapping_imported_generic_empty_impl) {
+    const std::string dir = "/tmp/rut_import_generic_empty_impl_overlap_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+Box<i32> impl Hashable {
+    func hash(self: Box<i32>) -> i32 => self.value
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    CHECK(!hir);
+}
+
 TEST(frontend, analyze_rejects_imported_impl_conflict_across_files_for_same_protocol_and_type) {
     const std::string dir = "/tmp/rut_import_impl_imported_conflict_frontend";
     std::filesystem::create_directories(dir);
@@ -575,6 +926,366 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch_with_parameter) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_param_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder { func add(x: i32) -> i32 => x }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_optional_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_optional_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => nil }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_error_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_error_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => error(.timeout) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_tuple_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_tuple_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func second(a: i32, b: i32) -> i32 => b
+func run<T: Pairable>(x: T) -> i32 => x.pair() | second(_2, _1)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func second(a: i32, b: i32) -> i32 => b
+func run<T: Pairable>(x: T) -> i32 => x.pair() | second(_2, _1)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_equality) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_eq_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Pairable>(x: T) -> (i32, i32) => x.pair()
+route GET "/users" { if run(Box(value: 1)) == (200, 500) { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_ordering) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_ord_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Pairable>(x: T) -> (i32, i32) => x.pair()
+route GET "/users" { if run(Box(value: 1)) < (200, 600) { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code()
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code()
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch_with_parameter) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_block_param_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch_with_parameter) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_block_param_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_if_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_if_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code(ok: bool) -> i32 { if ok { 200 } else { 500 } } }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code(true)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_if_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_if_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code(ok: bool) -> i32 { if ok { 200 } else { 500 } } }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code(true)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, lower_to_rir_supports_imported_generic_empty_impl_for_error_default_method_guard_match) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_error_guard_match_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code(ok: bool) -> i32 { if ok { 200 } else { error(.timeout) } } }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 {
+    let failed = x.code(false)
+    guard match failed else { case .timeout => 401 case _ => 500 }
+    200
+}
+route GET "/users" { if run(Box(value: 1)) == 401 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
 TEST(frontend, selective_import_relative_file_merges_selected_function_symbol) {
     const std::string dir = "/tmp/rut_selective_import_frontend";
     std::filesystem::create_directories(dir);
@@ -1949,6 +2660,15 @@ TEST(frontend, variant_match_all_cases_without_wildcard_is_exhaustive) {
     REQUIRE(mir);
     FrontendRirModule rir{};
     auto lowered = lower_to_rir(mir.value(), rir);
+    if (!lowered) {
+        std::fprintf(stderr,
+                     "imported_optional_default lowered err=%d detail=%.*s span=(%u,%u)\n",
+                     static_cast<int>(lowered.error().code),
+                     static_cast<int>(lowered.error().detail.len),
+                     lowered.error().detail.ptr,
+                     lowered.error().span.line,
+                     lowered.error().span.col);
+    }
     REQUIRE(lowered);
     rir.destroy();
 }
@@ -2019,6 +2739,15 @@ TEST(frontend, variant_payload_binding_flows_into_match_arm_if) {
     REQUIRE(mir);
     FrontendRirModule rir{};
     auto lowered = lower_to_rir(mir.value(), rir);
+    if (!lowered) {
+        std::fprintf(stderr,
+                     "imported_error_default lowered err=%d detail=%.*s span=(%u,%u)\n",
+                     static_cast<int>(lowered.error().code),
+                     static_cast<int>(lowered.error().detail.len),
+                     lowered.error().detail.ptr,
+                     lowered.error().span.line,
+                     lowered.error().span.col);
+    }
     REQUIRE(lowered);
     rir.destroy();
 }
@@ -2193,6 +2922,662 @@ TEST(frontend, route_match_struct_payload_binding_preserves_shape) {
              static_cast<u8>(HirMatchArm::BodyKind::If));
 }
 
+TEST(frontend, route_match_nested_struct_payload_projection) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "struct Outer { inner: Box }\n"
+        "variant Result { ok(Outer), err }\n"
+        "route GET \"/users\" { let state = Result.ok(Outer(inner: Box(value: 200))) match state { case .ok(v): { let code = v.inner.value if code == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(hir->routes[0].locals[1].type, HirTypeKind::I32);
+}
+
+TEST(frontend, import_namespace_route_match_nested_struct_payload_projection) {
+    const std::string dir = "/tmp/rut_import_namespace_match_nested_struct_payload_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "struct Outer { inner: Box }\n";
+        out << "variant Result { ok(Outer), err }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let state = proto.Result.ok(proto.Outer(inner: proto.Box(value: 200)))
+    match state {
+    case .ok(v): {
+        let code = v.inner.value
+        if code == 200 { return 200 } else { return 500 }
+    }
+    case .err: return 404
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(hir->routes[0].locals[1].type, HirTypeKind::I32);
+}
+
+TEST(frontend, import_namespace_match_payload_is_struct_and_carrier_ready_in_mir) {
+    const std::string dir = "/tmp/rut_import_namespace_match_payload_mir_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "struct Outer { inner: Box }\n";
+        out << "variant Result { ok(Outer), err }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let state = proto.Result.ok(proto.Outer(inner: proto.Box(value: 200)))
+    match state {
+    case .ok(v): {
+        let code = v.inner.value
+        if code == 200 { return 200 } else { return 500 }
+    }
+    case .err: return 404
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    bool found = false;
+    for (u32 fi = 0; fi < mir->functions.len; fi++) {
+        const auto& fn = mir->functions[fi];
+        for (u32 vi = 0; vi < fn.values.len; vi++) {
+            const auto& value = fn.values[vi];
+            if (value.kind != MirValueKind::MatchPayload) continue;
+            CHECK_EQ(value.type, MirTypeKind::Struct);
+            CHECK(value.struct_index < mir->structs.len);
+            CHECK(value.shape_index != 0xffffffffu);
+            REQUIRE(value.shape_index < mir->type_shapes.len);
+            const auto& shape = mir->type_shapes[value.shape_index];
+            CHECK_EQ(shape.type, MirTypeKind::Struct);
+            CHECK(shape.struct_index < mir->structs.len);
+            CHECK(shape.is_concrete);
+            CHECK(shape.carrier_ready);
+            found = true;
+        }
+    }
+    CHECK(found);
+}
+
+TEST(frontend, import_relative_file_preserves_imported_function_signature_shape_indices) {
+    const std::string dir = "/tmp/rut_import_function_signature_shape_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result<T> { ok(T), err }\n";
+        out << "struct Holder<T> { state: Result<T> }\n";
+        out << "func unwrap(x: Holder<i32>) -> Result<i32> => x.state\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+
+    const HirFunction* imported_fn = nullptr;
+    for (u32 i = 0; i < hir->functions.len; i++) {
+        if (hir->functions[i].name.eq(lit("unwrap"))) {
+            imported_fn = &hir->functions[i];
+            break;
+        }
+    }
+    REQUIRE(imported_fn != nullptr);
+    REQUIRE_EQ(imported_fn->params.len, 1u);
+    CHECK_EQ(imported_fn->params[0].type, HirTypeKind::Struct);
+    CHECK(imported_fn->params[0].shape_index != 0xffffffffu);
+    CHECK(imported_fn->params[0].type_args[0].shape_index != 0xffffffffu);
+    CHECK_EQ(imported_fn->return_type, HirTypeKind::Variant);
+    CHECK(imported_fn->return_shape_index != 0xffffffffu);
+    CHECK(imported_fn->return_type_args[0].shape_index != 0xffffffffu);
+}
+
+TEST(frontend, import_relative_file_preserves_imported_function_body_shape_indices_in_hir) {
+    const std::string dir = "/tmp/rut_import_function_body_shape_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "variant Result { ok, err }\n";
+        out << "func makeBox(ok: bool) -> Box { if ok { Box(value: 200) } else { Box(value: 500) } }\n";
+        out << "func maybe(ok: bool) { if ok { 200 } else { nil } }\n";
+        out << "func pickOr(ok: bool) -> i32 => or(maybe(ok), 500)\n";
+        out << "func pickMatch(x: Result) -> i32 {\n";
+        out << "    match x {\n";
+        out << "        case .ok => 200\n";
+        out << "        case .err => 500\n";
+        out << "    }\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+
+    const HirFunction* make_box = nullptr;
+    const HirFunction* pick_or = nullptr;
+    const HirFunction* pick_match = nullptr;
+    for (u32 i = 0; i < hir->functions.len; i++) {
+        if (hir->functions[i].name.eq(lit("makeBox"))) make_box = &hir->functions[i];
+        if (hir->functions[i].name.eq(lit("pickOr"))) pick_or = &hir->functions[i];
+        if (hir->functions[i].name.eq(lit("pickMatch"))) pick_match = &hir->functions[i];
+    }
+    REQUIRE(make_box != nullptr);
+    REQUIRE(pick_or != nullptr);
+    REQUIRE(pick_match != nullptr);
+
+    CHECK_EQ(static_cast<u8>(make_box->body.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK(make_box->body.shape_index != 0xffffffffu);
+    REQUIRE(make_box->body.shape_index < hir->type_shapes.len);
+    CHECK_EQ(hir->type_shapes[make_box->body.shape_index].type, HirTypeKind::Struct);
+    CHECK(hir->type_shapes[make_box->body.shape_index].struct_index < hir->structs.len);
+
+    CHECK_EQ(static_cast<u8>(pick_or->body.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK(pick_or->body.shape_index != 0xffffffffu);
+    REQUIRE(pick_or->body.shape_index < hir->type_shapes.len);
+    CHECK_EQ(hir->type_shapes[pick_or->body.shape_index].type, HirTypeKind::I32);
+    CHECK(hir->type_shapes[pick_or->body.shape_index].is_concrete);
+
+    CHECK_EQ(static_cast<u8>(pick_match->body.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK(pick_match->body.shape_index != 0xffffffffu);
+    REQUIRE(pick_match->body.shape_index < hir->type_shapes.len);
+    CHECK_EQ(hir->type_shapes[pick_match->body.shape_index].type, HirTypeKind::I32);
+    CHECK(hir->type_shapes[pick_match->body.shape_index].is_concrete);
+}
+
+TEST(frontend, import_relative_file_preserves_imported_protocol_default_method_wrapper_metadata_in_hir) {
+    const std::string dir = "/tmp/rut_import_protocol_default_wrapper_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => nil }\n";
+        out << "protocol MaybeFail { func code() -> i32 => error(.timeout) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+        out << "Box<T> impl MaybeFail {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+
+    const auto* maybe_code = [&]() -> const HirProtocol* {
+        for (u32 i = 0; i < hir->protocols.len; i++) {
+            if (hir->protocols[i].name.eq(lit("MaybeCode"))) return &hir->protocols[i];
+        }
+        return nullptr;
+    }();
+    REQUIRE(maybe_code != nullptr);
+    const auto* maybe_code_req = [&]() -> const HirProtocol::MethodDecl* {
+        for (u32 i = 0; i < maybe_code->methods.len; i++) {
+            if (maybe_code->methods[i].name.eq(lit("code"))) return &maybe_code->methods[i];
+        }
+        return nullptr;
+    }();
+    REQUIRE(maybe_code_req != nullptr);
+    CHECK(maybe_code_req->function_index != 0xffffffffu);
+    CHECK(maybe_code_req->return_may_nil);
+    CHECK_FALSE(maybe_code_req->return_may_error);
+
+    const auto* maybe_fail = [&]() -> const HirProtocol* {
+        for (u32 i = 0; i < hir->protocols.len; i++) {
+            if (hir->protocols[i].name.eq(lit("MaybeFail"))) return &hir->protocols[i];
+        }
+        return nullptr;
+    }();
+    REQUIRE(maybe_fail != nullptr);
+    const auto* maybe_fail_req = [&]() -> const HirProtocol::MethodDecl* {
+        for (u32 i = 0; i < maybe_fail->methods.len; i++) {
+            if (maybe_fail->methods[i].name.eq(lit("code"))) return &maybe_fail->methods[i];
+        }
+        return nullptr;
+    }();
+    REQUIRE(maybe_fail_req != nullptr);
+    CHECK(maybe_fail_req->function_index != 0xffffffffu);
+    CHECK_FALSE(maybe_fail_req->return_may_nil);
+    CHECK(maybe_fail_req->return_may_error);
+    CHECK(maybe_fail_req->return_error_variant_index != 0xffffffffu);
+}
+
+TEST(frontend, imported_generic_receiver_protocol_call_preserves_default_method_wrapper_metadata_in_hir) {
+    const std::string dir = "/tmp/rut_import_protocol_call_wrapper_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => nil }\n";
+        out << "protocol MaybeFail { func code() -> i32 => error(.timeout) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+        out << "Box<T> impl MaybeFail {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func runOpt<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func runErr<T: MaybeFail>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" {
+    if runOpt(Box(value: 1)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+
+    const auto* run_opt = [&]() -> const HirFunction* {
+        for (u32 i = 0; i < hir->functions.len; i++) {
+            if (hir->functions[i].name.eq(lit("runOpt"))) return &hir->functions[i];
+        }
+        return nullptr;
+    }();
+    REQUIRE(run_opt != nullptr);
+    REQUIRE(run_opt->body.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(run_opt->body.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(run_opt->body.lhs->kind), static_cast<u8>(HirExprKind::ProtocolCall));
+    CHECK(run_opt->body.lhs->may_nil);
+    CHECK_FALSE(run_opt->body.lhs->may_error);
+
+    const auto* run_err = [&]() -> const HirFunction* {
+        for (u32 i = 0; i < hir->functions.len; i++) {
+            if (hir->functions[i].name.eq(lit("runErr"))) return &hir->functions[i];
+        }
+        return nullptr;
+    }();
+    REQUIRE(run_err != nullptr);
+    REQUIRE(run_err->body.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(run_err->body.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(run_err->body.lhs->kind), static_cast<u8>(HirExprKind::ProtocolCall));
+    CHECK_FALSE(run_err->body.lhs->may_nil);
+    CHECK(run_err->body.lhs->may_error);
+    CHECK(run_err->body.lhs->error_variant_index != 0xffffffffu);
+}
+
+TEST(frontend, import_relative_file_inlines_imported_generic_empty_impl_default_method_wrappers_in_route_hir) {
+    const std::string dir = "/tmp/rut_import_protocol_call_wrapper_route_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => nil }\n";
+        out << "protocol MaybeFail { func code() -> i32 => error(.timeout) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+        out << "Box<T> impl MaybeFail {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func runOpt<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func runErr<T: MaybeFail>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" {
+    let a = runOpt(Box(value: 1))
+    let b = runErr(Box(value: 1))
+    if a == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+
+    const auto& opt = hir->routes[0].locals[0].init;
+    CHECK_EQ(static_cast<u8>(opt.kind), static_cast<u8>(HirExprKind::Or));
+    REQUIRE(opt.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(opt.lhs->kind), static_cast<u8>(HirExprKind::Nil));
+    CHECK(opt.lhs->may_nil);
+    CHECK_FALSE(opt.lhs->may_error);
+
+    const auto& err = hir->routes[0].locals[1].init;
+    CHECK_EQ(static_cast<u8>(err.kind), static_cast<u8>(HirExprKind::Or));
+    REQUIRE(err.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(err.lhs->kind), static_cast<u8>(HirExprKind::Error));
+    CHECK_FALSE(err.lhs->may_nil);
+    CHECK(err.lhs->may_error);
+    CHECK(err.lhs->error_variant_index != 0xffffffffu);
+}
+
+TEST(frontend, import_relative_file_preserves_imported_decl_type_arg_shape_indices_in_hir) {
+    const std::string dir = "/tmp/rut_import_decl_type_arg_shapes_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Item { value: i32 }\n";
+        out << "struct Wrap<T> { value: T }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "struct Holder { value: Box<Wrap<Item>> }\n";
+        out << "variant Result { ok(Box<Wrap<Item>>), err }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+
+    const auto* holder = [&]() -> const HirStruct* {
+        for (u32 i = 0; i < hir->structs.len; i++) {
+            if (hir->structs[i].name.eq(lit("Holder"))) return &hir->structs[i];
+        }
+        return nullptr;
+    }();
+    REQUIRE(holder != nullptr);
+    const auto& field = holder->fields[0];
+    REQUIRE(field.type_arg_count == 1);
+    CHECK(field.type_args[0].shape_index != 0xffffffffu);
+    CHECK(hir->type_shapes[field.type_args[0].shape_index].type == HirTypeKind::Struct);
+
+    const auto* result = [&]() -> const HirVariant* {
+        for (u32 i = 0; i < hir->variants.len; i++) {
+            if (hir->variants[i].name.eq(lit("Result"))) return &hir->variants[i];
+        }
+        return nullptr;
+    }();
+    REQUIRE(result != nullptr);
+    const auto& payload = result->cases[0];
+    REQUIRE(payload.payload_type_arg_count == 1);
+    CHECK(payload.payload_type_args[0].shape_index != 0xffffffffu);
+    CHECK(hir->type_shapes[payload.payload_type_args[0].shape_index].type == HirTypeKind::Struct);
+}
+
+TEST(frontend, lower_to_rir_supports_imported_function_body_struct_init_projection) {
+    const std::string dir = "/tmp/rut_import_function_body_struct_init_lower_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "func make() -> Box => Box(value: 200)\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let box = make()
+    if box.value == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, lower_to_rir_supports_imported_function_body_variant_case_projection) {
+    const std::string dir = "/tmp/rut_import_function_body_variant_case_lower_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result { ok(i32), err }\n";
+        out << "struct Holder { state: Result }\n";
+        out << "func make() -> Result => Result.ok(200)\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let holder = proto.Holder(state: make())
+    if holder.state == proto.Result.ok(200) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, lower_to_rir_supports_imported_function_body_ifelse_struct_projection) {
+    const std::string dir = "/tmp/rut_import_function_body_ifelse_struct_lower_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "func make(ok: bool) -> Box {\n";
+        out << "    if ok { Box(value: 200) } else { Box(value: 500) }\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let box = make(true)
+    if box.value == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, lower_to_rir_supports_imported_function_body_or) {
+    const std::string dir = "/tmp/rut_import_function_body_or_lower_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "func maybe(ok: bool) { if ok { 200 } else { nil } }\n";
+        out << "func pick(ok: bool) -> i32 => or(maybe(ok), 500)\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let code = pick(true)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, lower_to_rir_supports_imported_generic_empty_impl_for_optional_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_optional_lower_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => nil }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, lower_to_rir_supports_imported_generic_empty_impl_for_error_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_error_lower_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => error(.timeout) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, lower_to_rir_supports_imported_function_body_match) {
+    const std::string dir = "/tmp/rut_import_function_body_match_lower_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result { ok, err }\n";
+        out << "func pick(x: Result) -> i32 {\n";
+        out << "    match x {\n";
+        out << "        case .ok => 200\n";
+        out << "        case .err => 500\n";
+        out << "    }\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let code = pick(proto.Result.ok)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, lower_to_rir_supports_import_namespace_route_match_nested_struct_payload_projection) {
+    const std::string dir = "/tmp/rut_import_namespace_match_nested_struct_payload_lower_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "struct Outer { inner: Box }\n";
+        out << "variant Result { ok(Outer), err }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let state = proto.Result.ok(proto.Outer(inner: proto.Box(value: 200)))
+    match state {
+    case .ok(v): {
+        let code = v.inner.value
+        if code == 200 { return 200 } else { return 500 }
+    }
+    case .err: return 404
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
 TEST(frontend, route_guard_bound_struct_preserves_shape_index) {
     const char* src =
         "struct Box { value: i32 }\n"
@@ -2297,6 +3682,9 @@ route GET "/users" {
     CHECK_EQ(inst.instance_type_arg_count, 1u);
     CHECK_EQ(inst.instance_type_args[0], HirTypeKind::Struct);
     CHECK_NE(inst.instance_shape_indices[0], 0xffffffffu);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_NE(hir->routes[0].locals[0].shape_index, 0xffffffffu);
+    CHECK_NE(hir->routes[0].locals[0].init.shape_index, 0xffffffffu);
 }
 TEST(frontend, generic_variant_constructor_infers_type_argument_from_single_payload_case) {
     const auto src = R"rut(
@@ -3089,6 +4477,126 @@ route GET "/users" {
     CHECK_EQ(hir->structs[0].fields[0].type, HirTypeKind::Variant);
     CHECK_EQ(hir->structs[0].fields[0].variant_index, 1u);
 }
+
+TEST(frontend, variant_struct_field_projection_supports_equality) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder { state: Result<i32> }
+route GET "/users" {
+    let holder = Holder(state: Result.ok(200))
+    if holder.state == Result.ok(200) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
+TEST(frontend, variant_struct_field_projection_supports_ordering) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder { state: Result<i32> }
+route GET "/users" {
+    let holder = Holder(state: Result.ok(200))
+    if holder.state < Result.ok(500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_namespace_variant_struct_field_projection_supports_equality) {
+    const std::string dir = "/tmp/rut_import_namespace_variant_field_eq_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result { ok(i32), err }\n";
+        out << "struct Holder { state: Result }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let holder = proto.Holder(state: proto.Result.ok(200))
+    if holder.state == proto.Result.ok(200) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_namespace_variant_struct_field_projection_supports_ordering) {
+    const std::string dir = "/tmp/rut_import_namespace_variant_field_ord_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result { ok(i32), err }\n";
+        out << "struct Holder { state: Result }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let holder = proto.Holder(state: proto.Result.ok(200))
+    if holder.state < proto.Result.ok(500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
+TEST(frontend, tuple_of_struct_field_projection_supports_ordering) {
+    const auto src = R"rut(
+struct Item { value: i32 }
+struct Holder { pair: (Item, i32) }
+route GET "/users" {
+    let holder = Holder(pair: (Item(value: 200), 500))
+    if holder.pair < (Item(value: 200), 600) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
+TEST(frontend, import_namespace_tuple_of_struct_field_projection_supports_ordering) {
+    const std::string dir = "/tmp/rut_import_namespace_tuple_struct_field_ord_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Item { value: i32 }\n";
+        out << "struct Holder { pair: (Item, i32) }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let holder = proto.Holder(pair: (proto.Item(value: 200), 500))
+    if holder.pair < (proto.Item(value: 200), 600) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
 TEST(frontend, concrete_generic_type_refs_are_supported_in_variant_payloads) {
     const auto src = R"rut(
 variant Result<T> { ok(T), err }
@@ -3285,6 +4793,9 @@ route GET "/users" {
     CHECK_EQ(inst.instance_type_arg_count, 1u);
     CHECK_EQ(inst.instance_type_args[0], HirTypeKind::Variant);
     CHECK_NE(inst.instance_shape_indices[0], 0xffffffffu);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_NE(hir->routes[0].locals[0].shape_index, 0xffffffffu);
+    CHECK_NE(hir->routes[0].locals[0].init.shape_index, 0xffffffffu);
 }
 TEST(frontend, concrete_nested_generic_variant_type_ref_records_instance_shape_index) {
     const auto src = R"rut(
@@ -3445,6 +4956,37 @@ TEST(frontend, plain_struct_tuple_field_can_flow_into_pipe_slots) {
     REQUIRE(lowered);
     CHECK(block_has_op(rir.module.functions[0].blocks[0], rir::Opcode::StructField));
     rir.destroy();
+}
+
+TEST(frontend, custom_error_nested_struct_field_projection) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "struct AuthError { err: Error, inner: Box }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", inner: Box(value: 200)) let code = failed.inner.value if code == 200 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir.value().routes[0].locals.len, 2u);
+    CHECK_EQ(hir.value().routes[0].locals[1].type, HirTypeKind::I32);
+}
+
+TEST(frontend, nested_struct_field_projection_preserves_projected_struct_type) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "struct Outer { inner: Box }\n"
+        "route GET \"/users\" { let outer = Outer(inner: Box(value: 200)) let code = outer.inner.value if code == 200 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(hir->routes[0].locals[0].type, HirTypeKind::Struct);
+    CHECK_EQ(hir->routes[0].locals[1].type, HirTypeKind::I32);
 }
 TEST(frontend, plain_struct_tuple_of_struct_field_projection_preserves_struct_slots) {
     const char* src =
@@ -5141,6 +6683,73 @@ route GET "/users" { return 200 }
     CHECK_EQ(body.generic_protocol_count, 1u);
     CHECK_NE(body.generic_protocol_indices[0], 0xffffffffu);
 }
+TEST(frontend, generic_protocol_constraint_survives_match_payload_binding_in_hir) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+variant Wrap<T> { some(T) }
+func unwrap<T: Hashable>(state: Wrap<T>) -> T {
+    match state {
+    case .some(v) => v
+    }
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    const auto& body = hir->functions[0].body;
+    CHECK_EQ(body.type, HirTypeKind::Generic);
+    CHECK_EQ(body.generic_protocol_count, 1u);
+    CHECK_NE(body.generic_protocol_indices[0], 0xffffffffu);
+}
+TEST(frontend, generic_protocol_constraint_survives_struct_field_projection_in_hir) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+struct Holder<T> { state: T }
+func unwrap<T: Hashable>(x: Holder<T>) -> i32 => x.state.hash()
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    const auto& body = hir->functions[0].body;
+    REQUIRE(body.lhs != nullptr);
+    CHECK_EQ(body.lhs->type, HirTypeKind::Generic);
+    CHECK_EQ(body.lhs->generic_protocol_count, 1u);
+    CHECK_NE(body.lhs->generic_protocol_indices[0], 0xffffffffu);
+}
+
+TEST(frontend, source_struct_field_projection_supports_method_dispatch) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable { func hash(self: Box) -> i32 => self.value }
+struct Holder { state: Box }
+route GET "/users" {
+    let holder = Holder(state: Box(value: 200))
+    let code = holder.state.hash()
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
 TEST(frontend, concretized_generic_call_result_clears_protocol_constraint_metadata) {
     const auto src = R"rut(
 protocol Hashable {
@@ -5952,6 +7561,58 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
+TEST(frontend, source_generic_receiver_custom_protocol_default_method_supports_tuple_return) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+func second(a: i32, b: i32) -> i32 => b
+func run<T: Pairable>(x: T) -> i32 => x.pair() | second(_2, _1)
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_custom_protocol_default_method_tuple_return_supports_ordering) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+func run<T: Pairable>(x: T) -> (i32, i32) => x.pair()
+route GET "/users" {
+    if run(Box(value: 7)) < (200, 600) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_custom_protocol_default_method_tuple_return_supports_equality) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+func run<T: Pairable>(x: T) -> (i32, i32) => x.pair()
+route GET "/users" {
+    if run(Box(value: 7)) == (200, 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
 TEST(frontend, analyze_rejects_empty_impl_when_protocol_method_has_no_default_body) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 }
@@ -6020,6 +7681,38 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
+TEST(frontend, source_custom_protocol_default_method_tuple_return_supports_ordering) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+route GET "/users" {
+    if Box(value: 7).pair() < (200, 600) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_custom_protocol_default_method_tuple_return_supports_equality) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+route GET "/users" {
+    if Box(value: 7).pair() == (200, 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
 TEST(frontend, source_custom_protocol_default_method_supports_optional_return) {
     const auto src = R"rut(
 protocol MaybeCode { func code() -> i32 => nil }
@@ -6066,6 +7759,113 @@ struct Box { value: i32 }
 Box impl MaybeCode {}
 route GET "/users" {
     if Box(value: 7).code() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
+TEST(frontend, source_generic_receiver_custom_protocol_default_method_supports_block_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code() -> i32 {
+        let x = 200
+        x
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+func run<T: MaybeCode>(x: T) -> i32 => x.code()
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_custom_protocol_default_method_supports_block_body_with_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Adder {}
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_custom_protocol_default_method_supports_block_body_with_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Adder {}
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" {
+    if run(Box(value: 7)) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_custom_protocol_default_method_supports_if_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+route GET "/users" {
+    if Box(value: 7).code(true) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_custom_protocol_default_method_supports_if_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+func run<T: MaybeCode>(x: T) -> i32 => x.code(true)
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
 }
 )rut";
     auto lexed = lex(lit(src));
@@ -6185,6 +7985,279 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
+TEST(frontend, source_impl_overrides_protocol_default_method_with_error_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => error(.timeout) }
+struct Box { value: i32 }
+Box impl MaybeCode { func code(self: Box) -> i32 => self.value }
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_impl_overrides_protocol_default_method_with_block_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code() -> i32 {
+        let x = 200
+        x
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode { func code(self: Box) -> i32 => self.value }
+route GET "/users" {
+    if Box(value: 7).code() == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_impl_overrides_protocol_default_method_with_if_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode { func code(self: Box, ok: bool) -> i32 => self.value }
+route GET "/users" {
+    if Box(value: 7).code(true) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_impl_overrides_protocol_default_method_with_block_body_and_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Adder { func add(self: Box, x: i32) -> i32 => self.value }
+route GET "/users" {
+    if Box(value: 7).add(201) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_impl_overrides_protocol_default_method_with_if_body_and_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box { value: i32 }
+Box impl Adder { func add(self: Box, ok: bool) -> i32 => self.value }
+route GET "/users" {
+    if Box(value: 7).add(true) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_impl_overrides_protocol_default_method_with_optional_return) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_optional_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => nil }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl MaybeCode { func code(self: Box) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_impl_overrides_protocol_default_method_with_error_return) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_error_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => error(.timeout) }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl MaybeCode { func code(self: Box) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_impl_overrides_protocol_default_method_with_block_body) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_block_body_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl MaybeCode { func code(self: Box) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).code() == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_impl_overrides_protocol_default_method_with_if_body) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_if_body_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code(ok: bool) -> i32 {\n";
+        out << "        if ok { 200 } else { 500 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl MaybeCode { func code(self: Box, ok: bool) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).code(true) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_impl_overrides_protocol_default_method_with_block_body_and_parameter) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_block_body_parameter_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Adder { func add(self: Box, x: i32) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(201) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_impl_overrides_protocol_default_method_with_if_body_and_parameter) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_if_body_parameter_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Adder { func add(self: Box, ok: bool) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(true) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_impl_takes_precedence_over_protocol_default_method) {
+    const std::string dir = "/tmp/rut_import_impl_precedence_over_default_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable { func hash(self: Box) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).hash() == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
 TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
@@ -6200,6 +8273,305 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => nil }
+struct Box<T> { value: T }
+Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => error(.timeout) }
+struct Box<T> { value: T }
+Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code() -> i32 {
+        let x = 200
+        x
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }
+func run<T: MaybeCode>(x: T) -> i32 => x.code()
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl MaybeCode { func code(self: Box<T>, ok: bool) -> i32 => 7 }
+func run<T: MaybeCode>(x: T) -> i32 => x.code(true)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl Adder { func add(self: Box<T>, x: i32) -> i32 => 7 }
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl Adder { func add(self: Box<T>, ok: bool) -> i32 => 7 }
+func run<T: Adder>(x: T) -> i32 => x.add(true)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_optional_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => nil }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_error_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => error(.timeout) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_block_body_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code()
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_if_body_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code(ok: bool) -> i32 {\n";
+        out << "        if ok { 200 } else { 500 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode { func code(self: Box<T>, ok: bool) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code(true)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_block_body_parameter_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Adder { func add(self: Box<T>, x: i32) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_if_body_parameter_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Adder { func add(self: Box<T>, ok: bool) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Adder>(x: T) -> i32 => x.add(true)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_default_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable { func hash(self: Box<T>) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
 TEST(frontend, source_generic_receiver_multi_protocol_default_method_dispatch_is_supported) {
@@ -6223,6 +8595,784 @@ route GET "/users" {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_multi_protocol_empty_impl_block_default_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_multi_protocol_empty_impl_block_default_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).add(3) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_multi_protocol_empty_impl_block_default_method_supports_block_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32 {
+        let x = 200
+        x
+    }
+}
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).add(3) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_multi_protocol_empty_impl_block_default_method_supports_if_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+route GET "/users" {
+    let h = Box(value: 7).hash(true)
+    if h == 200 {
+        if Box(value: 7).add(true) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_multi_protocol_empty_impl_block_default_method_supports_tuple_return) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Hashable, Pairable {}
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).pair() == (200, 500) { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_multi_protocol_empty_impl_block_default_method_tuple_return_supports_ordering) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Hashable, Pairable {}
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).pair() < (200, 600) { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_block_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32 {
+        let x = 200
+        x
+    }
+}
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_tuple_return) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Hashable, Pairable {}
+func run<T: Hashable, Pairable>(x: T) -> (i32, i32) {
+    let h = x.hash()
+    if h == 200 { x.pair() } else { (0, 0) }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == (200, 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_multi_protocol_empty_impl_block_default_method_tuple_return_supports_ordering) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Hashable, Pairable {}
+func run<T: Hashable, Pairable>(x: T) -> (i32, i32) {
+    let h = x.hash()
+    if h == 200 { x.pair() } else { (0, 0) }
+}
+route GET "/users" {
+    if run(Box(value: 7)) < (200, 600) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_if_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash(true)
+    if h == 200 { x.add(true) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_multi_protocol_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_multi_protocol_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Adder { func add(x: i32) -> i32 => x }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {}\n";
+        out << "Box<T> impl Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_tuple_default_impl_generic_multi_protocol_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Pairable>(x: T) -> (i32, i32) {
+    let h = x.hash()
+    if h == 200 { x.pair() } else { (0, 0) }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == (200, 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
+    const std::string dir = "/tmp/rut_import_tuple_ordering_default_impl_generic_multi_protocol_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Pairable>(x: T) -> (i32, i32) {
+    let h = x.hash()
+    if h == 200 { x.pair() } else { (0, 0) }
+}
+route GET "/users" {
+    if run(Box(value: 7)) < (200, 600) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_if_body_default_impl_generic_multi_protocol_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash(ok: bool) -> i32 {\n";
+        out << "        if ok { 200 } else { 500 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash(true)
+    if h == 200 { x.add(true) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_tuple_default_impl_multi_protocol_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).pair() == (200, 500) { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
+    const std::string dir = "/tmp/rut_import_tuple_ordering_default_impl_multi_protocol_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).pair() < (200, 600) { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_block_body_default_impl_generic_multi_protocol_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_if_body_default_impl_multi_protocol_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash(ok: bool) -> i32 {\n";
+        out << "        if ok { 200 } else { 500 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let h = Box(value: 7).hash(true)
+    if h == 200 {
+        if Box(value: 7).add(true) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_block_body_default_impl_multi_protocol_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).add(3) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_default_impl_multi_protocol_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Adder { func add(x: i32) -> i32 => x }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).add(3) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_multi_protocol_empty_impl_block_for_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_multi_protocol_block_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Adder { func add(x: i32) -> i32 => x }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_generic_receiver_multi_protocol_empty_impl_block_when_required_method_is_missing) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_imported_generic_multi_protocol_empty_impl_block_when_required_method_is_missing) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_multi_protocol_block_missing_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "protocol Adder { func add(x: i32) -> i32 => x }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_imported_generic_multi_protocol_empty_impl_block_with_conflicting_default_method_names) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_multi_protocol_conflict_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol P1 { func hash() -> i32 => 1 }\n";
+        out << "protocol P2 { func hash() -> i32 => 2 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl P1, P2 {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_imported_generic_multi_protocol_impl_block_with_ambiguous_method_name) {
+    const std::string dir = "/tmp/rut_import_generic_impl_multi_protocol_ambiguous_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol P1 { func hash() -> i32 }\n";
+        out << "protocol P2 { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl P1, P2 {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_imported_generic_multi_protocol_impl_block_with_duplicate_protocol_name) {
+    const std::string dir = "/tmp/rut_import_generic_impl_multi_protocol_duplicate_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Hashable {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_imported_generic_multi_protocol_impl_block_with_unknown_protocol_name) {
+    const std::string dir = "/tmp/rut_import_generic_impl_multi_protocol_unknown_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Missing {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_imported_duplicate_impl_for_same_protocol_and_type_via_empty_impl) {
+    const std::string dir = "/tmp/rut_import_empty_impl_duplicate_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {}\n";
+        out << "Box<T> impl Hashable {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_imported_overlapping_empty_impl_and_multi_protocol_impl) {
+    const std::string dir = "/tmp/rut_import_empty_impl_overlap_multi_protocol_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "protocol Adder { func add(x: i32) -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {}\n";
+        out << "Box<T> impl Hashable, Adder {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "    func add(self: Box<T>, x: i32) -> i32 => x\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
 TEST(frontend, analyze_rejects_generic_receiver_method_dispatch_when_multiple_protocol_constraints_define_same_name) {
     const auto src = R"rut(
@@ -6325,6 +9475,33 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
+TEST(frontend, import_relative_file_impl_may_omit_protocol_method_with_default_body) {
+    const std::string dir = "/tmp/rut_import_impl_omit_default_body_method_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "    func add(x: i32) -> i32 => x\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
 TEST(frontend, analyze_rejects_impl_missing_required_protocol_method_without_default_body) {
     const auto src = R"rut(
 protocol Hashable {
@@ -6369,6 +9546,150 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
+TEST(frontend, source_multi_protocol_impl_may_omit_methods_with_block_body_default) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_multi_protocol_impl_may_omit_methods_with_if_body_default) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 7).add(true) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_multi_protocol_impl_with_default_bodies) {
+    const std::string dir = "/tmp/rut_import_multi_protocol_impl_default_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "    func add(x: i32) -> i32 => x\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func mul(x: i32) -> i32 => x\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_multi_protocol_impl_with_block_body_default) {
+    const std::string dir = "/tmp/rut_import_multi_protocol_impl_block_body_default_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_multi_protocol_impl_with_if_body_default) {
+    const std::string dir = "/tmp/rut_import_multi_protocol_impl_if_body_default_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(true) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
 TEST(frontend, source_generic_multi_protocol_impl_may_omit_methods_with_default_bodies) {
     const auto src = R"rut(
 protocol Hashable {
@@ -6395,6 +9716,226 @@ route GET "/users" {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
+}
+TEST(frontend, source_generic_multi_protocol_impl_may_omit_methods_with_block_body_default) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl Hashable, Adder {
+    func hash(self: Box<T>) -> i32 => 7
+}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, source_generic_multi_protocol_impl_may_omit_methods_with_if_body_default) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl Hashable, Adder {
+    func hash(self: Box<T>) -> i32 => 7
+}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(true) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_multi_protocol_impl_with_default_bodies) {
+    const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_default_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 => x\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_multi_protocol_impl_with_block_body_default) {
+    const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_block_body_default_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, import_relative_file_merges_imported_generic_multi_protocol_impl_with_if_body_default) {
+    const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_if_body_default_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(true) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_imported_multi_protocol_impl_missing_required_method_without_default_body) {
+    const std::string dir = "/tmp/rut_import_multi_protocol_impl_missing_required_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "    func add(x: i32) -> i32 => x\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func mul(x: i32) -> i32\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
+}
+TEST(frontend, analyze_rejects_imported_generic_multi_protocol_impl_missing_required_method_without_default_body) {
+    const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_missing_required_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" { return 200 }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
 TEST(frontend, analyze_rejects_multi_protocol_impl_missing_required_method_without_default_body) {
     const auto src = R"rut(
@@ -7831,6 +11372,8 @@ route GET "/users" {
     CHECK(hir->routes[0].locals[0].may_nil);
     CHECK_FALSE(hir->routes[0].locals[0].may_error);
     CHECK(hir->routes[0].locals[1].type == HirTypeKind::Str);
+    CHECK(hir->routes[0].locals[1].init.kind == HirExprKind::Or);
+    CHECK_NE(hir->routes[0].locals[1].init.shape_index, 0xffffffffu);
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
 }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -26,9 +26,39 @@ static u32 block_op_count(const rir::Block& block, rir::Opcode op) {
     }
     return count;
 }
+// RAII wrapper for FrontendResult<T*>. The frontend APIs (parse_file,
+// analyze_file, build_mir) all .release() a unique_ptr and hand back a raw
+// pointer. Tests allocated hundreds of these without ever deleting; before
+// this guard the test binaries leaked ~75 MB per test case, pushing the full
+// test_frontend suite to ~44 GB resident and tripping CI OOM kills.
 template <typename T>
 struct HeapFrontendResult {
     FrontendResult<T*> inner;
+
+    HeapFrontendResult() = default;
+    HeapFrontendResult(FrontendResult<T*> v) : inner(std::move(v)) {}
+    HeapFrontendResult(const HeapFrontendResult&) = delete;
+    HeapFrontendResult& operator=(const HeapFrontendResult&) = delete;
+    HeapFrontendResult(HeapFrontendResult&& other) noexcept : inner(std::move(other.inner)) {
+        other.inner = core::make_unexpected(Diagnostic{});
+    }
+    HeapFrontendResult& operator=(HeapFrontendResult&& other) noexcept {
+        if (this != &other) {
+            reset();
+            inner = std::move(other.inner);
+            other.inner = core::make_unexpected(Diagnostic{});
+        }
+        return *this;
+    }
+    ~HeapFrontendResult() { reset(); }
+
+    void reset() {
+        if (inner.has_value()) {
+            delete inner.value();
+            inner = core::make_unexpected(Diagnostic{});
+        }
+    }
+
     bool has_value() const { return inner.has_value(); }
     explicit operator bool() const { return static_cast<bool>(inner); }
     T* operator->() { return inner.value(); }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -48,7 +48,8 @@ static HeapFrontendResult<HirModule> analyze_file_heap(const AstFile& file) {
     if (!hir) return {core::make_unexpected(hir.error())};
     return {hir.value()};
 }
-static HeapFrontendResult<HirModule> analyze_file_heap_with_path(const AstFile& file, const std::string& source_path) {
+static HeapFrontendResult<HirModule> analyze_file_heap_with_path(const AstFile& file,
+                                                                 const std::string& source_path) {
     Str path{source_path.c_str(), static_cast<u32>(source_path.size())};
     auto hir = analyze_file(file, path);
     if (!hir) return {core::make_unexpected(hir.error())};
@@ -111,7 +112,8 @@ TEST(frontend, parse_route_block_single_entry_no_decorators) {
 }
 
 TEST(frontend, parse_route_block_multiple_entries) {
-    const char* src = "route {\n  GET \"/users\" { return 200 }\n  POST \"/orders\" { return 201 }\n}\n";
+    const char* src =
+        "route {\n  GET \"/users\" { return 200 }\n  POST \"/orders\" { return 201 }\n}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -122,7 +124,9 @@ TEST(frontend, parse_route_block_multiple_entries) {
 }
 
 TEST(frontend, parse_route_block_wildcard_binding_applies_to_all_entries) {
-    const char* src = "route {\n  @auth \"*\"\n  GET \"/users\" { return 200 }\n  POST \"/orders\" { return 201 }\n}\n";
+    const char* src =
+        "route {\n  @auth \"*\"\n  GET \"/users\" { return 200 }\n  POST \"/orders\" { return 201 "
+        "}\n}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -135,7 +139,9 @@ TEST(frontend, parse_route_block_wildcard_binding_applies_to_all_entries) {
 }
 
 TEST(frontend, parse_route_block_prefix_binding_applies_only_to_matching_entries) {
-    const char* src = "route {\n  @auth \"/admin\"\n  GET \"/admin/users\" { return 200 }\n  GET \"/public/health\" { return 200 }\n}\n";
+    const char* src =
+        "route {\n  @auth \"/admin\"\n  GET \"/admin/users\" { return 200 }\n  GET "
+        "\"/public/health\" { return 200 }\n}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -147,7 +153,9 @@ TEST(frontend, parse_route_block_prefix_binding_applies_only_to_matching_entries
 }
 
 TEST(frontend, parse_route_block_entry_decorator_only_attached_to_its_entry) {
-    const char* src = "route {\n  @logResp\n  GET \"/users\" { return 200 }\n  GET \"/health\" { return 200 }\n}\n";
+    const char* src =
+        "route {\n  @logResp\n  GET \"/users\" { return 200 }\n  GET \"/health\" { return 200 "
+        "}\n}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -159,7 +167,9 @@ TEST(frontend, parse_route_block_entry_decorator_only_attached_to_its_entry) {
 }
 
 TEST(frontend, parse_route_block_binding_and_entry_decorators_are_merged) {
-    const char* src = "route {\n  @requestId \"*\"\n  @auth \"/admin\"\n  @maxBody\n  POST \"/admin/upload\" { return 200 }\n}\n";
+    const char* src =
+        "route {\n  @requestId \"*\"\n  @auth \"/admin\"\n  @maxBody\n  POST \"/admin/upload\" { "
+        "return 200 }\n}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -173,7 +183,8 @@ TEST(frontend, parse_route_block_binding_and_entry_decorators_are_merged) {
 }
 
 TEST(frontend, parse_route_block_lowercase_methods_are_accepted) {
-    const char* src = "route {\n  get \"/users\" { return 200 }\n  post \"/orders\" { return 201 }\n}\n";
+    const char* src =
+        "route {\n  get \"/users\" { return 200 }\n  post \"/orders\" { return 201 }\n}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -631,11 +642,12 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
-    if (!hir) std::fprintf(stderr,
-                           "import_namespace_default_method_struct_return err=%d line=%u col=%u\n",
-                           static_cast<int>(hir.error().code),
-                           hir.error().span.line,
-                           hir.error().span.col);
+    if (!hir)
+        std::fprintf(stderr,
+                     "import_namespace_default_method_struct_return err=%d line=%u col=%u\n",
+                     static_cast<int>(hir.error().code),
+                     hir.error().span.line,
+                     hir.error().span.col);
     REQUIRE(hir);
 }
 
@@ -870,7 +882,8 @@ route GET "/users" {
     const HirImpl* imported_impl = nullptr;
     for (u32 i = 0; i < hir->impls.len; i++) {
         const auto& impl = hir->impls[i];
-        if (impl.protocol_index != protocol_index || impl.is_generic_template || impl.type != HirTypeKind::Struct)
+        if (impl.protocol_index != protocol_index || impl.is_generic_template ||
+            impl.type != HirTypeKind::Struct)
             continue;
         if (impl.struct_index >= hir->structs.len) continue;
         const auto& st = hir->structs[impl.struct_index];
@@ -1155,7 +1168,8 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch) {
+TEST(frontend,
+     import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1177,7 +1191,9 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch_with_parameter) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch_with_parameter) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_param_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1199,7 +1215,8 @@ route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_optional_default_method_dispatch) {
+TEST(frontend,
+     import_relative_file_merges_imported_generic_empty_impl_for_optional_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_optional_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1221,7 +1238,8 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_error_default_method_dispatch) {
+TEST(frontend,
+     import_relative_file_merges_imported_generic_empty_impl_for_error_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_error_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1242,7 +1260,8 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_tuple_default_method_dispatch) {
+TEST(frontend,
+     import_relative_file_merges_imported_generic_empty_impl_for_tuple_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_tuple_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1265,7 +1284,9 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_dispatch) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1287,7 +1308,9 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_equality) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_equality) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_eq_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1308,7 +1331,9 @@ route GET "/users" { if run(Box(value: 1)) == (200, 500) { return 200 } else { r
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_ordering) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_ordering) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_ord_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1330,7 +1355,9 @@ route GET "/users" { if run(Box(value: 1)) < (200, 600) { return 200 } else { re
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_block_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1357,7 +1384,9 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_block_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1384,7 +1413,9 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch_with_parameter) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch_with_parameter) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_block_param_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1411,7 +1442,9 @@ route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch_with_parameter) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch_with_parameter) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_block_param_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1438,7 +1471,8 @@ route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_if_body_default_method_dispatch) {
+TEST(frontend,
+     import_relative_file_merges_imported_generic_empty_impl_for_if_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_if_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1460,7 +1494,9 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_if_body_default_method_dispatch) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_if_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_if_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1482,12 +1518,14 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(hir);
 }
 
-TEST(frontend, lower_to_rir_supports_imported_generic_empty_impl_for_error_default_method_guard_match) {
+TEST(frontend,
+     lower_to_rir_supports_imported_generic_empty_impl_for_error_default_method_guard_match) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_error_guard_match_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
-        out << "protocol MaybeCode { func code(ok: bool) -> i32 { if ok { 200 } else { error(.timeout) } } }\n";
+        out << "protocol MaybeCode { func code(ok: bool) -> i32 { if ok { 200 } else { "
+               "error(.timeout) } } }\n";
         out << "struct Box<T> { value: T }\n";
         out << "Box<T> impl MaybeCode {}\n";
     }
@@ -1657,7 +1695,8 @@ route GET "/users" { if run(proto.Box(value: 1)) == 1 { return 200 } else { retu
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, analyze_rejects_import_namespace_protocol_constraint_for_local_same_name_type_without_impl) {
+TEST(frontend,
+     analyze_rejects_import_namespace_protocol_constraint_for_local_same_name_type_without_impl) {
     const std::string dir = "/tmp/rut_import_namespace_protocol_constraint_same_name_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1682,7 +1721,8 @@ route GET "/users" {
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_import_namespace_generic_receiver_dispatch_with_local_same_name_protocol) {
+TEST(frontend,
+     analyze_rejects_import_namespace_generic_receiver_dispatch_with_local_same_name_protocol) {
     const std::string dir = "/tmp/rut_import_namespace_protocol_dispatch_same_name_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -1708,8 +1748,11 @@ route GET "/users" {
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_import_namespace_concrete_generic_receiver_dispatch_with_local_same_name_type) {
-    const std::string dir = "/tmp/rut_import_namespace_concrete_generic_receiver_dispatch_same_name_type_frontend";
+TEST(
+    frontend,
+    analyze_rejects_import_namespace_concrete_generic_receiver_dispatch_with_local_same_name_type) {
+    const std::string dir =
+        "/tmp/rut_import_namespace_concrete_generic_receiver_dispatch_same_name_type_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -1809,7 +1852,8 @@ route GET "/users" { let state = wrap(proto.Result<proto.Box<proto.Result<i32>>>
         if (variant.template_variant_index == 0xffffffffu) continue;
         bool variant_fully_instantiated = variant.instance_type_arg_count != 0;
         for (u32 ai = 0; variant_fully_instantiated && ai < variant.instance_type_arg_count; ai++) {
-            if (variant.instance_shape_indices[ai] == 0xffffffffu) variant_fully_instantiated = false;
+            if (variant.instance_shape_indices[ai] == 0xffffffffu)
+                variant_fully_instantiated = false;
         }
         if (!variant_fully_instantiated) continue;
         if (variant.cases.len == 0) continue;
@@ -1820,8 +1864,10 @@ route GET "/users" { let state = wrap(proto.Result<proto.Box<proto.Result<i32>>>
         const auto& payload_struct = mir->structs[c.payload_struct_index];
         if (payload_struct.template_struct_index == 0xffffffffu) continue;
         bool payload_fully_instantiated = payload_struct.instance_type_arg_count != 0;
-        for (u32 ai = 0; payload_fully_instantiated && ai < payload_struct.instance_type_arg_count; ai++) {
-            if (payload_struct.instance_shape_indices[ai] == 0xffffffffu) payload_fully_instantiated = false;
+        for (u32 ai = 0; payload_fully_instantiated && ai < payload_struct.instance_type_arg_count;
+             ai++) {
+            if (payload_struct.instance_shape_indices[ai] == 0xffffffffu)
+                payload_fully_instantiated = false;
         }
         if (!payload_fully_instantiated) continue;
         if (c.payload_shape_index == 0xffffffffu) continue;
@@ -2321,7 +2367,8 @@ route GET "/users" { if run(AuthBox(value: "x")) == 200 { return 200 } else { re
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_selective_import_struct_alias_impl_target_with_local_same_name_receiver_type) {
+TEST(frontend,
+     analyze_rejects_selective_import_struct_alias_impl_target_with_local_same_name_receiver_type) {
     const std::string dir = "/tmp/rut_selective_import_alias_struct_same_name_impl_target_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -2345,7 +2392,9 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_selective_import_protocol_alias_constraint_for_local_same_name_type_without_impl) {
+TEST(
+    frontend,
+    analyze_rejects_selective_import_protocol_alias_constraint_for_local_same_name_type_without_impl) {
     const std::string dir = "/tmp/rut_selective_import_alias_protocol_same_name_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -2371,8 +2420,12 @@ route GET "/users" {
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_selective_import_concrete_generic_receiver_dispatch_with_local_same_name_type) {
-    const std::string dir = "/tmp/rut_selective_import_alias_concrete_generic_receiver_dispatch_same_name_type_frontend";
+TEST(
+    frontend,
+    analyze_rejects_selective_import_concrete_generic_receiver_dispatch_with_local_same_name_type) {
+    const std::string dir =
+        "/tmp/"
+        "rut_selective_import_alias_concrete_generic_receiver_dispatch_same_name_type_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -2398,7 +2451,8 @@ route GET "/users" {
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_selective_import_protocol_alias_impl_binding_to_local_same_name_protocol) {
+TEST(frontend,
+     analyze_rejects_selective_import_protocol_alias_impl_binding_to_local_same_name_protocol) {
     const std::string dir = "/tmp/rut_selective_import_alias_protocol_impl_same_name_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -2420,8 +2474,11 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_selective_import_protocol_alias_empty_impl_binding_to_local_same_name_protocol) {
-    const std::string dir = "/tmp/rut_selective_import_alias_protocol_empty_impl_same_name_frontend";
+TEST(
+    frontend,
+    analyze_rejects_selective_import_protocol_alias_empty_impl_binding_to_local_same_name_protocol) {
+    const std::string dir =
+        "/tmp/rut_selective_import_alias_protocol_empty_impl_same_name_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -2443,8 +2500,10 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_selective_import_impl_method_with_mismatched_concrete_generic_return_type) {
-    const std::string dir = "/tmp/rut_selective_import_alias_protocol_concrete_generic_return_mismatch_frontend";
+TEST(frontend,
+     analyze_rejects_selective_import_impl_method_with_mismatched_concrete_generic_return_type) {
+    const std::string dir =
+        "/tmp/rut_selective_import_alias_protocol_concrete_generic_return_mismatch_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -2468,8 +2527,10 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_selective_import_impl_method_with_mismatched_concrete_generic_parameter_type) {
-    const std::string dir = "/tmp/rut_selective_import_alias_protocol_concrete_generic_parameter_mismatch_frontend";
+TEST(frontend,
+     analyze_rejects_selective_import_impl_method_with_mismatched_concrete_generic_parameter_type) {
+    const std::string dir =
+        "/tmp/rut_selective_import_alias_protocol_concrete_generic_parameter_mismatch_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -2813,12 +2874,14 @@ route GET "/users" { return 200 }
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
     REQUIRE_FALSE(ast);
-    CHECK(ast.error().code == FrontendError::UnexpectedToken || ast.error().code == FrontendError::UnsupportedSyntax);
+    CHECK(ast.error().code == FrontendError::UnexpectedToken ||
+          ast.error().code == FrontendError::UnsupportedSyntax);
 }
 TEST(frontend, variant_match_lowers_to_tag_compare) {
     const char* src =
         "variant AuthState { timeout, forbidden }\n"
-        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return 200 case _: return 403 } }\n";
+        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return "
+        "200 case _: return 403 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -2852,7 +2915,8 @@ TEST(frontend, variant_match_lowers_to_tag_compare) {
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
     REQUIRE_EQ(mir->functions[0].locals.len, 1u);
-    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].type), static_cast<u8>(MirTypeKind::Variant));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].type),
+             static_cast<u8>(MirTypeKind::Variant));
     CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
              static_cast<u8>(MirValueKind::VariantCase));
     FrontendRirModule rir{};
@@ -2867,7 +2931,8 @@ TEST(frontend, variant_match_lowers_to_tag_compare) {
 TEST(frontend, variant_match_all_cases_without_wildcard_is_exhaustive) {
     const char* src =
         "variant AuthState { timeout, forbidden }\n"
-        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return 200 case .forbidden: return 403 } }\n";
+        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return "
+        "200 case .forbidden: return 403 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -2903,7 +2968,8 @@ TEST(frontend, variant_match_all_cases_without_wildcard_is_exhaustive) {
 TEST(frontend, variant_single_payload_case_parses_and_lowers) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): return 200 case .err: return 500 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): return 200 "
+        "case .err: return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -2919,7 +2985,8 @@ TEST(frontend, variant_single_payload_case_parses_and_lowers) {
     REQUIRE_EQ(hir->variants.len, 1u);
     REQUIRE_EQ(hir->variants[0].cases.len, 2u);
     CHECK(hir->variants[0].cases[0].has_payload);
-    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[0].payload_type), static_cast<u8>(HirTypeKind::I32));
+    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[0].payload_type),
+             static_cast<u8>(HirTypeKind::I32));
     REQUIRE_EQ(hir->routes[0].locals.len, 1u);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
              static_cast<u8>(HirExprKind::VariantCase));
@@ -2941,7 +3008,8 @@ TEST(frontend, variant_single_payload_case_parses_and_lowers) {
 TEST(frontend, variant_payload_binding_flows_into_match_arm_if) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): if x == 200 { return 200 } else { return 500 } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): if x == 200 "
+        "{ return 200 } else { return 500 } case .err: return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -2982,7 +3050,8 @@ TEST(frontend, variant_payload_binding_flows_into_match_arm_if) {
 TEST(frontend, variant_payload_binding_flows_into_match_arm_block) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let y = x if y == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let y = x "
+        "if y == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -3013,7 +3082,9 @@ TEST(frontend, variant_payload_binding_flows_into_match_arm_block) {
 TEST(frontend, variant_payload_binding_flows_into_match_arm_block_with_guard) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed = error(7) guard failed else { return 401 } if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed "
+        "= error(7) guard failed else { return 401 } if x == 200 { return 200 } else { return 500 "
+        "} } case .err: return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -3043,7 +3114,9 @@ TEST(frontend, variant_payload_binding_flows_into_match_arm_block_with_guard) {
 TEST(frontend, variant_payload_binding_flows_into_match_arm_block_with_guard_match) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed = error(.timeout) guard match failed else { case .timeout: return 401 case _: return 402 } if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed "
+        "= error(.timeout) guard match failed else { case .timeout: return 401 case _: return 402 "
+        "} if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -3073,7 +3146,9 @@ TEST(frontend, variant_payload_binding_flows_into_match_arm_block_with_guard_mat
 TEST(frontend, variant_mixed_payload_cases_lower) {
     const char* src =
         "variant Mixed { count(i32), ready(bool), label(str), none }\n"
-        "route GET \"/users\" { let state = Mixed.ready(true) match state { case .count(x): return 200 case .ready(flag): if flag == true { return 201 } else { return 202 } case .label(name): return 203 case .none: return 204 } }\n";
+        "route GET \"/users\" { let state = Mixed.ready(true) match state { case .count(x): return "
+        "200 case .ready(flag): if flag == true { return 201 } else { return 202 } case "
+        ".label(name): return 203 case .none: return 204 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -3091,9 +3166,12 @@ TEST(frontend, variant_mixed_payload_cases_lower) {
     REQUIRE(hir);
     REQUIRE_EQ(hir->variants.len, 1u);
     REQUIRE_EQ(hir->variants[0].cases.len, 4u);
-    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[0].payload_type), static_cast<u8>(HirTypeKind::I32));
-    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[1].payload_type), static_cast<u8>(HirTypeKind::Bool));
-    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[2].payload_type), static_cast<u8>(HirTypeKind::Str));
+    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[0].payload_type),
+             static_cast<u8>(HirTypeKind::I32));
+    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[1].payload_type),
+             static_cast<u8>(HirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(hir->variants[0].cases[2].payload_type),
+             static_cast<u8>(HirTypeKind::Str));
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
     FrontendRirModule rir{};
@@ -3105,7 +3183,9 @@ TEST(frontend, variant_tuple_payload_binding_flows_into_pipe_multi_slot) {
     const char* src =
         "variant Result { ok((i32, i32)), err }\n"
         "func second(a: i32, b: i32) -> i32 => b\n"
-        "route GET \"/users\" { let state = Result.ok((200, 500)) match state { case .ok(pair): { let code = pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok((200, 500)) match state { case .ok(pair): { "
+        "let code = pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } } case "
+        ".err: return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -3135,7 +3215,9 @@ TEST(frontend, route_match_struct_payload_binding_preserves_shape) {
         "struct Box { value: i32 }\n"
         "variant Result { ok(Box), err }\n"
         "func boxCode(x: Box) -> i32 => x.value\n"
-        "route GET \"/users\" { let state = Result.ok(Box(value: 200)) match state { case .ok(box): { let code = box | boxCode(_) if code == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(Box(value: 200)) match state { case "
+        ".ok(box): { let code = box | boxCode(_) if code == 200 { return 200 } else { return 500 } "
+        "} case .err: return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -3155,7 +3237,9 @@ TEST(frontend, route_match_nested_struct_payload_projection) {
         "struct Box { value: i32 }\n"
         "struct Outer { inner: Box }\n"
         "variant Result { ok(Outer), err }\n"
-        "route GET \"/users\" { let state = Result.ok(Outer(inner: Box(value: 200))) match state { case .ok(v): { let code = v.inner.value if code == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(Outer(inner: Box(value: 200))) match state { "
+        "case .ok(v): { let code = v.inner.value if code == 200 { return 200 } else { return 500 } "
+        "} case .err: return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -3296,7 +3380,8 @@ TEST(frontend, import_relative_file_preserves_imported_function_body_shape_indic
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
         out << "struct Box { value: i32 }\n";
         out << "variant Result { ok, err }\n";
-        out << "func makeBox(ok: bool) -> Box { if ok { Box(value: 200) } else { Box(value: 500) } }\n";
+        out << "func makeBox(ok: bool) -> Box { if ok { Box(value: 200) } else { Box(value: 500) } "
+               "}\n";
         out << "func maybe(ok: bool) { if ok { 200 } else { nil } }\n";
         out << "func pickOr(ok: bool) -> i32 => or(maybe(ok), 500)\n";
         out << "func pickMatch(x: Result) -> i32 {\n";
@@ -3350,7 +3435,8 @@ route GET "/users" {
     CHECK(hir->type_shapes[pick_match->body.shape_index].is_concrete);
 }
 
-TEST(frontend, import_relative_file_preserves_imported_protocol_default_method_wrapper_metadata_in_hir) {
+TEST(frontend,
+     import_relative_file_preserves_imported_protocol_default_method_wrapper_metadata_in_hir) {
     const std::string dir = "/tmp/rut_import_protocol_default_wrapper_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -3412,7 +3498,8 @@ route GET "/users" {
     CHECK(maybe_fail_req->return_error_variant_index != 0xffffffffu);
 }
 
-TEST(frontend, imported_generic_receiver_protocol_call_preserves_default_method_wrapper_metadata_in_hir) {
+TEST(frontend,
+     imported_generic_receiver_protocol_call_preserves_default_method_wrapper_metadata_in_hir) {
     const std::string dir = "/tmp/rut_import_protocol_call_wrapper_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -3466,7 +3553,9 @@ route GET "/users" {
     CHECK(run_err->body.lhs->error_variant_index != 0xffffffffu);
 }
 
-TEST(frontend, import_relative_file_inlines_imported_generic_empty_impl_default_method_wrappers_in_route_hir) {
+TEST(
+    frontend,
+    import_relative_file_inlines_imported_generic_empty_impl_default_method_wrappers_in_route_hir) {
     const std::string dir = "/tmp/rut_import_protocol_call_wrapper_route_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -3680,7 +3769,8 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(frontend, lower_to_rir_supports_imported_generic_empty_impl_for_optional_default_method_dispatch) {
+TEST(frontend,
+     lower_to_rir_supports_imported_generic_empty_impl_for_optional_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_optional_lower_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -3708,7 +3798,8 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     rir.destroy();
 }
 
-TEST(frontend, lower_to_rir_supports_imported_generic_empty_impl_for_error_default_method_dispatch) {
+TEST(frontend,
+     lower_to_rir_supports_imported_generic_empty_impl_for_error_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_error_lower_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -3770,7 +3861,8 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(frontend, lower_to_rir_supports_import_namespace_route_match_nested_struct_payload_projection) {
+TEST(frontend,
+     lower_to_rir_supports_import_namespace_route_match_nested_struct_payload_projection) {
     const std::string dir = "/tmp/rut_import_namespace_match_nested_struct_payload_lower_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -3810,7 +3902,8 @@ TEST(frontend, route_guard_bound_struct_preserves_shape_index) {
     const char* src =
         "struct Box { value: i32 }\n"
         "func maybeBox(ok: bool) -> Box { if ok { Box(value: 200) } else { nil } }\n"
-        "route GET \"/users\" { guard let picked = maybeBox(true) else { return 401 } if picked.value == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { guard let picked = maybeBox(true) else { return 401 } if "
+        "picked.value == 200 { return 200 } else { return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -3827,7 +3920,8 @@ TEST(frontend, route_guard_bound_runtime_error_struct_preserves_init_shape) {
     const char* src =
         "struct Box { value: i32 }\n"
         "func maybeBox(ok: bool) -> Box { if ok { Box(value: 200) } else { error(.timeout) } }\n"
-        "route GET \"/users\" { guard let picked = maybeBox(true) else { return 401 } if picked.value == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { guard let picked = maybeBox(true) else { return 401 } if "
+        "picked.value == 200 { return 200 } else { return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -3850,7 +3944,9 @@ TEST(frontend, match_arm_guard_bound_struct_preserves_shape_index) {
         "struct Box { value: i32 }\n"
         "variant Result { ok, err }\n"
         "func maybeBox(ok: bool) -> Box { if ok { Box(value: 200) } else { nil } }\n"
-        "route GET \"/users\" { let state = Result.ok match state { case .ok: { guard let picked = maybeBox(true) else { return 401 } if picked.value == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok match state { case .ok: { guard let picked = "
+        "maybeBox(true) else { return 401 } if picked.value == 200 { return 200 } else { return "
+        "500 } } case .err: return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4027,7 +4123,8 @@ route GET "/users" {
 }
 TEST(frontend, named_errors_aggregate_into_hidden_error_variant) {
     const char* src =
-        "route GET \"/users\" { let timeout = error(.timeout) let denied = error(.forbidden) return 200 }\n";
+        "route GET \"/users\" { let timeout = error(.timeout) let denied = error(.forbidden) "
+        "return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4050,7 +4147,8 @@ TEST(frontend, named_errors_aggregate_into_hidden_error_variant) {
 }
 TEST(frontend, error_message_is_preserved_for_named_error) {
     const char* src =
-        "route GET \"/users\" { let timeout = error(.timeout, \"request timed out\") return 200 }\n";
+        "route GET \"/users\" { let timeout = error(.timeout, \"request timed out\") return 200 "
+        "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4069,7 +4167,8 @@ TEST(frontend, error_message_is_preserved_for_named_error) {
 TEST(frontend, custom_error_struct_can_be_used_in_error_constructor) {
     const char* src =
         "struct AuthError { err: Error }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\") return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\") return 200 "
+        "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4086,7 +4185,8 @@ TEST(frontend, custom_error_struct_can_be_used_in_error_constructor) {
     CHECK(hir->structs[0].name.eq(lit("AuthError")));
     CHECK(hir->structs[0].conforms_error);
     REQUIRE_EQ(hir->routes[0].locals.len, 1u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind), static_cast<u8>(HirExprKind::Error));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::Error));
     CHECK_EQ(hir->routes[0].locals[0].init.error_struct_index, 0u);
     CHECK(hir->routes[0].locals[0].init.msg.eq(lit("timed out")));
     auto mir = build_mir_heap(hir.value());
@@ -4097,7 +4197,8 @@ TEST(frontend, custom_error_struct_can_be_used_in_error_constructor) {
 TEST(frontend, custom_error_struct_with_extra_fields_lowers_to_rir_struct) {
     const char* src =
         "struct AuthError { err: Error, token: str, retry: i32 }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: "
+        "\"abc\", retry: 3) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4139,7 +4240,8 @@ TEST(frontend, custom_error_struct_with_extra_fields_lowers_to_rir_struct) {
 TEST(frontend, custom_error_struct_constructor_preserves_extra_field_inits) {
     const char* src =
         "struct AuthError { err: Error, token: str, retry: i32 }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: "
+        "\"abc\", retry: 3) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4165,7 +4267,8 @@ TEST(frontend, custom_error_struct_constructor_preserves_extra_field_inits) {
 TEST(frontend, custom_error_struct_with_tuple_field_lowers_to_rir_struct) {
     const char* src =
         "struct AuthError { err: Error, pair: (i32, i32) }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, 500)) return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, "
+        "500)) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4213,7 +4316,8 @@ TEST(frontend, analyze_rejects_non_error_struct_in_error_constructor) {
 TEST(frontend, analyze_rejects_custom_error_constructor_missing_extra_fields) {
     const char* src =
         "struct AuthError { err: Error, token: str, retry: i32 }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\") return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: "
+        "\"abc\") return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4225,7 +4329,8 @@ TEST(frontend, analyze_rejects_custom_error_constructor_missing_extra_fields) {
 TEST(frontend, analyze_rejects_custom_error_constructor_unknown_extra_field) {
     const char* src =
         "struct AuthError { err: Error, token: str }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", retry: 3) return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", retry: 3) "
+        "return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4237,7 +4342,8 @@ TEST(frontend, analyze_rejects_custom_error_constructor_unknown_extra_field) {
 TEST(frontend, analyze_rejects_custom_error_constructor_wrong_extra_field_type) {
     const char* src =
         "struct AuthError { err: Error, retry: i32 }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", retry: \"soon\") return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", retry: "
+        "\"soon\") return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4290,7 +4396,8 @@ TEST(frontend, explicit_error_variant_is_not_wrapped_again) {
 TEST(frontend, error_message_is_preserved_for_explicit_error_variant) {
     const char* src =
         "variant AuthError { timeout, forbidden }\n"
-        "route GET \"/users\" { let failed = error(AuthError.timeout, \"timed out\") return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError.timeout, \"timed out\") return 200 "
+        "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4306,7 +4413,8 @@ TEST(frontend, error_message_is_preserved_for_explicit_error_variant) {
 }
 TEST(frontend, lower_to_rir_emits_standard_error_struct) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = or(failed, 200) return 200 }\n";
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = or(failed, "
+        "200) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4336,7 +4444,8 @@ TEST(frontend, lower_to_rir_emits_standard_error_struct) {
 }
 TEST(frontend, lower_to_rir_uses_module_name_for_error_file_field) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = or(failed, 200) return 200 }\n";
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = or(failed, "
+        "200) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4368,7 +4477,8 @@ TEST(frontend, lower_to_rir_uses_module_name_for_error_file_field) {
 TEST(frontend, custom_error_struct_lowers_with_standard_error_metadata) {
     const char* src =
         "struct AuthError { err: Error }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\") let code = or(failed, 200) return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\") let code = "
+        "or(failed, 200) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4410,7 +4520,8 @@ TEST(frontend, custom_error_struct_lowers_with_standard_error_metadata) {
 TEST(frontend, custom_error_struct_extra_fields_enter_runtime_lowering) {
     const char* src =
         "struct AuthError { err: Error, token: str, retry: i32 }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) let code = or(failed, 200) return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: "
+        "\"abc\", retry: 3) let code = or(failed, 200) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4429,10 +4540,10 @@ TEST(frontend, custom_error_struct_extra_fields_enter_runtime_lowering) {
         const auto& block = rir.module.functions[0].blocks[bi];
         for (u32 ii = 0; ii < block.inst_count; ii++) {
             const auto& inst = block.insts[ii];
-            if (inst.op == rir::Opcode::StructCreate && inst.imm.struct_ref.name.eq(lit("AuthError")))
+            if (inst.op == rir::Opcode::StructCreate &&
+                inst.imm.struct_ref.name.eq(lit("AuthError")))
                 saw_auth_error_create = true;
-            if (inst.op == rir::Opcode::ConstI32 && inst.imm.i32_val == 3)
-                saw_retry = true;
+            if (inst.op == rir::Opcode::ConstI32 && inst.imm.i32_val == 3) saw_retry = true;
             if (inst.op == rir::Opcode::ConstStr && inst.imm.str_val.eq(lit("abc")))
                 saw_token = true;
         }
@@ -4445,7 +4556,9 @@ TEST(frontend, custom_error_struct_extra_fields_enter_runtime_lowering) {
 TEST(frontend, custom_error_struct_fields_can_be_projected_from_known_error_local) {
     const char* src =
         "struct AuthError { err: Error, token: str, retry: i32 }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) let token = failed.token let retry = failed.retry if retry == 3 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: "
+        "\"abc\", retry: 3) let token = failed.token let retry = failed.retry if retry == 3 { "
+        "return 200 } else { return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4454,17 +4567,21 @@ TEST(frontend, custom_error_struct_fields_can_be_projected_from_known_error_loca
     REQUIRE(hir);
     REQUIRE_EQ(hir.value().routes[0].locals.len, 3u);
     CHECK_EQ(hir.value().routes[0].locals[1].type, HirTypeKind::Str);
-    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::StrLit));
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::StrLit));
     CHECK(hir.value().routes[0].locals[1].init.str_value.eq(lit("abc")));
     CHECK_EQ(hir.value().routes[0].locals[2].type, HirTypeKind::I32);
-    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[2].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[2].init.kind),
+             static_cast<u8>(HirExprKind::IntLit));
     CHECK_EQ(hir.value().routes[0].locals[2].init.int_value, 3);
 }
 TEST(frontend, custom_error_struct_tuple_field_can_flow_into_pipe_slots) {
     const char* src =
         "struct AuthError { err: Error, pair: (i32, i32) }\n"
         "func second(a: i32, b: i32) -> i32 => b\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, 500)) let code = failed.pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, "
+        "500)) let code = failed.pair | second(_2, _1) if code == 200 { return 200 } else { return "
+        "500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4483,7 +4600,8 @@ TEST(frontend, custom_error_struct_tuple_field_can_flow_into_pipe_slots) {
 TEST(frontend, plain_struct_constructor_and_field_projection_are_supported) {
     constexpr auto src =
         "struct Foo { code: i32, msg: str }\n"
-        "route GET \"/users\" { let foo = Foo(code: 200, msg: \"ok\") let code = foo.code let msg = foo.msg if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let foo = Foo(code: 200, msg: \"ok\") let code = foo.code let msg "
+        "= foo.msg if code == 200 { return 200 } else { return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4506,7 +4624,8 @@ TEST(frontend, plain_struct_constructor_and_field_projection_are_supported) {
 TEST(frontend, generic_struct_constructor_and_field_projection_are_supported) {
     const char* src =
         "struct Box<T> { value: T }\n"
-        "route GET \"/users\" { let box = Box<i32>(value: 200) if box.value == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let box = Box<i32>(value: 200) if box.value == 200 { return 200 } "
+        "else { return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -4935,7 +5054,8 @@ route GET "/users" {
     CHECK_EQ(hir->variants[1].template_variant_index, 0u);
     CHECK_EQ(hir->variants[1].cases[0].payload_type, HirTypeKind::Struct);
     REQUIRE(hir->variants[1].cases[0].payload_struct_index < hir->structs.len);
-    CHECK_EQ(hir->structs[hir->variants[1].cases[0].payload_struct_index].template_struct_index, 0u);
+    CHECK_EQ(hir->structs[hir->variants[1].cases[0].payload_struct_index].template_struct_index,
+             0u);
 }
 TEST(frontend, concrete_nested_generic_struct_type_refs_are_supported_in_function_signatures) {
     const auto src = R"rut(
@@ -5167,7 +5287,8 @@ TEST(frontend, plain_struct_tuple_field_can_flow_into_pipe_slots) {
     const char* src =
         "struct Foo { pair: (i32, i32) }\n"
         "func second(a: i32, b: i32) -> i32 => b\n"
-        "route GET \"/users\" { let foo = Foo(pair: (200, 500)) let code = foo.pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let foo = Foo(pair: (200, 500)) let code = foo.pair | second(_2, "
+        "_1) if code == 200 { return 200 } else { return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5190,7 +5311,9 @@ TEST(frontend, custom_error_nested_struct_field_projection) {
     const char* src =
         "struct Box { value: i32 }\n"
         "struct AuthError { err: Error, inner: Box }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", inner: Box(value: 200)) let code = failed.inner.value if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", inner: "
+        "Box(value: 200)) let code = failed.inner.value if code == 200 { return 200 } else { "
+        "return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5205,7 +5328,8 @@ TEST(frontend, nested_struct_field_projection_preserves_projected_struct_type) {
     const char* src =
         "struct Box { value: i32 }\n"
         "struct Outer { inner: Box }\n"
-        "route GET \"/users\" { let outer = Outer(inner: Box(value: 200)) let code = outer.inner.value if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let outer = Outer(inner: Box(value: 200)) let code = "
+        "outer.inner.value if code == 200 { return 200 } else { return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5220,7 +5344,8 @@ TEST(frontend, plain_struct_tuple_of_struct_field_projection_preserves_struct_sl
     const char* src =
         "struct Box { value: i32 }\n"
         "struct Foo { pair: (Box, i32) }\n"
-        "route GET \"/users\" { let foo = Foo(pair: (Box(value: 200), 500)) let pair = foo.pair return 200 }\n";
+        "route GET \"/users\" { let foo = Foo(pair: (Box(value: 200), 500)) let pair = foo.pair "
+        "return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5237,7 +5362,8 @@ TEST(frontend, plain_struct_variant_field_can_flow_into_match) {
     const char* src =
         "variant AuthState { timeout, forbidden }\n"
         "struct Foo { state: AuthState }\n"
-        "route GET \"/users\" { let foo = Foo(state: AuthState.timeout) match foo.state { case .timeout: return 200 case _: return 403 } }\n";
+        "route GET \"/users\" { let foo = Foo(state: AuthState.timeout) match foo.state { case "
+        ".timeout: return 200 case _: return 403 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5257,7 +5383,8 @@ TEST(frontend, plain_struct_variant_field_can_flow_into_match) {
 }
 TEST(frontend, source_error_standard_fields_are_accessible) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = failed.code let msg = failed.msg if code == 0 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = failed.code "
+        "let msg = failed.msg if code == 0 { return 200 } else { return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5266,14 +5393,17 @@ TEST(frontend, source_error_standard_fields_are_accessible) {
     REQUIRE(hir);
     REQUIRE_EQ(hir.value().routes[0].locals.len, 3u);
     CHECK_EQ(hir.value().routes[0].locals[1].type, HirTypeKind::I32);
-    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IntLit));
     CHECK_EQ(hir.value().routes[0].locals[2].type, HirTypeKind::Str);
-    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[2].init.kind), static_cast<u8>(HirExprKind::StrLit));
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[2].init.kind),
+             static_cast<u8>(HirExprKind::StrLit));
     CHECK(hir.value().routes[0].locals[2].init.str_value.eq(lit("timed out")));
 }
 TEST(frontend, source_error_line_field_is_accessible) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let line = failed.line if line == 1 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let line = failed.line "
+        "if line == 1 { return 200 } else { return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5282,12 +5412,14 @@ TEST(frontend, source_error_line_field_is_accessible) {
     REQUIRE(hir);
     REQUIRE_EQ(hir.value().routes[0].locals.len, 2u);
     CHECK_EQ(hir.value().routes[0].locals[1].type, HirTypeKind::I32);
-    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IntLit));
     CHECK_EQ(hir.value().routes[0].locals[1].init.int_value, 1);
 }
 TEST(frontend, source_error_file_and_func_fields_are_accessible) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let file_name = failed.file let fn_name = failed.func return 200 }\n";
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let file_name = "
+        "failed.file let fn_name = failed.func return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5296,10 +5428,12 @@ TEST(frontend, source_error_file_and_func_fields_are_accessible) {
     REQUIRE(hir);
     REQUIRE_EQ(hir.value().routes[0].locals.len, 3u);
     CHECK_EQ(hir.value().routes[0].locals[1].type, HirTypeKind::Str);
-    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Field));
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Field));
     CHECK(hir.value().routes[0].locals[1].init.str_value.eq(lit("file")));
     CHECK_EQ(hir.value().routes[0].locals[2].type, HirTypeKind::Str);
-    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[2].init.kind), static_cast<u8>(HirExprKind::Field));
+    CHECK_EQ(static_cast<u8>(hir.value().routes[0].locals[2].init.kind),
+             static_cast<u8>(HirExprKind::Field));
     CHECK(hir.value().routes[0].locals[2].init.str_value.eq(lit("func")));
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
@@ -5311,7 +5445,8 @@ TEST(frontend, source_error_file_and_func_fields_are_accessible) {
 }
 TEST(frontend, known_named_error_match_selects_error_case) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout) match failed { case .timeout: return 503 case _: return 200 } }\n";
+        "route GET \"/users\" { let failed = error(.timeout) match failed { case .timeout: return "
+        "503 case _: return 200 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5345,7 +5480,8 @@ TEST(frontend, if_const_selects_then_without_checking_else) {
 }
 TEST(frontend, if_const_rejects_runtime_condition) {
     const char* src =
-        "route GET \"/users\" { if const req.header(\"Host\") { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { if const req.header(\"Host\") { return 200 } else { return 500 } "
+        "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5357,7 +5493,8 @@ TEST(frontend, if_const_rejects_runtime_condition) {
 TEST(frontend, match_const_selects_variant_case_without_checking_other_arms) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match const state { case .ok(x): if x == 200 { return 200 } else { return 500 } case .err: forward missing } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match const state { case .ok(x): if x "
+        "== 200 { return 200 } else { return 500 } case .err: forward missing } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5386,7 +5523,8 @@ TEST(frontend, function_match_const_preserves_outer_payload_binding) {
         "    case .err => 404\n"
         "  }\n"
         "}\n"
-        "route GET \"/users\" { let code = pick(Result.ok(200)) if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let code = pick(Result.ok(200)) if code == 200 { return 200 } else "
+        "{ return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5399,7 +5537,8 @@ TEST(frontend, function_match_const_preserves_outer_payload_binding) {
 TEST(frontend, match_const_rejects_runtime_subject) {
     const char* src =
         "variant AuthState { timeout, forbidden }\n"
-        "route GET \"/users\" { match const req.header(\"Host\") { case .timeout: return 200 case _: return 500 } }\n";
+        "route GET \"/users\" { match const req.header(\"Host\") { case .timeout: return 200 case "
+        "_: return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5420,7 +5559,8 @@ TEST(frontend, analyze_rejects_variant_payload_type_mismatch) {
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
-TEST(frontend, analyze_rejects_generic_variant_constructor_when_not_all_type_arguments_can_be_inferred) {
+TEST(frontend,
+     analyze_rejects_generic_variant_constructor_when_not_all_type_arguments_can_be_inferred) {
     const auto src = R"rut(
 variant Pair<T, U> { one(T), two(U) }
 route GET "/users" {
@@ -5438,7 +5578,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     CHECK(!hir);
 }
-TEST(frontend, analyze_rejects_generic_struct_constructor_when_not_all_type_arguments_can_be_inferred) {
+TEST(frontend,
+     analyze_rejects_generic_struct_constructor_when_not_all_type_arguments_can_be_inferred) {
     const auto src = R"rut(
 struct Holder<T, U> { value: T, tag: i32 }
 route GET "/users" {
@@ -5480,7 +5621,8 @@ TEST(frontend, analyze_rejects_payload_on_payloadless_variant_case) {
 TEST(frontend, analyze_rejects_variant_match_missing_case_without_wildcard) {
     const char* src =
         "variant AuthState { timeout, forbidden }\n"
-        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return 200 } }\n";
+        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return "
+        "200 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5492,7 +5634,8 @@ TEST(frontend, analyze_rejects_variant_match_missing_case_without_wildcard) {
 TEST(frontend, analyze_rejects_duplicate_variant_match_case) {
     const char* src =
         "variant AuthState { timeout, forbidden }\n"
-        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return 200 case .timeout: return 403 } }\n";
+        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return "
+        "200 case .timeout: return 403 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5529,8 +5672,7 @@ TEST(frontend, lower_forward_route_to_rir) {
     REQUIRE_EQ(fn.blocks[0].inst_count, 2u);
     CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ConstI32));
     CHECK_EQ(fn.blocks[0].insts[0].imm.i32_val, 1);
-    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[1].op),
-             static_cast<u8>(rir::Opcode::RetForward));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[1].op), static_cast<u8>(rir::Opcode::RetForward));
     rir.destroy();
 }
 TEST(frontend, let_if_lowers_to_branching_rir) {
@@ -5571,7 +5713,8 @@ TEST(frontend, let_if_lowers_to_branching_rir) {
 }
 TEST(frontend, route_if_branch_block_with_let_lowers_via_match_shape) {
     const char* src =
-        "route GET \"/users\" { let ok = true if ok { let code = 200 if code == 200 { return 200 } else { return 500 } } else { return 404 } }\n";
+        "route GET \"/users\" { let ok = true if ok { let code = 200 if code == 200 { return 200 } "
+        "else { return 500 } } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5589,7 +5732,8 @@ TEST(frontend, route_if_branch_block_with_let_lowers_via_match_shape) {
 }
 TEST(frontend, route_if_branch_block_with_guard_is_supported) {
     const char* src =
-        "route GET \"/users\" { let ok = true if ok { let failed = error(7) guard failed else { return 401 } return 200 } else { return 404 } }\n";
+        "route GET \"/users\" { let ok = true if ok { let failed = error(7) guard failed else { "
+        "return 401 } return 200 } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5603,7 +5747,8 @@ TEST(frontend, route_if_branch_block_with_guard_is_supported) {
 TEST(frontend, guard_lowers_to_fail_and_continue_blocks) {
     const char* src =
         "upstream api\n"
-        "route GET \"/users\" { let failed = error(7) guard failed else { return 401 } forward api }\n";
+        "route GET \"/users\" { let failed = error(7) guard failed else { return 401 } forward api "
+        "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5639,7 +5784,8 @@ TEST(frontend, guard_lowers_to_fail_and_continue_blocks) {
 }
 TEST(frontend, guard_else_block_with_let_is_supported) {
     const char* src =
-        "route GET \"/users\" { let failed = error(7) guard failed else { let code = 401 if code == 401 { return 401 } else { return 500 } } return 200 }\n";
+        "route GET \"/users\" { let failed = error(7) guard failed else { let code = 401 if code "
+        "== 401 { return 401 } else { return 500 } } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5647,13 +5793,15 @@ TEST(frontend, guard_else_block_with_let_is_supported) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].guards.len, 1u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].fail_kind), static_cast<u8>(HirGuard::FailKind::Body));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].fail_kind),
+             static_cast<u8>(HirGuard::FailKind::Body));
     CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].fail_body.body_kind),
              static_cast<u8>(HirGuardBody::BodyKind::If));
 }
 TEST(frontend, guard_let_binds_success_value) {
     const char* src =
-        "route GET \"/users\" { guard let code = 200 else { return 401 } if code == 200 { return 200 } else { return 404 } }\n";
+        "route GET \"/users\" { guard let code = 200 else { return 401 } if code == 200 { return "
+        "200 } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5692,13 +5840,15 @@ TEST(frontend, guard_let_does_not_unwrap_nil) {
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Unknown));
     CHECK(hir->routes[0].locals[0].may_nil);
     CHECK_FALSE(hir->routes[0].locals[0].may_error);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].cond.kind), static_cast<u8>(HirExprKind::BoolLit));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].cond.kind),
+             static_cast<u8>(HirExprKind::BoolLit));
     CHECK(hir->routes[0].guards[0].cond.bool_value);
 }
 TEST(frontend, equality_expression_lowers_to_cmp_eq) {
     const char* src =
         "upstream api\n"
-        "route GET \"/users\" { let code = 200 if code == 200 { forward api } else { return 404 } }\n";
+        "route GET \"/users\" { let code = 200 if code == 200 { forward api } else { return 404 } "
+        "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5723,7 +5873,8 @@ TEST(frontend, equality_expression_lowers_to_cmp_eq) {
 }
 TEST(frontend, or_builtin_falls_back_from_nil) {
     const char* src =
-        "route GET \"/users\" { let code = or(nil, 200) if code == 200 { return 200 } else { return 404 } }\n";
+        "route GET \"/users\" { let code = or(nil, 200) if code == 200 { return 200 } else { "
+        "return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5739,12 +5890,14 @@ TEST(frontend, or_builtin_falls_back_from_nil) {
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::I32));
     CHECK_FALSE(hir->routes[0].locals[0].may_nil);
     CHECK_FALSE(hir->routes[0].locals[0].may_error);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::IntLit));
     CHECK_EQ(hir->routes[0].locals[0].init.int_value, 200);
 }
 TEST(frontend, req_header_flows_as_optional_str) {
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"fallback\") return 200 }\n";
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"fallback\") "
+        "return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5787,7 +5940,8 @@ TEST(frontend, req_header_flows_as_optional_str) {
 }
 TEST(frontend, req_header_alias_flows_as_optional_str) {
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let alias = host let value = or(alias, \"fallback\") return 200 }\n";
+        "route GET \"/users\" { let host = req.header(\"Host\") let alias = host let value = "
+        "or(alias, \"fallback\") return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5820,7 +5974,8 @@ TEST(frontend, req_header_alias_flows_as_optional_str) {
 }
 TEST(frontend, or_builtin_falls_back_from_nil_local) {
     const char* src =
-        "route GET \"/users\" { let maybe = nil let code = or(maybe, 200) if code == 200 { return 200 } else { return 404 } }\n";
+        "route GET \"/users\" { let maybe = nil let code = or(maybe, 200) if code == 200 { return "
+        "200 } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5831,10 +5986,12 @@ TEST(frontend, or_builtin_falls_back_from_nil_local) {
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Unknown));
     CHECK(hir->routes[0].locals[0].may_nil);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind), static_cast<u8>(HirExprKind::Nil));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::Nil));
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].type), static_cast<u8>(HirTypeKind::I32));
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IntLit));
     CHECK_EQ(hir->routes[0].locals[1].init.int_value, 200);
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
@@ -5842,7 +5999,8 @@ TEST(frontend, or_builtin_falls_back_from_nil_local) {
 }
 TEST(frontend, or_builtin_falls_back_from_error_local) {
     const char* src =
-        "route GET \"/users\" { let failed = error(7) let code = or(failed, 200) if code == 200 { return 200 } else { return 404 } }\n";
+        "route GET \"/users\" { let failed = error(7) let code = or(failed, 200) if code == 200 { "
+        "return 200 } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5851,18 +6009,21 @@ TEST(frontend, or_builtin_falls_back_from_error_local) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind), static_cast<u8>(HirExprKind::Error));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::Error));
     CHECK_FALSE(hir->routes[0].locals[0].may_nil);
     CHECK(hir->routes[0].locals[0].may_error);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].type), static_cast<u8>(HirTypeKind::I32));
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IntLit));
     CHECK_EQ(hir->routes[0].locals[1].init.int_value, 200);
 }
 TEST(frontend, or_builtin_falls_back_from_error_alias) {
     const char* src =
-        "route GET \"/users\" { let failed = error(7) let alias = failed let code = or(alias, 200) if code == 200 { return 200 } else { return 404 } }\n";
+        "route GET \"/users\" { let failed = error(7) let alias = failed let code = or(alias, 200) "
+        "if code == 200 { return 200 } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5873,7 +6034,8 @@ TEST(frontend, or_builtin_falls_back_from_error_alias) {
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[2].type), static_cast<u8>(HirTypeKind::I32));
     CHECK_FALSE(hir->routes[0].locals[2].may_nil);
     CHECK_FALSE(hir->routes[0].locals[2].may_error);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[2].init.kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[2].init.kind),
+             static_cast<u8>(HirExprKind::IntLit));
     CHECK_EQ(hir->routes[0].locals[2].init.int_value, 200);
 }
 TEST(frontend, analyze_rejects_unknown_upstream) {
@@ -5889,7 +6051,8 @@ TEST(frontend, analyze_rejects_unknown_upstream) {
 TEST(frontend, match_lowers_to_cmp_eq_chain) {
     const char* src =
         "upstream api\n"
-        "route GET \"/users\" { let code = 200 match code { case 200: forward api case _: return 404 } }\n";
+        "route GET \"/users\" { let code = 200 match code { case 200: forward api case _: return "
+        "404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5921,7 +6084,8 @@ TEST(frontend, match_lowers_to_cmp_eq_chain) {
 TEST(frontend, guard_then_match_lowers_to_guard_and_match_blocks) {
     const char* src =
         "upstream api\n"
-        "route GET \"/users\" { let failed = error(7) let code = 200 guard code else { return 401 } match code { case 200: forward api case _: return 404 } }\n";
+        "route GET \"/users\" { let failed = error(7) let code = 200 guard code else { return 401 "
+        "} match code { case 200: forward api case _: return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5945,7 +6109,8 @@ TEST(frontend, guard_then_match_lowers_to_guard_and_match_blocks) {
 }
 TEST(frontend, multiple_top_level_guards_are_allowed) {
     const char* src =
-        "route GET \"/users\" { let ok = 200 guard ok else { return 401 } let failed = error(7) guard failed else { return 402 } return 200 }\n";
+        "route GET \"/users\" { let ok = 200 guard ok else { return 401 } let failed = error(7) "
+        "guard failed else { return 402 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5964,7 +6129,8 @@ TEST(frontend, multiple_top_level_guards_are_allowed) {
 }
 TEST(frontend, guard_match_lowers_to_fail_side_match_arms) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case "
+        ".timeout: return 503 case _: return 500 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5987,7 +6153,8 @@ TEST(frontend, guard_match_lowers_to_fail_side_match_arms) {
 }
 TEST(frontend, analyze_rejects_guard_match_without_wildcard) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case .timeout: return 503 } return 200 }\n";
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case "
+        ".timeout: return 503 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5998,7 +6165,8 @@ TEST(frontend, analyze_rejects_guard_match_without_wildcard) {
 }
 TEST(frontend, analyze_rejects_guard_match_wildcard_before_last) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case _: return 500 case .timeout: return 503 } return 200 }\n";
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case _: "
+        "return 500 case .timeout: return 503 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -6009,7 +6177,8 @@ TEST(frontend, analyze_rejects_guard_match_wildcard_before_last) {
 }
 TEST(frontend, analyze_rejects_guard_match_duplicate_case) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case .timeout: return 503 case .timeout: return 504 case _: return 500 } return 200 }\n";
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case "
+        ".timeout: return 503 case .timeout: return 504 case _: return 500 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -6021,7 +6190,8 @@ TEST(frontend, analyze_rejects_guard_match_duplicate_case) {
 TEST(frontend, analyze_rejects_guard_match_pattern_type_mismatch) {
     const char* src =
         "variant AuthError { timeout, forbidden }\n"
-        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case AuthError.timeout: return 503 case _: return 500 } return 200 }\n";
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case "
+        "AuthError.timeout: return 503 case _: return 500 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -6033,7 +6203,9 @@ TEST(frontend, analyze_rejects_guard_match_pattern_type_mismatch) {
 TEST(frontend, analyze_rejects_match_arm_block_guard_match_on_non_error_value) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { guard match x else { case .timeout: return 401 case _: return 402 } if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { guard "
+        "match x else { case .timeout: return 401 case _: return 402 } if x == 200 { return 200 } "
+        "else { return 500 } } case .err: return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -6056,7 +6228,8 @@ TEST(frontend, analyze_rejects_match_without_wildcard) {
 TEST(frontend, guard_lowers_from_error_alias) {
     const char* src =
         "upstream api\n"
-        "route GET \"/users\" { let failed = error(7) let alias = failed guard alias else { return 401 } forward api }\n";
+        "route GET \"/users\" { let failed = error(7) let alias = failed guard alias else { return "
+        "401 } forward api }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -6071,7 +6244,8 @@ TEST(frontend, guard_lowers_from_error_alias) {
 }
 TEST(frontend, analyze_rejects_match_wildcard_before_last) {
     const char* src =
-        "route GET \"/users\" { let code = 200 match code { case _: return 404 case 200: return 200 } }\n";
+        "route GET \"/users\" { let code = 200 match code { case _: return 404 case 200: return "
+        "200 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -6082,7 +6256,8 @@ TEST(frontend, analyze_rejects_match_wildcard_before_last) {
 }
 TEST(frontend, analyze_rejects_match_pattern_type_mismatch) {
     const char* src =
-        "route GET \"/users\" { let ok = true match ok { case 200: return 200 case _: return 404 } }\n";
+        "route GET \"/users\" { let ok = true match ok { case 200: return 200 case _: return 404 } "
+        "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -6103,8 +6278,7 @@ TEST(frontend, analyze_rejects_or_with_mismatched_types) {
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_or_with_fallible_fallback) {
-    const char* src =
-        "route GET \"/users\" { let code = or(nil, error(7)) return 200 }\n";
+    const char* src = "route GET \"/users\" { let code = or(nil, error(7)) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -6126,7 +6300,8 @@ TEST(frontend, analyze_rejects_guard_let_binding_error_value) {
 }
 TEST(frontend, analyze_rejects_guard_let_binding_error_alias) {
     const char* src =
-        "route GET \"/users\" { let failed = error(7) let alias = failed guard let code = alias else { return 401 } return 200 }\n";
+        "route GET \"/users\" { let failed = error(7) let alias = failed guard let code = alias "
+        "else { return 401 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -6474,9 +6649,11 @@ TEST(frontend, lower_to_rir_supports_runtime_optional_str_or_value) {
     CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[1].op), static_cast<u8>(rir::Opcode::OptWrap));
     CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[2].op), static_cast<u8>(rir::Opcode::ConstStr));
     CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[3].op), static_cast<u8>(rir::Opcode::OptIsNil));
-    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[4].op), static_cast<u8>(rir::Opcode::OptUnwrap));
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[4].op),
+             static_cast<u8>(rir::Opcode::OptUnwrap));
     CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[5].op), static_cast<u8>(rir::Opcode::Select));
-    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[6].op), static_cast<u8>(rir::Opcode::RetStatus));
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[6].op),
+             static_cast<u8>(rir::Opcode::RetStatus));
     rir.destroy();
 }
 TEST(frontend, lower_to_rir_supports_runtime_no_error_guard) {
@@ -7180,7 +7357,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, analyze_rejects_generic_function_call_with_custom_protocol_constraint_without_impls) {
+TEST(frontend,
+     analyze_rejects_generic_function_call_with_custom_protocol_constraint_without_impls) {
     const auto src = R"rut(
 protocol Hashable {}
 func hash<T: Hashable>(x: T) -> i32 => 200
@@ -7363,7 +7541,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_custom_protocol_method_dispatch_with_generic_impl_target_is_supported) {
+TEST(
+    frontend,
+    source_generic_receiver_custom_protocol_method_dispatch_with_generic_impl_target_is_supported) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 }
 struct Box<T> { value: T }
@@ -7382,7 +7562,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_custom_protocol_method_dispatch_with_generic_impl_target_tuple_of_struct_arg_is_supported) {
+TEST(
+    frontend,
+    source_generic_receiver_custom_protocol_method_dispatch_with_generic_impl_target_tuple_of_struct_arg_is_supported) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 }
 struct Item { value: i32 }
@@ -7562,7 +7744,8 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_impl_method_with_mismatched_imported_namespace_same_name_parameter_type) {
+TEST(frontend,
+     analyze_rejects_impl_method_with_mismatched_imported_namespace_same_name_parameter_type) {
     const std::string dir = "/tmp/rut_import_namespace_protocol_requirement_mismatch_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -7587,8 +7770,10 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_impl_method_with_mismatched_imported_namespace_same_name_return_type) {
-    const std::string dir = "/tmp/rut_import_namespace_protocol_requirement_return_mismatch_frontend";
+TEST(frontend,
+     analyze_rejects_impl_method_with_mismatched_imported_namespace_same_name_return_type) {
+    const std::string dir =
+        "/tmp/rut_import_namespace_protocol_requirement_return_mismatch_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -7612,7 +7797,8 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_impl_method_with_mismatched_concrete_generic_requirement_parameter_type) {
+TEST(frontend,
+     analyze_rejects_impl_method_with_mismatched_concrete_generic_requirement_parameter_type) {
     const auto src = R"rut(
 protocol Consumer { func take(x: Box<i32>) -> i32 }
 struct Box<T> { value: T }
@@ -7630,8 +7816,10 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_impl_method_with_mismatched_imported_namespace_concrete_generic_return_type) {
-    const std::string dir = "/tmp/rut_import_namespace_protocol_requirement_generic_return_mismatch_frontend";
+TEST(frontend,
+     analyze_rejects_impl_method_with_mismatched_imported_namespace_concrete_generic_return_type) {
+    const std::string dir =
+        "/tmp/rut_import_namespace_protocol_requirement_generic_return_mismatch_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -7654,8 +7842,11 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_impl_method_with_mismatched_imported_namespace_concrete_generic_parameter_type) {
-    const std::string dir = "/tmp/rut_import_namespace_protocol_requirement_generic_param_mismatch_frontend";
+TEST(
+    frontend,
+    analyze_rejects_impl_method_with_mismatched_imported_namespace_concrete_generic_parameter_type) {
+    const std::string dir =
+        "/tmp/rut_import_namespace_protocol_requirement_generic_param_mismatch_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -7756,7 +7947,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_concrete_custom_protocol_default_method_dispatch_with_parameter_is_supported) {
+TEST(frontend,
+     source_concrete_custom_protocol_default_method_dispatch_with_parameter_is_supported) {
     const auto src = R"rut(
 protocol Adder { func add(x: i32) -> i32 => x }
 struct Box { value: i32 }
@@ -7772,7 +7964,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_custom_protocol_default_method_dispatch_with_parameter_is_supported) {
+TEST(frontend,
+     source_generic_receiver_custom_protocol_default_method_dispatch_with_parameter_is_supported) {
     const auto src = R"rut(
 protocol Adder { func add(x: i32) -> i32 => x }
 struct Box { value: i32 }
@@ -7807,7 +8000,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_custom_protocol_default_method_tuple_return_supports_ordering) {
+TEST(frontend,
+     source_generic_receiver_custom_protocol_default_method_tuple_return_supports_ordering) {
     const auto src = R"rut(
 protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
 struct Box { value: i32 }
@@ -7824,7 +8018,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_custom_protocol_default_method_tuple_return_supports_equality) {
+TEST(frontend,
+     source_generic_receiver_custom_protocol_default_method_tuple_return_supports_equality) {
     const auto src = R"rut(
 protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
 struct Box { value: i32 }
@@ -7858,7 +8053,8 @@ route GET "/users" {
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_generic_receiver_custom_protocol_default_method_dispatch_without_conformance) {
+TEST(frontend,
+     analyze_rejects_generic_receiver_custom_protocol_default_method_dispatch_without_conformance) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
 struct Box { value: i32 }
@@ -7875,7 +8071,8 @@ route GET "/users" {
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_concrete_custom_protocol_default_method_dispatch_without_conformance) {
+TEST(frontend,
+     analyze_rejects_concrete_custom_protocol_default_method_dispatch_without_conformance) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
 struct Box { value: i32 }
@@ -8040,7 +8237,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_custom_protocol_default_method_supports_block_body_with_parameter) {
+TEST(frontend,
+     source_generic_receiver_custom_protocol_default_method_supports_block_body_with_parameter) {
     const auto src = R"rut(
 protocol Adder {
     func add(x: i32) -> i32 {
@@ -8411,8 +8609,10 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_impl_overrides_protocol_default_method_with_block_body_and_parameter) {
-    const std::string dir = "/tmp/rut_import_impl_overrides_block_body_parameter_default_method_frontend";
+TEST(frontend,
+     import_relative_file_impl_overrides_protocol_default_method_with_block_body_and_parameter) {
+    const std::string dir =
+        "/tmp/rut_import_impl_overrides_block_body_parameter_default_method_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8438,8 +8638,10 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_impl_overrides_protocol_default_method_with_if_body_and_parameter) {
-    const std::string dir = "/tmp/rut_import_impl_overrides_if_body_parameter_default_method_frontend";
+TEST(frontend,
+     import_relative_file_impl_overrides_protocol_default_method_with_if_body_and_parameter) {
+    const std::string dir =
+        "/tmp/rut_import_impl_overrides_if_body_parameter_default_method_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8503,7 +8705,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
+TEST(frontend,
+     source_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
     const auto src = R"rut(
 protocol MaybeCode { func code() -> i32 => nil }
 struct Box<T> { value: T }
@@ -8520,7 +8723,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
+TEST(frontend,
+     source_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
     const auto src = R"rut(
 protocol MaybeCode { func code() -> i32 => error(.timeout) }
 struct Box<T> { value: T }
@@ -8537,7 +8741,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
+TEST(frontend,
+     source_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
     const auto src = R"rut(
 protocol MaybeCode {
     func code() -> i32 {
@@ -8559,7 +8764,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body) {
+TEST(frontend,
+     source_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body) {
     const auto src = R"rut(
 protocol MaybeCode {
     func code(ok: bool) -> i32 {
@@ -8580,7 +8786,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
+TEST(
+    frontend,
+    source_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
     const auto src = R"rut(
 protocol Adder {
     func add(x: i32) -> i32 {
@@ -8602,7 +8810,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
+TEST(
+    frontend,
+    source_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
     const auto src = R"rut(
 protocol Adder {
     func add(ok: bool) -> i32 {
@@ -8623,8 +8833,11 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_optional_default_method_frontend";
+TEST(
+    frontend,
+    import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
+    const std::string dir =
+        "/tmp/rut_import_generic_impl_overrides_generic_receiver_optional_default_method_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8646,8 +8859,11 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_error_default_method_frontend";
+TEST(
+    frontend,
+    import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
+    const std::string dir =
+        "/tmp/rut_import_generic_impl_overrides_generic_receiver_error_default_method_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8669,8 +8885,12 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_block_body_default_method_frontend";
+TEST(
+    frontend,
+    import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
+    const std::string dir =
+        "/tmp/"
+        "rut_import_generic_impl_overrides_generic_receiver_block_body_default_method_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8697,8 +8917,11 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_if_body_default_method_frontend";
+TEST(
+    frontend,
+    import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body) {
+    const std::string dir =
+        "/tmp/rut_import_generic_impl_overrides_generic_receiver_if_body_default_method_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8724,8 +8947,13 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_block_body_parameter_default_method_frontend";
+TEST(
+    frontend,
+    import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
+    const std::string dir =
+        "/tmp/"
+        "rut_import_generic_impl_overrides_generic_receiver_block_body_parameter_default_method_"
+        "frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8752,8 +8980,13 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_if_body_parameter_default_method_frontend";
+TEST(
+    frontend,
+    import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
+    const std::string dir =
+        "/tmp/"
+        "rut_import_generic_impl_overrides_generic_receiver_if_body_parameter_default_method_"
+        "frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8779,8 +9012,10 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_default_method_frontend";
+TEST(frontend,
+     import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method) {
+    const std::string dir =
+        "/tmp/rut_import_generic_impl_overrides_generic_receiver_default_method_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8824,7 +9059,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_multi_protocol_empty_impl_block_default_method_dispatch_is_supported) {
+TEST(frontend,
+     source_generic_receiver_multi_protocol_empty_impl_block_default_method_dispatch_is_supported) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
 protocol Adder { func add(x: i32) -> i32 => x }
@@ -8951,7 +9187,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_multi_protocol_empty_impl_block_default_method_tuple_return_supports_ordering) {
+TEST(frontend,
+     source_multi_protocol_empty_impl_block_default_method_tuple_return_supports_ordering) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
 protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
@@ -8973,7 +9210,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_block_body) {
+TEST(frontend,
+     source_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_block_body) {
     const auto src = R"rut(
 protocol Hashable {
     func hash() -> i32 {
@@ -9004,7 +9242,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_tuple_return) {
+TEST(frontend,
+     source_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_tuple_return) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
 protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
@@ -9025,7 +9264,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_multi_protocol_empty_impl_block_default_method_tuple_return_supports_ordering) {
+TEST(
+    frontend,
+    source_generic_receiver_multi_protocol_empty_impl_block_default_method_tuple_return_supports_ordering) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
 protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
@@ -9046,7 +9287,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, source_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_if_body) {
+TEST(frontend,
+     source_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_if_body) {
     const auto src = R"rut(
 protocol Hashable {
     func hash(ok: bool) -> i32 {
@@ -9075,7 +9317,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_multi_protocol_default_method_dispatch) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_multi_protocol_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_multi_protocol_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9103,8 +9347,11 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
-    const std::string dir = "/tmp/rut_import_tuple_default_impl_generic_multi_protocol_block_frontend";
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
+    const std::string dir =
+        "/tmp/rut_import_tuple_default_impl_generic_multi_protocol_block_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9130,8 +9377,11 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
-    const std::string dir = "/tmp/rut_import_tuple_ordering_default_impl_generic_multi_protocol_block_frontend";
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
+    const std::string dir =
+        "/tmp/rut_import_tuple_ordering_default_impl_generic_multi_protocol_block_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9157,8 +9407,11 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
-    const std::string dir = "/tmp/rut_import_if_body_default_impl_generic_multi_protocol_block_frontend";
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
+    const std::string dir =
+        "/tmp/rut_import_if_body_default_impl_generic_multi_protocol_block_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9192,7 +9445,9 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_tuple_default_impl_multi_protocol_block_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9220,8 +9475,11 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
-    const std::string dir = "/tmp/rut_import_tuple_ordering_default_impl_multi_protocol_block_frontend";
+TEST(
+    frontend,
+    import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
+    const std::string dir =
+        "/tmp/rut_import_tuple_ordering_default_impl_multi_protocol_block_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9248,8 +9506,11 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
-    const std::string dir = "/tmp/rut_import_block_body_default_impl_generic_multi_protocol_block_frontend";
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
+    const std::string dir =
+        "/tmp/rut_import_block_body_default_impl_generic_multi_protocol_block_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9285,7 +9546,9 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_if_body_default_impl_multi_protocol_block_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9321,7 +9584,9 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_block_body_default_impl_multi_protocol_block_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9359,7 +9624,9 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_default_method_dispatch) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_default_impl_multi_protocol_block_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9387,7 +9654,9 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_multi_protocol_empty_impl_block_for_default_method_dispatch) {
+TEST(
+    frontend,
+    import_relative_file_merges_imported_generic_multi_protocol_empty_impl_block_for_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_multi_protocol_block_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9414,7 +9683,9 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, analyze_rejects_generic_receiver_multi_protocol_empty_impl_block_when_required_method_is_missing) {
+TEST(
+    frontend,
+    analyze_rejects_generic_receiver_multi_protocol_empty_impl_block_when_required_method_is_missing) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 }
 protocol Adder { func add(x: i32) -> i32 => x }
@@ -9434,8 +9705,11 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_imported_generic_multi_protocol_empty_impl_block_when_required_method_is_missing) {
-    const std::string dir = "/tmp/rut_import_generic_default_impl_multi_protocol_block_missing_frontend";
+TEST(
+    frontend,
+    analyze_rejects_imported_generic_multi_protocol_empty_impl_block_when_required_method_is_missing) {
+    const std::string dir =
+        "/tmp/rut_import_generic_default_impl_multi_protocol_block_missing_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9460,7 +9734,9 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_imported_generic_multi_protocol_empty_impl_block_with_conflicting_default_method_names) {
+TEST(
+    frontend,
+    analyze_rejects_imported_generic_multi_protocol_empty_impl_block_with_conflicting_default_method_names) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_multi_protocol_conflict_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9482,7 +9758,8 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_imported_generic_multi_protocol_impl_block_with_ambiguous_method_name) {
+TEST(frontend,
+     analyze_rejects_imported_generic_multi_protocol_impl_block_with_ambiguous_method_name) {
     const std::string dir = "/tmp/rut_import_generic_impl_multi_protocol_ambiguous_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9506,7 +9783,8 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_imported_generic_multi_protocol_impl_block_with_duplicate_protocol_name) {
+TEST(frontend,
+     analyze_rejects_imported_generic_multi_protocol_impl_block_with_duplicate_protocol_name) {
     const std::string dir = "/tmp/rut_import_generic_impl_multi_protocol_duplicate_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9529,7 +9807,8 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_imported_generic_multi_protocol_impl_block_with_unknown_protocol_name) {
+TEST(frontend,
+     analyze_rejects_imported_generic_multi_protocol_impl_block_with_unknown_protocol_name) {
     const std::string dir = "/tmp/rut_import_generic_impl_multi_protocol_unknown_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9602,7 +9881,9 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_generic_receiver_method_dispatch_when_multiple_protocol_constraints_define_same_name) {
+TEST(
+    frontend,
+    analyze_rejects_generic_receiver_method_dispatch_when_multiple_protocol_constraints_define_same_name) {
     const auto src = R"rut(
 protocol A { func hash() -> i32 => 1 }
 protocol B { func hash() -> i32 => 2 }
@@ -9622,7 +9903,9 @@ route GET "/users" {
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_selective_import_protocol_alias_generic_receiver_dispatch_with_local_same_name_protocol) {
+TEST(
+    frontend,
+    analyze_rejects_selective_import_protocol_alias_generic_receiver_dispatch_with_local_same_name_protocol) {
     const std::string dir = "/tmp/rut_selective_import_alias_protocol_dispatch_same_name_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -9647,7 +9930,9 @@ route GET "/users" {
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_concrete_receiver_method_dispatch_when_multiple_protocol_impls_define_same_name) {
+TEST(
+    frontend,
+    analyze_rejects_concrete_receiver_method_dispatch_when_multiple_protocol_impls_define_same_name) {
     const auto src = R"rut(
 protocol A { func hash() -> i32 => 1 }
 protocol B { func hash() -> i32 => 2 }
@@ -10004,7 +10289,8 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_multi_protocol_impl_with_default_bodies) {
+TEST(frontend,
+     import_relative_file_merges_imported_generic_multi_protocol_impl_with_default_bodies) {
     const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_default_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -10037,8 +10323,10 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_multi_protocol_impl_with_block_body_default) {
-    const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_block_body_default_frontend";
+TEST(frontend,
+     import_relative_file_merges_imported_generic_multi_protocol_impl_with_block_body_default) {
+    const std::string dir =
+        "/tmp/rut_import_generic_multi_protocol_impl_block_body_default_frontend";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -10073,7 +10361,8 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, import_relative_file_merges_imported_generic_multi_protocol_impl_with_if_body_default) {
+TEST(frontend,
+     import_relative_file_merges_imported_generic_multi_protocol_impl_with_if_body_default) {
     const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_if_body_default_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -10108,7 +10397,8 @@ route GET "/users" {
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
 }
-TEST(frontend, analyze_rejects_imported_multi_protocol_impl_missing_required_method_without_default_body) {
+TEST(frontend,
+     analyze_rejects_imported_multi_protocol_impl_missing_required_method_without_default_body) {
     const std::string dir = "/tmp/rut_import_multi_protocol_impl_missing_required_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -10137,7 +10427,9 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_imported_generic_multi_protocol_impl_missing_required_method_without_default_body) {
+TEST(
+    frontend,
+    analyze_rejects_imported_generic_multi_protocol_impl_missing_required_method_without_default_body) {
     const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_missing_required_frontend";
     std::filesystem::create_directories(dir);
     {
@@ -10188,7 +10480,8 @@ route GET "/users" { return 200 }
     REQUIRE_FALSE(hir);
     CHECK(hir.error().code == FrontendError::UnsupportedSyntax);
 }
-TEST(frontend, analyze_rejects_generic_multi_protocol_impl_missing_required_method_without_default_body) {
+TEST(frontend,
+     analyze_rejects_generic_multi_protocol_impl_missing_required_method_without_default_body) {
     const auto src = R"rut(
 protocol Hashable {
     func hash() -> i32

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -286,6 +286,15 @@ route GET "/users" { if jwtAuth() == 200 { return 200 } else { return 500 } }
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    if (!hir) {
+        std::fprintf(stderr,
+                     "hir error code=%d detail=%.*s span=(%u,%u)\n",
+                     static_cast<int>(hir.error().code),
+                     static_cast<int>(hir.error().detail.len),
+                     hir.error().detail.ptr,
+                     hir.error().span.line,
+                     hir.error().span.col);
+    }
     REQUIRE(hir);
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
@@ -336,6 +345,13 @@ route GET "/users" { let state = AuthState.ok match state { case .ok: return 200
     REQUIRE(mir);
     FrontendRirModule rir{};
     auto lowered = lower_to_rir(mir.value(), rir);
+    if (!lowered) {
+        std::fprintf(stderr,
+                     "lower err code=%d line=%u col=%u\n",
+                     static_cast<int>(lowered.error().code),
+                     lowered.error().span.line,
+                     lowered.error().span.col);
+    }
     REQUIRE(lowered);
     auto cg = codegen(rir.module);
     REQUIRE(cg.ok);
@@ -392,6 +408,184 @@ route GET "/users" { if run(Box(value: 1)) == 1 { return 200 } else { return 500
     rir.destroy();
 }
 
+TEST(jit, frontend_import_relative_file_merges_imported_generic_impl_symbol) {
+    const std::string dir = "/tmp/rut_import_generic_impl_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 200\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 123)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_concrete_generic_impl_symbol) {
+    const std::string dir = "/tmp/rut_import_concrete_generic_impl_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<i32> impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_allows_distinct_local_concrete_generic_impl) {
+    const std::string dir = "/tmp/rut_import_concrete_generic_impl_distinct_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<i32> impl Hashable {\n";
+        out << "    func hash(self: Box<i32>) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+Box<str> impl Hashable {
+    func hash(self: Box<str>) -> i32 => 200
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: "ok")) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_dispatches_distinct_concrete_generic_impls) {
+    const std::string dir = "/tmp/rut_import_concrete_generic_impl_dual_dispatch_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<i32> impl Hashable {\n";
+        out << "    func hash(self: Box<i32>) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+Box<str> impl Hashable {
+    func hash(self: Box<str>) -> i32 => 200
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 7)) == 7 {
+        if run(Box(value: "ok")) == 200 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_import_relative_file_merges_imported_empty_impl_for_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_default_impl_jit";
     std::filesystem::create_directories(dir);
@@ -405,6 +599,614 @@ TEST(jit, frontend_import_relative_file_merges_imported_empty_impl_for_default_m
 import "proto.rut"
 func run<T: Hashable>(x: T) -> i32 => x.hash()
 route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch_with_parameter) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_param_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder { func add(x: i32) -> i32 => x }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_optional_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_optional_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => nil }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_error_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_error_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => error(.timeout) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_tuple_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_tuple_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func second(a: i32, b: i32) -> i32 => b
+func run<T: Pairable>(x: T) -> i32 => x.pair() | second(_2, _1)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func second(a: i32, b: i32) -> i32 => b
+func run<T: Pairable>(x: T) -> i32 => x.pair() | second(_2, _1)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_equality) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_eq_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Pairable>(x: T) -> (i32, i32) => x.pair()
+route GET "/users" { if run(Box(value: 1)) == (200, 500) { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_ordering) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_ord_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Pairable>(x: T) -> (i32, i32) => x.pair()
+route GET "/users" { if run(Box(value: 1)) < (200, 600) { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code()
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code()
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch_with_parameter) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_block_param_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch_with_parameter) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_block_param_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_if_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_if_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code(ok: bool) -> i32 { if ok { 200 } else { 500 } } }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code(true)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_if_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_if_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code(ok: bool) -> i32 { if ok { 200 } else { 500 } } }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code(true)
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_error_default_method_guard_match) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_error_guard_match_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code(ok: bool) -> i32 { if ok { 200 } else { error(.timeout) } } }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 {
+    let failed = x.code(false)
+    guard match failed else { case .timeout => 401 case _ => 500 }
+    200
+}
+route GET "/users" { if run(Box(value: 1)) == 401 { return 200 } else { return 500 } }
 )rut";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -1577,6 +2379,50 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_route_match_nested_struct_payload_projection) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+struct Outer { inner: Box }
+variant Result { ok(Outer), err }
+route GET "/users" {
+    let state = Result.ok(Outer(inner: Box(value: 200)))
+    match state {
+    case .ok(v): {
+        let code = v.inner.value
+        if code == 200 { return 200 } else { return 500 }
+    }
+    case .err: return 404
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_generic_variant_tuple_of_struct_payload_binding) {
     const auto src = R"rut(
 struct Item { value: i32 }
@@ -2127,6 +2973,282 @@ TEST(jit, frontend_concrete_generic_type_refs_are_supported_in_struct_fields) {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_struct_field_projection_equality) {
+    const char* src =
+        "variant Result<T> { ok(T), err }\n"
+        "struct Holder { state: Result<i32> }\n"
+        "route GET \"/users\" { let holder = Holder(state: Result.ok(200)) if holder.state == Result.ok(200) { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_struct_field_projection_ordering) {
+    const char* src =
+        "variant Result<T> { ok(T), err }\n"
+        "struct Holder { state: Result<i32> }\n"
+        "route GET \"/users\" { let holder = Holder(state: Result.ok(200)) if holder.state < Result.ok(500) { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_namespace_variant_struct_field_projection_equality) {
+    const std::string dir = "/tmp/rut_import_namespace_variant_field_eq_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result { ok(i32), err }\n";
+        out << "struct Holder { state: Result }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let holder = proto.Holder(state: proto.Result.ok(200))
+    if holder.state == proto.Result.ok(200) { return 200 } else { return 500 }
+}
+)rut";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_namespace_variant_struct_field_projection_ordering) {
+    const std::string dir = "/tmp/rut_import_namespace_variant_field_ord_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result { ok(i32), err }\n";
+        out << "struct Holder { state: Result }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let holder = proto.Holder(state: proto.Result.ok(200))
+    if holder.state < proto.Result.ok(500) { return 200 } else { return 500 }
+}
+)rut";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_tuple_of_struct_field_projection_ordering) {
+    const char* src =
+        "struct Item { value: i32 }\n"
+        "struct Holder { pair: (Item, i32) }\n"
+        "route GET \"/users\" { let holder = Holder(pair: (Item(value: 200), 500)) if holder.pair < (Item(value: 200), 600) { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_namespace_tuple_of_struct_field_projection_ordering) {
+    const std::string dir = "/tmp/rut_import_namespace_tuple_struct_field_ord_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Item { value: i32 }\n";
+        out << "struct Holder { pair: (Item, i32) }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let holder = proto.Holder(pair: (proto.Item(value: 200), 500))
+    if holder.pair < (proto.Item(value: 200), 600) { return 200 } else { return 500 }
+}
+)rut";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
     auto r = HandlerResult::unpack(handler(nullptr,
                                            nullptr,
                                            reinterpret_cast<const u8*>(kGetApiRequest),
@@ -4024,6 +5146,47 @@ TEST(jit, frontend_custom_error_struct_tuple_field_projection_pipe) {
     rir.destroy();
 }
 
+TEST(jit, frontend_custom_error_nested_struct_field_projection) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "struct AuthError { err: Error, inner: Box }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", inner: Box(value: 200)) let code = failed.inner.value if code == 200 { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_plain_struct_constructor_and_field_projection) {
     constexpr auto src =
         "struct Foo { code: i32, msg: str }\n"
@@ -4068,6 +5231,47 @@ TEST(jit, frontend_plain_struct_tuple_field_projection_pipe) {
         "struct Foo { pair: (i32, i32) }\n"
         "func second(a: i32, b: i32) -> i32 => b\n"
         "route GET \"/users\" { let foo = Foo(pair: (200, 500)) let code = foo.pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_nested_struct_field_projection) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "struct Outer { inner: Box }\n"
+        "route GET \"/users\" { let outer = Outer(inner: Box(value: 200)) let code = outer.inner.value if code == 200 { return 200 } else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -4541,6 +5745,88 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_generic_match_payload_binding_preserves_protocol_constraint) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+i32 impl Hashable { func hash(self: i32) -> i32 => self }
+variant Wrap<T> { some(T) }
+func run<T: Hashable>(state: Wrap<T>) -> i32 {
+    match state {
+    case .some(v) => v.hash()
+    }
+}
+route GET "/users" {
+    let code = run(Wrap<i32>.some(200))
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_struct_field_projection_preserves_protocol_constraint) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+i32 impl Hashable { func hash(self: i32) -> i32 => self }
+struct Holder<T> { state: T }
+func run<T: Hashable>(x: Holder<T>) -> i32 => x.state.hash()
+route GET "/users" {
+    let code = run(Holder<i32>(state: 200))
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_concrete_nested_generic_struct_type_refs_are_supported_in_function_signatures) {
     const auto src = R"rut(
 variant Result<T> { ok(T), err }
@@ -4559,6 +5845,229 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_imported_function_body_struct_init_projection) {
+    const std::string dir = "/tmp/rut_import_function_body_struct_init_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "func make() -> Box => Box(value: 200)\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let box = make()
+    if box.value == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_imported_function_body_variant_case_projection) {
+    const std::string dir = "/tmp/rut_import_function_body_variant_case_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result { ok(i32), err }\n";
+        out << "struct Holder { state: Result }\n";
+        out << "func make() -> Result => Result.ok(200)\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let holder = proto.Holder(state: make())
+    if holder.state == proto.Result.ok(200) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_imported_function_body_ifelse_struct_projection) {
+    const std::string dir = "/tmp/rut_import_function_body_ifelse_struct_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+        out << "func make(ok: bool) -> Box {\n";
+        out << "    if ok { Box(value: 200) } else { Box(value: 500) }\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let box = make(true)
+    if box.value == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_imported_function_body_or) {
+    const std::string dir = "/tmp/rut_import_function_body_or_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "func maybe(ok: bool) { if ok { 200 } else { nil } }\n";
+        out << "func pick(ok: bool) -> i32 => or(maybe(ok), 500)\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let code = pick(true)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_imported_function_body_match) {
+    const std::string dir = "/tmp/rut_import_function_body_match_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result { ok, err }\n";
+        out << "func pick(x: Result) -> i32 {\n";
+        out << "    match x {\n";
+        out << "        case .ok => 200\n";
+        out << "        case .err => 500\n";
+        out << "    }\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let code = pick(proto.Result.ok)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
@@ -5099,6 +6608,47 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_struct_field_projection_method_dispatch) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable { func hash(self: Box) -> i32 => self.value }
+struct Holder { state: Box }
+route GET "/users" {
+    let holder = Holder(state: Box(value: 200))
+    let code = holder.state.hash()
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_concrete_custom_protocol_default_method_dispatch) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
@@ -5236,6 +6786,109 @@ route GET "/users" {
     engine.shutdown();
     rir.destroy();
 }
+TEST(jit, frontend_generic_receiver_custom_protocol_default_method_supports_tuple_return) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+func second(a: i32, b: i32) -> i32 => b
+func run<T: Pairable>(x: T) -> i32 => x.pair() | second(_2, _1)
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_receiver_custom_protocol_default_method_tuple_return_supports_ordering) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+func run<T: Pairable>(x: T) -> (i32, i32) => x.pair()
+route GET "/users" {
+    if run(Box(value: 7)) < (200, 600) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_receiver_custom_protocol_default_method_tuple_return_supports_equality) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+func run<T: Pairable>(x: T) -> (i32, i32) => x.pair()
+route GET "/users" {
+    if run(Box(value: 7)) == (200, 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
 
 TEST(jit, frontend_generic_multi_protocol_impl_may_omit_methods_with_default_bodies) {
     const auto src = R"rut(
@@ -5262,6 +6915,436 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_multi_protocol_impl_may_omit_methods_with_block_body_default) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl Hashable, Adder {
+    func hash(self: Box<T>) -> i32 => 7
+}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_multi_protocol_impl_may_omit_methods_with_if_body_default) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl Hashable, Adder {
+    func hash(self: Box<T>) -> i32 => 7
+}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(true) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_multi_protocol_impl_with_default_bodies) {
+    const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_default_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 => x\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_multi_protocol_impl_with_block_body_default) {
+    const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_block_body_default_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_multi_protocol_impl_with_if_body_default) {
+    const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_if_body_default_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {\n";
+        out << "    func hash(self: Box<T>) -> i32 => 7\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(true) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_multi_protocol_impl_may_omit_methods_with_block_body_default) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_multi_protocol_impl_may_omit_methods_with_if_body_default) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 7).add(true) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_impl_with_block_body_default) {
+    const std::string dir = "/tmp/rut_import_multi_protocol_impl_block_body_default_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_impl_with_if_body_default) {
+    const std::string dir = "/tmp/rut_import_multi_protocol_impl_if_body_default_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(true) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
@@ -5323,6 +7406,53 @@ route GET "/users" {
     engine.shutdown();
     rir.destroy();
 }
+TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_impl_with_default_bodies) {
+    const std::string dir = "/tmp/rut_import_multi_protocol_impl_default_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "    func add(x: i32) -> i32 => x\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func mul(x: i32) -> i32 => x\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
 
 TEST(jit, frontend_custom_protocol_default_method_supports_tuple_return) {
     const auto src = R"rut(
@@ -5333,6 +7463,74 @@ func second(a: i32, b: i32) -> i32 => b
 route GET "/users" {
     let code = Box(value: 7).pair() | second(_2, _1)
     if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_protocol_default_method_tuple_return_supports_ordering) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+route GET "/users" {
+    if Box(value: 7).pair() < (200, 600) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_protocol_default_method_tuple_return_supports_equality) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+route GET "/users" {
+    if Box(value: 7).pair() == (200, 500) { return 200 } else { return 500 }
 }
 )rut";
     auto lexed = lex(lit(src));
@@ -5394,7 +7592,6 @@ route GET "/users" {
     engine.shutdown();
     rir.destroy();
 }
-
 TEST(jit, frontend_custom_protocol_default_method_supports_error_return) {
     const auto src = R"rut(
 protocol MaybeCode { func code() -> i32 => error(.timeout) }
@@ -5429,7 +7626,6 @@ route GET "/users" {
     engine.shutdown();
     rir.destroy();
 }
-
 TEST(jit, frontend_custom_protocol_default_method_supports_block_body) {
     const auto src = R"rut(
 protocol MaybeCode {
@@ -5442,6 +7638,201 @@ struct Box { value: i32 }
 Box impl MaybeCode {}
 route GET "/users" {
     if Box(value: 7).code() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_receiver_custom_protocol_default_method_supports_block_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code() -> i32 {
+        let x = 200
+        x
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+func run<T: MaybeCode>(x: T) -> i32 => x.code()
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_protocol_default_method_supports_block_body_with_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Adder {}
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_receiver_custom_protocol_default_method_supports_block_body_with_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Adder {}
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" {
+    if run(Box(value: 7)) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_protocol_default_method_supports_if_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+route GET "/users" {
+    if Box(value: 7).code(true) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_receiver_custom_protocol_default_method_supports_if_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+func run<T: MaybeCode>(x: T) -> i32 => x.code(true)
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
 }
 )rut";
     auto lexed = lex(lit(src));
@@ -5585,6 +7976,566 @@ route GET "/users" {
     engine.shutdown();
     rir.destroy();
 }
+TEST(jit, frontend_import_relative_file_impl_overrides_protocol_default_method_with_optional_return) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_optional_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => nil }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl MaybeCode { func code(self: Box) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_impl_overrides_protocol_default_method_with_error_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => error(.timeout) }
+struct Box { value: i32 }
+Box impl MaybeCode { func code(self: Box) -> i32 => self.value }
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_impl_overrides_protocol_default_method_with_block_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code() -> i32 {
+        let x = 200
+        x
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode { func code(self: Box) -> i32 => self.value }
+route GET "/users" {
+    if Box(value: 7).code() == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_impl_overrides_protocol_default_method_with_if_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode { func code(self: Box, ok: bool) -> i32 => self.value }
+route GET "/users" {
+    if Box(value: 7).code(true) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_impl_overrides_protocol_default_method_with_block_body_and_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Adder { func add(self: Box, x: i32) -> i32 => self.value }
+route GET "/users" {
+    if Box(value: 7).add(201) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_impl_overrides_protocol_default_method_with_if_body_and_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box { value: i32 }
+Box impl Adder { func add(self: Box, ok: bool) -> i32 => self.value }
+route GET "/users" {
+    if Box(value: 7).add(true) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_impl_overrides_protocol_default_method_with_error_return) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_error_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => error(.timeout) }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl MaybeCode { func code(self: Box) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_impl_overrides_protocol_default_method_with_block_body) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_block_body_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl MaybeCode { func code(self: Box) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).code() == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_impl_overrides_protocol_default_method_with_if_body) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_if_body_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code(ok: bool) -> i32 {\n";
+        out << "        if ok { 200 } else { 500 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl MaybeCode { func code(self: Box, ok: bool) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).code(true) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_impl_overrides_protocol_default_method_with_block_body_and_parameter) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_block_body_parameter_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Adder { func add(self: Box, x: i32) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(201) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_impl_overrides_protocol_default_method_with_if_body_and_parameter) {
+    const std::string dir = "/tmp/rut_import_impl_overrides_if_body_parameter_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Adder { func add(self: Box, ok: bool) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(true) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_impl_takes_precedence_over_protocol_default_method) {
+    const std::string dir = "/tmp/rut_import_impl_precedence_over_default_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable { func hash(self: Box) -> i32 => self.value }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).hash() == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_impl_may_omit_protocol_method_with_default_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+    func add(x: i32) -> i32 => x
+}
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_impl_may_omit_protocol_method_with_default_body) {
+    const std::string dir = "/tmp/rut_import_impl_omit_default_body_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32\n";
+        out << "    func add(x: i32) -> i32 => x\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
 
 TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method) {
     const auto src = R"rut(
@@ -5601,6 +8552,526 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => nil }
+struct Box<T> { value: T }
+Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => error(.timeout) }
+struct Box<T> { value: T }
+Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code() -> i32 {
+        let x = 200
+        x
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }
+func run<T: MaybeCode>(x: T) -> i32 => x.code()
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl MaybeCode { func code(self: Box<T>, ok: bool) -> i32 => 7 }
+func run<T: MaybeCode>(x: T) -> i32 => x.code(true)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl Adder { func add(self: Box<T>, x: i32) -> i32 => 7 }
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
+    const auto src = R"rut(
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box<T> { value: T }
+Box<T> impl Adder { func add(self: Box<T>, ok: bool) -> i32 => 7 }
+func run<T: Adder>(x: T) -> i32 => x.add(true)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_optional_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => nil }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_error_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode { func code() -> i32 => error(.timeout) }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_block_body_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code()
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_if_body_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol MaybeCode {\n";
+        out << "    func code(ok: bool) -> i32 {\n";
+        out << "        if ok { 200 } else { 500 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl MaybeCode { func code(self: Box<T>, ok: bool) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: MaybeCode>(x: T) -> i32 => x.code(true)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_block_body_parameter_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Adder { func add(self: Box<T>, x: i32) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_if_body_parameter_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Adder { func add(self: Box<T>, ok: bool) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Adder>(x: T) -> i32 => x.add(true)
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method) {
+    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_default_method_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable { func hash(self: Box<T>) -> i32 => 7 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
@@ -5641,6 +9112,953 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_multi_protocol_empty_impl_block_default_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).add(3) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_multi_protocol_empty_impl_block_default_method_supports_block_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32 {
+        let x = 200
+        x
+    }
+}
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).add(3) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_block_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32 {
+        let x = 200
+        x
+    }
+}
+protocol Adder {
+    func add(x: i32) -> i32 {
+        let y = x
+        y
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_multi_protocol_empty_impl_block_default_method_supports_if_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+route GET "/users" {
+    let h = Box(value: 7).hash(true)
+    if h == 200 {
+        if Box(value: 7).add(true) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_multi_protocol_empty_impl_block_default_method_supports_tuple_return) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Hashable, Pairable {}
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).pair() == (200, 500) { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_multi_protocol_empty_impl_block_default_method_tuple_return_supports_ordering) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Hashable, Pairable {}
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).pair() < (200, 600) { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_if_body) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash(ok: bool) -> i32 {
+        if ok { 200 } else { 500 }
+    }
+}
+protocol Adder {
+    func add(ok: bool) -> i32 {
+        if ok { 3 } else { 0 }
+    }
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash(true)
+    if h == 200 { x.add(true) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_tuple_return) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Hashable, Pairable {}
+func run<T: Hashable, Pairable>(x: T) -> (i32, i32) {
+    let h = x.hash()
+    if h == 200 { x.pair() } else { (0, 0) }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == (200, 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_tuple_return_supports_ordering) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Hashable, Pairable {}
+func run<T: Hashable, Pairable>(x: T) -> (i32, i32) {
+    let h = x.hash()
+    if h == 200 { x.pair() } else { (0, 0) }
+}
+route GET "/users" {
+    if run(Box(value: 7)) < (200, 600) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_multi_protocol_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_generic_multi_protocol_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Adder { func add(x: i32) -> i32 => x }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable {}\n";
+        out << "Box<T> impl Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_tuple_default_impl_generic_multi_protocol_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Pairable>(x: T) -> (i32, i32) {
+    let h = x.hash()
+    if h == 200 { x.pair() } else { (0, 0) }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == (200, 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
+    const std::string dir = "/tmp/rut_import_tuple_ordering_default_impl_generic_multi_protocol_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Pairable>(x: T) -> (i32, i32) {
+    let h = x.hash()
+    if h == 200 { x.pair() } else { (0, 0) }
+}
+route GET "/users" {
+    if run(Box(value: 7)) < (200, 600) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_if_body_default_impl_generic_multi_protocol_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash(ok: bool) -> i32 {\n";
+        out << "        if ok { 200 } else { 500 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash(true)
+    if h == 200 { x.add(true) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_tuple_default_impl_multi_protocol_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).pair() == (200, 500) { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
+    const std::string dir = "/tmp/rut_import_tuple_ordering_default_impl_multi_protocol_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Pairable { func pair() -> (i32, i32) => (200, 500) }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Pairable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).pair() < (200, 600) { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_if_body_default_impl_multi_protocol_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash(ok: bool) -> i32 {\n";
+        out << "        if ok { 200 } else { 500 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(ok: bool) -> i32 {\n";
+        out << "        if ok { 3 } else { 0 }\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let h = Box(value: 7).hash(true)
+    if h == 200 {
+        if Box(value: 7).add(true) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_block_body_default_impl_multi_protocol_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).add(3) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_block_body_default_impl_generic_multi_protocol_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable {\n";
+        out << "    func hash() -> i32 {\n";
+        out << "        let x = 200\n";
+        out << "        x\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "protocol Adder {\n";
+        out << "    func add(x: i32) -> i32 {\n";
+        out << "        let y = x\n";
+        out << "        y\n";
+        out << "    }\n";
+        out << "}\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_default_impl_multi_protocol_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Adder { func add(x: i32) -> i32 => x }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    let h = Box(value: 7).hash()
+    if h == 200 {
+        if Box(value: 7).add(3) == 3 { return 200 } else { return 500 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_relative_file_merges_imported_generic_multi_protocol_empty_impl_block_for_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_generic_default_impl_multi_protocol_block_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "protocol Adder { func add(x: i32) -> i32 => x }\n";
+        out << "struct Box<T> { value: T }\n";
+        out << "Box<T> impl Hashable, Adder {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -1,10 +1,10 @@
-#include "rut/compiler/rir.h"
-#include "rut/compiler/rir_builder.h"
 #include "rut/compiler/analyze.h"
 #include "rut/compiler/lexer.h"
 #include "rut/compiler/lower_rir.h"
 #include "rut/compiler/mir_build.h"
 #include "rut/compiler/parser.h"
+#include "rut/compiler/rir.h"
+#include "rut/compiler/rir_builder.h"
 #include "rut/jit/codegen.h"
 #include "rut/jit/handler_abi.h"
 #include "rut/jit/jit_engine.h"
@@ -52,7 +52,8 @@ static HeapFrontendResult<HirModule> analyze_file_heap(const AstFile& file) {
     return {hir.value()};
 }
 
-static HeapFrontendResult<HirModule> analyze_file_heap_with_path(const AstFile& file, const std::string& source_path) {
+static HeapFrontendResult<HirModule> analyze_file_heap_with_path(const AstFile& file,
+                                                                 const std::string& source_path) {
     Str path{source_path.c_str(), static_cast<u32>(source_path.size())};
     auto hir = analyze_file(file, path);
     if (!hir) return {core::make_unexpected(hir.error())};
@@ -185,7 +186,8 @@ TEST(jit, return_200) {
 
 TEST(jit, frontend_req_header_or_fallback) {
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"fallback\") return 200 }\n";
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"fallback\") "
+        "return 200 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -360,7 +362,11 @@ route GET "/users" { let state = AuthState.ok match state { case .ok: return 200
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -401,7 +407,11 @@ route GET "/users" { if run(Box(value: 1)) == 1 { return 200 } else { return 500
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -442,7 +452,11 @@ route GET "/users" { if run(Box(value: 123)) == 200 { return 200 } else { return
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -483,7 +497,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -529,7 +547,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -579,7 +601,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -618,14 +644,19 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch) {
+TEST(jit,
+     frontend_import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_jit";
     std::filesystem::create_directories(dir);
     {
@@ -657,14 +688,20 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch_with_parameter) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_default_method_dispatch_with_parameter) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_param_jit";
     std::filesystem::create_directories(dir);
     {
@@ -696,14 +733,20 @@ route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_optional_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_optional_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_optional_jit";
     std::filesystem::create_directories(dir);
     {
@@ -735,14 +778,20 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_error_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_error_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_error_jit";
     std::filesystem::create_directories(dir);
     {
@@ -774,13 +823,19 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_tuple_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_tuple_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_tuple_jit";
     std::filesystem::create_directories(dir);
     {
@@ -813,14 +868,20 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_jit";
     std::filesystem::create_directories(dir);
     {
@@ -853,13 +914,19 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_equality) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_equality) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_eq_jit";
     std::filesystem::create_directories(dir);
     {
@@ -891,13 +958,19 @@ route GET "/users" { if run(Box(value: 1)) == (200, 500) { return 200 } else { r
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_ordering) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_tuple_default_method_ordering) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_tuple_ord_jit";
     std::filesystem::create_directories(dir);
     {
@@ -929,14 +1002,20 @@ route GET "/users" { if run(Box(value: 1)) < (200, 600) { return 200 } else { re
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_block_jit";
     std::filesystem::create_directories(dir);
     {
@@ -973,14 +1052,20 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_block_jit";
     std::filesystem::create_directories(dir);
     {
@@ -1017,14 +1102,20 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch_with_parameter) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_block_body_default_method_dispatch_with_parameter) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_block_param_jit";
     std::filesystem::create_directories(dir);
     {
@@ -1061,14 +1152,20 @@ route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch_with_parameter) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_block_body_default_method_dispatch_with_parameter) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_block_param_jit";
     std::filesystem::create_directories(dir);
     {
@@ -1105,14 +1202,20 @@ route GET "/users" { if run(Box(value: 1)) == 201 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_if_body_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_if_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_if_jit";
     std::filesystem::create_directories(dir);
     {
@@ -1144,14 +1247,20 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_if_body_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_if_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_if_jit";
     std::filesystem::create_directories(dir);
     {
@@ -1183,19 +1292,26 @@ route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_error_default_method_guard_match) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_error_default_method_guard_match) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_error_guard_match_jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
-        out << "protocol MaybeCode { func code(ok: bool) -> i32 { if ok { 200 } else { error(.timeout) } } }\n";
+        out << "protocol MaybeCode { func code(ok: bool) -> i32 { if ok { 200 } else { "
+               "error(.timeout) } } }\n";
         out << "struct Box<T> { value: T }\n";
         out << "Box<T> impl MaybeCode {}\n";
     }
@@ -1226,7 +1342,11 @@ route GET "/users" { if run(Box(value: 1)) == 401 { return 200 } else { return 5
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1263,7 +1383,11 @@ route GET "/users" { if jwtAuth() == 200 { return 200 } else { return 500 } }
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1299,7 +1423,11 @@ route GET "/users" { if auth.jwtAuth() == 200 { return 200 } else { return 500 }
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1336,7 +1464,11 @@ route GET "/users" { if auth.jwtAuth() == 200 { return 200 } else { return 500 }
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1379,7 +1511,11 @@ route GET "/users" { if jwt.jwtAuth() == 200 { return 200 } else { return 500 } 
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1418,13 +1554,16 @@ route GET "/users" { if run(proto.Box(value: 1)) == read(proto.Box(value: 1)) { 
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-
 
 TEST(jit, frontend_import_namespace_generic_type_ref) {
     const std::string dir = "/tmp/rut_import_namespace_generic_type_ref_jit";
@@ -1456,7 +1595,11 @@ route GET "/users" { let state = wrap(proto.Result<i32>.ok(1)) match state { cas
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1494,7 +1637,11 @@ route GET "/users" { let state = wrap(proto.Result<proto.Box<proto.Result<i32>>>
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1530,7 +1677,11 @@ route GET "/users" { if proto.Box(value: 1).value == 1 { return 200 } else { ret
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1570,7 +1721,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1610,7 +1765,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1652,7 +1811,11 @@ route GET "/users" { if authA.jwtAuth() == 200 { return 200 } else { return 500 
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1688,7 +1851,11 @@ route GET "/users" { if authV1() == 200 { return 200 } else { return 500 } }
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1728,7 +1895,11 @@ route GET "/users" { if run(AuthBox(value: 1)) == 1 { return 200 } else { return
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1768,7 +1939,11 @@ route GET "/users" { if run(Box(value: 1)) == 1 { return 200 } else { return 500
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -1819,7 +1994,8 @@ route GET "/users" { if authV1() == 200 { return 200 } else { return 500 } }
 
 TEST(jit, frontend_req_header_alias_or_fallback) {
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let alias = host let value = or(alias, \"fallback\") return 200 }\n";
+        "route GET \"/users\" { let host = req.header(\"Host\") let alias = host let value = "
+        "or(alias, \"fallback\") return 200 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -1859,7 +2035,8 @@ TEST(jit, frontend_req_header_alias_or_fallback) {
 TEST(jit, frontend_variant_match) {
     const char* src =
         "variant AuthState { timeout, forbidden }\n"
-        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return 200 case _: return 403 } }\n";
+        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return "
+        "200 case _: return 403 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -1899,7 +2076,8 @@ TEST(jit, frontend_variant_match) {
 TEST(jit, frontend_variant_single_payload_match) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): return 200 case .err: return 500 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): return 200 "
+        "case .err: return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -1939,7 +2117,8 @@ TEST(jit, frontend_variant_single_payload_match) {
 TEST(jit, frontend_variant_payload_binding_match_if) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): if x == 200 { return 200 } else { return 500 } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): if x == 200 "
+        "{ return 200 } else { return 500 } case .err: return 404 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -1979,7 +2158,8 @@ TEST(jit, frontend_variant_payload_binding_match_if) {
 TEST(jit, frontend_variant_payload_binding_match_block) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let y = x if y == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let y = x "
+        "if y == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2019,7 +2199,9 @@ TEST(jit, frontend_variant_payload_binding_match_block) {
 TEST(jit, frontend_variant_payload_binding_match_block_with_guard) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed = error(7) guard failed else { return 401 } if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed "
+        "= error(7) guard failed else { return 401 } if x == 200 { return 200 } else { return 500 "
+        "} } case .err: return 404 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2059,7 +2241,9 @@ TEST(jit, frontend_variant_payload_binding_match_block_with_guard) {
 TEST(jit, frontend_variant_payload_binding_match_block_with_guard_match) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed = error(.timeout) guard match failed else { case .timeout: return 401 case _: return 402 } if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed "
+        "= error(.timeout) guard match failed else { case .timeout: return 401 case _: return 402 "
+        "} if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2097,8 +2281,7 @@ TEST(jit, frontend_variant_payload_binding_match_block_with_guard_match) {
 }
 
 TEST(jit, frontend_if_const) {
-    const char* src =
-        "route GET \"/users\" { if const true { return 200 } else { return 500 } }\n";
+    const char* src = "route GET \"/users\" { if const true { return 200 } else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2138,7 +2321,8 @@ TEST(jit, frontend_if_const) {
 TEST(jit, frontend_match_const_variant) {
     const char* src =
         "variant Result { ok(i32), err }\n"
-        "route GET \"/users\" { let state = Result.ok(200) match const state { case .ok(x): if x == 200 { return 200 } else { return 500 } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok(200) match const state { case .ok(x): if x "
+        "== 200 { return 200 } else { return 500 } case .err: return 404 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2178,7 +2362,9 @@ TEST(jit, frontend_match_const_variant) {
 TEST(jit, frontend_variant_mixed_payload_match) {
     const char* src =
         "variant Mixed { count(i32), ready(bool), label(str), none }\n"
-        "route GET \"/users\" { let state = Mixed.ready(true) match state { case .count(x): return 200 case .ready(flag): if flag == true { return 201 } else { return 202 } case .label(name): return 203 case .none: return 204 } }\n";
+        "route GET \"/users\" { let state = Mixed.ready(true) match state { case .count(x): return "
+        "200 case .ready(flag): if flag == true { return 201 } else { return 202 } case "
+        ".label(name): return 203 case .none: return 204 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2219,7 +2405,9 @@ TEST(jit, frontend_variant_tuple_payload_match_pipe_multi_slot) {
     const char* src =
         "variant Result { ok((i32, i32)), err }\n"
         "func second(a: i32, b: i32) -> i32 => b\n"
-        "route GET \"/users\" { let state = Result.ok((200, 500)) match state { case .ok(pair): { let code = pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+        "route GET \"/users\" { let state = Result.ok((200, 500)) match state { case .ok(pair): { "
+        "let code = pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } } case "
+        ".err: return 404 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2507,7 +2695,8 @@ route GET "/users" {
 
 TEST(jit, frontend_known_named_error_match) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout) match failed { case .timeout: return 503 case _: return 200 } }\n";
+        "route GET \"/users\" { let failed = error(.timeout) match failed { case .timeout: return "
+        "503 case _: return 200 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2547,7 +2736,8 @@ TEST(jit, frontend_known_named_error_match) {
 TEST(jit, frontend_explicit_error_variant_match) {
     const char* src =
         "variant AuthError { timeout, forbidden }\n"
-        "route GET \"/users\" { let failed = error(AuthError.forbidden) match failed { case .forbidden: return 403 case _: return 200 } }\n";
+        "route GET \"/users\" { let failed = error(AuthError.forbidden) match failed { case "
+        ".forbidden: return 403 case _: return 200 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2587,7 +2777,8 @@ TEST(jit, frontend_explicit_error_variant_match) {
 TEST(jit, frontend_custom_error_struct_guard_match) {
     const char* src =
         "struct AuthError { err: Error }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\") guard match failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\") guard match "
+        "failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2627,7 +2818,9 @@ TEST(jit, frontend_custom_error_struct_guard_match) {
 TEST(jit, frontend_custom_error_struct_with_extra_fields_guard_match) {
     const char* src =
         "struct AuthError { err: Error, token: str, retry: i32 }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) guard match failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: "
+        "\"abc\", retry: 3) guard match failed else { case .timeout: return 503 case _: return 500 "
+        "} return 200 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2667,7 +2860,9 @@ TEST(jit, frontend_custom_error_struct_with_extra_fields_guard_match) {
 TEST(jit, frontend_custom_error_struct_with_tuple_field_guard_match) {
     const char* src =
         "struct AuthError { err: Error, pair: (i32, i32) }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, 500)) guard match failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, "
+        "500)) guard match failed else { case .timeout: return 503 case _: return 500 } return 200 "
+        "}\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2706,7 +2901,8 @@ TEST(jit, frontend_custom_error_struct_with_tuple_field_guard_match) {
 
 TEST(jit, frontend_multiple_top_level_guards) {
     const char* src =
-        "route GET \"/users\" { let ok = 200 guard ok else { return 401 } let failed = error(7) guard failed else { return 402 } return 200 }\n";
+        "route GET \"/users\" { let ok = 200 guard ok else { return 401 } let failed = error(7) "
+        "guard failed else { return 402 } return 200 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2746,7 +2942,8 @@ TEST(jit, frontend_multiple_top_level_guards) {
 TEST(jit, frontend_generic_struct_constructor_and_field_projection) {
     const char* src =
         "struct Box<T> { value: T }\n"
-        "route GET \"/users\" { let box = Box<i32>(value: 200) if box.value == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let box = Box<i32>(value: 200) if box.value == 200 { return 200 } "
+        "else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2786,7 +2983,8 @@ TEST(jit, frontend_generic_struct_constructor_and_field_projection) {
 TEST(jit, frontend_generic_struct_constructor_infers_type_argument_from_field_shape) {
     const char* src =
         "struct Box<T> { value: T }\n"
-        "route GET \"/users\" { let box = Box(value: 200) if box.value == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let box = Box(value: 200) if box.value == 200 { return 200 } else "
+        "{ return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2826,7 +3024,8 @@ TEST(jit, frontend_generic_struct_constructor_infers_type_argument_from_field_sh
 TEST(jit, frontend_concrete_generic_type_refs_are_supported_in_let_types) {
     const char* src =
         "variant Result<T> { ok(T), err }\n"
-        "route GET \"/users\" { let state: Result<i32> = Result.ok(200) match state { case .ok(v): return 200 case .err: return 500 } }\n";
+        "route GET \"/users\" { let state: Result<i32> = Result.ok(200) match state { case .ok(v): "
+        "return 200 case .err: return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2867,7 +3066,8 @@ TEST(jit, frontend_concrete_generic_type_refs_are_supported_in_function_signatur
     const char* src =
         "variant Result<T> { ok(T), err }\n"
         "func wrap(x: Result<i32>) -> Result<i32> => x\n"
-        "route GET \"/users\" { let state = wrap(Result.ok(200)) match state { case .ok(v): return 200 case .err: return 500 } }\n";
+        "route GET \"/users\" { let state = wrap(Result.ok(200)) match state { case .ok(v): return "
+        "200 case .err: return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2911,7 +3111,8 @@ TEST(jit, frontend_concrete_generic_struct_type_refs_are_supported_in_function_s
     const char* src =
         "struct Box<T> { value: T }\n"
         "func wrap(x: Box<i32>) -> Box<i32> => x\n"
-        "route GET \"/users\" { let box = wrap(Box(value: 200)) if box.value == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let box = wrap(Box(value: 200)) if box.value == 200 { return 200 } "
+        "else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2950,7 +3151,8 @@ TEST(jit, frontend_concrete_generic_type_refs_are_supported_in_struct_fields) {
     const char* src =
         "variant Result<T> { ok(T), err }\n"
         "struct Holder { state: Result<i32> }\n"
-        "route GET \"/users\" { let holder = Holder(state: Result.ok(200)) match holder.state { case .ok(v): return 200 case .err: return 500 } }\n";
+        "route GET \"/users\" { let holder = Holder(state: Result.ok(200)) match holder.state { "
+        "case .ok(v): return 200 case .err: return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -2989,7 +3191,8 @@ TEST(jit, frontend_variant_struct_field_projection_equality) {
     const char* src =
         "variant Result<T> { ok(T), err }\n"
         "struct Holder { state: Result<i32> }\n"
-        "route GET \"/users\" { let holder = Holder(state: Result.ok(200)) if holder.state == Result.ok(200) { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let holder = Holder(state: Result.ok(200)) if holder.state == "
+        "Result.ok(200) { return 200 } else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -3030,7 +3233,8 @@ TEST(jit, frontend_variant_struct_field_projection_ordering) {
     const char* src =
         "variant Result<T> { ok(T), err }\n"
         "struct Holder { state: Result<i32> }\n"
-        "route GET \"/users\" { let holder = Holder(state: Result.ok(200)) if holder.state < Result.ok(500) { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let holder = Holder(state: Result.ok(200)) if holder.state < "
+        "Result.ok(500) { return 200 } else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -3173,7 +3377,8 @@ TEST(jit, frontend_tuple_of_struct_field_projection_ordering) {
     const char* src =
         "struct Item { value: i32 }\n"
         "struct Holder { pair: (Item, i32) }\n"
-        "route GET \"/users\" { let holder = Holder(pair: (Item(value: 200), 500)) if holder.pair < (Item(value: 200), 600) { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let holder = Holder(pair: (Item(value: 200), 500)) if holder.pair "
+        "< (Item(value: 200), 600) { return 200 } else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -3316,7 +3521,9 @@ TEST(jit, frontend_concrete_generic_struct_type_refs_are_supported_in_variant_pa
         "struct Box<T> { value: T }\n"
         "variant Outer { wrap(Box<i32>), bad }\n"
         "func is200(x: Box<i32>) -> bool => x.value == 200\n"
-        "route GET \"/users\" { let state = Outer.wrap(Box(value: 200)) match state { case .wrap(inner): { let ok = is200(inner) if ok { return 200 } else { return 500 } } case .bad: return 404 } }\n";
+        "route GET \"/users\" { let state = Outer.wrap(Box(value: 200)) match state { case "
+        ".wrap(inner): { let ok = is200(inner) if ok { return 200 } else { return 500 } } case "
+        ".bad: return 404 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -3353,7 +3560,8 @@ TEST(jit, frontend_concrete_generic_struct_type_refs_are_supported_in_variant_pa
 
 TEST(jit, frontend_route_if_branch_block_with_let) {
     const char* src =
-        "route GET \"/users\" { let ok = true if ok { let code = 200 if code == 200 { return 200 } else { return 500 } } else { return 404 } }\n";
+        "route GET \"/users\" { let ok = true if ok { let code = 200 if code == 200 { return 200 } "
+        "else { return 500 } } else { return 404 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -3392,7 +3600,8 @@ TEST(jit, frontend_route_if_branch_block_with_let) {
 
 TEST(jit, frontend_route_if_branch_block_with_guard) {
     const char* src =
-        "route GET \"/users\" { let ok = true if ok { let failed = error(7) guard failed else { return 401 } return 200 } else { return 404 } }\n";
+        "route GET \"/users\" { let ok = true if ok { let failed = error(7) guard failed else { "
+        "return 401 } return 200 } else { return 404 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -3431,7 +3640,8 @@ TEST(jit, frontend_route_if_branch_block_with_guard) {
 
 TEST(jit, frontend_guard_else_block_with_let) {
     const char* src =
-        "route GET \"/users\" { let failed = error(7) guard failed else { let code = 401 if code == 401 { return 401 } else { return 500 } } return 200 }\n";
+        "route GET \"/users\" { let failed = error(7) guard failed else { let code = 401 if code "
+        "== 401 { return 401 } else { return 500 } } return 200 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -3471,7 +3681,8 @@ TEST(jit, frontend_guard_else_block_with_let) {
 TEST(jit, frontend_guard_match_routes_fail_and_success_paths) {
     {
         const char* src =
-            "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+            "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case "
+            ".timeout: return 503 case _: return 500 } return 200 }\n";
 
         auto lexed = lex(lit(src));
         REQUIRE(lexed);
@@ -3510,7 +3721,8 @@ TEST(jit, frontend_guard_match_routes_fail_and_success_paths) {
 
     {
         const char* src =
-            "route GET \"/users\" { let ok = 200 guard match ok else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+            "route GET \"/users\" { let ok = 200 guard match ok else { case .timeout: return 503 "
+            "case _: return 500 } return 200 }\n";
 
         auto lexed = lex(lit(src));
         REQUIRE(lexed);
@@ -3726,10 +3938,10 @@ TEST(jit, runtime_error_code_field_from_mir) {
     REQUIRE(handler != nullptr);
 
     auto r = HandlerResult::unpack(handler(nullptr,
-                                          nullptr,
-                                          reinterpret_cast<const u8*>(kGetApiRequest),
-                                          sizeof(kGetApiRequest) - 1,
-                                          nullptr));
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
 
@@ -5068,7 +5280,9 @@ TEST(jit, lookup_nonexistent) {
 TEST(jit, frontend_custom_error_struct_field_projection) {
     const char* src =
         "struct AuthError { err: Error, token: str, retry: i32 }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) let retry = failed.retry if retry == 3 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: "
+        "\"abc\", retry: 3) let retry = failed.retry if retry == 3 { return 200 } else { return "
+        "500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -5109,7 +5323,9 @@ TEST(jit, frontend_custom_error_struct_tuple_field_projection_pipe) {
     const char* src =
         "struct AuthError { err: Error, pair: (i32, i32) }\n"
         "func second(a: i32, b: i32) -> i32 => b\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, 500)) let code = failed.pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, "
+        "500)) let code = failed.pair | second(_2, _1) if code == 200 { return 200 } else { return "
+        "500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -5150,7 +5366,9 @@ TEST(jit, frontend_custom_error_nested_struct_field_projection) {
     const char* src =
         "struct Box { value: i32 }\n"
         "struct AuthError { err: Error, inner: Box }\n"
-        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", inner: Box(value: 200)) let code = failed.inner.value if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", inner: "
+        "Box(value: 200)) let code = failed.inner.value if code == 200 { return 200 } else { "
+        "return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -5190,7 +5408,8 @@ TEST(jit, frontend_custom_error_nested_struct_field_projection) {
 TEST(jit, frontend_plain_struct_constructor_and_field_projection) {
     constexpr auto src =
         "struct Foo { code: i32, msg: str }\n"
-        "route GET \"/users\" { let foo = Foo(code: 200, msg: \"ok\") let code = foo.code let msg = foo.msg if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let foo = Foo(code: 200, msg: \"ok\") let code = foo.code let msg "
+        "= foo.msg if code == 200 { return 200 } else { return 500 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -5230,7 +5449,8 @@ TEST(jit, frontend_plain_struct_tuple_field_projection_pipe) {
     const char* src =
         "struct Foo { pair: (i32, i32) }\n"
         "func second(a: i32, b: i32) -> i32 => b\n"
-        "route GET \"/users\" { let foo = Foo(pair: (200, 500)) let code = foo.pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let foo = Foo(pair: (200, 500)) let code = foo.pair | second(_2, "
+        "_1) if code == 200 { return 200 } else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -5271,7 +5491,8 @@ TEST(jit, frontend_nested_struct_field_projection) {
     const char* src =
         "struct Box { value: i32 }\n"
         "struct Outer { inner: Box }\n"
-        "route GET \"/users\" { let outer = Outer(inner: Box(value: 200)) let code = outer.inner.value if code == 200 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let outer = Outer(inner: Box(value: 200)) let code = "
+        "outer.inner.value if code == 200 { return 200 } else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -5312,7 +5533,8 @@ TEST(jit, frontend_plain_struct_variant_field_projection_match) {
     const char* src =
         "variant AuthState { timeout, forbidden }\n"
         "struct Foo { state: AuthState }\n"
-        "route GET \"/users\" { let foo = Foo(state: AuthState.timeout) match foo.state { case .timeout: return 200 case _: return 403 } }\n";
+        "route GET \"/users\" { let foo = Foo(state: AuthState.timeout) match foo.state { case "
+        ".timeout: return 200 case _: return 403 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -5351,7 +5573,8 @@ TEST(jit, frontend_plain_struct_variant_field_projection_match) {
 
 TEST(jit, frontend_error_standard_field_projection) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = failed.code if code == 0 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = failed.code "
+        "if code == 0 { return 200 } else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -5390,7 +5613,8 @@ TEST(jit, frontend_error_standard_field_projection) {
 
 TEST(jit, frontend_error_line_field_projection) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let line = failed.line if line == 1 { return 200 } else { return 500 } }\n";
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let line = failed.line "
+        "if line == 1 { return 200 } else { return 500 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -5429,7 +5653,8 @@ TEST(jit, frontend_error_line_field_projection) {
 
 TEST(jit, frontend_error_file_and_func_field_projection) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let file_name = failed.file let fn_name = failed.func return 200 }\n";
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let file_name = "
+        "failed.file let fn_name = failed.func return 200 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -6522,7 +6747,6 @@ route GET "/users" {
     rir.destroy();
 }
 
-
 TEST(jit, frontend_concrete_custom_protocol_method_dispatch_with_parameter) {
     const auto src = R"rut(
 protocol Hashable { func hash(x: i32) -> i32 }
@@ -6569,7 +6793,6 @@ route GET "/users" {
     rir.destroy();
 }
 
-
 TEST(jit, frontend_multi_protocol_impl_block) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 }
@@ -6601,7 +6824,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -6676,7 +6903,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -6711,7 +6942,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -6745,7 +6980,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -6780,7 +7019,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -6815,7 +7058,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -6849,7 +7096,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -6883,7 +7134,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -6928,7 +7183,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -6975,7 +7234,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7021,13 +7284,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_multi_protocol_impl_with_default_bodies) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_multi_protocol_impl_with_default_bodies) {
     const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_default_jit";
     std::filesystem::create_directories(dir);
     {
@@ -7071,13 +7340,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_multi_protocol_impl_with_block_body_default) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_multi_protocol_impl_with_block_body_default) {
     const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_block_body_default_jit";
     std::filesystem::create_directories(dir);
     {
@@ -7124,13 +7399,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_multi_protocol_impl_with_if_body_default) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_multi_protocol_impl_with_if_body_default) {
     const std::string dir = "/tmp/rut_import_generic_multi_protocol_impl_if_body_default_jit";
     std::filesystem::create_directories(dir);
     {
@@ -7176,7 +7457,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7219,7 +7504,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7261,13 +7550,18 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_impl_with_block_body_default) {
+TEST(jit,
+     frontend_import_relative_file_merges_imported_multi_protocol_impl_with_block_body_default) {
     const std::string dir = "/tmp/rut_import_multi_protocol_impl_block_body_default_jit";
     std::filesystem::create_directories(dir);
     {
@@ -7310,7 +7604,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7358,7 +7656,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7400,7 +7702,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7447,7 +7753,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7483,7 +7793,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7517,7 +7831,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7551,7 +7869,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7586,7 +7908,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7620,7 +7946,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7658,7 +7988,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7698,7 +8032,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7737,14 +8075,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
 
-TEST(jit, frontend_generic_receiver_custom_protocol_default_method_supports_block_body_with_parameter) {
+TEST(jit,
+     frontend_generic_receiver_custom_protocol_default_method_supports_block_body_with_parameter) {
     const auto src = R"rut(
 protocol Adder {
     func add(x: i32) -> i32 {
@@ -7777,7 +8120,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7815,7 +8162,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7853,7 +8204,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7894,7 +8249,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7935,7 +8294,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -7970,13 +8333,18 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_impl_overrides_protocol_default_method_with_optional_return) {
+TEST(jit,
+     frontend_import_relative_file_impl_overrides_protocol_default_method_with_optional_return) {
     const std::string dir = "/tmp/rut_import_impl_overrides_optional_default_method_jit";
     std::filesystem::create_directories(dir);
     {
@@ -8010,7 +8378,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8044,7 +8416,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8082,7 +8458,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8119,7 +8499,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8157,7 +8541,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8194,7 +8582,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8234,7 +8626,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8278,7 +8674,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8321,14 +8721,21 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_impl_overrides_protocol_default_method_with_block_body_and_parameter) {
-    const std::string dir = "/tmp/rut_import_impl_overrides_block_body_parameter_default_method_jit";
+TEST(
+    jit,
+    frontend_import_relative_file_impl_overrides_protocol_default_method_with_block_body_and_parameter) {
+    const std::string dir =
+        "/tmp/rut_import_impl_overrides_block_body_parameter_default_method_jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8365,13 +8772,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_impl_overrides_protocol_default_method_with_if_body_and_parameter) {
+TEST(
+    jit,
+    frontend_import_relative_file_impl_overrides_protocol_default_method_with_if_body_and_parameter) {
     const std::string dir = "/tmp/rut_import_impl_overrides_if_body_parameter_default_method_jit";
     std::filesystem::create_directories(dir);
     {
@@ -8408,7 +8821,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8447,7 +8864,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8486,7 +8907,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8530,7 +8955,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8565,13 +8994,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
+TEST(
+    jit,
+    frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
     const auto src = R"rut(
 protocol MaybeCode { func code() -> i32 => nil }
 struct Box<T> { value: T }
@@ -8599,13 +9034,18 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
+TEST(jit,
+     frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
     const auto src = R"rut(
 protocol MaybeCode { func code() -> i32 => error(.timeout) }
 struct Box<T> { value: T }
@@ -8633,13 +9073,18 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
+TEST(jit,
+     frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
     const auto src = R"rut(
 protocol MaybeCode {
     func code() -> i32 {
@@ -8672,7 +9117,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -8710,13 +9159,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
+TEST(
+    jit,
+    frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
     const auto src = R"rut(
 protocol Adder {
     func add(x: i32) -> i32 {
@@ -8749,13 +9204,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
+TEST(
+    jit,
+    frontend_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
     const auto src = R"rut(
 protocol Adder {
     func add(ok: bool) -> i32 {
@@ -8787,14 +9248,21 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_optional_default_method_jit";
+TEST(
+    jit,
+    frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_optional_return) {
+    const std::string dir =
+        "/tmp/rut_import_generic_impl_overrides_generic_receiver_optional_default_method_jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8827,14 +9295,21 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_error_default_method_jit";
+TEST(
+    jit,
+    frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_error_return) {
+    const std::string dir =
+        "/tmp/rut_import_generic_impl_overrides_generic_receiver_error_default_method_jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8867,14 +9342,21 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_block_body_default_method_jit";
+TEST(
+    jit,
+    frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body) {
+    const std::string dir =
+        "/tmp/rut_import_generic_impl_overrides_generic_receiver_block_body_default_method_jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8912,14 +9394,21 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_if_body_default_method_jit";
+TEST(
+    jit,
+    frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body) {
+    const std::string dir =
+        "/tmp/rut_import_generic_impl_overrides_generic_receiver_if_body_default_method_jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -8956,14 +9445,23 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_block_body_parameter_default_method_jit";
+TEST(
+    jit,
+    frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_block_body_and_parameter) {
+    const std::string dir =
+        "/tmp/"
+        "rut_import_generic_impl_overrides_generic_receiver_block_body_parameter_default_method_"
+        "jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9001,14 +9499,22 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_if_body_parameter_default_method_jit";
+TEST(
+    jit,
+    frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method_with_if_body_and_parameter) {
+    const std::string dir =
+        "/tmp/"
+        "rut_import_generic_impl_overrides_generic_receiver_if_body_parameter_default_method_jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9045,14 +9551,21 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method) {
-    const std::string dir = "/tmp/rut_import_generic_impl_overrides_generic_receiver_default_method_jit";
+TEST(
+    jit,
+    frontend_import_relative_file_generic_impl_overrides_generic_receiver_protocol_default_method) {
+    const std::string dir =
+        "/tmp/rut_import_generic_impl_overrides_generic_receiver_default_method_jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9085,7 +9598,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -9125,13 +9642,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_dispatch_is_supported) {
+TEST(
+    jit,
+    frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_dispatch_is_supported) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
 protocol Adder { func add(x: i32) -> i32 => x }
@@ -9163,7 +9686,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -9202,7 +9729,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -9251,13 +9782,18 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_block_body) {
+TEST(jit,
+     frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_block_body) {
     const auto src = R"rut(
 protocol Hashable {
     func hash() -> i32 {
@@ -9299,7 +9835,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -9346,7 +9886,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -9385,7 +9929,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -9424,13 +9972,18 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_if_body) {
+TEST(jit,
+     frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_if_body) {
     const auto src = R"rut(
 protocol Hashable {
     func hash(ok: bool) -> i32 {
@@ -9470,13 +10023,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_tuple_return) {
+TEST(
+    jit,
+    frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_supports_tuple_return) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
 protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
@@ -9508,13 +10067,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_tuple_return_supports_ordering) {
+TEST(
+    jit,
+    frontend_generic_receiver_multi_protocol_empty_impl_block_default_method_tuple_return_supports_ordering) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 => 200 }
 protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
@@ -9546,13 +10111,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_multi_protocol_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_empty_impl_for_generic_receiver_multi_protocol_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_generic_multi_protocol_jit";
     std::filesystem::create_directories(dir);
     {
@@ -9591,13 +10162,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_tuple_default_impl_generic_multi_protocol_block_jit";
     std::filesystem::create_directories(dir);
     {
@@ -9635,14 +10212,21 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
-    const std::string dir = "/tmp/rut_import_tuple_ordering_default_impl_generic_multi_protocol_block_jit";
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
+    const std::string dir =
+        "/tmp/rut_import_tuple_ordering_default_impl_generic_multi_protocol_block_jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9679,13 +10263,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_if_body_default_impl_generic_multi_protocol_block_jit";
     std::filesystem::create_directories(dir);
     {
@@ -9731,13 +10321,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_tuple_default_impl_multi_protocol_block_jit";
     std::filesystem::create_directories(dir);
     {
@@ -9776,13 +10372,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_tuple_default_method_ordering) {
     const std::string dir = "/tmp/rut_import_tuple_ordering_default_impl_multi_protocol_block_jit";
     std::filesystem::create_directories(dir);
     {
@@ -9821,13 +10423,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_if_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_if_body_default_impl_multi_protocol_block_jit";
     std::filesystem::create_directories(dir);
     {
@@ -9874,13 +10482,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_block_body_default_impl_multi_protocol_block_jit";
     std::filesystem::create_directories(dir);
     {
@@ -9929,14 +10543,21 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
-    const std::string dir = "/tmp/rut_import_block_body_default_impl_generic_multi_protocol_block_jit";
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_receiver_multi_protocol_empty_impl_block_for_block_body_default_method_dispatch) {
+    const std::string dir =
+        "/tmp/rut_import_block_body_default_impl_generic_multi_protocol_block_jit";
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
@@ -9983,13 +10604,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_multi_protocol_empty_impl_block_for_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_default_impl_multi_protocol_block_jit";
     std::filesystem::create_directories(dir);
     {
@@ -10028,13 +10655,19 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
     rir.destroy();
 }
-TEST(jit, frontend_import_relative_file_merges_imported_generic_multi_protocol_empty_impl_block_for_default_method_dispatch) {
+TEST(
+    jit,
+    frontend_import_relative_file_merges_imported_generic_multi_protocol_empty_impl_block_for_default_method_dispatch) {
     const std::string dir = "/tmp/rut_import_generic_default_impl_multi_protocol_block_jit";
     std::filesystem::create_directories(dir);
     {
@@ -10072,7 +10705,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -10106,7 +10743,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -10252,7 +10893,9 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_generic_receiver_custom_protocol_method_dispatch_with_generic_impl_target_tuple_of_struct_arg) {
+TEST(
+    jit,
+    frontend_generic_receiver_custom_protocol_method_dispatch_with_generic_impl_target_tuple_of_struct_arg) {
     const auto src = R"rut(
 protocol Hashable { func hash() -> i32 }
 struct Item { value: i32 }
@@ -10420,7 +11063,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -10584,7 +11231,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -10616,7 +11267,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -10650,7 +11305,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 500);
     engine.shutdown();
@@ -10938,7 +11597,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), static_cast<u32>(sizeof(kGetApiRequest) - 1), nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           static_cast<u32>(sizeof(kGetApiRequest) - 1),
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -11012,7 +11675,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), static_cast<u32>(sizeof(kGetApiRequest) - 1), nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           static_cast<u32>(sizeof(kGetApiRequest) - 1),
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();
@@ -11047,7 +11714,11 @@ route GET "/users" {
     REQUIRE(engine.compile(cg.mod, cg.ctx));
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
-    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), static_cast<u32>(sizeof(kGetApiRequest) - 1), nullptr));
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           static_cast<u32>(sizeof(kGetApiRequest) - 1),
+                                           nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
     engine.shutdown();

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -1,11 +1,18 @@
 #include "rut/compiler/rir.h"
 #include "rut/compiler/rir_builder.h"
+#include "rut/compiler/analyze.h"
+#include "rut/compiler/lexer.h"
+#include "rut/compiler/lower_rir.h"
+#include "rut/compiler/mir_build.h"
+#include "rut/compiler/parser.h"
 #include "rut/jit/codegen.h"
 #include "rut/jit/handler_abi.h"
 #include "rut/jit/jit_engine.h"
 #include "rut/jit/runtime_helpers.h"
 #include "rut/runtime/connection.h"
 #include "test.h"
+#include <filesystem>
+#include <fstream>
 
 using namespace rut;
 using namespace rut::rir;
@@ -17,6 +24,45 @@ static Str lit(const char* s) {
     u32 n = 0;
     while (s[n]) n++;
     return {s, n};
+}
+
+template <typename T>
+struct HeapFrontendResult {
+    FrontendResult<T*> inner;
+
+    bool has_value() const { return inner.has_value(); }
+    explicit operator bool() const { return static_cast<bool>(inner); }
+    T* operator->() { return inner.value(); }
+    const T* operator->() const { return inner.value(); }
+    T& value() { return *inner.value(); }
+    const T& value() const { return *inner.value(); }
+    Diagnostic& error() { return inner.error(); }
+    const Diagnostic& error() const { return inner.error(); }
+};
+
+static HeapFrontendResult<AstFile> parse_file_heap(const LexedTokens& tokens) {
+    auto ast = parse_file(tokens);
+    if (!ast) return {core::make_unexpected(ast.error())};
+    return {ast.value()};
+}
+
+static HeapFrontendResult<HirModule> analyze_file_heap(const AstFile& file) {
+    auto hir = analyze_file(file);
+    if (!hir) return {core::make_unexpected(hir.error())};
+    return {hir.value()};
+}
+
+static HeapFrontendResult<HirModule> analyze_file_heap_with_path(const AstFile& file, const std::string& source_path) {
+    Str path{source_path.c_str(), static_cast<u32>(source_path.size())};
+    auto hir = analyze_file(file, path);
+    if (!hir) return {core::make_unexpected(hir.error())};
+    return {hir.value()};
+}
+
+static HeapFrontendResult<MirModule> build_mir_heap(const HirModule& module) {
+    auto mir = build_mir(module);
+    if (!mir) return {core::make_unexpected(mir.error())};
+    return {mir.value()};
 }
 
 // Unwrap Expected.
@@ -135,6 +181,2438 @@ TEST(jit, return_200) {
 
     engine.shutdown();
     tc.destroy();
+}
+
+TEST(jit, frontend_req_header_or_fallback) {
+    const char* src =
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"fallback\") return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_function_symbols) {
+    const std::string dir = "/tmp/rut_import_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route GET "/users" { if jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_with_package_decl_merges_imported_function_symbols) {
+    const std::string dir = "/tmp/rut_import_packaged_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "package auth\n";
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route GET "/users" { if jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_variant_symbol) {
+    const std::string dir = "/tmp/rut_import_variant_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/types.rut", std::ios::binary);
+        out << "variant AuthState { ok, err }\n";
+    }
+    const auto src = R"rut(
+import "types.rut"
+route GET "/users" { let state = AuthState.ok match state { case .ok: return 200 case _: return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_impl_symbol) {
+    const std::string dir = "/tmp/rut_import_impl_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 1)) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_relative_file_merges_imported_empty_impl_for_default_method_dispatch) {
+    const std::string dir = "/tmp/rut_import_default_impl_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 => 200 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {}\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_selective_import_relative_file_merges_selected_function_symbol) {
+    const std::string dir = "/tmp/rut_selective_import_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+        out << "func basicAuth() -> i32 => 500\n";
+    }
+    const auto src = R"rut(
+import { jwtAuth } from "auth.rut"
+route GET "/users" { if jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_namespace_function_call) {
+    const std::string dir = "/tmp/rut_import_namespace_function_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route GET "/users" { if auth.jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_namespace_function_call_for_file_with_package_decl) {
+    const std::string dir = "/tmp/rut_import_namespace_packaged_function_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "package auth\n";
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route GET "/users" { if auth.jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_same_package_multiple_files_still_use_file_namespaces) {
+    const std::string dir = "/tmp/rut_import_same_package_file_namespaces_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/jwt.rut", std::ios::binary);
+        out << "package auth\n";
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    {
+        std::ofstream out(dir + "/basic.rut", std::ios::binary);
+        out << "package auth\n";
+        out << "func basicAuth() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "jwt.rut"
+import "basic.rut"
+route GET "/users" { if jwt.jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_namespace_type_ref_and_protocol_constraint) {
+    const std::string dir = "/tmp/rut_import_namespace_type_ref_constraint_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+proto.Box impl proto.Hashable { func hash(self: proto.Box) -> i32 => self.value }
+func run<T: proto.Hashable>(x: T) -> i32 => x.hash()
+func read(x: proto.Box) -> i32 => x.value
+route GET "/users" { if run(proto.Box(value: 1)) == read(proto.Box(value: 1)) { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+
+TEST(jit, frontend_import_namespace_generic_type_ref) {
+    const std::string dir = "/tmp/rut_import_namespace_generic_type_ref_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result<T> { ok(T), err }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+func wrap(x: proto.Result<i32>) -> proto.Result<i32> => x
+route GET "/users" { let state = wrap(proto.Result<i32>.ok(1)) match state { case .ok(v): return 200 case .err: return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_namespace_nested_generic_payload_lowering_path) {
+    const std::string dir = "/tmp/rut_import_namespace_nested_generic_type_arg_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box<T> { value: T }\n";
+        out << "variant Result<T> { ok(T), err }\n";
+    }
+    const auto src = R"rut(
+import * as proto from "proto.rut"
+func wrap(x: proto.Result<proto.Box<proto.Result<i32>>>) -> proto.Result<proto.Box<proto.Result<i32>>> => x
+route GET "/users" { let state = wrap(proto.Result<proto.Box<proto.Result<i32>>>.ok(proto.Box<proto.Result<i32>>(value: proto.Result<i32>.ok(1)))) match state { case .ok(v): return 200 case .err: return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_namespace_struct_init) {
+    const std::string dir = "/tmp/rut_import_namespace_struct_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "struct Box { value: i32 }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" { if proto.Box(value: 1).value == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_namespace_variant_constructor) {
+    const std::string dir = "/tmp/rut_import_namespace_variant_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Result { ok(i32), err }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    match proto.Result.ok(200) {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_import_namespace_payloadless_variant_case) {
+    const std::string dir = "/tmp/rut_import_namespace_payloadless_variant_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "variant Token { ready, wait }\n";
+    }
+    const auto src = R"rut(
+import "proto.rut"
+route GET "/users" {
+    match proto.Token.ready {
+    case .ready: return 200
+    case .wait: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_import_namespace_alias_resolves_same_stem_conflict) {
+    const std::string dir = "/tmp/rut_import_namespace_alias_conflict_jit";
+    std::filesystem::create_directories(dir + "/a");
+    std::filesystem::create_directories(dir + "/b");
+    {
+        std::ofstream out(dir + "/a/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+    }
+    {
+        std::ofstream out(dir + "/b/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 500\n";
+    }
+    const auto src = R"rut(
+import * as authA from "a/auth.rut"
+import * as authB from "b/auth.rut"
+route GET "/users" { if authA.jwtAuth() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_selective_import_relative_file_aliases_selected_function_symbol) {
+    const std::string dir = "/tmp/rut_selective_import_alias_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func jwtAuth() -> i32 => 200\n";
+        out << "func basicAuth() -> i32 => 500\n";
+    }
+    const auto src = R"rut(
+import { jwtAuth as authV1 } from "auth.rut"
+route GET "/users" { if authV1() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_selective_import_relative_file_aliases_selected_protocol_and_struct_with_impl) {
+    const std::string dir = "/tmp/rut_selective_import_alias_impl_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import { Hashable as Digestible, Box as AuthBox } from "proto.rut"
+func run<T: Digestible>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(AuthBox(value: 1)) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_selective_import_relative_file_merges_selected_protocol_and_struct_with_impl) {
+    const std::string dir = "/tmp/rut_selective_import_impl_jit";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/proto.rut", std::ios::binary);
+        out << "protocol Hashable { func hash() -> i32 }\n";
+        out << "struct Box { value: i32 }\n";
+        out << "Box impl Hashable {\n";
+        out << "    func hash(self: Box) -> i32 => self.value\n";
+        out << "}\n";
+    }
+    const auto src = R"rut(
+import { Hashable, Box } from "proto.rut"
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" { if run(Box(value: 1)) == 1 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_using_alias_function_call) {
+    const auto src = R"rut(
+using authV1 = v1.jwtAuth
+func jwtAuth() -> i32 => 200
+route GET "/users" { if authV1() == 200 { return 200 } else { return 500 } }
+)rut";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_header_alias_or_fallback) {
+    const char* src =
+        "route GET \"/users\" { let host = req.header(\"Host\") let alias = host let value = or(alias, \"fallback\") return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_match) {
+    const char* src =
+        "variant AuthState { timeout, forbidden }\n"
+        "route GET \"/users\" { let state = AuthState.timeout match state { case .timeout: return 200 case _: return 403 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_single_payload_match) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): return 200 case .err: return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_payload_binding_match_if) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): if x == 200 { return 200 } else { return 500 } case .err: return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_payload_binding_match_block) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let y = x if y == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_payload_binding_match_block_with_guard) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed = error(7) guard failed else { return 401 } if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 401);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_payload_binding_match_block_with_guard_match) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(x): { let failed = error(.timeout) guard match failed else { case .timeout: return 401 case _: return 402 } if x == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 401);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_if_const) {
+    const char* src =
+        "route GET \"/users\" { if const true { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_match_const_variant) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match const state { case .ok(x): if x == 200 { return 200 } else { return 500 } case .err: return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_mixed_payload_match) {
+    const char* src =
+        "variant Mixed { count(i32), ready(bool), label(str), none }\n"
+        "route GET \"/users\" { let state = Mixed.ready(true) match state { case .count(x): return 200 case .ready(flag): if flag == true { return 201 } else { return 202 } case .label(name): return 203 case .none: return 204 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 201);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_tuple_payload_match_pipe_multi_slot) {
+    const char* src =
+        "variant Result { ok((i32, i32)), err }\n"
+        "func second(a: i32, b: i32) -> i32 => b\n"
+        "route GET \"/users\" { let state = Result.ok((200, 500)) match state { case .ok(pair): { let code = pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } } case .err: return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_variant_constructor_and_match) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+route GET "/users" {
+    let state = Result<i32>.ok(200)
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_explicit_generic_variant_constructor_nested_type_arg) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+variant Wrap<T> { some(T), none }
+route GET "/users" {
+    match Wrap<Box<i32>>.some(Box<i32>(value: 200)) {
+    case .some(v): {
+        if v.value == 200 { return 200 } else { return 500 }
+    }
+    case .none: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_variant_tuple_of_struct_payload_binding) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+variant Result { ok((Box, i32)), err }
+func boxCode(x: Box) -> i32 => x.value
+route GET "/users" {
+    match Result.ok((Box(value: 200), 7)) {
+    case .ok(v): {
+        let code = v | boxCode(_1)
+        if code == 200 { return 200 } else { return 500 }
+    }
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_variant_tuple_of_struct_payload_binding) {
+    const auto src = R"rut(
+struct Item { value: i32 }
+variant Result<T> { ok(T), err }
+func itemCode(x: Item) -> i32 => x.value
+route GET "/users" {
+    match Result.ok((Item(value: 200), 7)) {
+    case .ok(v): {
+        let code = v | itemCode(_1)
+        if code == 200 { return 200 } else { return 500 }
+    }
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_variant_constructor_infers_type_argument_from_single_payload_case) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+route GET "/users" {
+    let state = Result.ok(200)
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_known_named_error_match) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) match failed { case .timeout: return 503 case _: return 200 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 503);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_explicit_error_variant_match) {
+    const char* src =
+        "variant AuthError { timeout, forbidden }\n"
+        "route GET \"/users\" { let failed = error(AuthError.forbidden) match failed { case .forbidden: return 403 case _: return 200 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 403);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_error_struct_guard_match) {
+    const char* src =
+        "struct AuthError { err: Error }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\") guard match failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 503);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_error_struct_with_extra_fields_guard_match) {
+    const char* src =
+        "struct AuthError { err: Error, token: str, retry: i32 }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) guard match failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 503);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_error_struct_with_tuple_field_guard_match) {
+    const char* src =
+        "struct AuthError { err: Error, pair: (i32, i32) }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, 500)) guard match failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 503);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_multiple_top_level_guards) {
+    const char* src =
+        "route GET \"/users\" { let ok = 200 guard ok else { return 401 } let failed = error(7) guard failed else { return 402 } return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 402);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_struct_constructor_and_field_projection) {
+    const char* src =
+        "struct Box<T> { value: T }\n"
+        "route GET \"/users\" { let box = Box<i32>(value: 200) if box.value == 200 { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_struct_constructor_infers_type_argument_from_field_shape) {
+    const char* src =
+        "struct Box<T> { value: T }\n"
+        "route GET \"/users\" { let box = Box(value: 200) if box.value == 200 { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_generic_type_refs_are_supported_in_let_types) {
+    const char* src =
+        "variant Result<T> { ok(T), err }\n"
+        "route GET \"/users\" { let state: Result<i32> = Result.ok(200) match state { case .ok(v): return 200 case .err: return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_generic_type_refs_are_supported_in_function_signatures) {
+    const char* src =
+        "variant Result<T> { ok(T), err }\n"
+        "func wrap(x: Result<i32>) -> Result<i32> => x\n"
+        "route GET \"/users\" { let state = wrap(Result.ok(200)) match state { case .ok(v): return 200 case .err: return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    if (r.status_code != 200) {
+        rut::test::out("    status=");
+        rut::test::out_int(r.status_code);
+        rut::test::out("\n");
+    }
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(r.status_code, 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_generic_struct_type_refs_are_supported_in_function_signatures) {
+    const char* src =
+        "struct Box<T> { value: T }\n"
+        "func wrap(x: Box<i32>) -> Box<i32> => x\n"
+        "route GET \"/users\" { let box = wrap(Box(value: 200)) if box.value == 200 { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_generic_type_refs_are_supported_in_struct_fields) {
+    const char* src =
+        "variant Result<T> { ok(T), err }\n"
+        "struct Holder { state: Result<i32> }\n"
+        "route GET \"/users\" { let holder = Holder(state: Result.ok(200)) match holder.state { case .ok(v): return 200 case .err: return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_generic_type_refs_are_supported_in_variant_payloads) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+variant Outer { wrap(Result<i32>), bad }
+route GET "/users" {
+    let state = Outer.wrap(Result.ok(200))
+    match state {
+    case .wrap(inner): {
+        let copied = inner
+        return 200
+    }
+    case .bad:
+        return 404
+    }
+}
+)rut";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(r.status_code, 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_generic_struct_type_refs_are_supported_in_variant_payloads) {
+    const char* src =
+        "struct Box<T> { value: T }\n"
+        "variant Outer { wrap(Box<i32>), bad }\n"
+        "func is200(x: Box<i32>) -> bool => x.value == 200\n"
+        "route GET \"/users\" { let state = Outer.wrap(Box(value: 200)) match state { case .wrap(inner): { let ok = is200(inner) if ok { return 200 } else { return 500 } } case .bad: return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_if_branch_block_with_let) {
+    const char* src =
+        "route GET \"/users\" { let ok = true if ok { let code = 200 if code == 200 { return 200 } else { return 500 } } else { return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_if_branch_block_with_guard) {
+    const char* src =
+        "route GET \"/users\" { let ok = true if ok { let failed = error(7) guard failed else { return 401 } return 200 } else { return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 401);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_guard_else_block_with_let) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(7) guard failed else { let code = 401 if code == 401 { return 401 } else { return 500 } } return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 401);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_guard_match_routes_fail_and_success_paths) {
+    {
+        const char* src =
+            "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(hir);
+        auto mir = build_mir_heap(hir.value());
+        REQUIRE(mir);
+
+        FrontendRirModule rir{};
+        auto lowered = lower_to_rir(mir.value(), rir);
+        REQUIRE(lowered);
+
+        auto cg = codegen(rir.module);
+        REQUIRE(cg.ok);
+
+        JitEngine engine;
+        REQUIRE(engine.init());
+        REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+        auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+        REQUIRE(handler != nullptr);
+
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetApiRequest),
+                                               sizeof(kGetApiRequest) - 1,
+                                               nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 503);
+
+        engine.shutdown();
+        rir.destroy();
+    }
+
+    {
+        const char* src =
+            "route GET \"/users\" { let ok = 200 guard match ok else { case .timeout: return 503 case _: return 500 } return 200 }\n";
+
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(hir);
+        auto mir = build_mir_heap(hir.value());
+        REQUIRE(mir);
+
+        FrontendRirModule rir{};
+        auto lowered = lower_to_rir(mir.value(), rir);
+        REQUIRE(lowered);
+
+        auto cg = codegen(rir.module);
+        REQUIRE(cg.ok);
+
+        JitEngine engine;
+        REQUIRE(engine.init());
+        REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+        auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+        REQUIRE(handler != nullptr);
+
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               nullptr,
+                                               reinterpret_cast<const u8*>(kGetApiRequest),
+                                               sizeof(kGetApiRequest) - 1,
+                                               nullptr));
+        CHECK(r.action == HandlerAction::ReturnStatus);
+        CHECK(r.status_code == 200);
+
+        engine.shutdown();
+        rir.destroy();
+    }
+}
+
+TEST(jit, runtime_error_kind_match_from_mir) {
+    auto* mir = new MirModule{};
+    MirVariant err_variant{};
+    err_variant.span = {1, 1, 1, 1};
+    err_variant.name = lit("AuthError");
+    MirVariant::CaseDecl timeout{};
+    timeout.name = lit("timeout");
+    MirVariant::CaseDecl forbidden{};
+    forbidden.name = lit("forbidden");
+    REQUIRE(err_variant.cases.push(timeout));
+    REQUIRE(err_variant.cases.push(forbidden));
+    REQUIRE(mir->variants.push(err_variant));
+
+    MirFunction fn{};
+    fn.span = {1, 1, 1, 1};
+    fn.method = 'G';
+    fn.path = lit("/users");
+    fn.name = lit("route");
+
+    MirLocal failed{};
+    failed.span = fn.span;
+    failed.name = lit("failed");
+    failed.type = MirTypeKind::I32;
+    failed.may_error = true;
+    failed.error_variant_index = 0;
+    failed.init.kind = MirValueKind::Error;
+    failed.init.type = MirTypeKind::Unknown;
+    failed.init.may_error = true;
+    failed.init.error_variant_index = 0;
+    failed.init.error_case_index = 1;
+    REQUIRE(fn.locals.push(failed));
+
+    MirValue subject{};
+    subject.kind = MirValueKind::LocalRef;
+    subject.type = MirTypeKind::I32;
+    subject.may_error = true;
+    subject.local_index = 0;
+    subject.error_variant_index = 0;
+    REQUIRE(fn.values.push(subject));
+
+    MirValue timeout_pat{};
+    timeout_pat.kind = MirValueKind::VariantCase;
+    timeout_pat.type = MirTypeKind::Variant;
+    timeout_pat.variant_index = 0;
+    timeout_pat.case_index = 0;
+    timeout_pat.int_value = 0;
+    REQUIRE(fn.values.push(timeout_pat));
+
+    MirBlock test{};
+    test.label = lit("entry");
+    test.term.kind = MirTerminatorKind::Branch;
+    test.term.use_cmp = true;
+    test.term.span = fn.span;
+    test.term.lhs = fn.values[0];
+    test.term.rhs = fn.values[1];
+    test.term.then_block = 1;
+    test.term.else_block = 2;
+    REQUIRE(fn.blocks.push(test));
+
+    MirBlock then_block{};
+    then_block.label = lit("then");
+    then_block.term.kind = MirTerminatorKind::ReturnStatus;
+    then_block.term.span = fn.span;
+    then_block.term.status_code = 503;
+    REQUIRE(fn.blocks.push(then_block));
+
+    MirBlock else_block{};
+    else_block.label = lit("else");
+    else_block.term.kind = MirTerminatorKind::ReturnStatus;
+    else_block.term.span = fn.span;
+    else_block.term.status_code = 403;
+    REQUIRE(fn.blocks.push(else_block));
+    REQUIRE(mir->functions.push(fn));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir, rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 403);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, runtime_error_code_field_from_mir) {
+    auto* hir = new HirModule{};
+    HirRoute route{};
+    route.span = {1, 1, 1, 1};
+    route.method = 'G';
+    route.path = lit("/users");
+
+    HirLocal failed{};
+    failed.span = route.span;
+    failed.name = lit("failed");
+    failed.type = HirTypeKind::I32;
+    failed.may_error = true;
+    failed.init.kind = HirExprKind::Error;
+    failed.init.type = HirTypeKind::Unknown;
+    failed.init.may_error = true;
+    failed.init.int_value = 503;
+    failed.init.msg = lit("boom");
+    REQUIRE(route.locals.push(failed));
+
+    HirExpr failed_ref{};
+    failed_ref.kind = HirExprKind::LocalRef;
+    failed_ref.type = HirTypeKind::I32;
+    failed_ref.may_error = true;
+    failed_ref.local_index = 0;
+    REQUIRE(route.exprs.push(failed_ref));
+
+    HirLocal code{};
+    code.span = route.span;
+    code.name = lit("code");
+    code.type = HirTypeKind::I32;
+    code.init.kind = HirExprKind::Field;
+    code.init.type = HirTypeKind::I32;
+    code.init.lhs = &route.exprs[0];
+    code.init.str_value = lit("code");
+    REQUIRE(route.locals.push(code));
+
+    route.control.kind = HirControlKind::If;
+    route.control.cond.kind = HirExprKind::Eq;
+    route.control.cond.type = HirTypeKind::Bool;
+
+    HirExpr code_ref{};
+    code_ref.kind = HirExprKind::LocalRef;
+    code_ref.type = HirTypeKind::I32;
+    code_ref.local_index = 1;
+    REQUIRE(route.exprs.push(code_ref));
+
+    HirExpr expected{};
+    expected.kind = HirExprKind::IntLit;
+    expected.type = HirTypeKind::I32;
+    expected.int_value = 503;
+    REQUIRE(route.exprs.push(expected));
+
+    route.control.cond.lhs = &route.exprs[1];
+    route.control.cond.rhs = &route.exprs[2];
+    route.control.then_term.kind = HirTerminatorKind::ReturnStatus;
+    route.control.then_term.status_code = 200;
+    route.control.else_term.kind = HirTerminatorKind::ReturnStatus;
+    route.control.else_term.status_code = 500;
+    REQUIRE(hir->routes.push(route));
+
+    auto mir = build_mir(*hir);
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                          nullptr,
+                                          reinterpret_cast<const u8*>(kGetApiRequest),
+                                          sizeof(kGetApiRequest) - 1,
+                                          nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
 }
 
 // Test: Handler with path prefix guard.
@@ -784,6 +3262,380 @@ TEST(jit, opt_unwrap_and_use) {
     tc.destroy();
 }
 
+// handler:
+//   %some = opt.wrap 7
+//   %nil = opt.is_nil %some
+//   %val = opt.unwrap %some
+//   %fb = const.i32 200
+//   %sel = select %nil, %fb, %val
+//   %want = const.i32 7
+//   %ok = cmp.eq %sel, %want
+//   br %ok, ok, bad
+//   ok: ret.status 207
+//   bad: ret.status 500
+TEST(jit, optional_i32_select_value_flow) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("opt_i32_select"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto bad = V(b.create_block(fn, lit("bad")));
+
+    auto i32_ty = V(b.make_type(TypeKind::I32));
+
+    b.set_insert_point(fn, entry);
+    auto seven = V(b.emit_const_i32(7));
+    auto some = V(b.emit_opt_wrap(seven));
+    auto is_nil = V(b.emit_opt_is_nil(some));
+    auto unwrapped = V(b.emit_opt_unwrap(some, i32_ty));
+    auto fallback = V(b.emit_const_i32(200));
+    auto selected = V(b.emit_select(is_nil, fallback, unwrapped));
+    auto want = V(b.emit_const_i32(7));
+    auto eq = V(b.emit_cmp(Opcode::CmpEq, selected, want));
+    VOK(b.emit_br(eq, ok, bad));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(207));
+
+    b.set_insert_point(fn, bad);
+    VOK(b.emit_ret_status(500));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_opt_i32_select"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 207);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// handler:
+//   %none = opt.nil(i32)
+//   %nil = opt.is_nil %none
+//   %val = opt.unwrap %none
+//   %fb = const.i32 200
+//   %sel = select %nil, %fb, %val
+//   %want = const.i32 200
+//   %ok = cmp.eq %sel, %want
+//   br %ok, ok, bad
+//   ok: ret.status 200
+//   bad: ret.status 500
+TEST(jit, optional_i32_select_fallback_from_nil) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("opt_i32_nil_select"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto bad = V(b.create_block(fn, lit("bad")));
+
+    auto i32_ty = V(b.make_type(TypeKind::I32));
+
+    b.set_insert_point(fn, entry);
+    auto none = V(b.emit_opt_nil(i32_ty));
+    auto is_nil = V(b.emit_opt_is_nil(none));
+    auto unwrapped = V(b.emit_opt_unwrap(none, i32_ty));
+    auto fallback = V(b.emit_const_i32(200));
+    auto selected = V(b.emit_select(is_nil, fallback, unwrapped));
+    auto want = V(b.emit_const_i32(200));
+    auto eq = V(b.emit_cmp(Opcode::CmpEq, selected, want));
+    VOK(b.emit_br(eq, ok, bad));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, bad);
+    VOK(b.emit_ret_status(500));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_opt_i32_nil_select"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// handler:
+//   %v = opt.wrap 7
+//   %nil = opt.is_nil %v
+//   %false = const.bool false
+//   %ok = cmp.eq %nil, %false
+//   br %ok, pass, fail
+//   pass: ret.status 200
+//   fail: ret.status 401
+TEST(jit, optional_i32_no_error_guard_shape) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("opt_i32_guard"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto pass = V(b.create_block(fn, lit("pass")));
+    auto fail = V(b.create_block(fn, lit("fail")));
+
+    b.set_insert_point(fn, entry);
+    auto seven = V(b.emit_const_i32(7));
+    auto wrapped = V(b.emit_opt_wrap(seven));
+    auto is_nil = V(b.emit_opt_is_nil(wrapped));
+    auto false_v = V(b.emit_const_bool(false));
+    auto no_error = V(b.emit_cmp(Opcode::CmpEq, is_nil, false_v));
+    VOK(b.emit_br(no_error, pass, fail));
+
+    b.set_insert_point(fn, pass);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, fail);
+    VOK(b.emit_ret_status(401));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_opt_i32_guard"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// handler:
+//   %prefix = const.str "api"
+//   %some = opt.wrap %prefix
+//   %nil = opt.is_nil %some
+//   %fb = const.str "fallback"
+//   %val = opt.unwrap %some
+//   %sel = select %nil, %fb, %val
+//   %want = const.str "api"
+//   %ok = str.has_prefix %sel, %want
+//   br %ok, ok, bad
+//   ok: ret.status 200
+//   bad: ret.status 500
+TEST(jit, optional_str_select_value_flow) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("opt_str_select"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto bad = V(b.create_block(fn, lit("bad")));
+
+    auto str_ty = V(b.make_type(TypeKind::Str));
+
+    b.set_insert_point(fn, entry);
+    auto prefix = V(b.emit_const_str(lit("api")));
+    auto some = V(b.emit_opt_wrap(prefix));
+    auto is_nil = V(b.emit_opt_is_nil(some));
+    auto fallback = V(b.emit_const_str(lit("fallback")));
+    auto unwrapped = V(b.emit_opt_unwrap(some, str_ty));
+    auto selected = V(b.emit_select(is_nil, fallback, unwrapped));
+    auto want = V(b.emit_const_str(lit("api")));
+    auto has_prefix = V(b.emit_str_has_prefix(selected, want));
+    VOK(b.emit_br(has_prefix, ok, bad));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, bad);
+    VOK(b.emit_ret_status(500));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_opt_str_select"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// handler:
+//   %inner_none = opt.nil(i32)
+//   %outer_some = opt.wrap %inner_none
+//   %is_error = opt.is_nil %outer_some
+//   %inner = opt.unwrap %outer_some
+//   %is_nil = opt.is_nil %inner
+//   %t = const.bool true
+//   %missing = select %is_error, %t, %is_nil
+//   %val = opt.unwrap %inner
+//   %fb = const.i32 200
+//   %sel = select %missing, %fb, %val
+//   ...
+TEST(jit, optional_optional_i32_select_value_flow) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("opt_opt_i32_select"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto bad = V(b.create_block(fn, lit("bad")));
+
+    auto i32_ty = V(b.make_type(TypeKind::I32));
+    auto opt_i32_ty = V(b.make_type(TypeKind::Optional, i32_ty));
+    b.set_insert_point(fn, entry);
+    auto inner_none = V(b.emit_opt_nil(i32_ty));
+    auto outer_some = V(b.emit_opt_wrap(inner_none));
+    auto is_error = V(b.emit_opt_is_nil(outer_some));
+    auto inner = V(b.emit_opt_unwrap(outer_some, opt_i32_ty));
+    auto is_nil = V(b.emit_opt_is_nil(inner));
+    auto t = V(b.emit_const_bool(true));
+    auto missing = V(b.emit_select(is_error, t, is_nil));
+    auto val = V(b.emit_opt_unwrap(inner, i32_ty));
+    auto fallback = V(b.emit_const_i32(200));
+    auto selected = V(b.emit_select(missing, fallback, val));
+    auto want = V(b.emit_const_i32(200));
+    auto eq = V(b.emit_cmp(Opcode::CmpEq, selected, want));
+    VOK(b.emit_br(eq, ok, bad));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, bad);
+    VOK(b.emit_ret_status(500));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_opt_opt_i32_select"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+// handler:
+//   %inner_none = opt.nil(i32)
+//   %outer_some = opt.wrap %inner_none
+//   %is_error = opt.is_nil %outer_some
+//   %false = const.bool false
+//   %ok = cmp.eq %is_error, %false
+//   br %ok, pass, fail
+TEST(jit, optional_optional_i32_no_error_guard_shape) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("opt_opt_i32_guard"), lit("/"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto pass = V(b.create_block(fn, lit("pass")));
+    auto fail = V(b.create_block(fn, lit("fail")));
+
+    auto i32_ty = V(b.make_type(TypeKind::I32));
+
+    b.set_insert_point(fn, entry);
+    auto inner_none = V(b.emit_opt_nil(i32_ty));
+    auto outer_some = V(b.emit_opt_wrap(inner_none));
+    auto is_error = V(b.emit_opt_is_nil(outer_some));
+    auto false_v = V(b.emit_const_bool(false));
+    auto no_error = V(b.emit_cmp(Opcode::CmpEq, is_error, false_v));
+    VOK(b.emit_br(no_error, pass, fail));
+
+    b.set_insert_point(fn, pass);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, fail);
+    VOK(b.emit_ret_status(401));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_opt_opt_i32_guard"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
 // ── Codegen: StrTrimPrefix ────────────────────────────────────────
 
 // handler:
@@ -1091,6 +3943,325 @@ TEST(jit, lookup_nonexistent) {
     engine.shutdown();
 }
 
+TEST(jit, frontend_custom_error_struct_field_projection) {
+    const char* src =
+        "struct AuthError { err: Error, token: str, retry: i32 }\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: \"abc\", retry: 3) let retry = failed.retry if retry == 3 { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_error_struct_tuple_field_projection_pipe) {
+    const char* src =
+        "struct AuthError { err: Error, pair: (i32, i32) }\n"
+        "func second(a: i32, b: i32) -> i32 => b\n"
+        "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", pair: (200, 500)) let code = failed.pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_plain_struct_constructor_and_field_projection) {
+    constexpr auto src =
+        "struct Foo { code: i32, msg: str }\n"
+        "route GET \"/users\" { let foo = Foo(code: 200, msg: \"ok\") let code = foo.code let msg = foo.msg if code == 200 { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_plain_struct_tuple_field_projection_pipe) {
+    const char* src =
+        "struct Foo { pair: (i32, i32) }\n"
+        "func second(a: i32, b: i32) -> i32 => b\n"
+        "route GET \"/users\" { let foo = Foo(pair: (200, 500)) let code = foo.pair | second(_2, _1) if code == 200 { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_plain_struct_variant_field_projection_match) {
+    const char* src =
+        "variant AuthState { timeout, forbidden }\n"
+        "struct Foo { state: AuthState }\n"
+        "route GET \"/users\" { let foo = Foo(state: AuthState.timeout) match foo.state { case .timeout: return 200 case _: return 403 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_error_standard_field_projection) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = failed.code if code == 0 { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_error_line_field_projection) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let line = failed.line if line == 1 { return 200 } else { return 500 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_error_file_and_func_field_projection) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let file_name = failed.file let fn_name = failed.func return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 // ── Codegen: RetForward ─────────────────────────────────────────────
 
 // handler:
@@ -1244,6 +4415,4166 @@ TEST(jit, multi_guard) {
 
     engine.shutdown();
     tc.destroy();
+}
+
+TEST(jit, frontend_function_call_inlines_i32_expression_body) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = id(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    if (r.status_code != 200) {
+        rut::test::out("    status=");
+        rut::test::out_int(r.status_code);
+        rut::test::out("\n");
+    }
+    CHECK_EQ(r.status_code, 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_struct_can_reference_generic_variant_with_same_type_arg) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: Result<T> }
+route GET "/users" {
+    let holder = Holder<i32>(state: Result.ok(200))
+    match holder.state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_variant_can_reference_generic_struct_with_same_type_arg) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+variant Wrap<T> { some(Box<T>), none }
+route GET "/users" {
+    let state = Wrap<i32>.some(Box(value: 200))
+    match state {
+    case .some(box): {
+        if box.value == 200 { return 200 } else { return 500 }
+    }
+    case .none:
+        return 404
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_nested_generic_struct_type_refs_are_supported_in_function_signatures) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: Result<T> }
+func unwrap(x: Holder<i32>) -> Result<i32> => x.state
+route GET "/users" {
+    let state = unwrap(Holder<i32>(state: Result.ok(200)))
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_nested_generic_struct_type_ref_preserves_instance_shape_index) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: T }
+func unwrap(x: Holder<Result<i32>>) -> Result<i32> => x.state
+route GET "/users" {
+    let state = unwrap(Holder<Result<i32>>(state: Result.ok(200)))
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_explicit_generic_struct_init_nested_type_arg) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: T }
+route GET "/users" {
+    let holder = Holder<Result<i32>>(state: Result<i32>.ok(200))
+    match holder.state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_nested_generic_variant_type_refs_are_supported_in_function_signatures) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+variant Wrap<T> { some(Box<T>), none }
+func make() -> Wrap<i32> => Wrap<i32>.some(Box(value: 200))
+route GET "/users" {
+    let x = make()
+    match x {
+    case .some(box): {
+        if box.value == 200 { return 200 } else { return 500 }
+    }
+    case .none:
+        return 404
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK_EQ(r.status_code, 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_call_inlines_i32_expression_body_without_return_annotation) {
+    const auto src = R"(
+func id(x: i32) => x
+route GET "/users" {
+    let code = id(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_call_inlines_i32_expression_body) {
+    const auto src = R"rut(
+func id<T>(x: T) -> T => x
+route GET "/users" {
+    let code = id(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_reuses_same_type_parameter_shape) {
+    const auto src = R"rut(
+func first<T>(x: T, y: T) -> T => x
+route GET "/users" {
+    let code = first(200, 500)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_explicit_type_arguments) {
+    const auto src = R"rut(
+func id<T>(x: T) -> T => x
+route GET "/users" {
+    let code = id<i32>(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_supports_nested_generic_param_and_return_shapes) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+struct Holder<T> { state: Result<T> }
+func unwrap<T>(x: Holder<T>) -> Result<T> => x.state
+route GET "/users" {
+    let state = unwrap(Holder(state: Result.ok(200)))
+    match state {
+    case .ok(v): return 200
+    case .err: return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_custom_protocol_method_dispatch) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 200).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_receiver_custom_protocol_method_dispatch) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box) -> i32 => self.value
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 200)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+
+TEST(jit, frontend_concrete_custom_protocol_method_dispatch_with_parameter) {
+    const auto src = R"rut(
+protocol Hashable { func hash(x: i32) -> i32 }
+struct Box { value: i32 }
+Box impl Hashable {
+    func hash(self: Box, x: i32) -> i32 => x
+}
+route GET "/users" {
+    if Box(value: 200).hash(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+
+TEST(jit, frontend_multi_protocol_impl_block) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+protocol Adder { func add(x: i32) -> i32 }
+struct Box { value: i32 }
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+    func add(self: Box, x: i32) -> i32 => x
+}
+route GET "/users" {
+    if Box(value: 7).hash() == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_custom_protocol_default_method_dispatch) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box { value: i32 }
+Box impl Hashable {}
+route GET "/users" {
+    if Box(value: 7).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_receiver_custom_protocol_default_method_dispatch) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box { value: i32 }
+Box impl Hashable {}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_custom_protocol_default_method_dispatch_with_parameter) {
+    const auto src = R"rut(
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Adder {}
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_receiver_custom_protocol_default_method_dispatch_with_parameter) {
+    const auto src = R"rut(
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Adder {}
+func run<T: Adder>(x: T) -> i32 => x.add(201)
+route GET "/users" {
+    if run(Box(value: 7)) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_multi_protocol_impl_may_omit_methods_with_default_bodies) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+}
+protocol Adder {
+    func add(x: i32) -> i32 => x
+}
+struct Box<T> { value: T }
+Box<T> impl Hashable, Adder {
+    func hash(self: Box<T>) -> i32 => 7
+}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 7 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 11)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_multi_protocol_impl_may_omit_methods_with_default_bodies) {
+    const auto src = R"rut(
+protocol Hashable {
+    func hash() -> i32
+    func add(x: i32) -> i32 => x
+}
+protocol Adder {
+    func mul(x: i32) -> i32 => x
+}
+struct Box { value: i32 }
+Box impl Hashable, Adder {
+    func hash(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 7).add(201) == 201 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_protocol_default_method_supports_tuple_return) {
+    const auto src = R"rut(
+protocol Pairable { func pair() -> (i32, i32) => (200, 500) }
+struct Box { value: i32 }
+Box impl Pairable {}
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = Box(value: 7).pair() | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_protocol_default_method_supports_optional_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => nil }
+struct Box { value: i32 }
+Box impl MaybeCode {}
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_protocol_default_method_supports_error_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => error(.timeout) }
+struct Box { value: i32 }
+Box impl MaybeCode {}
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_protocol_default_method_supports_block_body) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code() -> i32 {
+        let x = 200
+        x
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+route GET "/users" {
+    if Box(value: 7).code() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_protocol_default_method_supports_guard_prefix) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        let y = maybefail(ok)
+        guard y else { 401 }
+        200
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+func maybefail(ok: bool) -> i32 { if ok { 200 } else { error(.timeout) } }
+route GET "/users" {
+    if Box(value: 7).code(true) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_custom_protocol_default_method_supports_guard_match_prefix) {
+    const auto src = R"rut(
+protocol MaybeCode {
+    func code(ok: bool) -> i32 {
+        let y = maybefail(ok)
+        guard match y else { case .timeout => 401 case _ => 500 }
+        200
+    }
+}
+struct Box { value: i32 }
+Box impl MaybeCode {}
+func maybefail(ok: bool) -> i32 { if ok { 200 } else { error(.timeout) } }
+route GET "/users" {
+    if Box(value: 7).code(false) == 401 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_impl_overrides_protocol_default_method_with_optional_return) {
+    const auto src = R"rut(
+protocol MaybeCode { func code() -> i32 => nil }
+struct Box { value: i32 }
+Box impl MaybeCode { func code(self: Box) -> i32 => self.value }
+route GET "/users" {
+    let code = or(Box(value: 7).code(), 200)
+    if code == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_impl_overrides_generic_receiver_protocol_default_method) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box<T> { value: T }
+Box<T> impl Hashable { func hash(self: Box<T>) -> i32 => 7 }
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_receiver_multi_protocol_default_method_dispatch_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+protocol Adder { func add(x: i32) -> i32 => x }
+struct Box { value: i32 }
+Box impl Hashable {}
+Box impl Adder {}
+func run<T: Hashable, Adder>(x: T) -> i32 {
+    let h = x.hash()
+    if h == 200 { x.add(3) } else { 0 }
+}
+route GET "/users" {
+    if run(Box(value: 7)) == 3 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_impl_takes_precedence_over_protocol_default_method) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box { value: i32 }
+Box impl Hashable { func hash(self: Box) -> i32 => self.value }
+route GET "/users" {
+    if Box(value: 7).hash() == 7 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_concrete_generic_struct_impl_method_dispatch) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box<T> { value: T }
+Box<i32> impl Hashable {
+    func hash(self: Box<i32>) -> i32 => self.value
+}
+route GET "/users" {
+    if Box(value: 200).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_struct_impl_method_dispatch) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box<T> { value: T }
+Box<T> impl Hashable {
+    func hash(self: Box<T>) -> i32 => 200
+}
+route GET "/users" {
+    if Box(value: 123).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_receiver_custom_protocol_method_dispatch_with_generic_impl_target) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box<T> { value: T }
+Box<T> impl Hashable {
+    func hash(self: Box<T>) -> i32 => 200
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 123)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_receiver_custom_protocol_method_dispatch_with_generic_impl_target_tuple_of_struct_arg) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Item { value: i32 }
+struct Box<T> { value: T }
+Box<T> impl Hashable {
+    func hash(self: Box<T>) -> i32 => 200
+}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: (Item(value: 7), 9))) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_impl_target_accepts_renamed_placeholder) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Box<T> { value: T }
+Box<U> impl Hashable {
+    func hash(self: Box<U>) -> i32 => 200
+}
+route GET "/users" {
+    if Box(value: 7).hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_impl_target_accepts_multiple_type_params) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 }
+struct Pair<T, U> { left: T, right: U }
+Pair<A, B> impl Hashable {
+    func hash(self: Pair<A, B>) -> i32 => 200
+}
+route GET "/users" {
+    if Pair(left: 7, right: "x").hash() == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_struct_instance_custom_protocol_conformance_is_supported) {
+    const auto src = R"rut(
+protocol Hashable { func hash() -> i32 => 200 }
+struct Box<T> { value: T }
+Box<i32> impl Hashable {}
+func run<T: Hashable>(x: T) -> i32 => x.hash()
+route GET "/users" {
+    if run(Box(value: 7)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_custom_protocol_constraint_for_builtin_conformance) {
+    const auto src = R"rut(
+protocol Hashable {}
+i32 impl Hashable {}
+func hash<T: Hashable>(x: T) -> i32 => 200
+route GET "/users" {
+    if hash(200) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_custom_protocol_constraint_for_struct_conformance) {
+    const auto src = R"rut(
+protocol Hashable {}
+struct Box { value: i32 }
+Box impl Hashable {}
+func hash<T: Hashable>(x: T) -> i32 => 200
+route GET "/users" {
+    if hash(Box(value: 200)) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_error_constraint_and_standard_field_access) {
+    const auto src = R"rut(
+struct AuthError { err: Error, retry: i32 }
+func codeOf<E: Error>(x: E) -> i32 => x.code
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_eq_constraint_and_ne_method) {
+    const auto src = R"rut(
+func diff<T: Eq>(x: T, y: T) -> bool => x.ne(y)
+route GET "/users" {
+    if diff(200, 300) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_ord_constraint_and_le_ge_methods) {
+    const auto src = R"rut(
+func clampOk<T: Ord>(x: T, lo: T, hi: T) -> bool => x.ge(lo).eq(x.le(hi))
+route GET "/users" {
+    if clampOk(5, 1, 9) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_error_standard_fields_are_accessible_via_methods) {
+    const auto src = R"rut(
+route GET "/users" {
+    let failed = error(.timeout, "timed out")
+    let code = failed.code()
+    let line = failed.line()
+    if code == line { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), sizeof(kGetApiRequest) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 500);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_eq_constraint_and_eq_method) {
+    const auto src = R"rut(
+func same<T: Eq>(x: T, y: T) -> bool => x.eq(y)
+route GET "/users" {
+    if same(200, 200) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_ord_constraint_and_lt_method) {
+    const auto src = R"rut(
+func min<T: Ord>(x: T, y: T) -> T {
+    if x.lt(y) { x } else { y }
+}
+route GET "/users" {
+    if min(200, 300) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_eq_constraint_and_equality) {
+    const auto src = R"rut(
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    if same("a", "a") { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_eq_constraint_for_tuple) {
+    const auto src = R"rut(
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    if same((200, 500), (200, 500)) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_eq_constraint_for_tuple_of_struct) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    if same((Box(value: 200), 500), (Box(value: 200), 500)) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_ord_constraint_and_lt_for_str) {
+    const auto src = R"rut(
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min("alpha", "beta") == "alpha" { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           static_cast<u32>(sizeof(kGetApiRequest) - 1),
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_ord_constraint_for_tuple) {
+    const auto src = R"rut(
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min((200, 500), (200, 600)) == (200, 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), static_cast<u32>(sizeof(kGetApiRequest) - 1), nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_ord_constraint_for_tuple_of_struct) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min((Box(value: 200), 500), (Box(value: 200), 600)) == (Box(value: 200), 500) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           static_cast<u32>(sizeof(kGetApiRequest) - 1),
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_ord_constraint_for_struct) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min(Box(value: 200), Box(value: 500)) == Box(value: 200) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), static_cast<u32>(sizeof(kGetApiRequest) - 1), nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_ord_constraint_for_variant) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min(Result<i32>.ok(200), Result<i32>.ok(500)) == Result<i32>.ok(200) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr, nullptr, reinterpret_cast<const u8*>(kGetApiRequest), static_cast<u32>(sizeof(kGetApiRequest) - 1), nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_eq_constraint_for_struct) {
+    const auto src = R"rut(
+struct Box<T> { value: T }
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    if same(Box(value: 200), Box(value: 200)) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_ord_constraint_and_lt) {
+    const auto src = R"rut(
+func min<T: Ord>(x: T, y: T) -> T {
+    if x < y { x } else { y }
+}
+route GET "/users" {
+    if min(200, 500) == 200 { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_accepts_eq_constraint_for_variant_payload) {
+    const auto src = R"rut(
+variant Result<T> { ok(T), err }
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route GET "/users" {
+    if same(Result.ok(200), Result.ok(500)) { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 500);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_call_inlines_variant_expression_body) {
+    const auto src = R"(
+variant AuthState { ok, err }
+func success() -> AuthState => AuthState.ok
+route GET "/users" {
+    match success() {
+    case .ok: return 200
+    case _: return 500
+    }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_call_inlines_variant_expression_body_without_return_annotation) {
+    const auto src = R"(
+variant AuthState { ok, err }
+func success() => AuthState.ok
+route GET "/users" {
+    match success() {
+    case .ok: return 200
+    case _: return 500
+    }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_supports_explicit_tuple_return_type) {
+    const auto src = R"(
+func pair() -> (i32, i32) { (200, 500) }
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = pair() | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_supports_explicit_tuple_param_type) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+func pick(pair: (i32, i32)) -> i32 => pair | second(_2, _1)
+route GET "/users" {
+    let code = pick((200, 500))
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_let_supports_explicit_tuple_type) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let pair: (i32, i32) = (200, 500)
+    let code = pair | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_block_let_supports_explicit_tuple_type) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+func pick() -> i32 {
+    let pair: (i32, i32) = (200, 500)
+    pair | second(_2, _1)
+}
+route GET "/users" {
+    let code = pick()
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_call_propagates_optional_value_flow) {
+    const auto src = R"(
+func maybe() -> i32 => nil
+route GET "/users" {
+    let code = or(maybe(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_block_body_allows_pure_nil_with_explicit_return_type) {
+    const auto src = R"(
+func maybe() -> i32 {
+    nil
+}
+route GET "/users" {
+    let code = or(maybe(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_infers_optional_return_from_if_without_annotation) {
+    const auto src = R"(
+func maybe(ok: bool) {
+    if ok { 200 } else { nil }
+}
+route GET "/users" {
+    let code = or(maybe(true), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_call_propagates_error_value_flow) {
+    const auto src = R"(
+func fail() -> i32 => error(.timeout)
+route GET "/users" {
+    let code = or(fail(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_block_body_allows_pure_error_with_explicit_return_type) {
+    const auto src = R"(
+func fail() -> i32 {
+    error(.timeout)
+}
+route GET "/users" {
+    let code = or(fail(), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_infers_error_return_from_if_without_annotation) {
+    const auto src = R"(
+func maybefail(ok: bool) {
+    if ok { 200 } else { error(.timeout) }
+}
+route GET "/users" {
+    let code = or(maybefail(true), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_allows_pure_nil_if_with_explicit_return_type) {
+    const auto src = R"(
+func maybe(ok: bool) -> i32 {
+    if ok { nil } else { nil }
+}
+route GET "/users" {
+    let code = or(maybe(true), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_block_body_with_let_prefix_inlines) {
+    const auto src = R"(
+func wrap(x: i32) -> i32 {
+    let y = x
+    y
+}
+route GET "/users" {
+    let code = wrap(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_block_body_with_guard_prefix_inlines) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func wrap(ok: bool) -> i32 {
+    let y = maybefail(ok)
+    guard y else { 401 }
+    200
+}
+route GET "/users" {
+    let code = wrap(false)
+    if code == 401 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_block_body_with_guard_let_prefix_binds_value) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func wrap(ok: bool) -> i32 {
+    guard let y = maybefail(ok) else { 401 }
+    y
+}
+route GET "/users" {
+    let code = wrap(true)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_block_body_with_guard_match_prefix_inlines) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func wrap(ok: bool) -> i32 {
+    let y = maybefail(ok)
+    guard match y else { case .timeout => 401 case _ => 500 }
+    200
+}
+route GET "/users" {
+    let code = wrap(false)
+    if code == 401 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_block_body_with_final_if_inlines) {
+    const auto src = R"(
+func wrap(x: i32) -> i32 {
+    let y = x
+    if y == 200 { 200 } else { 500 }
+}
+route GET "/users" {
+    let code = wrap(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_block_body_with_final_match_inlines) {
+    const auto src = R"(
+variant Result { ok, err }
+func pick(x: Result) -> i32 {
+    let y = x
+    match y {
+        case .ok => 200
+        case .err => 500
+    }
+}
+route GET "/users" {
+    let code = pick(Result.ok)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_match_arm_block_with_let_inlines) {
+    const auto src = R"(
+variant Result { ok, err }
+func pick(x: Result) -> i32 {
+    match x {
+        case .ok => { let y = 200 y }
+        case .err => { let z = 500 z }
+    }
+}
+route GET "/users" {
+    let code = pick(Result.ok)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_infers_optional_return_from_match_without_annotation) {
+    const auto src = R"(
+variant Result { ok, err }
+func pick(x: Result) {
+    match x {
+        case .ok => 200
+        case .err => nil
+    }
+}
+route GET "/users" {
+    let code = or(pick(Result.ok), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_infers_error_return_from_match_without_annotation) {
+    const auto src = R"(
+variant Result { ok, err }
+func pick(x: Result) {
+    match x {
+        case .ok => 200
+        case .err => error(.timeout)
+    }
+}
+route GET "/users" {
+    let code = or(pick(Result.ok), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_function_allows_pure_error_match_with_explicit_return_type) {
+    const auto src = R"(
+variant Result { ok, err }
+func pick(x: Result) -> i32 {
+    match x {
+        case .ok => error(.timeout)
+        case .err => error(.timeout)
+    }
+}
+route GET "/users" {
+    let code = or(pick(Result.ok), 200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_single_stage) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(_)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_chained_stages) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(_) | id(_)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_placeholder_position) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = 200 | second(500, _)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_placeholder_slot_one_alias) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = 200 | second(500, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_tuple_literal_multi_slot_placeholders) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = (200, 500) | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_tuple_returning_function_multi_slot_placeholders) {
+    const auto src = R"(
+func pair() { (200, 500) }
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = pair() | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_tuple_of_struct_binding_preserves_struct_slots) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+func id<T>(x: T) -> T => x
+func boxCode(b: Box) -> i32 => b.value
+route GET "/users" {
+    let pair = id((Box(value: 200), 1))
+    let code = pair | boxCode(_1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_generic_function_explicit_tuple_of_struct_type_arg_preserves_struct_slots) {
+    const auto src = R"rut(
+struct Box { value: i32 }
+func id<T>(x: T) -> T => x
+func boxCode(b: Box) -> i32 => b.value
+route GET "/users" {
+    let pair = id<(Box, i32)>((Box(value: 200), 1))
+    let code = pair | boxCode(_1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)rut";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_tuple_local_alias_multi_slot_placeholders) {
+    const auto src = R"(
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let pair = (200, 500)
+    let code = pair | second(_2, _1)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_chains_tuple_returning_stage_multi_slot_placeholders) {
+    const auto src = R"(
+func swap(a: i32, b: i32) { (b, a) }
+func second(a: i32, b: i32) -> i32 => b
+route GET "/users" {
+    let code = (200, 500) | swap(_1, _2) | second(_1, _2)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_placeholder_slot_eleven_is_rejected_at_parse) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(_11)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE_FALSE(ast.has_value());
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(jit, frontend_pipe_runtime_fallible_lhs_slot_two_is_rejected) {
+    const auto src = R"(
+func id(x: str) -> str => x
+route GET "/users" {
+    let code = req.header("Host") | id(_2)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(jit, frontend_pipe_known_nil_falls_back_via_or) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = nil | id(_)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_known_error_falls_back_via_or) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let failed = error(.timeout)
+    let code = failed | id(_)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_runtime_optional_lhs_flows_via_or) {
+    const auto src = R"(
+func id(x: str) -> str => x
+route GET "/users" {
+    let host = req.header("Host") | id(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_runtime_error_lhs_flows_via_or) {
+    const auto src = R"(
+func fail() -> i32 => error(.timeout)
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = fail() | id(_)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_or_nil_branch) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { nil } else { error(.timeout) }
+}
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = maybefail(true) | id(_)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_or_error_branch) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { nil } else { error(.timeout) }
+}
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = maybefail(false) | id(_)
+    let safe = or(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_runtime_optional_lhs_flows_into_optional_stage_via_or) {
+    const auto src = R"(
+func drop(x: str) -> str { nil }
+route GET "/users" {
+    let host = req.header("Host") | drop(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_runtime_optional_lhs_flows_into_error_stage_via_or) {
+    const auto src = R"(
+func failstage(x: str) -> str => error(.timeout)
+route GET "/users" {
+    let host = req.header("Host") | failstage(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_runtime_error_lhs_flows_into_optional_stage_via_or) {
+    const auto src = R"(
+func fail() -> str => error(.timeout)
+func drop(x: str) -> str { nil }
+route GET "/users" {
+    let host = fail() | drop(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_runtime_error_lhs_flows_into_error_stage_via_or) {
+    const auto src = R"(
+func fail() -> str => error(.timeout)
+func failstage(x: str) -> str => error(.timeout)
+route GET "/users" {
+    let host = fail() | failstage(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_runtime_optional_lhs_flows_into_optional_error_stage_via_or) {
+    const auto src = R"(
+func tri(x: str) -> str {
+    if x == "host" { nil } else { error(.timeout) }
+}
+route GET "/users" {
+    let host = req.header("Host") | tri(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_runtime_optional_error_stage_direct_via_or) {
+    const auto src = R"(
+func tri(x: str) -> str {
+    if x == "host" { nil } else { error(.timeout) }
+}
+route GET "/users" {
+    let raw = req.header("Host")
+    let input = or(raw, "fallback")
+    let host = tri(input)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_runtime_error_lhs_flows_into_optional_error_stage_via_or) {
+    const auto src = R"(
+func fail() -> str => error(.timeout)
+func tri(x: str) -> str {
+    if x == "host" { nil } else { error(.timeout) }
+}
+route GET "/users" {
+    let host = fail() | tri(_)
+    let safe = or(host, "missing")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
 }
 
 int main(int argc, char** argv) {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -26,9 +26,36 @@ static Str lit(const char* s) {
     return {s, n};
 }
 
+// RAII wrapper — frontend APIs (parse_file/analyze_file/build_mir) all
+// .release() a unique_ptr. Without ownership the raw pointer leaks; the
+// test suite was leaking ~75 MB per test case before this guard landed.
 template <typename T>
 struct HeapFrontendResult {
     FrontendResult<T*> inner;
+
+    HeapFrontendResult() = default;
+    HeapFrontendResult(FrontendResult<T*> v) : inner(std::move(v)) {}
+    HeapFrontendResult(const HeapFrontendResult&) = delete;
+    HeapFrontendResult& operator=(const HeapFrontendResult&) = delete;
+    HeapFrontendResult(HeapFrontendResult&& other) noexcept : inner(std::move(other.inner)) {
+        other.inner = core::make_unexpected(Diagnostic{});
+    }
+    HeapFrontendResult& operator=(HeapFrontendResult&& other) noexcept {
+        if (this != &other) {
+            reset();
+            inner = std::move(other.inner);
+            other.inner = core::make_unexpected(Diagnostic{});
+        }
+        return *this;
+    }
+    ~HeapFrontendResult() { reset(); }
+
+    void reset() {
+        if (inner.has_value()) {
+            delete inner.value();
+            inner = core::make_unexpected(Diagnostic{});
+        }
+    }
 
     bool has_value() const { return inner.has_value(); }
     explicit operator bool() const { return static_cast<bool>(inner); }

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -12995,6 +12995,116 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_route_decorator_pass_runs_handler) {
+    const auto src = R"rut(
+func passing(_ req: i32) -> i32 => 0
+route {
+    @passing "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK_EQ(r.status_code, 200);  // handler ran
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_decorator_reject_short_circuits_handler) {
+    const auto src = R"rut(
+func rejecting(_ req: i32) -> i32 => 401
+route {
+    @rejecting "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK_EQ(r.status_code, 401);  // decorator's return short-circuited the handler
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_decorator_chain_second_rejects) {
+    const auto src = R"rut(
+func passing(_ req: i32) -> i32 => 0
+func rejecting(_ req: i32) -> i32 => 403
+route {
+    @passing "*"
+    @rejecting "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK_EQ(r.status_code, 403);  // first decorator passed, second rejected
+    engine.shutdown();
+    rir.destroy();
+}
+
 int main(int argc, char** argv) {
     return rut::test::run_all(argc, argv);
 }


### PR DESCRIPTION
## Summary

Brings the `syntax` branch to a state where (a) the frontend type checker
fully validates imports, generics, protocols, and type-shape carry-through
end-to-end, and (b) the Swift-style `@decorator` middleware syntax from
DESIGN.md §3.4.4 is implemented from `.rut` source through JIT.

29 commits / +50.5k / −3.2k (most of the bulk is in test_frontend.cc and
test_jit.cc — ~620 new tests covering the frontend and JIT paths).

## What's in here

The session's new work sits at the tip:

| Commit | Scope |
|---|---|
| `a87cb47` | Apply clang-format across compiler/jit/tests (reflow only, no semantics) |
| `dfb39c5` | Decorator semantics: HIR/MIR/RIR runtime-value return + analyze inlining + 8 tests |
| `95ca97b` | Decorator syntax: lexer (`@`, lowercase methods) + AST + parser block form + `_` param + 12 tests |
| `91ba636` | Frontend: imports, generics, protocols, type-shape carry-through (codex; ~600 tests) |

The earlier 25 commits on the branch are previously-reviewed work
(language design refinement, Proxy→Forward rename, LLVM 18 upgrade,
frontend pipeline scaffolding) that landed in the merged squash from
PR #25 but remain as individual commits on `syntax`.

## Decorator end-to-end

A `route` block can carry pre-middleware via `@decorator pattern` bindings
or entry-prefix `@decorator`:

```swift
func auth(_ req: i32) -> i32 => 0
route {
    @auth \"*\"                      // binding: applies to all entries
    @logResp \"/admin\"              // binding: prefix-matched
    GET \"/users\" { return 200 }
}
```

Locked design decisions (see commit messages for rationale):

| | Choice |
|---|---|
| First parameter | **Strict**: must be \`_ name: Type\` (Swift omitted-label). Relaxing later is non-breaking. |
| Return type | \`i32\` — runtime treats 0 as pass-through, non-zero as HTTP status to short-circuit. |
| Inlining | Each decorator body inlines into a synthetic local; a guard short-circuits on non-zero. |
| Runtime value flow | New \`HirTerminatorSourceKind::LocalRef\` mode lets terminator read i32 from a local. |

Codegen needed no changes — \`codegen.cc:689\` already routed \`RetStatus\`
through either operand or immediate, so threading the operand from the
HIR/MIR/RIR layers above was sufficient.

## Known limitations / not in this PR

- Decorator function bodies cannot reference the param meaningfully: the
  implicit \`req\` is filled with \`IntConst(0)\` placeholder until a real
  \`Request\` domain type lands. Decorators access request data via the
  \`req.header(...)\` parser-level sugar (independent of the param value).
- Block-body decorators with computed branches inline as IfElse expressions
  but route locals all evaluate eagerly — short-circuit happens at the
  guard layer, not the decorator-call layer. For pure decorators (the v1
  reality, since user functions can't do I/O) this is correct, just slightly
  wasteful when an early decorator rejects.
- Validator does not yet check first param type is \`Request\` — HIR has no
  Request type.

## Pre-existing issues (not introduced here)

- 768 clang-tidy warnings: ~261 \`readability-identifier-naming\` (the
  \`.clang-tidy\` ConstantCase=CamelCase+k rule is stricter than what the
  frontend actually uses), ~242 \`misc-include-cleaner\` (missing direct
  includes), ~237 \`misc-const-correctness\`. All from codex-era code.
  My new code follows the existing snake_case pattern for consistency
  rather than fighting the codebase. Mass-fix is a separate cleanup PR.
- One \`HirRoute::DecoratorRef\` + \`decorators\` field in commit
  \`91ba636\` is dead until commit \`dfb39c5\` uses it (small accidental
  inclusion when splitting commits; functionally harmless).

## Test plan

- [x] \`./dev.sh build\` succeeds
- [x] \`./dev.sh test\` — 20/20 ctest suites pass
  - Notable: \`test_frontend\` (compiler), \`test_jit\` (frontend → JIT integration)
- [x] \`./dev.sh format\` — clean after \`a87cb47\`
- [x] New tests cover:
  - Lexer: \`@\` token, lowercase HTTP methods
  - Parser: route block with \`*\` and prefix bindings, entry-prefix decorators, binding+entry merge order, lowercase methods, legacy form regression
  - Analyze: decorator name → function index resolution; rejects unknown decorator, 0-param sig, missing \`_\`, non-i32 return
  - JIT end-to-end: \`@passing\` returns 0 → handler runs (200); \`@rejecting\` returns 401 → short-circuit (401); \`@passing @rejecting\` chain → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)