### PR TITLE
Duration literals for wait(): 500ms, 2s, 5m, 1h

### DIFF
--- a/include/rut/compiler/lexer.h
+++ b/include/rut/compiler/lexer.h
@@ -13,6 +13,10 @@ enum class TokenType : u8 {
     StringLit,
     IntLit,
     FloatLit,
+    // Duration literal: digit run + unit suffix (ms, s, m, h). Emitted
+    // only when the suffix follows the digits with no whitespace.
+    // Value and unit both live in `text`; parser does the conversion.
+    DurLit,
 
     // Keywords
     KwFunc,

--- a/src/compiler/lexer.cc
+++ b/src/compiler/lexer.cc
@@ -122,6 +122,36 @@ LexResult lex(Str source) {
                 pos++;
                 col++;
             }
+            // Duration suffix check. Must immediately follow the digits
+            // (no whitespace). Recognized units: ms, s, m, h. "ms" is
+            // greedier than "m", so check it first. Unit must be at a
+            // token boundary (not followed by another identifier char)
+            // so e.g. `5mystery` isn't consumed as "5m" + "ystery".
+            auto is_boundary = [&](u32 after) {
+                return after >= source.len || !is_ident_continue(source.ptr[after]);
+            };
+            bool dur_matched = false;
+            u32 unit_end = pos;
+            if (pos + 1 < source.len && source.ptr[pos] == 'm' && source.ptr[pos + 1] == 's' &&
+                is_boundary(pos + 2)) {
+                unit_end = pos + 2;
+                dur_matched = true;
+            } else if (pos < source.len && is_boundary(pos + 1) &&
+                       (source.ptr[pos] == 's' || source.ptr[pos] == 'm' ||
+                        source.ptr[pos] == 'h')) {
+                unit_end = pos + 1;
+                dur_matched = true;
+            }
+            if (dur_matched) {
+                col += unit_end - pos;
+                pos = unit_end;
+                tok.end = pos;
+                tok.text = source.slice(tok.start, tok.end);
+                tok.type = TokenType::DurLit;
+                if (!out.tokens.push(tok))
+                    return frontend_error(FrontendError::TooManyTokens, token_span(tok));
+                continue;
+            }
             tok.end = pos;
             tok.text = source.slice(tok.start, tok.end);
             tok.type = TokenType::IntLit;

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -727,24 +727,55 @@ struct Parser {
             return stmt;
         }
         if (take(TokenType::KwWait)) {
-            // v1: `wait(IntLit)` — IntLit is milliseconds. Duration literals
-            // (`1s`, `500ms`) are future work.
+            // Accepts either a bare IntLit (milliseconds, legacy form) or
+            // a DurLit (digits + ms/s/m/h suffix). u64 accumulator +
+            // UINT32_MAX cap — the yield payload is 32 bits wide, so
+            // waits up to ~49 days are expressible.
             auto lparen = expect(TokenType::LParen);
             if (!lparen) return core::make_unexpected(lparen.error());
-            auto ms_tok = expect(TokenType::IntLit);
-            if (!ms_tok) return core::make_unexpected(ms_tok.error());
-            // u64 accumulator + UINT32_MAX cap — the yield payload is 32
-            // bits wide (status_code + upstream_id packed), so waits up
-            // to ~49 days are expressible.
-            u64 ms = 0;
-            for (u32 i = 0; i < ms_tok.value()->text.len; i++) {
-                const u32 digit = static_cast<u32>(ms_tok.value()->text.ptr[i] - '0');
-                if (ms > (static_cast<u64>(0xffffffffu) - static_cast<u64>(digit)) / 10)
-                    return frontend_error(FrontendError::InvalidInteger,
-                                          span_from(*ms_tok.value()),
-                                          ms_tok.value()->text);
-                ms = ms * 10 + static_cast<u64>(digit);
+            const Token* arg = nullptr;
+            if (const Token* t = take(TokenType::IntLit)) {
+                arg = t;
+            } else if (const Token* t = take(TokenType::DurLit)) {
+                arg = t;
+            } else {
+                return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
             }
+            // Peel the unit suffix (if any) off the end of the text:
+            // DurLit ends in ms/s/m/h; IntLit has no suffix.
+            u32 digit_len = arg->text.len;
+            u64 multiplier_ms = 1;  // default: bare IntLit = ms
+            if (arg->type == TokenType::DurLit) {
+                if (digit_len >= 2 && arg->text.ptr[digit_len - 2] == 'm' &&
+                    arg->text.ptr[digit_len - 1] == 's') {
+                    digit_len -= 2;
+                    multiplier_ms = 1;
+                } else if (digit_len >= 1) {
+                    char unit = arg->text.ptr[digit_len - 1];
+                    digit_len -= 1;
+                    if (unit == 's')
+                        multiplier_ms = 1000;
+                    else if (unit == 'm')
+                        multiplier_ms = 60ull * 1000;
+                    else if (unit == 'h')
+                        multiplier_ms = 3600ull * 1000;
+                    else
+                        return frontend_error(
+                            FrontendError::InvalidInteger, span_from(*arg), arg->text);
+                }
+            }
+            u64 value = 0;
+            for (u32 i = 0; i < digit_len; i++) {
+                const u32 digit = static_cast<u32>(arg->text.ptr[i] - '0');
+                if (value > (static_cast<u64>(0xffffffffu) - static_cast<u64>(digit)) / 10)
+                    return frontend_error(
+                        FrontendError::InvalidInteger, span_from(*arg), arg->text);
+                value = value * 10 + static_cast<u64>(digit);
+            }
+            // Apply unit; re-check against u32 range after multiplication.
+            const u64 ms = value * multiplier_ms;
+            if (ms > 0xffffffffull)
+                return frontend_error(FrontendError::InvalidInteger, span_from(*arg), arg->text);
             auto rparen = expect(TokenType::RParen);
             if (!rparen) return core::make_unexpected(rparen.error());
             AstStatement stmt{};

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -285,6 +285,73 @@ TEST(frontend, analyze_rejects_let_after_wait) {
     CHECK(!hir);
 }
 
+TEST(frontend, parse_wait_accepts_ms_suffix) {
+    const char* src = "route GET \"/x\" { wait(500ms) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+    CHECK_EQ(hir->routes[0].waits[0].ms, 500u);
+}
+
+TEST(frontend, parse_wait_accepts_s_suffix) {
+    const char* src = "route GET \"/x\" { wait(2s) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(hir->routes[0].waits[0].ms, 2000u);
+}
+
+TEST(frontend, parse_wait_accepts_m_suffix) {
+    const char* src = "route GET \"/x\" { wait(5m) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(hir->routes[0].waits[0].ms, 5u * 60u * 1000u);
+}
+
+TEST(frontend, parse_wait_accepts_h_suffix) {
+    const char* src = "route GET \"/x\" { wait(1h) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(hir->routes[0].waits[0].ms, 3600u * 1000u);
+}
+
+TEST(frontend, parse_wait_rejects_duration_overflowing_u32) {
+    // ~50 days in ms > UINT32_MAX (~49.7 days). 50h * 3600 * 1000 is
+    // well under, so use 50000h ≈ 5.7 years.
+    const char* src = "route GET \"/x\" { wait(50000h) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    CHECK(!ast);
+}
+
+TEST(frontend, parse_wait_rejects_unknown_suffix) {
+    // `5d` — days aren't a supported unit. Lexer still tokenizes `5`
+    // as IntLit (boundary check rejects suffix d because single-char
+    // match only accepts s/m/h), so parser sees wait(5 d) which is
+    // a syntax error at the `d`.
+    const char* src = "route GET \"/x\" { wait(5d) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    CHECK(!ast);
+}
+
 TEST(frontend, analyze_rejects_wait_after_let_guard) {
     // Non-let non-wait statements still gate subsequent waits. A guard
     // between a let and a wait introduces a terminal-ish control path

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -137,6 +137,37 @@ TEST(frontend, lex_recognizes_wait_keyword) {
     CHECK_EQ(static_cast<u8>(lexed->tokens[0].type), static_cast<u8>(TokenType::KwWait));
 }
 
+TEST(frontend, lex_duration_suffix_boundary) {
+    // `5ms` is one DurLit; the suffix must sit at a token boundary so
+    // `5mystery` stays `5` (IntLit) + `mystery` (Ident). Similarly
+    // `5ms2` can't consume `s2` — the boundary check rejects the
+    // whole suffix, yielding `5` (IntLit) + `ms2` (Ident).
+    struct Case {
+        const char* src;
+        TokenType first_type;
+        const char* first_text;  // nullptr = don't check text
+        u32 token_count;         // including the EOF token
+    };
+    const Case cases[] = {
+        {"5ms", TokenType::DurLit, "5ms", 2},
+        {"500ms", TokenType::DurLit, "500ms", 2},
+        {"2s", TokenType::DurLit, "2s", 2},
+        {"5m", TokenType::DurLit, "5m", 2},
+        {"1h", TokenType::DurLit, "1h", 2},
+        {"5mystery", TokenType::IntLit, "5", 3},
+        {"5ms2", TokenType::IntLit, "5", 3},
+        {"5sec", TokenType::IntLit, "5", 3},
+        {"5", TokenType::IntLit, "5", 2},
+    };
+    for (const auto& tc : cases) {
+        auto lexed = lex(lit(tc.src));
+        REQUIRE(lexed);
+        REQUIRE_EQ(lexed->tokens.len, tc.token_count);
+        CHECK_EQ(static_cast<u8>(lexed->tokens[0].type), static_cast<u8>(tc.first_type));
+        if (tc.first_text) CHECK(lexed->tokens[0].text.eq(lit(tc.first_text)));
+    }
+}
+
 TEST(frontend, parse_route_accepts_wait_statement) {
     const char* src = "route GET \"/sleep\" { wait(1000) return 200 }\n";
     auto lexed = lex(lit(src));
@@ -335,9 +366,10 @@ TEST(frontend, analyze_wait_accepts_h_suffix) {
 
 TEST(frontend, parse_wait_rejects_duration_overflowing_u32) {
     // UINT32_MAX ms ≈ 49.7 days ≈ 1193h. Anything above ~1193h
-    // overflows the 32-bit ms payload. 50000h (~5.7 years) is well
-    // past the cap, so the parser must reject before multiplication
-    // completes.
+    // overflows the 32-bit ms payload. The parser computes
+    // `value * multiplier_ms` in u64 and then range-checks the
+    // result against UINT32_MAX, so 50000h (~5.7 years) is rejected
+    // at that post-multiplication check.
     const char* src = "route GET \"/x\" { wait(50000h) return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -305,6 +305,7 @@ TEST(frontend, parse_wait_accepts_s_suffix) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
     CHECK_EQ(hir->routes[0].waits[0].ms, 2000u);
 }
 
@@ -316,6 +317,7 @@ TEST(frontend, parse_wait_accepts_m_suffix) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
     CHECK_EQ(hir->routes[0].waits[0].ms, 5u * 60u * 1000u);
 }
 
@@ -327,6 +329,7 @@ TEST(frontend, parse_wait_accepts_h_suffix) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
     CHECK_EQ(hir->routes[0].waits[0].ms, 3600u * 1000u);
 }
 

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -285,7 +285,7 @@ TEST(frontend, analyze_rejects_let_after_wait) {
     CHECK(!hir);
 }
 
-TEST(frontend, parse_wait_accepts_ms_suffix) {
+TEST(frontend, analyze_wait_accepts_ms_suffix) {
     const char* src = "route GET \"/x\" { wait(500ms) return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -297,7 +297,7 @@ TEST(frontend, parse_wait_accepts_ms_suffix) {
     CHECK_EQ(hir->routes[0].waits[0].ms, 500u);
 }
 
-TEST(frontend, parse_wait_accepts_s_suffix) {
+TEST(frontend, analyze_wait_accepts_s_suffix) {
     const char* src = "route GET \"/x\" { wait(2s) return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -309,7 +309,7 @@ TEST(frontend, parse_wait_accepts_s_suffix) {
     CHECK_EQ(hir->routes[0].waits[0].ms, 2000u);
 }
 
-TEST(frontend, parse_wait_accepts_m_suffix) {
+TEST(frontend, analyze_wait_accepts_m_suffix) {
     const char* src = "route GET \"/x\" { wait(5m) return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -321,7 +321,7 @@ TEST(frontend, parse_wait_accepts_m_suffix) {
     CHECK_EQ(hir->routes[0].waits[0].ms, 5u * 60u * 1000u);
 }
 
-TEST(frontend, parse_wait_accepts_h_suffix) {
+TEST(frontend, analyze_wait_accepts_h_suffix) {
     const char* src = "route GET \"/x\" { wait(1h) return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -334,8 +334,10 @@ TEST(frontend, parse_wait_accepts_h_suffix) {
 }
 
 TEST(frontend, parse_wait_rejects_duration_overflowing_u32) {
-    // ~50 days in ms > UINT32_MAX (~49.7 days). 50h * 3600 * 1000 is
-    // well under, so use 50000h ≈ 5.7 years.
+    // UINT32_MAX ms ≈ 49.7 days ≈ 1193h. Anything above ~1193h
+    // overflows the 32-bit ms payload. 50000h (~5.7 years) is well
+    // past the cap, so the parser must reject before multiplication
+    // completes.
     const char* src = "route GET \"/x\" { wait(50000h) return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);


### PR DESCRIPTION
## Summary

Adds duration-literal syntax to the `wait()` primitive so routes can say `wait(500ms)` / `wait(2s)` / `wait(5m)` / `wait(1h)` instead of stringing bare millisecond integers. Value is converted to ms at parse time and range-checked against UINT32_MAX (same cap as the bare form).

## What changed

**Lexer** — new `TokenType::DurLit`: a digit run followed immediately (no whitespace) by `ms` / `s` / `m` / `h`, at a token boundary. `5mystery` still lexes as `5` + `mystery`; `5ms` becomes one DurLit token.

**Parser** — `wait()` accepts either IntLit (legacy, treated as ms) or DurLit. The unit suffix is peeled off in the parser, multiplied into ms, and re-checked against UINT32_MAX after multiplication so `50000h` correctly fails rather than overflowing silently.

No downstream changes: HIR / MIR / RIR / codegen all still see a u32 millisecond value on the Wait statement.

## Tests

Frontend:
- `parse_wait_accepts_ms_suffix` / `_s_suffix` / `_m_suffix` / `_h_suffix` — each unit round-trips to the expected ms value.
- `parse_wait_rejects_duration_overflowing_u32` — `wait(50000h)` rejected.
- `parse_wait_rejects_unknown_suffix` — `wait(5d)` rejected (days aren't supported; parser sees `5` + `d`).

All 2074 tests pass.

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test` (2074 passed, 0 failed)
- [x] `./dev.sh format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)