### PR TITLE
let-across-wait: frontend relaxation for pure-init locals crossing wait(ms)

### DIFF
--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9401,31 +9401,34 @@ static FrontendResult<HirModule*> analyze_file_internal(
         if (route.method == 0)
             return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
 
-        // Slice-0 constraint: all waits must appear as a contiguous prefix
-        // of the route body (possibly empty, followed by non-wait code).
-        // The current codegen dispatches the state-machine prologue BEFORE
-        // the entry block, so a wait placed after other statements would
-        // run those statements only after the final yield — source order
-        // would not match execution order for interleaved guard/let/wait.
-        // Proper mid-body yields land with the submit/any/all slices.
+        // Slice-1 constraint: a route body has the shape
+        //   let* ; wait* ; terminal*
+        // — zero or more `let`s, zero or more `wait`s, then the rest
+        // (guard / if / match / return / forward). Locals initialized
+        // before a wait are spilled into HandlerCtx slots by codegen
+        // and reloaded in the terminal block after all yields. Other
+        // mid-body yields (guard before wait, submit/any/all) land
+        // with later slices.
         //
-        // Decorators are also routed through the entry block (once wired
+        // Decorators are routed through the entry block (once wired
         // from HIR to codegen), so mixing waits with decorators would
-        // sleep before running the decorator — a route like
-        // `@auth GET "/x" { wait(50) return 204 }` would let an
-        // unauthorized request sleep before rejecting. Reject that
-        // combination here until decorators land in codegen with a
-        // proper pre-yield placement.
+        // sleep before running the decorator — `@auth GET "/x" {
+        // wait(50) return 204 }` would let an unauthorized request
+        // sleep before rejecting. Reject that combination here until
+        // decorators land with pre-yield placement.
         //
         // wait(0) is rejected: it has no meaning for a sleep primitive
-        // and would stall 1s under the wheel fallback. If concurrent-I/O
-        // primitives grow a legitimate "yield control" use-case, this
-        // check can be lifted.
-        bool seen_non_wait = false;
+        // and would stall 1s under the wheel fallback.
+        // Only non-let non-wait statements block subsequent waits. Lets
+        // are always admissible (pre-wait lets are spilled to ctx slots
+        // by codegen; post-wait lets stay SSA-only in the terminal
+        // block). Non-wait routes with any interleaving of lets + other
+        // statements remain valid since no wait ever reaches this flag.
+        bool seen_non_let_non_wait = false;
         for (u32 si = 0; si < item.route.statements.len; si++) {
             const auto& stmt = item.route.statements[si];
             if (stmt.kind == AstStmtKind::Wait) {
-                if (seen_non_wait)
+                if (seen_non_let_non_wait)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 if (stmt.status_code == 0)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
@@ -9442,7 +9445,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
                     return frontend_error(FrontendError::TooManyItems, stmt.span);
                 continue;
             }
-            seen_non_wait = true;
+            if (stmt.kind != AstStmtKind::Let) seen_non_let_non_wait = true;
             if (stmt.kind == AstStmtKind::Let) {
                 HirLocal local{};
                 local.span = stmt.span;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9402,9 +9402,10 @@ static FrontendResult<HirModule*> analyze_file_internal(
             return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
 
         // Slice-1 constraint: a route body has the shape
-        //   let* ; wait* ; terminal*
-        // — zero or more `let`s, zero or more `wait`s, then the rest
-        // (guard / if / match / return / forward).
+        //   let* ; wait* ; terminal
+        // — zero or more `let`s, zero or more `wait`s, then one
+        // top-level terminal statement (return / forward / guard /
+        // if / match / block containing that terminal region).
         //
         // Mechanism (slice 1, pure-expression surface): codegen routes
         // states 0..N-1 to dead-end yield blocks that emit the packed
@@ -9458,12 +9459,12 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 continue;
             }
             // Pre-wait lets are allowed; post-wait lets are not. Any
-            // other statement (guard/if/match/return/forward) counts
+            // other statement (guard/if/match/return/forward/...) counts
             // as the terminal region and gates further waits.
-            if (stmt.kind == AstStmtKind::Let) {
-                if (seen_wait) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
-            } else {
+            if (stmt.kind != AstStmtKind::Let) {
                 seen_non_let_non_wait = true;
+            } else if (seen_wait) {
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
             }
             if (stmt.kind == AstStmtKind::Let) {
                 HirLocal local{};

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9406,16 +9406,17 @@ static FrontendResult<HirModule*> analyze_file_internal(
         // — zero or more `let`s, zero or more `wait`s, then the rest
         // (guard / if / match / return / forward).
         //
-        // Mechanism (for slice 1's pure-expression surface): codegen
-        // routes states 0..N-1 to dead-end yield blocks that emit the
-        // packed Yield; state N (terminal) runs the original entry
-        // block, which re-materializes every local fresh via
+        // Mechanism (slice 1, pure-expression surface): codegen routes
+        // states 0..N-1 to dead-end yield blocks that emit the packed
+        // Yield; state N (terminal) runs the original entry block,
+        // which re-materializes every local fresh via
         // materialize_local_init. For pure initializers that's
         // idempotent, so pre-wait locals reach the post-wait terminal
-        // with the right value — no spill/reload of HandlerCtx slots
-        // is needed. Once initializers gain side effects (I/O calls
-        // in later slices) this becomes incorrect and spill/reload
-        // must be wired.
+        // with the right value. The HandlerCtx slot helpers
+        // (load_slot/store_slot in include/rut/jit/handler_abi.h) are
+        // NOT used today — they stay parked until impure initializers
+        // (I/O expressions) arrive and re-materialization becomes
+        // incorrect.
         //
         // `let` after the first `wait` is rejected: it would still
         // execute in the terminal block (so pure inits would work in

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9402,10 +9402,14 @@ static FrontendResult<HirModule*> analyze_file_internal(
             return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
 
         // Slice-1 constraint: a route body has the shape
-        //   let* ; wait* ; terminal
-        // — zero or more `let`s, zero or more `wait`s, then one
-        // top-level terminal statement (return / forward / guard /
-        // if / match / block containing that terminal region).
+        //   let* ; wait* ; guard* ; terminal_control
+        // — zero or more `let`s, zero or more `wait`s, zero or more
+        // top-level `guard`s (each guard requires a following
+        // statement), then one top-level terminal control statement
+        // (return / forward / if / match / block containing that
+        // terminal region). Guards gate subsequent waits the same
+        // way any other non-let non-wait does, but are called out
+        // separately because they're common pre-terminal filters.
         //
         // Mechanism (slice 1, pure-expression surface): codegen routes
         // states 0..N-1 to dead-end yield blocks that emit the packed

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9404,26 +9404,36 @@ static FrontendResult<HirModule*> analyze_file_internal(
         // Slice-1 constraint: a route body has the shape
         //   let* ; wait* ; terminal*
         // — zero or more `let`s, zero or more `wait`s, then the rest
-        // (guard / if / match / return / forward). Locals initialized
-        // before a wait are spilled into HandlerCtx slots by codegen
-        // and reloaded in the terminal block after all yields. Other
-        // mid-body yields (guard before wait, submit/any/all) land
-        // with later slices.
+        // (guard / if / match / return / forward).
         //
-        // Decorators are routed through the entry block (once wired
-        // from HIR to codegen), so mixing waits with decorators would
-        // sleep before running the decorator — `@auth GET "/x" {
-        // wait(50) return 204 }` would let an unauthorized request
-        // sleep before rejecting. Reject that combination here until
-        // decorators land with pre-yield placement.
+        // Mechanism (for slice 1's pure-expression surface): codegen
+        // routes states 0..N-1 to dead-end yield blocks that emit the
+        // packed Yield; state N (terminal) runs the original entry
+        // block, which re-materializes every local fresh via
+        // materialize_local_init. For pure initializers that's
+        // idempotent, so pre-wait locals reach the post-wait terminal
+        // with the right value — no spill/reload of HandlerCtx slots
+        // is needed. Once initializers gain side effects (I/O calls
+        // in later slices) this becomes incorrect and spill/reload
+        // must be wired.
+        //
+        // `let` after the first `wait` is rejected: it would still
+        // execute in the terminal block (so pure inits would work in
+        // principle), but the source order would misrepresent when
+        // the initializer actually runs, and the mechanism extends
+        // awkwardly once impure inits land. Deferring until the
+        // state-machine has real per-state code gen.
+        //
+        // Decorators are routed through the entry block, so mixing
+        // waits with decorators would sleep before running the
+        // decorator — `@auth GET "/x" { wait(50) return 204 }` would
+        // let an unauthorized request sleep before rejecting. Reject
+        // that combination here until decorators gain pre-yield
+        // placement.
         //
         // wait(0) is rejected: it has no meaning for a sleep primitive
         // and would stall 1s under the wheel fallback.
-        // Only non-let non-wait statements block subsequent waits. Lets
-        // are always admissible (pre-wait lets are spilled to ctx slots
-        // by codegen; post-wait lets stay SSA-only in the terminal
-        // block). Non-wait routes with any interleaving of lets + other
-        // statements remain valid since no wait ever reaches this flag.
+        bool seen_wait = false;
         bool seen_non_let_non_wait = false;
         for (u32 si = 0; si < item.route.statements.len; si++) {
             const auto& stmt = item.route.statements[si];
@@ -9434,6 +9444,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 if (!item.route.decorators.empty())
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                seen_wait = true;
                 // ms payload is the 32-bit Yield slot (status_code +
                 // upstream_id co-opted); the parser already caps at
                 // UINT32_MAX. Duration literals (`1s`, `500ms`) are future
@@ -9445,7 +9456,14 @@ static FrontendResult<HirModule*> analyze_file_internal(
                     return frontend_error(FrontendError::TooManyItems, stmt.span);
                 continue;
             }
-            if (stmt.kind != AstStmtKind::Let) seen_non_let_non_wait = true;
+            // Pre-wait lets are allowed; post-wait lets are not. Any
+            // other statement (guard/if/match/return/forward) counts
+            // as the terminal region and gates further waits.
+            if (stmt.kind == AstStmtKind::Let) {
+                if (seen_wait) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+            } else {
+                seen_non_let_non_wait = true;
+            }
             if (stmt.kind == AstStmtKind::Let) {
                 HirLocal local{};
                 local.span = stmt.span;

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -256,9 +256,9 @@ TEST(frontend, analyze_rejects_wait_zero) {
 
 TEST(frontend, analyze_accepts_let_before_wait) {
     // Slice 1: lets can appear before waits. Codegen re-materializes
-    // the value in the terminal/entry block across the yield boundary;
-    // for the pure initializers slice 0 supports, this is idempotent
-    // so no HandlerCtx spill/reload machinery is needed yet.
+    // the value in the terminal/entry block across the yield boundary
+    // (idempotent for pure initializers). The HandlerCtx slot helpers
+    // in handler_abi.h are not wired.
     const char* src = "route GET \"/x\" { let k = 42 wait(50) return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -255,8 +255,10 @@ TEST(frontend, analyze_rejects_wait_zero) {
 }
 
 TEST(frontend, analyze_accepts_let_before_wait) {
-    // Slice 1: lets can appear before waits. Codegen spills them into
-    // HandlerCtx slots so they survive across yields.
+    // Slice 1: lets can appear before waits. Codegen re-materializes
+    // the value in the terminal/entry block across the yield boundary;
+    // for the pure initializers slice 0 supports, this is idempotent
+    // so no HandlerCtx spill/reload machinery is needed yet.
     const char* src = "route GET \"/x\" { let k = 42 wait(50) return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -266,6 +268,21 @@ TEST(frontend, analyze_accepts_let_before_wait) {
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 1u);
     REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+}
+
+TEST(frontend, analyze_rejects_let_after_wait) {
+    // Slice-1 shape is `let* ; wait* ; terminal*`. A let between
+    // waits (or after all waits) would still execute only in the
+    // terminal block, which misrepresents source order and extends
+    // awkwardly once impure initializers land. Defer until the
+    // state machine gains real per-state code generation.
+    const char* src = "route GET \"/x\" { wait(50) let k = 42 wait(50) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
 }
 
 TEST(frontend, analyze_rejects_wait_after_let_guard) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -254,6 +254,34 @@ TEST(frontend, analyze_rejects_wait_zero) {
     CHECK(!hir);
 }
 
+TEST(frontend, analyze_accepts_let_before_wait) {
+    // Slice 1: lets can appear before waits. Codegen spills them into
+    // HandlerCtx slots so they survive across yields.
+    const char* src = "route GET \"/x\" { let k = 42 wait(50) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+}
+
+TEST(frontend, analyze_rejects_wait_after_let_guard) {
+    // Non-let non-wait statements still gate subsequent waits. A guard
+    // between a let and a wait introduces a terminal-ish control path
+    // the state machine can't yet thread through.
+    const char* src =
+        "route GET \"/x\" { let k = 42 guard k else { return 401 } wait(50) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
 TEST(frontend, analyze_rejects_wait_in_decorated_route) {
     // The codegen state-machine prologue routes states 0..yield_count-1
     // to yield blocks before the entry block. Once decorators are wired

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2299,7 +2299,8 @@ TEST(route, let_across_wait_drives_return_real_socket) {
 
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
-    send_all(c, "GET /let HTTP/1.1\r\nHost: x\r\n\r\n", 30);
+    const char kLetReq[] = "GET /let HTTP/1.1\r\nHost: x\r\n\r\n";
+    send_all(c, kLetReq, sizeof(kLetReq) - 1);
     char buf[1024];
     i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
     CHECK_GT(n, 0);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2300,9 +2300,17 @@ TEST(route, let_across_wait_drives_return_real_socket) {
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
     const char kLetReq[] = "GET /let HTTP/1.1\r\nHost: x\r\n\r\n";
+    struct timespec t0;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
     send_all(c, kLetReq, sizeof(kLetReq) - 1);
     char buf[1024];
     i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+    struct timespec t1;
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    i64 elapsed_ns = static_cast<i64>(t1.tv_sec - t0.tv_sec) * 1'000'000'000LL +
+                     (static_cast<i64>(t1.tv_nsec) - static_cast<i64>(t0.tv_nsec));
+    i64 elapsed_ms = elapsed_ns / 1'000'000LL;
+
     CHECK_GT(n, 0);
     bool found_201 = false;
     for (i32 i = 0; i + 2 < n; i++) {
@@ -2312,6 +2320,12 @@ TEST(route, let_across_wait_drives_return_real_socket) {
         }
     }
     CHECK(found_201);
+    // wait(100) must actually fire — otherwise this test could pass
+    // even if the yield path was bypassed and state 0 fell through
+    // to state N immediately. Floor at 80ms for scheduler jitter on
+    // slow CI; ceiling at 500ms to flag anything unusually slow.
+    CHECK_GT(elapsed_ms, 80);
+    CHECK_LT(elapsed_ms, 500);
 
     close(c);
     lt.stop();

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2248,6 +2248,79 @@ TEST(route, wait_ms_precision_sub_second) {
     rir.destroy();
 }
 
+// Slice 1: a let initializer whose value drives the terminal return
+// must survive across a wait. The current codegen re-materializes the
+// local inside the terminal block, which works for pure initializers.
+// End-to-end check via a real JIT + epoll loop that `let code = 201;
+// wait(100); if code == 201 { return 201 } else { return 500 }` returns
+// 201, proving the local's value reaches the branch post-yield.
+TEST(route, let_across_wait_drives_return_real_socket) {
+    using namespace rut;
+
+    const char* src =
+        "route GET \"/let\" { let code = 201 wait(100) if code == 201 { return 201 } else { "
+        "return 500 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler_fn = reinterpret_cast<jit::HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler_fn != nullptr);
+
+    RouteConfig cfg{};
+    REQUIRE(cfg.add_jit_handler("/let", 'G', handler_fn));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /let HTTP/1.1\r\nHost: x\r\n\r\n", 30);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+    CHECK_GT(n, 0);
+    bool found_201 = false;
+    for (i32 i = 0; i + 2 < n; i++) {
+        if (buf[i] == '2' && buf[i + 1] == '0' && buf[i + 2] == '1') {
+            found_201 = true;
+            break;
+        }
+    }
+    CHECK(found_201);
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
 // Regression: a wait(ms) longer than keepalive_timeout must NOT be woken
 // early by the 1-second TimerWheel tick. Before the fix, yielded conns
 // remained on the keepalive wheel and the tick callback resumed them via

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -393,10 +393,11 @@ TEST(simulate_engine, wait_handler_drives_state_machine_to_terminal_status) {
 }
 
 TEST(simulate_engine, let_before_wait_drives_to_terminal) {
-    // Slice 1: a let before a wait runs when the terminal state
-    // reaches the entry block. For a pure constant initializer like
-    // `let k = 200`, the value is materialized fresh in the terminal
-    // block and the return picks it up.
+    // Slice 1 acceptance: a let before a wait runs when the terminal
+    // state reaches the entry block, and the yield chain still drives
+    // to the terminal status cleanly. The let's value doesn't
+    // participate in the return here — that's covered by
+    // let_used_after_wait_in_if below.
     const char* src = "route GET \"/x\" { let k = 200 wait(50) return 200 }\n";
     FrontendRirModule rir{};
     REQUIRE(compile_to_rir(src, rir));

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -414,8 +414,9 @@ TEST(simulate_engine, let_before_wait_drives_to_terminal) {
 TEST(simulate_engine, let_used_after_wait_in_if) {
     // The real test of slice 1: the let's value has to survive the
     // yield and actually drive the branch in the terminal block.
-    // With pure-constant initializer + re-materialize-in-terminal, this
-    // works without explicit slot spilling.
+    // The pure-constant initializer is re-materialized fresh in the
+    // terminal block, so the branch compares against the correct
+    // value without any HandlerCtx slot storage.
     const char* src =
         "route GET \"/x\" { let code = 201 wait(50) if code == 201 { return 201 } else { return "
         "500 } }\n";

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -392,6 +392,44 @@ TEST(simulate_engine, wait_handler_drives_state_machine_to_terminal_status) {
     rir.destroy();
 }
 
+TEST(simulate_engine, let_before_wait_drives_to_terminal) {
+    // Slice 1: a let before a wait runs when the terminal state
+    // reaches the entry block. For a pure constant initializer like
+    // `let k = 200`, the value is materialized fresh in the terminal
+    // block and the return picks it up.
+    const char* src = "route GET \"/x\" { let k = 200 wait(50) return 200 }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 200));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 200u);
+    CHECK_EQ(result.yield_count, 1u);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(simulate_engine, let_used_after_wait_in_if) {
+    // The real test of slice 1: the let's value has to survive the
+    // yield and actually drive the branch in the terminal block.
+    // With pure-constant initializer + re-materialize-in-terminal, this
+    // works without explicit slot spilling.
+    const char* src =
+        "route GET \"/x\" { let code = 201 wait(50) if code == 201 { return 201 } else { return "
+        "500 } }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 201));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 201u);
+    CHECK_EQ(result.yield_count, 1u);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(simulate_engine, multiple_waits_all_drive_then_return) {
     const char* src = "route GET \"/multi\" { wait(100) wait(200) wait(300) return 201 }\n";
     FrontendRirModule rir{};


### PR DESCRIPTION
## Summary

Lifts the slice-0 restriction that required `wait()` to be a contiguous prefix of a route body with nothing before it. The new shape is:

```
let* ; wait* ; anything_else*
```

So a route like `route GET "/x" { let code = 201 wait(100) if code == 201 { return 201 } else { return 500 } }` now compiles and runs correctly.

## Why this is essentially free for slice 1

The state-machine codegen routes states `0..N-1` to dead-end yield blocks that emit a packed `Yield` and return. State `N` (terminal) runs the full entry block — which already calls `materialize_local_init` for every local. For the pure initializers that slice 0's expression surface supports (constants, domain-type constructors, pure reads), re-materializing the local in the terminal state is idempotent, so the local's value reaches the post-wait `return`/branch correctly without any spill/reload machinery.

The `HandlerCtx` slot infrastructure (`load_slot` / `store_slot` in `include/rut/jit/handler_abi.h`) stays unused — it becomes necessary only when initializers gain side effects (I/O expressions in later slices).

## What changed

- **analyze.cc**: tracking variable renamed from `seen_non_wait` to `seen_non_let_non_wait`; Lets no longer set the gate. Non-wait non-let statements (guard, if, match, return, forward) still do, so `let; guard; wait` is rejected as before.
- **No MIR / RIR / codegen changes.**

## Tests

- `frontend` — `analyze_accepts_let_before_wait`, `analyze_rejects_wait_after_let_guard` (flow regression)
- `simulate_engine` — `let_before_wait_drives_to_terminal`, `let_used_after_wait_in_if` (local value drives post-wait branch)
- `integration` — `let_across_wait_drives_return_real_socket` (real JIT + epoll loop)

All 2067 tests pass; format clean.

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test` (2067 passed, 0 failed)
- [x] `./dev.sh format`
- [x] End-to-end: `let code = 201; wait(100); if code == 201 { return 201 } else { return 500 }` returns 201 over a real socket.

## What's deferred to later slices
- Side-effectful let initializers (require HandlerCtx spill/reload).
- Mid-body yields (guards/ifs before waits).
- New lets introduced between waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)