### PR TITLE
Runtime: custom response body via RouteConfig::response_bodies

### DIFF
--- a/include/rut/jit/handler_abi.h
+++ b/include/rut/jit/handler_abi.h
@@ -36,9 +36,14 @@ enum class YieldKind : u8 {
 //   byte 5-6: next_state   (u16, for Yield)
 //   byte 7:   yield_kind   (YieldKind)
 //
-// For Yield actions, the status_code + upstream_id slots are unused by
-// their named role and instead carry a 32-bit payload (e.g. Timer ms).
-// See make_yield_payload / yield_payload_u32 for the u32 view.
+// Slot reuse by action:
+//   - Yield:        status_code + upstream_id carry a packed u32
+//                   payload (e.g. Timer ms). See make_yield_payload
+//                   / yield_payload_u32.
+//   - ReturnStatus: upstream_id carries a 1-based index into
+//                   RouteConfig::response_bodies (0 = no custom body,
+//                   runtime uses default status-reason phrase).
+//   - Forward:      upstream_id is the real upstream index.
 //
 // IMPORTANT: We use u64 as the function return type (not a struct)
 // because clang uses sret (hidden pointer) for packed structs even

--- a/include/rut/jit/handler_abi.h
+++ b/include/rut/jit/handler_abi.h
@@ -32,7 +32,7 @@ enum class YieldKind : u8 {
 //
 //   byte 0:   action       (HandlerAction)
 //   byte 1-2: status_code  (u16, for ReturnStatus)
-//   byte 3-4: upstream_id  (u16, for Forward)
+//   byte 3-4: upstream_id  (u16, for Forward / body-index on ReturnStatus)
 //   byte 5-6: next_state   (u16, for Yield)
 //   byte 7:   yield_kind   (YieldKind)
 //

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -29,6 +29,12 @@ bool pipeline_recover(Connection& conn);
 void capture_stage_headers(Connection& conn);
 const char* status_reason(u16 code);
 void format_static_response(Connection& conn, u16 code, bool keep_alive);
+// Custom-body variant: writes status line + Content-Length matching
+// body_len + default Content-Type (text/plain; charset=utf-8) + body
+// bytes. For codes that must have no body (1xx / 204 / 304) falls
+// back to format_static_response.
+void format_response_with_body(
+    Connection& conn, u16 code, const char* body_data, u32 body_len, bool keep_alive);
 void prepare_early_response_state(Connection& conn);
 u32 consume_upstream_sent(Connection& conn);
 
@@ -305,14 +311,27 @@ void handle_jit_outcome(Loop* loop,
                         jit::HandlerFn fn,
                         bool keep_alive) {
     switch (outcome.kind) {
-        case JitDispatchOutcome::Kind::ReturnStatus:
+        case JitDispatchOutcome::Kind::ReturnStatus: {
             conn.pending_handler_fn = nullptr;
             conn.state = ConnState::Sending;
             conn.resp_status = outcome.status_code;
-            format_static_response(conn, outcome.status_code, keep_alive);
+            // ABI: upstream_id is a 1-based index into the pinned
+            // route config's response_bodies table (0 = use default
+            // status-reason body). Out-of-range indices fall back to
+            // the default rather than rendering garbage.
+            const RouteConfig* cfg = conn.request_config;
+            if (outcome.response_body_idx != 0 && cfg != nullptr &&
+                outcome.response_body_idx <= cfg->response_body_count) {
+                const auto& body = cfg->response_bodies[outcome.response_body_idx - 1];
+                format_response_with_body(
+                    conn, outcome.status_code, body.data, body.len, keep_alive);
+            } else {
+                format_static_response(conn, outcome.status_code, keep_alive);
+            }
             conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);
             loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
             return;
+        }
         case JitDispatchOutcome::Kind::TimerYield: {
             // Stash fn + next_state so the resume path can re-enter the
             // handler with ctx.state = handler_state. Slots stay clear —

--- a/include/rut/runtime/jit_dispatch.h
+++ b/include/rut/runtime/jit_dispatch.h
@@ -37,6 +37,10 @@ struct JitDispatchOutcome {
     u16 upstream_id = 0;
     u16 next_state = 0;
     u32 timer_ms = 0;  // raw ms payload; callers pick their own precision
+    // 1-based index into RouteConfig::response_bodies for
+    // Kind::ReturnStatus; 0 = no custom body (use the default status
+    // reason phrase). Decoded from the upstream_id slot per handler ABI.
+    u16 response_body_idx = 0;
 };
 
 // Round-up conversion from ms to seconds. Callers using a 1-second
@@ -74,6 +78,9 @@ inline JitDispatchOutcome invoke_jit_handler(jit::HandlerFn fn,
         case jit::HandlerAction::ReturnStatus:
             out.kind = JitDispatchOutcome::Kind::ReturnStatus;
             out.status_code = r.status_code;
+            // ABI: upstream_id carries a 1-based response-body index
+            // for ReturnStatus (0 = default body).
+            out.response_body_idx = r.upstream_id;
             return out;
         case jit::HandlerAction::Forward:
             out.kind = JitDispatchOutcome::Kind::Forward;

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -70,12 +70,30 @@ struct RouteEntry {
 struct RouteConfig {
     static constexpr u32 kMaxRoutes = 128;
     static constexpr u32 kMaxUpstreams = 64;
+    // Response-body table. Populated at compile/config time; referenced
+    // by JIT handlers via a 1-based index packed into
+    // HandlerResult.upstream_id for ReturnStatus (0 = no custom body,
+    // use the default status reason phrase).
+    static constexpr u32 kMaxResponseBodies = 128;
+    static constexpr u32 kResponseBodyPoolBytes = 8 * 1024;
 
     RouteEntry routes[kMaxRoutes];
     u32 route_count = 0;
 
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
+
+    // Body entries point into body_pool; pool is a bump-allocated char
+    // buffer so body bytes live alongside the config and get reclaimed
+    // with it during RCU swap.
+    struct ResponseBody {
+        const char* data;
+        u32 len;
+    };
+    ResponseBody response_bodies[kMaxResponseBodies];
+    u32 response_body_count = 0;
+    char body_pool[kResponseBodyPoolBytes];
+    u32 body_pool_used = 0;
 
     // Add a proxy route: path prefix → upstream target.
     // Returns false if table full, upstream_id invalid, or path too long.
@@ -140,6 +158,22 @@ struct RouteConfig {
         r.fn = fn;
         route_count++;
         return true;
+    }
+
+    // Register a response body. Copies the bytes into body_pool so the
+    // caller doesn't need to keep the source alive. Returns a 1-based
+    // index (0 is reserved as "no body") that JIT handlers can encode
+    // in the HandlerResult upstream_id slot for ReturnStatus.
+    // Returns 0 if the body table or pool is full.
+    u16 add_response_body(const char* data, u32 len) {
+        if (response_body_count >= kMaxResponseBodies) return 0;
+        if (body_pool_used + len > kResponseBodyPoolBytes) return 0;
+        char* dst = body_pool + body_pool_used;
+        for (u32 i = 0; i < len; i++) dst[i] = data[i];
+        body_pool_used += len;
+        const u32 idx = response_body_count++;
+        response_bodies[idx] = {dst, len};
+        return static_cast<u16>(idx + 1);  // 1-based; 0 reserved
     }
 
     // Add an upstream target. Returns its index, or error if at capacity.

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -164,10 +164,15 @@ struct RouteConfig {
     // caller doesn't need to keep the source alive. Returns a 1-based
     // index (0 is reserved as "no body") that JIT handlers can encode
     // in the HandlerResult upstream_id slot for ReturnStatus.
-    // Returns 0 if the body table or pool is full.
+    // Returns 0 if the body table or pool is full, or if the arguments
+    // are nonsensical (null data with non-zero len).
     u16 add_response_body(const char* data, u32 len) {
         if (response_body_count >= kMaxResponseBodies) return 0;
-        if (body_pool_used + len > kResponseBodyPoolBytes) return 0;
+        if (len > 0 && data == nullptr) return 0;
+        // Subtraction-based capacity check: `body_pool_used + len`
+        // would wrap on a large u32 `len` and silently pass, leading
+        // to an out-of-bounds write into body_pool.
+        if (len > kResponseBodyPoolBytes - body_pool_used) return 0;
         char* dst = body_pool + body_pool_used;
         for (u32 i = 0; i < len; i++) dst[i] = data[i];
         body_pool_used += len;

--- a/src/runtime/callbacks.cc
+++ b/src/runtime/callbacks.cc
@@ -303,12 +303,19 @@ const char* status_reason(u16 code) {
     }
 }
 
-void format_static_response(Connection& conn, u16 code, bool keep_alive) {
+// Shared writer: status line + Content-Length + Connection header,
+// used by both the default (reason-phrase) body path and the custom
+// body path. Leaves the builder positioned just past "\r\n" so the
+// caller can write the body bytes (if any).
+static void write_response_headers(Connection& conn,
+                                   u16 code,
+                                   u32 body_len,
+                                   bool keep_alive,
+                                   const char* content_type,
+                                   u32 content_type_len) {
     const char* reason = status_reason(code);
     u32 reason_len = 0;
     while (reason[reason_len]) reason_len++;
-    const bool kNoBody = (code < 200 || code == 204 || code == 304);
-    const u32 kBodyLen = kNoBody ? 0 : reason_len;
     conn.send_buf.reset();
     conn.send_buf.write(reinterpret_cast<const u8*>("HTTP/1.1 "), 9);
     char code_buf[3];
@@ -319,24 +326,82 @@ void format_static_response(Connection& conn, u16 code, bool keep_alive) {
     conn.send_buf.write(reinterpret_cast<const u8*>(" "), 1);
     conn.send_buf.write(reinterpret_cast<const u8*>(reason), reason_len);
     conn.send_buf.write(reinterpret_cast<const u8*>("\r\n"), 2);
+    // Content-Length: decimal digits, always emitted (even for 0).
     conn.send_buf.write(reinterpret_cast<const u8*>("Content-Length: "), 16);
-    if (kBodyLen >= 100) {
-        char d = static_cast<char>('0' + kBodyLen / 100);
+    if (body_len >= 1000000000u) {
+        char d = static_cast<char>('0' + (body_len / 1000000000u) % 10);
         conn.send_buf.write(reinterpret_cast<const u8*>(&d), 1);
     }
-    if (kBodyLen >= 10) {
-        char d = static_cast<char>('0' + (kBodyLen / 10) % 10);
+    if (body_len >= 100000000u) {
+        char d = static_cast<char>('0' + (body_len / 100000000u) % 10);
         conn.send_buf.write(reinterpret_cast<const u8*>(&d), 1);
     }
-    char d = static_cast<char>('0' + kBodyLen % 10);
+    if (body_len >= 10000000u) {
+        char d = static_cast<char>('0' + (body_len / 10000000u) % 10);
+        conn.send_buf.write(reinterpret_cast<const u8*>(&d), 1);
+    }
+    if (body_len >= 1000000u) {
+        char d = static_cast<char>('0' + (body_len / 1000000u) % 10);
+        conn.send_buf.write(reinterpret_cast<const u8*>(&d), 1);
+    }
+    if (body_len >= 100000u) {
+        char d = static_cast<char>('0' + (body_len / 100000u) % 10);
+        conn.send_buf.write(reinterpret_cast<const u8*>(&d), 1);
+    }
+    if (body_len >= 10000u) {
+        char d = static_cast<char>('0' + (body_len / 10000u) % 10);
+        conn.send_buf.write(reinterpret_cast<const u8*>(&d), 1);
+    }
+    if (body_len >= 1000u) {
+        char d = static_cast<char>('0' + (body_len / 1000u) % 10);
+        conn.send_buf.write(reinterpret_cast<const u8*>(&d), 1);
+    }
+    if (body_len >= 100u) {
+        char d = static_cast<char>('0' + (body_len / 100u) % 10);
+        conn.send_buf.write(reinterpret_cast<const u8*>(&d), 1);
+    }
+    if (body_len >= 10u) {
+        char d = static_cast<char>('0' + (body_len / 10u) % 10);
+        conn.send_buf.write(reinterpret_cast<const u8*>(&d), 1);
+    }
+    char d = static_cast<char>('0' + body_len % 10);
     conn.send_buf.write(reinterpret_cast<const u8*>(&d), 1);
     conn.send_buf.write(reinterpret_cast<const u8*>("\r\n"), 2);
+    if (content_type_len > 0) {
+        conn.send_buf.write(reinterpret_cast<const u8*>("Content-Type: "), 14);
+        conn.send_buf.write(reinterpret_cast<const u8*>(content_type), content_type_len);
+        conn.send_buf.write(reinterpret_cast<const u8*>("\r\n"), 2);
+    }
     if (keep_alive)
         conn.send_buf.write(reinterpret_cast<const u8*>("Connection: keep-alive\r\n"), 24);
     else
         conn.send_buf.write(reinterpret_cast<const u8*>("Connection: close\r\n"), 19);
     conn.send_buf.write(reinterpret_cast<const u8*>("\r\n"), 2);
+}
+
+void format_static_response(Connection& conn, u16 code, bool keep_alive) {
+    const char* reason = status_reason(code);
+    u32 reason_len = 0;
+    while (reason[reason_len]) reason_len++;
+    const bool kNoBody = (code < 200 || code == 204 || code == 304);
+    const u32 kBodyLen = kNoBody ? 0 : reason_len;
+    write_response_headers(conn, code, kBodyLen, keep_alive, nullptr, 0);
     if (kBodyLen > 0) conn.send_buf.write(reinterpret_cast<const u8*>(reason), kBodyLen);
+}
+
+void format_response_with_body(
+    Connection& conn, u16 code, const char* body_data, u32 body_len, bool keep_alive) {
+    // 204 / 304 / 1xx carry no body per HTTP spec; fall back to the
+    // default formatter for those codes even if a body was supplied.
+    const bool kNoBody = (code < 200 || code == 204 || code == 304);
+    if (kNoBody) {
+        format_static_response(conn, code, keep_alive);
+        return;
+    }
+    static const char kDefaultContentType[] = "text/plain; charset=utf-8";
+    write_response_headers(
+        conn, code, body_len, keep_alive, kDefaultContentType, sizeof(kDefaultContentType) - 1);
+    if (body_len > 0) conn.send_buf.write(reinterpret_cast<const u8*>(body_data), body_len);
 }
 
 void prepare_early_response_state(Connection& conn) {

--- a/src/runtime/callbacks.cc
+++ b/src/runtime/callbacks.cc
@@ -306,16 +306,16 @@ const char* status_reason(u16 code) {
 // Shared writer: status line + Content-Length + Connection header,
 // used by both the default (reason-phrase) body path and the custom
 // body path. Leaves the builder positioned just past "\r\n" so the
-// caller can write the body bytes (if any).
+// caller can write the body bytes (if any). Callers pre-compute the
+// reason string so status_reason/strlen only runs once per response.
 static void write_response_headers(Connection& conn,
                                    u16 code,
+                                   const char* reason,
+                                   u32 reason_len,
                                    u32 body_len,
                                    bool keep_alive,
                                    const char* content_type,
                                    u32 content_type_len) {
-    const char* reason = status_reason(code);
-    u32 reason_len = 0;
-    while (reason[reason_len]) reason_len++;
     conn.send_buf.reset();
     conn.send_buf.write(reinterpret_cast<const u8*>("HTTP/1.1 "), 9);
     char code_buf[3];
@@ -385,7 +385,7 @@ void format_static_response(Connection& conn, u16 code, bool keep_alive) {
     while (reason[reason_len]) reason_len++;
     const bool kNoBody = (code < 200 || code == 204 || code == 304);
     const u32 kBodyLen = kNoBody ? 0 : reason_len;
-    write_response_headers(conn, code, kBodyLen, keep_alive, nullptr, 0);
+    write_response_headers(conn, code, reason, reason_len, kBodyLen, keep_alive, nullptr, 0);
     if (kBodyLen > 0) conn.send_buf.write(reinterpret_cast<const u8*>(reason), kBodyLen);
 }
 
@@ -398,9 +398,18 @@ void format_response_with_body(
         format_static_response(conn, code, keep_alive);
         return;
     }
+    const char* reason = status_reason(code);
+    u32 reason_len = 0;
+    while (reason[reason_len]) reason_len++;
     static const char kDefaultContentType[] = "text/plain; charset=utf-8";
-    write_response_headers(
-        conn, code, body_len, keep_alive, kDefaultContentType, sizeof(kDefaultContentType) - 1);
+    write_response_headers(conn,
+                           code,
+                           reason,
+                           reason_len,
+                           body_len,
+                           keep_alive,
+                           kDefaultContentType,
+                           sizeof(kDefaultContentType) - 1);
     if (body_len > 0) conn.send_buf.write(reinterpret_cast<const u8*>(body_data), body_len);
 }
 

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2707,14 +2707,31 @@ TEST(route, jit_handler_unknown_body_idx_falls_back) {
     char buf[1024];
     i32 n = recv_timeout(c, buf, sizeof(buf), 1000);
     CHECK_GT(n, 0);
-    bool has_200 = false;
-    for (i32 i = 0; i + 2 < n; i++) {
-        if (buf[i] == '2' && buf[i + 1] == '0' && buf[i + 2] == '0') {
-            has_200 = true;
-            break;
+    // Assert the default reason-phrase body — not just that 200 is
+    // anywhere in the response. For 200 the default body is "OK" (2
+    // bytes), and format_static_response does NOT emit Content-Type,
+    // so the response shape is distinct from the custom-body path.
+    const Str response{buf, static_cast<u32>(n)};
+    auto contains = [&](const char* needle, u32 nlen) {
+        for (u32 i = 0; i + nlen <= response.len; i++) {
+            bool match = true;
+            for (u32 j = 0; j < nlen; j++) {
+                if (response.ptr[i + j] != static_cast<u8>(needle[j])) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) return true;
         }
-    }
-    CHECK(has_200);
+        return false;
+    };
+    CHECK(contains("200 OK", 6));
+    CHECK(contains("Content-Length: 2\r\n", 19));
+    // Default formatter must NOT emit Content-Type — that would mean
+    // the custom-body path ran despite the out-of-range index.
+    CHECK(!contains("Content-Type:", 13));
+    // Body bytes at end of response: "...\r\n\r\nOK".
+    CHECK(contains("\r\n\r\nOK", 6));
 
     close(c);
     lt.stop();

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2549,6 +2549,180 @@ TEST(route, forward_jit_handler_rejects_unknown_upstream_id) {
     destroy_real_loop(loop);
 }
 
+// Minimal hand-written JIT handler that returns ReturnStatus(200)
+// with upstream_id = 1 — the ABI slot for a 1-based response-body
+// index. Used to validate the runtime body-render path without
+// needing the (not-yet-wired) compiler pipeline for bodies.
+static u64 return_200_with_body_1_handler(void* /*conn*/,
+                                          rut::jit::HandlerCtx* /*ctx*/,
+                                          const u8* /*req*/,
+                                          u32 /*len*/,
+                                          void* /*arena*/) {
+    rut::jit::HandlerResult r{rut::jit::HandlerAction::ReturnStatus,
+                              200,
+                              /*upstream_id=*/1,
+                              0,
+                              rut::jit::YieldKind::HttpGet};
+    return r.pack();
+}
+
+// End-to-end: handler returns ReturnStatus with body_idx=1;
+// RouteConfig has a body pre-registered; runtime formats response
+// with the body bytes + matching Content-Length + default Content-Type.
+TEST(route, jit_handler_custom_body_real_socket) {
+    using namespace rut;
+
+    RouteConfig cfg{};
+    const char kBody[] = "Hello, world";
+    const u16 body_idx = cfg.add_response_body(kBody, sizeof(kBody) - 1);
+    REQUIRE_EQ(body_idx, 1u);
+    REQUIRE(cfg.add_jit_handler("/hello", 'G', &return_200_with_body_1_handler));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 100};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    const char kReq[] = "GET /hello HTTP/1.1\r\nHost: x\r\n\r\n";
+    send_all(c, kReq, sizeof(kReq) - 1);
+    char buf[2048];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 1000);
+    CHECK_GT(n, 0);
+    buf[n < static_cast<i32>(sizeof(buf)) ? n : static_cast<i32>(sizeof(buf)) - 1] = '\0';
+
+    // Response must contain "200", "Content-Length: 12", default
+    // Content-Type, and the body bytes literal.
+    const Str response{buf, static_cast<u32>(n)};
+    bool has_200 = false;
+    bool has_cl = false;
+    bool has_ct = false;
+    bool has_body = false;
+    for (u32 i = 0; i + 2 < response.len; i++) {
+        if (response.ptr[i] == '2' && response.ptr[i + 1] == '0' && response.ptr[i + 2] == '0') {
+            has_200 = true;
+            break;
+        }
+    }
+    static const char kCL[] = "Content-Length: 12";
+    for (u32 i = 0; i + sizeof(kCL) - 1 <= response.len; i++) {
+        bool match = true;
+        for (u32 j = 0; j < sizeof(kCL) - 1; j++) {
+            if (response.ptr[i + j] != static_cast<u8>(kCL[j])) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            has_cl = true;
+            break;
+        }
+    }
+    static const char kCT[] = "Content-Type: text/plain";
+    for (u32 i = 0; i + sizeof(kCT) - 1 <= response.len; i++) {
+        bool match = true;
+        for (u32 j = 0; j < sizeof(kCT) - 1; j++) {
+            if (response.ptr[i + j] != static_cast<u8>(kCT[j])) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            has_ct = true;
+            break;
+        }
+    }
+    for (u32 i = 0; i + sizeof(kBody) - 1 <= response.len; i++) {
+        bool match = true;
+        for (u32 j = 0; j < sizeof(kBody) - 1; j++) {
+            if (response.ptr[i + j] != static_cast<u8>(kBody[j])) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            has_body = true;
+            break;
+        }
+    }
+    CHECK(has_200);
+    CHECK(has_cl);
+    CHECK(has_ct);
+    CHECK(has_body);
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+// Handler returns ReturnStatus with an out-of-range body_idx (e.g. no
+// body was registered). Runtime must fall back to the default status-
+// reason body rather than rendering garbage or hanging.
+static u64 return_200_with_body_99_handler(void* /*conn*/,
+                                           rut::jit::HandlerCtx* /*ctx*/,
+                                           const u8* /*req*/,
+                                           u32 /*len*/,
+                                           void* /*arena*/) {
+    rut::jit::HandlerResult r{rut::jit::HandlerAction::ReturnStatus,
+                              200,
+                              /*upstream_id=*/99,
+                              0,
+                              rut::jit::YieldKind::HttpGet};
+    return r.pack();
+}
+
+TEST(route, jit_handler_unknown_body_idx_falls_back) {
+    using namespace rut;
+
+    RouteConfig cfg{};
+    // No response bodies registered. upstream_id=99 is out of range.
+    REQUIRE(cfg.add_jit_handler("/hello", 'G', &return_200_with_body_99_handler));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 100};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    const char kReq[] = "GET /hello HTTP/1.1\r\nHost: x\r\n\r\n";
+    send_all(c, kReq, sizeof(kReq) - 1);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 1000);
+    CHECK_GT(n, 0);
+    bool has_200 = false;
+    for (i32 i = 0; i + 2 < n; i++) {
+        if (buf[i] == '2' && buf[i + 1] == '0' && buf[i + 2] == '0') {
+            has_200 = true;
+            break;
+        }
+    }
+    CHECK(has_200);
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 int main(int argc, char** argv) {
     return rut::test::run_all(argc, argv);
 }

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -2310,6 +2310,45 @@ TEST(route, add_upstream_at_capacity) {
     CHECK(!cfg.add_upstream("overflow", 0x7F000001, 9999).has_value());  // full
 }
 
+TEST(route, add_response_body_basic) {
+    RouteConfig cfg;
+    const u16 idx = cfg.add_response_body("Hello", 5);
+    REQUIRE_EQ(idx, 1u);
+    REQUIRE_EQ(cfg.response_body_count, 1u);
+    CHECK_EQ(cfg.response_bodies[0].len, 5u);
+    CHECK_EQ(cfg.response_bodies[0].data[0], 'H');
+    CHECK_EQ(cfg.response_bodies[0].data[4], 'o');
+    // Second body gets a distinct index.
+    const u16 idx2 = cfg.add_response_body("World", 5);
+    CHECK_EQ(idx2, 2u);
+}
+
+TEST(route, add_response_body_rejects_overflowing_len) {
+    // Subtraction-based capacity check: `body_pool_used + len` would
+    // wrap when len is near u32 max. The guarded code rejects the
+    // request cleanly rather than writing out of bounds.
+    RouteConfig cfg;
+    // Body table + pool start empty. Try a len that would overflow
+    // kResponseBodyPoolBytes - body_pool_used = kResponseBodyPoolBytes.
+    CHECK_EQ(cfg.add_response_body("x", 0xFFFFFFFFu), 0u);
+    // After a small successful add, a len near u32 max still overflows.
+    const u16 ok = cfg.add_response_body("Hi", 2);
+    REQUIRE_EQ(ok, 1u);
+    CHECK_EQ(cfg.add_response_body("x", 0xFFFFFFFEu), 0u);
+    // Null data with non-zero len is also rejected.
+    CHECK_EQ(cfg.add_response_body(nullptr, 1), 0u);
+    // Null data with zero len is a valid (empty) body.
+    CHECK_EQ(cfg.add_response_body(nullptr, 0), 2u);
+}
+
+TEST(route, add_response_body_rejects_at_capacity) {
+    RouteConfig cfg;
+    for (u32 i = 0; i < RouteConfig::kMaxResponseBodies; i++) {
+        CHECK_EQ(cfg.add_response_body("", 0), static_cast<u16>(i + 1));
+    }
+    CHECK_EQ(cfg.add_response_body("x", 1), 0u);  // table full
+}
+
 TEST(route, add_route_at_capacity) {
     RouteConfig cfg;
     (void)cfg.add_upstream("x", 0x7F000001, 80);


### PR DESCRIPTION
## Summary

Adds end-to-end runtime plumbing for custom response bodies on `ReturnStatus` — the runtime half of the `response()` builder story. Compiler wiring (plumbing body literals from AST → HIR → RIR → codegen) is tracked as a follow-up; this slice establishes the ABI + runtime format path so a handler can already produce a custom body end-to-end.

## What changed

**`RouteConfig`**
- New `response_bodies[]` (up to 128 entries) + 8 KB backing char pool + `add_response_body(data, len) → u16` helper (1-based; 0 reserved).

**Handler ABI (`handler_abi.h`)**
- The `upstream_id` slot, previously unused for `ReturnStatus`, now carries a 1-based body index. `0` means "use the default status-reason body". Documented inline on `HandlerResult`.

**`JitDispatchOutcome`**
- New `response_body_idx` field decoded from `r.upstream_id` for `ReturnStatus` outcomes.

**Runtime (`callbacks.cc` / `callbacks_impl.h`)**
- `format_response_with_body` writes status line, matching `Content-Length`, default `Content-Type: text/plain; charset=utf-8`, and the body bytes.
- `handle_jit_outcome::ReturnStatus` looks up the body via `conn.request_config`; out-of-range indices and `1xx` / `204` / `304` codes fall back to `format_static_response`.
- Refactored the Content-Length digit emission into a shared `write_response_headers` helper used by both formatters.

## Tests

- `jit_handler_custom_body_real_socket` — hand-written handler returns `ReturnStatus(200, upstream_id=1)`; `RouteConfig::add_response_body("Hello, world")` pre-populates the table; real epoll loop round-trips the response; asserts presence of `200`, `Content-Length: 12`, `Content-Type: text/plain`, and the body literal.
- `jit_handler_unknown_body_idx_falls_back` — out-of-range `upstream_id = 99` against an empty body table renders the default reason phrase rather than garbage.

All 2081 tests pass.

## What's deferred (follow-up slice)

Wiring the DSL's `return response(200, body: "...")` through the compiler to actually populate this table at compile time. `analyze` still rejects the `body:` kwarg with `UnsupportedSyntax`. Hand-written handlers can already use the ABI.

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test` (2081 passed, 0 failed)
- [x] `./dev.sh format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)