### PR TITLE
Compiler: thread response() body through HIR → MIR → RIR → codegen

### DIFF
--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -534,8 +534,13 @@ struct HirTerminator {
     u32 local_ref_index = 0xffffffffu;
     u32 upstream_index = 0;
     // Optional response body literal (populated when the source was
-    // `return response(N, body: "...")`). Empty Str means no custom
-    // body — runtime uses the default status-reason phrase.
+    // `return response(N, body: "...")`). Sentinel by ptr, not len:
+    //   ptr == nullptr   → no body kwarg, use default status-reason.
+    //   ptr != nullptr   → explicit body (including `body: ""` which
+    //                      keeps ptr non-null with len == 0).
+    // lower_rir.cc::analyze_term only copies this when the Ast source
+    // had `has_response_body == true`, so the sentinel is preserved
+    // end-to-end.
     Str response_body{};
 };
 

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -533,6 +533,10 @@ struct HirTerminator {
     i32 status_code = 0;
     u32 local_ref_index = 0xffffffffu;
     u32 upstream_index = 0;
+    // Optional response body literal (populated when the source was
+    // `return response(N, body: "...")`). Empty Str means no custom
+    // body — runtime uses the default status-reason phrase.
+    Str response_body{};
 };
 
 struct HirGuardBody {

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -538,7 +538,7 @@ struct HirTerminator {
     //   ptr == nullptr   → no body kwarg, use default status-reason.
     //   ptr != nullptr   → explicit body (including `body: ""` which
     //                      keeps ptr non-null with len == 0).
-    // lower_rir.cc::analyze_term only copies this when the Ast source
+    // analyze.cc::analyze_term only copies this when the Ast source
     // had `has_response_body == true`, so the sentinel is preserved
     // end-to-end.
     Str response_body{};

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -186,6 +186,10 @@ struct MirTerminator {
     MirValue rhs{};
     u32 then_block = 0;
     u32 else_block = 0;
+    // Optional response body literal — carried verbatim from HIR for
+    // ReturnStatus terminators. lower_rir maps identical literals to a
+    // shared body_idx that codegen packs into HandlerResult.upstream_id.
+    Str response_body{};
 };
 
 struct MirBlock {

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -361,11 +361,14 @@ struct Module {
     u32 func_cap;
 
     // Response-body literals collected from RetStatus terminators.
-    // Entry 0 is reserved as "no custom body"; real literals start at
-    // index 1 (matching the 1-based body_idx the JIT handler packs
-    // into HandlerResult.upstream_id). Identical literals are
-    // deduplicated during lowering so the table stays small.
-    // Populated at lower_to_rir time; codegen references it by index.
+    // The array is 0-based, but the emit_ret_status body_idx and the
+    // handler ABI use 1-based indices (0 reserved as "no custom
+    // body"), so `body_idx = i + 1` maps to `response_bodies[i]`.
+    // Identical literals are deduplicated during lowering so the
+    // table stays small. Populated at lower_to_rir time; the table is
+    // then consumed by whatever populates RouteConfig (tests / future
+    // compile→config helper) — codegen itself only packs the index
+    // into the handler's return value, it doesn't read the bytes.
     static constexpr u32 kMaxResponseBodies = 128;
     Str response_bodies[kMaxResponseBodies];
     u32 response_body_count = 0;

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -206,7 +206,12 @@ enum class Opcode : u8 {
     // ── Terminators ── (must be last instruction in a block)
     Br,          // br %cond, then_block, else_block
     Jmp,         // jmp target_block
-    RetStatus,   // ret.status code [, headers/body]
+    RetStatus,   // ret.status packed-imm (imm.i32_val = status | body_idx<<16)
+                 //   low  16 bits: HTTP status code (0..65535)
+                 //   high 16 bits: 1-based response_bodies index, 0 = no body
+                 //   Any printer/decoder MUST decode both fields — printing
+                 //   imm.i32_val as a raw status will be misleading when
+                 //   body_idx > 0.
     RetForward,  // ret.forward upstream [, options]
 
     // ── Yield (I/O suspend → state machine boundary) ──
@@ -238,7 +243,9 @@ struct Instruction {
     // Instruction-specific immediate data (tagged by opcode).
     union Immediate {
         Str str_val;               // ConstStr, ReqHeader, ReqParam, ReqCookie, etc.
-        i32 i32_val;               // ConstI32, ConstStatus, RetStatus
+        i32 i32_val;               // ConstI32, ConstStatus; RetStatus packs
+                                   // (status | body_idx<<16) — decode before
+                                   // display (see RetStatus opcode comment).
         i64 i64_val;               // ConstI64, ConstDuration, ConstByteSize
         bool bool_val;             // ConstBool
         u8 method_val;             // ConstMethod (HTTP method enum)

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -360,6 +360,16 @@ struct Module {
     u32 func_count;
     u32 func_cap;
 
+    // Response-body literals collected from RetStatus terminators.
+    // Entry 0 is reserved as "no custom body"; real literals start at
+    // index 1 (matching the 1-based body_idx the JIT handler packs
+    // into HandlerResult.upstream_id). Identical literals are
+    // deduplicated during lowering so the table stays small.
+    // Populated at lower_to_rir time; codegen references it by index.
+    static constexpr u32 kMaxResponseBodies = 128;
+    Str response_bodies[kMaxResponseBodies];
+    u32 response_body_count = 0;
+
     // Arena that owns all IR memory (mmap-backed, compiler use).
     MmapArena* arena;
 };

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -206,12 +206,19 @@ enum class Opcode : u8 {
     // ── Terminators ── (must be last instruction in a block)
     Br,          // br %cond, then_block, else_block
     Jmp,         // jmp target_block
-    RetStatus,   // ret.status packed-imm (imm.i32_val = status | body_idx<<16)
-                 //   low  16 bits: HTTP status code (0..65535)
-                 //   high 16 bits: 1-based response_bodies index, 0 = no body
-                 //   Any printer/decoder MUST decode both fields — printing
-                 //   imm.i32_val as a raw status will be misleading when
-                 //   body_idx > 0.
+    RetStatus,   // ret.status — two encodings, disambiguated by operand_count:
+                 //   operand_count == 0 (literal form): imm.i32_val holds
+                 //     a packed (status | body_idx<<16):
+                 //       low  16 bits: HTTP status code (0..65535)
+                 //       high 16 bits: 1-based response_bodies index,
+                 //                     0 = no body
+                 //   operand_count >  0 (value form):   operands[0] is an
+                 //     SSA i32 status code; imm is unused and body_idx is
+                 //     implicitly 0 (no custom body today).
+                 //   Printers/decoders MUST branch on operand_count before
+                 //   reading imm.i32_val — doing otherwise will print
+                 //   garbage for the value form and miss body_idx in the
+                 //   literal form.
     RetForward,  // ret.forward upstream [, options]
 
     // ── Yield (I/O suspend → state machine boundary) ──

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -721,10 +721,19 @@ struct Builder {
 
     // Intern a response body literal into the module's table. Returns
     // a 1-based index suitable for emit_ret_status. Deduplicates
-    // byte-identical literals. Returns 0 if the table is full, which
-    // caller should treat as "no custom body" + flag an error.
+    // byte-identical literals. Returns 0 ONLY on failure (table full
+    // or arena OOM) — callers should surface this as a hard error;
+    // 0 does NOT mean "no custom body" (that's the absence of a
+    // terminator's response_body in the first place).
+    //
+    // Body bytes are copied into the module's arena so entries survive
+    // after the caller's source buffer (e.g. transient file-read
+    // storage) goes away. Downstream consumers (RouteConfig::
+    // add_response_body) still make their own copy into config-owned
+    // storage, but the module is self-contained between lowering and
+    // config population.
     u16 intern_response_body(Str body) {
-        if (!mod) return 0;
+        if (!mod || !mod->arena) return 0;
         for (u32 i = 0; i < mod->response_body_count; i++) {
             const Str& existing = mod->response_bodies[i];
             if (existing.len == body.len) {
@@ -739,8 +748,14 @@ struct Builder {
             }
         }
         if (mod->response_body_count >= Module::kMaxResponseBodies) return 0;
+        char* buf = nullptr;
+        if (body.len > 0) {
+            buf = mod->arena->alloc_array<char>(body.len);
+            if (!buf) return 0;
+            for (u32 i = 0; i < body.len; i++) buf[i] = body.ptr[i];
+        }
         const u32 idx = mod->response_body_count++;
-        mod->response_bodies[idx] = body;
+        mod->response_bodies[idx] = {buf, body.len};
         return static_cast<u16>(idx + 1);
     }
 

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -707,10 +707,41 @@ struct Builder {
         return {};
     }
 
-    VoidResult emit_ret_status(i32 code, SourceLoc loc = {}) {
+    // Literal status form. body_idx is a 1-based index into the
+    // module's response_bodies table (0 = no custom body, runtime
+    // renders the default status-reason phrase). Status fits in
+    // 16 bits (100..999); body_idx fits in 16 bits. Both pack
+    // into the immediate slot: low 16 = status, high 16 = body_idx.
+    VoidResult emit_ret_status(i32 code, SourceLoc loc = {}, u16 body_idx = 0) {
         auto r = TRY(emit(Opcode::RetStatus, nullptr, loc));
-        r.inst->imm.i32_val = code;
+        r.inst->imm.i32_val = static_cast<i32>((static_cast<u32>(body_idx) << 16) |
+                                               (static_cast<u32>(code) & 0xffffu));
         return {};
+    }
+
+    // Intern a response body literal into the module's table. Returns
+    // a 1-based index suitable for emit_ret_status. Deduplicates
+    // byte-identical literals. Returns 0 if the table is full, which
+    // caller should treat as "no custom body" + flag an error.
+    u16 intern_response_body(Str body) {
+        if (!mod) return 0;
+        for (u32 i = 0; i < mod->response_body_count; i++) {
+            const Str& existing = mod->response_bodies[i];
+            if (existing.len == body.len) {
+                bool match = true;
+                for (u32 j = 0; j < body.len; j++) {
+                    if (existing.ptr[j] != body.ptr[j]) {
+                        match = false;
+                        break;
+                    }
+                }
+                if (match) return static_cast<u16>(i + 1);
+            }
+        }
+        if (mod->response_body_count >= Module::kMaxResponseBodies) return 0;
+        const u32 idx = mod->response_body_count++;
+        mod->response_bodies[idx] = body;
+        return static_cast<u16>(idx + 1);
     }
 
     // Runtime-value form: status code is read from a SSA value (e.g. result

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -735,17 +735,7 @@ struct Builder {
     u16 intern_response_body(Str body) {
         if (!mod || !mod->arena) return 0;
         for (u32 i = 0; i < mod->response_body_count; i++) {
-            const Str& existing = mod->response_bodies[i];
-            if (existing.len == body.len) {
-                bool match = true;
-                for (u32 j = 0; j < body.len; j++) {
-                    if (existing.ptr[j] != body.ptr[j]) {
-                        match = false;
-                        break;
-                    }
-                }
-                if (match) return static_cast<u16>(i + 1);
-            }
+            if (mod->response_bodies[i].eq(body)) return static_cast<u16>(i + 1);
         }
         if (mod->response_body_count >= Module::kMaxResponseBodies) return 0;
         char* buf = nullptr;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5243,17 +5243,14 @@ static FrontendResult<HirTerminator> analyze_term(const AstStatement& stmt, cons
     if (stmt.kind == AstStmtKind::ReturnStatus) {
         if (stmt.status_code < 100 || stmt.status_code > 999)
             return frontend_error(FrontendError::InvalidStatusCode, stmt.span);
-        // `response(N, body: "...")` syntax is parsed but custom body
-        // rendering isn't wired to the runtime yet. Reject at analyze
-        // to avoid silently dropping the payload — including the
-        // explicit-empty `body: ""` case, which would otherwise slip
-        // through a len-based check. Follow-up slice will plumb
-        // bodies through HIR → MIR → RIR → codegen → format_*.
-        if (stmt.has_response_body)
-            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
         term.kind = HirTerminatorKind::ReturnStatus;
         // Validated to 100..999 above; fits in HirTerminator::status_code.
         term.status_code = static_cast<i32>(stmt.status_code);
+        // Carry the body literal if present. Empty body is preserved
+        // distinct from "no body" via has_response_body semantics:
+        // analyze stores an explicit zero-length non-null Str when the
+        // user wrote `body: ""`; lower_rir de-dupes on content.
+        if (stmt.has_response_body) term.response_body = stmt.response_body;
         return term;
     }
 

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2366,12 +2366,24 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
         if (term.source_kind == MirTerminatorSourceKind::LocalRef) {
             if (term.local_ref_index >= local_count)
                 return frontend_error(FrontendError::UnsupportedSyntax, term.span);
+            // Runtime-value status doesn't carry a body literal today
+            // (source syntax is `return <local>`, no response()
+            // builder form on this path). Body plumbing on that path
+            // can follow when response(localVar) becomes valid.
             const auto code_id = locals[term.local_ref_index];
             if (!b.emit_ret_status(code_id, {term.span.line, term.span.col}))
                 return frontend_error(FrontendError::OutOfMemory, term.span);
             return {};
         }
-        if (!b.emit_ret_status(term.status_code, {term.span.line, term.span.col}))
+        // Literal form: intern the body (if any) into the module table
+        // and pack the 1-based idx into RetStatus's immediate. Empty /
+        // missing body ⇒ idx = 0 ⇒ runtime uses default status-reason.
+        u16 body_idx = 0;
+        if (term.response_body.ptr != nullptr && term.response_body.len > 0) {
+            body_idx = b.intern_response_body(term.response_body);
+            if (body_idx == 0) return frontend_error(FrontendError::TooManyItems, term.span);
+        }
+        if (!b.emit_ret_status(term.status_code, {term.span.line, term.span.col}, body_idx))
             return frontend_error(FrontendError::OutOfMemory, term.span);
         return {};
     }

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2381,7 +2381,16 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
         u16 body_idx = 0;
         if (term.response_body.ptr != nullptr && term.response_body.len > 0) {
             body_idx = b.intern_response_body(term.response_body);
-            if (body_idx == 0) return frontend_error(FrontendError::TooManyItems, term.span);
+            if (body_idx == 0) {
+                // intern returns 0 for both "table full" and "arena
+                // OOM for the body-bytes copy". Distinguish here so
+                // the diagnostic isn't misleading: if the count is
+                // still under the cap, the arena must have failed.
+                const auto err = b.mod->response_body_count < rir::Module::kMaxResponseBodies
+                                     ? FrontendError::OutOfMemory
+                                     : FrontendError::TooManyItems;
+                return frontend_error(err, term.span);
+            }
         }
         if (!b.emit_ret_status(term.status_code, {term.span.line, term.span.col}, body_idx))
             return frontend_error(FrontendError::OutOfMemory, term.span);

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -799,6 +799,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                                    ? MirTerminatorSourceKind::LocalRef
                                    : MirTerminatorSourceKind::Literal;
             out->local_ref_index = term.local_ref_index;
+            out->response_body = term.response_body;
         };
         auto guard_fail_block_count = [&](const HirGuard& guard) -> u32 {
             if (guard.fail_kind == HirGuard::FailKind::Term) return 1;

--- a/src/compiler/rir_printer.cc
+++ b/src/compiler/rir_printer.cc
@@ -579,7 +579,15 @@ void print_instruction(PrintBuf& buf, const Instruction& inst, const Function& f
             if (inst.operand_count > 0) {
                 print_value_ref(buf, inst.operands[0]);
             } else {
-                buf.put_i32(inst.imm.i32_val);
+                // Literal form packs (status | body_idx<<16); decode both
+                // so human-facing output stays truthful.
+                u32 packed = static_cast<u32>(inst.imm.i32_val);
+                buf.put_i32(static_cast<i32>(packed & 0xffffu));
+                u32 body_idx = packed >> 16;
+                if (body_idx != 0) {
+                    buf.put_cstr(", body#");
+                    buf.put_u32(body_idx);
+                }
             }
             break;
         case Opcode::RetForward:

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -759,6 +759,13 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
                 if (LLVMTypeOf(status) != c.i32_ty) {
                     status = LLVMBuildZExt(c.builder, status, c.i32_ty, "code.ext");
                 }
+                // Mask to 16 bits so a runtime-produced status value
+                // above 0xffff can't spill into the upstream_id slot
+                // (which carries the body_idx for ReturnStatus). The
+                // operand form doesn't carry a body_idx today, so
+                // body_idx_imm stays 0.
+                status = LLVMBuildAnd(
+                    c.builder, status, LLVMConstInt(c.i32_ty, 0xffffu, 0), "code.mask");
             } else {
                 const u32 packed = static_cast<u32>(inst.imm.i32_val);
                 const u32 status_u = packed & 0xffffu;

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -741,28 +741,41 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             break;
         }
         case rir::Opcode::RetStatus: {
-            // Pack HandlerResult as i64: action=0 (ReturnStatus), status_code from operand or
-            // immediate.
-            LLVMValueRef code;
+            // Pack HandlerResult as i64: action=ReturnStatus,
+            // status_code in bytes 1-2 (low 16 of status slot),
+            // body_idx in bytes 3-4 (the "upstream_id" slot repurposed
+            // per handler ABI — 1-based index into RouteConfig's
+            // response_bodies; 0 = default status-reason body).
+            //
+            // For the operand form (runtime-value status), body_idx is
+            // always 0 because that source path doesn't yet support
+            // custom bodies. For the literal form, RIR packs status
+            // and body_idx into imm.i32_val: low 16 = status, high 16
+            // = body_idx — decode both here.
+            LLVMValueRef status;
+            u32 body_idx_imm = 0;
             if (inst.operand_count > 0) {
-                code = c.get_value(inst.operands[0]);
-                // Ensure it's i32
-                if (LLVMTypeOf(code) != c.i32_ty) {
-                    code = LLVMBuildZExt(c.builder, code, c.i32_ty, "code.ext");
+                status = c.get_value(inst.operands[0]);
+                if (LLVMTypeOf(status) != c.i32_ty) {
+                    status = LLVMBuildZExt(c.builder, status, c.i32_ty, "code.ext");
                 }
             } else {
-                code = LLVMConstInt(c.i32_ty, static_cast<u32>(inst.imm.i32_val), 0);
+                const u32 packed = static_cast<u32>(inst.imm.i32_val);
+                const u32 status_u = packed & 0xffffu;
+                body_idx_imm = (packed >> 16) & 0xffffu;
+                status = LLVMConstInt(c.i32_ty, status_u, 0);
             }
-            // Build packed i64: action(8) | status(16) | upstream(16) | next_state(16) |
-            // yield_kind(8) Byte layout (packed struct, little-endian):
-            //   byte 0: action = 0 (ReturnStatus)
-            //   byte 1-2: status_code (u16)
-            //   byte 3-7: zeros
-            LLVMValueRef action = LLVMConstInt(c.i64_ty, 0, 0);  // ReturnStatus
-            LLVMValueRef status_ext = LLVMBuildZExt(c.builder, code, c.i64_ty, "st.ext");
-            LLVMValueRef shifted =
+            LLVMValueRef action =
+                LLVMConstInt(c.i64_ty, static_cast<u64>(HandlerAction::ReturnStatus), 0);
+            LLVMValueRef status_ext = LLVMBuildZExt(c.builder, status, c.i64_ty, "st.ext");
+            LLVMValueRef status_shifted =
                 LLVMBuildShl(c.builder, status_ext, LLVMConstInt(c.i64_ty, 8, 0), "st.shl");
-            LLVMValueRef result = LLVMBuildOr(c.builder, action, shifted, "result");
+            LLVMValueRef result = LLVMBuildOr(c.builder, action, status_shifted, "result.st");
+            if (body_idx_imm != 0) {
+                LLVMValueRef body_slot =
+                    LLVMConstInt(c.i64_ty, static_cast<u64>(body_idx_imm) << 24, 0);
+                result = LLVMBuildOr(c.builder, result, body_slot, "result.body");
+            }
             LLVMBuildRet(c.builder, result);
             break;
         }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -193,9 +193,10 @@ TEST(frontend, parse_return_response_with_body) {
 }
 
 TEST(frontend, parse_return_response_empty_body_is_noop) {
-    // `body: ""` has the explicit-empty flag but zero bytes; lower_rir
-    // treats it as "no custom body" (same as if the kwarg had been
-    // omitted), so no entry is interned into the module table.
+    // `body: ""` has the explicit-empty flag but zero bytes; HIR
+    // preserves the kwarg (ptr != nullptr, len == 0 — the documented
+    // sentinel), and lower_rir treats it as "no custom body" so no
+    // entry is interned into the module table.
     const char* src = "route GET \"/x\" { return response(200, body: \"\") }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -206,9 +207,21 @@ TEST(frontend, parse_return_response_empty_body_is_noop) {
     CHECK(ast->items[0].route.statements[0].has_response_body);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
-    // HIR preserves the empty string so downstream passes can see the
-    // explicit kwarg; the interning step later skips zero-length bodies.
-    CHECK_EQ(hir->routes[0].control.direct_term.response_body.len, 0u);
+    // HIR preserves the explicit kwarg via ptr-based sentinel: ptr
+    // non-null distinguishes `body: ""` from the no-kwarg case even
+    // though len == 0 in both. Asserting ptr != nullptr catches
+    // regressions that would silently drop the kwarg.
+    const auto& term = hir->routes[0].control.direct_term;
+    CHECK(term.response_body.ptr != nullptr);
+    CHECK_EQ(term.response_body.len, 0u);
+    // Lower through MIR → RIR and verify the module table stays empty:
+    // zero-length bodies should not produce an intern entry.
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    CHECK_EQ(rir.module.response_body_count, 0u);
 }
 
 TEST(frontend, parse_return_response_rejects_unknown_kwarg) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -201,6 +201,7 @@ TEST(frontend, parse_return_response_with_body) {
     REQUIRE_EQ(rir.module.response_body_count, 1u);
     REQUIRE_EQ(rir.module.response_bodies[0].len, 5u);
     CHECK(rir.module.response_bodies[0].eq(lit("Hello")));
+    rir.destroy();
 }
 
 TEST(frontend, parse_return_response_empty_body_is_noop) {
@@ -233,6 +234,7 @@ TEST(frontend, parse_return_response_empty_body_is_noop) {
     auto lowered = lower_to_rir(mir.value(), rir);
     REQUIRE(lowered);
     CHECK_EQ(rir.module.response_body_count, 0u);
+    rir.destroy();
 }
 
 TEST(frontend, parse_return_response_rejects_unknown_kwarg) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -166,10 +166,11 @@ TEST(frontend, parse_return_response_status_only) {
 }
 
 TEST(frontend, parse_return_response_with_body) {
-    // Parser recognises the body: "..." kwarg; analyze propagates the
-    // literal into HirTerminator.response_body; lower_rir interns it
-    // into rir::Module::response_bodies and emits body_idx on
-    // RetStatus; codegen packs body_idx into HandlerResult.upstream_id.
+    // Covers the body: "..." kwarg through the compile-side pipeline:
+    // parser → AST.response_body, analyze → HirTerminator.response_body,
+    // lower_rir → rir::Module::response_bodies (non-empty entry interned,
+    // body_idx = 1). Codegen and runtime behavior are exercised by
+    // tests/test_integration.cc::dsl_response_body_real_socket.
     const char* src = "route GET \"/x\" { return response(200, body: \"Hello\") }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -190,6 +191,16 @@ TEST(frontend, parse_return_response_with_body) {
     CHECK_EQ(term.status_code, 200);
     REQUIRE_EQ(term.response_body.len, 5u);
     CHECK(term.response_body.eq(lit("Hello")));
+    // Lower through MIR → RIR and verify a single body was interned at
+    // slot 0 (body_idx 1) with the exact bytes.
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.response_body_count, 1u);
+    REQUIRE_EQ(rir.module.response_bodies[0].len, 5u);
+    CHECK(rir.module.response_bodies[0].eq(lit("Hello")));
 }
 
 TEST(frontend, parse_return_response_empty_body_is_noop) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -166,9 +166,10 @@ TEST(frontend, parse_return_response_status_only) {
 }
 
 TEST(frontend, parse_return_response_with_body) {
-    // Parser recognises the body: "..." kwarg and stores the literal;
-    // analyze rejects it with UnsupportedSyntax because the runtime
-    // body-render path hasn't landed (tracked for follow-up slice).
+    // Parser recognises the body: "..." kwarg; analyze propagates the
+    // literal into HirTerminator.response_body; lower_rir interns it
+    // into rir::Module::response_bodies and emits body_idx on
+    // RetStatus; codegen packs body_idx into HandlerResult.upstream_id.
     const char* src = "route GET \"/x\" { return response(200, body: \"Hello\") }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -182,14 +183,19 @@ TEST(frontend, parse_return_response_with_body) {
     CHECK(stmt.response_body.eq(lit("Hello")));
     CHECK(stmt.has_response_body);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE(!hir);
-    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    const auto& term = hir->routes[0].control.direct_term;
+    CHECK_EQ(static_cast<u8>(term.kind), static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(term.status_code, 200);
+    REQUIRE_EQ(term.response_body.len, 5u);
+    CHECK(term.response_body.eq(lit("Hello")));
 }
 
-TEST(frontend, parse_return_response_rejects_empty_body) {
-    // `body: ""` is an explicit empty string; has_response_body
-    // distinguishes it from the no-kwarg case so analyze still
-    // rejects, not silently treating it as a plain `return`.
+TEST(frontend, parse_return_response_empty_body_is_noop) {
+    // `body: ""` has the explicit-empty flag but zero bytes; lower_rir
+    // treats it as "no custom body" (same as if the kwarg had been
+    // omitted), so no entry is interned into the module table.
     const char* src = "route GET \"/x\" { return response(200, body: \"\") }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -199,8 +205,10 @@ TEST(frontend, parse_return_response_rejects_empty_body) {
     REQUIRE_EQ(ast->items[0].route.statements.len, 1u);
     CHECK(ast->items[0].route.statements[0].has_response_body);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE(!hir);
-    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+    REQUIRE(hir);
+    // HIR preserves the empty string so downstream passes can see the
+    // explicit kwarg; the interning step later skips zero-length bodies.
+    CHECK_EQ(hir->routes[0].control.direct_term.response_body.len, 0u);
 }
 
 TEST(frontend, parse_return_response_rejects_unknown_kwarg) {

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -884,6 +884,24 @@ inline bool has_200(const char* buf, i32 n) {
     return false;
 }
 
+// Byte-literal substring search over a fixed-length buffer. Returns true
+// iff `[needle, needle+nlen)` appears anywhere in `[hay, hay+hlen)`.
+// Handles nlen == 0 (always true) and nlen > hlen (always false).
+inline bool buf_contains(const char* hay, u32 hlen, const char* needle, u32 nlen) {
+    if (nlen > hlen) return false;
+    for (u32 i = 0; i + nlen <= hlen; i++) {
+        bool match = true;
+        for (u32 j = 0; j < nlen; j++) {
+            if (hay[i + j] != needle[j]) {
+                match = false;
+                break;
+            }
+        }
+        if (match) return true;
+    }
+    return false;
+}
+
 struct LoopThread {
     RealLoop* loop;
     pthread_t thread;

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2740,6 +2740,93 @@ TEST(route, jit_handler_unknown_body_idx_falls_back) {
     destroy_real_loop(loop);
 }
 
+// End-to-end: compile `route GET "/x" { return response(200, body: "Hi") }`
+// from source, populate RouteConfig.response_bodies from the compiled
+// rir::Module, and verify a real client receives the exact body.
+TEST(route, dsl_response_body_real_socket) {
+    using namespace rut;
+
+    const char* src = "route GET \"/x\" { return response(200, body: \"Hi!\") }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler_fn = reinterpret_cast<jit::HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler_fn != nullptr);
+
+    RouteConfig cfg{};
+    // Mirror the module's body table (1-based) into cfg. This loop is
+    // what a future compile→RouteConfig helper will do in production.
+    REQUIRE_EQ(rir.module.response_body_count, 1u);
+    for (u32 i = 0; i < rir.module.response_body_count; i++) {
+        const auto& body = rir.module.response_bodies[i];
+        const u16 idx = cfg.add_response_body(body.ptr, body.len);
+        REQUIRE_EQ(idx, static_cast<u16>(i + 1));
+    }
+    REQUIRE(cfg.add_jit_handler("/x", 'G', handler_fn));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 100};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    const char kReq[] = "GET /x HTTP/1.1\r\nHost: x\r\n\r\n";
+    send_all(c, kReq, sizeof(kReq) - 1);
+    char buf[2048];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 1000);
+    CHECK_GT(n, 0);
+    const Str response{buf, static_cast<u32>(n)};
+    auto contains = [&](const char* needle, u32 nlen) {
+        for (u32 i = 0; i + nlen <= response.len; i++) {
+            bool match = true;
+            for (u32 j = 0; j < nlen; j++) {
+                if (response.ptr[i + j] != static_cast<u8>(needle[j])) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) return true;
+        }
+        return false;
+    };
+    CHECK(contains("200 OK", 6));
+    CHECK(contains("Content-Length: 3\r\n", 19));
+    CHECK(contains("Content-Type: text/plain", 24));
+    CHECK(contains("\r\n\r\nHi!", 7));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
 int main(int argc, char** argv) {
     return rut::test::run_all(argc, argv);
 }

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2731,7 +2731,7 @@ TEST(route, jit_handler_unknown_body_idx_falls_back) {
     destroy_real_loop(loop);
 }
 
-// End-to-end: compile `route GET "/x" { return response(200, body: "Hi") }`
+// End-to-end: compile `route GET "/x" { return response(200, body: "Hi!") }`
 // from source, populate RouteConfig.response_bodies from the compiled
 // rir::Module, and verify a real client receives the exact body.
 TEST(route, dsl_response_body_real_socket) {

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2712,26 +2712,17 @@ TEST(route, jit_handler_unknown_body_idx_falls_back) {
     // bytes), and format_static_response does NOT emit Content-Type,
     // so the response shape is distinct from the custom-body path.
     const Str response{buf, static_cast<u32>(n)};
-    auto contains = [&](const char* needle, u32 nlen) {
-        for (u32 i = 0; i + nlen <= response.len; i++) {
-            bool match = true;
-            for (u32 j = 0; j < nlen; j++) {
-                if (response.ptr[i + j] != static_cast<u8>(needle[j])) {
-                    match = false;
-                    break;
-                }
-            }
-            if (match) return true;
-        }
-        return false;
+    auto has = [&](const char* needle, u32 nlen) {
+        return buf_contains(
+            reinterpret_cast<const char*>(response.ptr), response.len, needle, nlen);
     };
-    CHECK(contains("200 OK", 6));
-    CHECK(contains("Content-Length: 2\r\n", 19));
+    CHECK(has("200 OK", 6));
+    CHECK(has("Content-Length: 2\r\n", 19));
     // Default formatter must NOT emit Content-Type — that would mean
     // the custom-body path ran despite the out-of-range index.
-    CHECK(!contains("Content-Type:", 13));
+    CHECK(!has("Content-Type:", 13));
     // Body bytes at end of response: "...\r\n\r\nOK".
-    CHECK(contains("\r\n\r\nOK", 6));
+    CHECK(has("\r\n\r\nOK", 6));
 
     close(c);
     lt.stop();
@@ -2800,23 +2791,14 @@ TEST(route, dsl_response_body_real_socket) {
     i32 n = recv_timeout(c, buf, sizeof(buf), 1000);
     CHECK_GT(n, 0);
     const Str response{buf, static_cast<u32>(n)};
-    auto contains = [&](const char* needle, u32 nlen) {
-        for (u32 i = 0; i + nlen <= response.len; i++) {
-            bool match = true;
-            for (u32 j = 0; j < nlen; j++) {
-                if (response.ptr[i + j] != static_cast<u8>(needle[j])) {
-                    match = false;
-                    break;
-                }
-            }
-            if (match) return true;
-        }
-        return false;
+    auto has = [&](const char* needle, u32 nlen) {
+        return buf_contains(
+            reinterpret_cast<const char*>(response.ptr), response.len, needle, nlen);
     };
-    CHECK(contains("200 OK", 6));
-    CHECK(contains("Content-Length: 3\r\n", 19));
-    CHECK(contains("Content-Type: text/plain", 24));
-    CHECK(contains("\r\n\r\nHi!", 7));
+    CHECK(has("200 OK", 6));
+    CHECK(has("Content-Length: 3\r\n", 19));
+    CHECK(has("Content-Type: text/plain", 24));
+    CHECK(has("\r\n\r\nHi!", 7));
 
     close(c);
     lt.stop();


### PR DESCRIPTION
## Summary

Completes the `response()` builder story started in #30 and #31. `return response(200, body: "Hello")` now compiles and runs end-to-end — the handler returns status 200 + body "Hello" + a matching Content-Length.

## Pipeline plumbing

**analyze** — accepts the `body:` kwarg instead of rejecting with `UnsupportedSyntax`. Propagates the literal from `AstStatement::response_body` into a new `HirTerminator::response_body` field.

**MIR** — `MirTerminator::response_body` carried through `mir_build`'s `set_term_from_hir` helper.

**RIR** — `rir::Module` grows a `response_bodies[128]` table. `Builder` gains `intern_response_body(Str) → u16` that deduplicates identical literals and returns a 1-based index (0 = no body). The `RetStatus` immediate is repacked: low 16 bits = status code, high 16 bits = body index — no new opcode or operand needed because status fits in 16 bits (100..999).

**lower_rir** — the Literal return path calls `intern_response_body` when the terminator carries a non-empty body and passes the idx into `emit_ret_status`. Empty bodies are treated as "no custom body" (default status-reason phrase), consistent with the runtime fallback.

**codegen** — decodes the packed `i32_val` into `(status, body_idx)` and emits `body_idx << 24` into the HandlerResult i64 — matching the ABI slot #31 defined (`upstream_id` doubles as body-index for `ReturnStatus`).

## Tests

- `parse_return_response_with_body` — now verifies HIR carries the literal through analyze.
- `parse_return_response_empty_body_is_noop` — replaces the old rejection test; empty body preserved through HIR, skipped by the interner.
- `dsl_response_body_real_socket` — compiles the DSL source end to end, populates `RouteConfig.response_bodies` from `rir::Module` (the step a future compile→RouteConfig helper will automate), drives a real socket, and asserts the response contains `200 OK`, `Content-Length: 3`, `Content-Type: text/plain`, and the terminal `\r\n\r\nHi!`.

All 2085 tests pass.

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test` (2085 passed, 0 failed)
- [x] `./dev.sh format`

## What's deferred

- Custom headers / content-type (`header:` kwarg or `.header()` fluent).
- Consolidated compile→RouteConfig helper (tests currently duplicate the small "copy bodies into cfg" loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)