### PR TITLE
response() builder: syntactic entry point in return

### DIFF
--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -101,9 +101,11 @@ struct AstStatement {
     // payload range (~49 days); semantic validation is in analyze.
     u32 status_code = 0;
     // Response body literal, populated when `return` uses the
-    // `response(N, body: "...")` form. Empty `Str` means no custom
-    // body — runtime falls back to the default (status reason phrase).
+    // `response(N, body: "...")` form. `has_response_body` distinguishes
+    // an omitted kwarg from an explicit empty string — the latter must
+    // still be rejected while body plumbing is not wired end-to-end.
     Str response_body{};
+    bool has_response_body = false;
     AstStatement* then_stmt = nullptr;
     AstStatement* else_stmt = nullptr;
     static constexpr u32 kMaxBlockStatements = 8;

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -100,6 +100,10 @@ struct AstStatement {
     // `wait(N)`. u32 fits both the HTTP range and the full u32 yield
     // payload range (~49 days); semantic validation is in analyze.
     u32 status_code = 0;
+    // Response body literal, populated when `return` uses the
+    // `response(N, body: "...")` form. Empty `Str` means no custom
+    // body — runtime falls back to the default (status reason phrase).
+    Str response_body{};
     AstStatement* then_stmt = nullptr;
     AstStatement* else_stmt = nullptr;
     static constexpr u32 kMaxBlockStatements = 8;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5243,6 +5243,12 @@ static FrontendResult<HirTerminator> analyze_term(const AstStatement& stmt, cons
     if (stmt.kind == AstStmtKind::ReturnStatus) {
         if (stmt.status_code < 100 || stmt.status_code > 999)
             return frontend_error(FrontendError::InvalidStatusCode, stmt.span);
+        // `response(N, body: "...")` syntax is parsed but custom body
+        // rendering isn't wired to the runtime yet. Reject at analyze
+        // to avoid silently dropping the payload. Follow-up slice will
+        // plumb bodies through HIR → MIR → RIR → codegen → format_*.
+        if (stmt.response_body.len > 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
         term.kind = HirTerminatorKind::ReturnStatus;
         // Validated to 100..999 above; fits in HirTerminator::status_code.
         term.status_code = static_cast<i32>(stmt.status_code);

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5245,9 +5245,11 @@ static FrontendResult<HirTerminator> analyze_term(const AstStatement& stmt, cons
             return frontend_error(FrontendError::InvalidStatusCode, stmt.span);
         // `response(N, body: "...")` syntax is parsed but custom body
         // rendering isn't wired to the runtime yet. Reject at analyze
-        // to avoid silently dropping the payload. Follow-up slice will
-        // plumb bodies through HIR → MIR → RIR → codegen → format_*.
-        if (stmt.response_body.len > 0)
+        // to avoid silently dropping the payload — including the
+        // explicit-empty `body: ""` case, which would otherwise slip
+        // through a len-based check. Follow-up slice will plumb
+        // bodies through HIR → MIR → RIR → codegen → format_*.
+        if (stmt.has_response_body)
             return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
         term.kind = HirTerminatorKind::ReturnStatus;
         // Validated to 100..999 above; fits in HirTerminator::status_code.

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -709,6 +709,69 @@ struct Parser {
             return stmt;
         }
         if (take(TokenType::KwReturn)) {
+            // Two forms:
+            //   return <IntLit>                          (legacy)
+            //   return response(<IntLit>[, body: "..."]) (response builder)
+            // The body variant lets the handler supply a custom payload
+            // that the runtime writes verbatim with an auto Content-Length.
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::ReturnStatus;
+
+            // Peek for the builder form. We recognise `response` by the
+            // literal identifier text; no dedicated keyword yet because
+            // `response` is also a valid identifier in other contexts.
+            const Token& peek = cur();
+            const bool kIsBuilder = peek.type == TokenType::Ident && peek.text.len == 8 &&
+                                    peek.text.ptr[0] == 'r' && peek.text.ptr[1] == 'e' &&
+                                    peek.text.ptr[2] == 's' && peek.text.ptr[3] == 'p' &&
+                                    peek.text.ptr[4] == 'o' && peek.text.ptr[5] == 'n' &&
+                                    peek.text.ptr[6] == 's' && peek.text.ptr[7] == 'e';
+            if (kIsBuilder) {
+                pos++;  // consume `response`
+                auto lparen = expect(TokenType::LParen);
+                if (!lparen) return core::make_unexpected(lparen.error());
+                auto status = expect(TokenType::IntLit);
+                if (!status) return core::make_unexpected(status.error());
+                i32 value = 0;
+                for (u32 i = 0; i < status.value()->text.len; i++) {
+                    const u32 digit = static_cast<u32>(status.value()->text.ptr[i] - '0');
+                    if (value > (static_cast<i32>(0x7fffffff) - static_cast<i32>(digit)) / 10)
+                        return frontend_error(FrontendError::InvalidInteger,
+                                              span_from(*status.value()),
+                                              status.value()->text);
+                    value = value * 10 + static_cast<i32>(digit);
+                }
+                stmt.status_code = value;
+                // Optional `, body: "<StringLit>"` — no other kwargs yet.
+                if (take(TokenType::Comma)) {
+                    auto kw = expect(TokenType::Ident);
+                    if (!kw) return core::make_unexpected(kw.error());
+                    if (!(kw.value()->text.len == 4 && kw.value()->text.ptr[0] == 'b' &&
+                          kw.value()->text.ptr[1] == 'o' && kw.value()->text.ptr[2] == 'd' &&
+                          kw.value()->text.ptr[3] == 'y')) {
+                        return frontend_error(FrontendError::UnexpectedToken,
+                                              span_from(*kw.value()),
+                                              kw.value()->text);
+                    }
+                    auto colon = expect(TokenType::Colon);
+                    if (!colon) return core::make_unexpected(colon.error());
+                    auto body_tok = expect(TokenType::StringLit);
+                    if (!body_tok) return core::make_unexpected(body_tok.error());
+                    // Strip the surrounding quotes. Lexer keeps them in text.
+                    const Str raw = body_tok.value()->text;
+                    if (raw.len >= 2 && raw.ptr[0] == '"' && raw.ptr[raw.len - 1] == '"') {
+                        stmt.response_body = Str{raw.ptr + 1, raw.len - 2};
+                    } else {
+                        stmt.response_body = raw;
+                    }
+                }
+                auto rparen = expect(TokenType::RParen);
+                if (!rparen) return core::make_unexpected(rparen.error());
+                stmt.span = Span{start.start, rparen.value()->end, start.line, start.col};
+                return stmt;
+            }
+
+            // Legacy `return <IntLit>`.
             auto status = expect(TokenType::IntLit);
             if (!status) return core::make_unexpected(status.error());
             i32 value = 0;
@@ -720,8 +783,6 @@ struct Parser {
                                           status.value()->text);
                 value = value * 10 + static_cast<i32>(digit);
             }
-            AstStatement stmt{};
-            stmt.kind = AstStmtKind::ReturnStatus;
             stmt.status_code = value;
             stmt.span = Span{start.start, status.value()->end, start.line, start.col};
             return stmt;

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -720,6 +720,20 @@ struct Parser {
             AstStatement stmt{};
             stmt.kind = AstStmtKind::ReturnStatus;
 
+            // Expect an IntLit and parse it as a signed i32 with the
+            // INT_MAX overflow check that both branches share.
+            auto parse_status_i32 = [&](const Token& tok) -> FrontendResult<i32> {
+                i32 value = 0;
+                for (u32 i = 0; i < tok.text.len; i++) {
+                    const u32 digit = static_cast<u32>(tok.text.ptr[i] - '0');
+                    if (value > (static_cast<i32>(0x7fffffff) - static_cast<i32>(digit)) / 10)
+                        return frontend_error(
+                            FrontendError::InvalidInteger, span_from(tok), tok.text);
+                    value = value * 10 + static_cast<i32>(digit);
+                }
+                return value;
+            };
+
             // Peek for the builder form. We recognise `response` by the
             // literal identifier text; no dedicated keyword yet because
             // `response` is also a valid identifier in other contexts.
@@ -731,16 +745,9 @@ struct Parser {
                 if (!lparen) return core::make_unexpected(lparen.error());
                 auto status = expect(TokenType::IntLit);
                 if (!status) return core::make_unexpected(status.error());
-                i32 value = 0;
-                for (u32 i = 0; i < status.value()->text.len; i++) {
-                    const u32 digit = static_cast<u32>(status.value()->text.ptr[i] - '0');
-                    if (value > (static_cast<i32>(0x7fffffff) - static_cast<i32>(digit)) / 10)
-                        return frontend_error(FrontendError::InvalidInteger,
-                                              span_from(*status.value()),
-                                              status.value()->text);
-                    value = value * 10 + static_cast<i32>(digit);
-                }
-                stmt.status_code = value;
+                auto parsed = parse_status_i32(*status.value());
+                if (!parsed) return core::make_unexpected(parsed.error());
+                stmt.status_code = parsed.value();
                 // Optional `, body: "<StringLit>"` — no other kwargs yet.
                 if (take(TokenType::Comma)) {
                     auto kw = expect(TokenType::Ident);
@@ -767,16 +774,9 @@ struct Parser {
             // Legacy `return <IntLit>`.
             auto status = expect(TokenType::IntLit);
             if (!status) return core::make_unexpected(status.error());
-            i32 value = 0;
-            for (u32 i = 0; i < status.value()->text.len; i++) {
-                const u32 digit = static_cast<u32>(status.value()->text.ptr[i] - '0');
-                if (value > (static_cast<i32>(0x7fffffff) - static_cast<i32>(digit)) / 10)
-                    return frontend_error(FrontendError::InvalidInteger,
-                                          span_from(*status.value()),
-                                          status.value()->text);
-                value = value * 10 + static_cast<i32>(digit);
-            }
-            stmt.status_code = value;
+            auto parsed = parse_status_i32(*status.value());
+            if (!parsed) return core::make_unexpected(parsed.error());
+            stmt.status_code = parsed.value();
             stmt.span = Span{start.start, status.value()->end, start.line, start.col};
             return stmt;
         }

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -712,8 +712,11 @@ struct Parser {
             // Two forms:
             //   return <IntLit>                          (legacy)
             //   return response(<IntLit>[, body: "..."]) (response builder)
-            // The body variant lets the handler supply a custom payload
-            // that the runtime writes verbatim with an auto Content-Length.
+            // The builder form is the syntactic entry point for richer
+            // responses (body / headers / content-type). Today only
+            // response(<IntLit>) is semantically identical to `return
+            // <IntLit>`; analyze rejects the `body:` kwarg until the
+            // runtime body-render path lands.
             AstStatement stmt{};
             stmt.kind = AstStmtKind::ReturnStatus;
 
@@ -721,12 +724,8 @@ struct Parser {
             // literal identifier text; no dedicated keyword yet because
             // `response` is also a valid identifier in other contexts.
             const Token& peek = cur();
-            const bool kIsBuilder = peek.type == TokenType::Ident && peek.text.len == 8 &&
-                                    peek.text.ptr[0] == 'r' && peek.text.ptr[1] == 'e' &&
-                                    peek.text.ptr[2] == 's' && peek.text.ptr[3] == 'p' &&
-                                    peek.text.ptr[4] == 'o' && peek.text.ptr[5] == 'n' &&
-                                    peek.text.ptr[6] == 's' && peek.text.ptr[7] == 'e';
-            if (kIsBuilder) {
+            const bool is_builder = peek.type == TokenType::Ident && peek.text.eq({"response", 8});
+            if (is_builder) {
                 pos++;  // consume `response`
                 auto lparen = expect(TokenType::LParen);
                 if (!lparen) return core::make_unexpected(lparen.error());
@@ -746,9 +745,7 @@ struct Parser {
                 if (take(TokenType::Comma)) {
                     auto kw = expect(TokenType::Ident);
                     if (!kw) return core::make_unexpected(kw.error());
-                    if (!(kw.value()->text.len == 4 && kw.value()->text.ptr[0] == 'b' &&
-                          kw.value()->text.ptr[1] == 'o' && kw.value()->text.ptr[2] == 'd' &&
-                          kw.value()->text.ptr[3] == 'y')) {
+                    if (!kw.value()->text.eq({"body", 4})) {
                         return frontend_error(FrontendError::UnexpectedToken,
                                               span_from(*kw.value()),
                                               kw.value()->text);
@@ -757,13 +754,9 @@ struct Parser {
                     if (!colon) return core::make_unexpected(colon.error());
                     auto body_tok = expect(TokenType::StringLit);
                     if (!body_tok) return core::make_unexpected(body_tok.error());
-                    // Strip the surrounding quotes. Lexer keeps them in text.
-                    const Str raw = body_tok.value()->text;
-                    if (raw.len >= 2 && raw.ptr[0] == '"' && raw.ptr[raw.len - 1] == '"') {
-                        stmt.response_body = Str{raw.ptr + 1, raw.len - 2};
-                    } else {
-                        stmt.response_body = raw;
-                    }
+                    // Lexer strips the surrounding quotes already.
+                    stmt.response_body = body_tok.value()->text;
+                    stmt.has_response_body = true;
                 }
                 auto rparen = expect(TokenType::RParen);
                 if (!rparen) return core::make_unexpected(rparen.error());

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -137,6 +137,50 @@ TEST(frontend, lex_recognizes_wait_keyword) {
     CHECK_EQ(static_cast<u8>(lexed->tokens[0].type), static_cast<u8>(TokenType::KwWait));
 }
 
+TEST(frontend, parse_return_response_status_only) {
+    // `return response(200)` is the builder entry point. With no body
+    // kwarg it's semantically identical to `return 200`; the HIR
+    // terminator produces the same ReturnStatus instruction.
+    const char* src = "route GET \"/x\" { return response(200) }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& route = ast->items[0].route;
+    REQUIRE_EQ(route.statements.len, 1u);
+    CHECK_EQ(static_cast<u8>(route.statements[0].kind), static_cast<u8>(AstStmtKind::ReturnStatus));
+    CHECK_EQ(route.statements[0].status_code, 200u);
+    CHECK_EQ(route.statements[0].response_body.len, 0u);
+    // Analyze accepts, producing the same HIR shape as `return 200`.
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
+TEST(frontend, parse_return_response_with_body) {
+    // Parser recognises the body: "..." kwarg and stores the literal;
+    // analyze rejects it for now because the runtime body-render path
+    // hasn't landed (tracked for follow-up slice).
+    const char* src = "route GET \"/x\" { return response(200, body: \"Hello\") }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& stmt = ast->items[0].route.statements[0];
+    CHECK_EQ(stmt.status_code, 200u);
+    REQUIRE_EQ(stmt.response_body.len, 5u);
+    CHECK(stmt.response_body.eq(lit("Hello")));
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, parse_return_response_rejects_unknown_kwarg) {
+    const char* src = "route GET \"/x\" { return response(200, header: \"foo\") }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    CHECK(!ast);
+}
+
 TEST(frontend, lex_duration_suffix_boundary) {
     // `5ms` is one DurLit; the suffix must sit at a token boundary so
     // `5mystery` stays `5` (IntLit) + `mystery` (Ident). Similarly

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -158,8 +158,8 @@ TEST(frontend, parse_return_response_status_only) {
 
 TEST(frontend, parse_return_response_with_body) {
     // Parser recognises the body: "..." kwarg and stores the literal;
-    // analyze rejects it for now because the runtime body-render path
-    // hasn't landed (tracked for follow-up slice).
+    // analyze rejects it with UnsupportedSyntax because the runtime
+    // body-render path hasn't landed (tracked for follow-up slice).
     const char* src = "route GET \"/x\" { return response(200, body: \"Hello\") }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -169,8 +169,25 @@ TEST(frontend, parse_return_response_with_body) {
     CHECK_EQ(stmt.status_code, 200u);
     REQUIRE_EQ(stmt.response_body.len, 5u);
     CHECK(stmt.response_body.eq(lit("Hello")));
+    CHECK(stmt.has_response_body);
     auto hir = analyze_file_heap(ast.value());
-    CHECK(!hir);
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, parse_return_response_rejects_empty_body) {
+    // `body: ""` is an explicit empty string; has_response_body
+    // distinguishes it from the no-kwarg case so analyze still
+    // rejects, not silently treating it as a plain `return`.
+    const char* src = "route GET \"/x\" { return response(200, body: \"\") }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    CHECK(ast->items[0].route.statements[0].has_response_body);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
 TEST(frontend, parse_return_response_rejects_unknown_kwarg) {
@@ -178,7 +195,9 @@ TEST(frontend, parse_return_response_rejects_unknown_kwarg) {
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
-    CHECK(!ast);
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+    CHECK(ast.error().detail.eq(lit("header")));
 }
 
 TEST(frontend, lex_duration_suffix_boundary) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -146,6 +146,7 @@ TEST(frontend, parse_return_response_status_only) {
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
     const auto& route = ast->items[0].route;
     REQUIRE_EQ(route.statements.len, 1u);
     CHECK_EQ(static_cast<u8>(route.statements[0].kind), static_cast<u8>(AstStmtKind::ReturnStatus));
@@ -173,6 +174,8 @@ TEST(frontend, parse_return_response_with_body) {
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 1u);
     const auto& stmt = ast->items[0].route.statements[0];
     CHECK_EQ(stmt.status_code, 200u);
     REQUIRE_EQ(stmt.response_body.len, 5u);
@@ -192,6 +195,8 @@ TEST(frontend, parse_return_response_rejects_empty_body) {
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 1u);
     CHECK(ast->items[0].route.statements[0].has_response_body);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(!hir);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -151,9 +151,17 @@ TEST(frontend, parse_return_response_status_only) {
     CHECK_EQ(static_cast<u8>(route.statements[0].kind), static_cast<u8>(AstStmtKind::ReturnStatus));
     CHECK_EQ(route.statements[0].status_code, 200u);
     CHECK_EQ(route.statements[0].response_body.len, 0u);
-    // Analyze accepts, producing the same HIR shape as `return 200`.
+    CHECK(!route.statements[0].has_response_body);
+    // Analyze accepts; HIR terminator matches the plain `return 200`
+    // shape (Direct control flow, ReturnStatus with status 200).
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    const auto& hir_route = hir->routes[0];
+    CHECK_EQ(static_cast<u8>(hir_route.control.kind), static_cast<u8>(HirControlKind::Direct));
+    CHECK_EQ(static_cast<u8>(hir_route.control.direct_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(hir_route.control.direct_term.status_code, 200);
 }
 
 TEST(frontend, parse_return_response_with_body) {


### PR DESCRIPTION
## Summary

Lands the syntactic entry point for the `response()` builder that DESIGN §3 describes, as the first step toward a richer response API (headers, custom body, content-type).

Parser now recognises two forms after `return`:

```
return <IntLit>                        # legacy, unchanged
return response(<IntLit>[, body: "…"]) # builder form
```

`return response(200)` is semantically equivalent to `return 200` — analyze produces the identical `HirTerminator::ReturnStatus`. The `body: "…"` kwarg is parsed into `AstStatement::response_body` but **analyze rejects it** with `UnsupportedSyntax` until the runtime body-render path lands (tracked for follow-up).

Rationale for the deliberate scope split:
- The builder syntax is the stable surface; once extensions land, user code doesn't need to change.
- Silently accepting `body:` at this point would drop the payload on the floor. Explicit rejection makes the gap obvious until the downstream plumbing (HIR → MIR → RIR → codegen → runtime body formatter) catches up.
- Unknown kwargs (e.g. `header: "…"`) fail at parse, so the space is reserved for specific follow-up extensions.

## What changed
- `include/rut/compiler/ast.h`: new `AstStatement::response_body` + `has_response_body` fields.
- `src/compiler/parser.cc`: `return` recognises `response(...)`; parses optional `body: <StringLit>`. Shared `parse_status_i32` lambda between builder and legacy branches.
- `src/compiler/analyze.cc`: `ReturnStatus` path rejects non-omitted `has_response_body` (covers both non-empty and empty strings).
- 4 new frontend tests.

No HIR / MIR / RIR / codegen / runtime changes.

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test` (2079 passed, 0 failed)
- [x] `./dev.sh format`

## What's deferred
- Plumbing the body literal through HIR / MIR / RIR / codegen.
- Runtime body formatter + computed Content-Length.
- Custom headers (`header:` kwarg, or `.header()` fluent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)