### PR TITLE
DSL: upstream address syntax (`at "host:port"` + dict form + helper)

### DIFF
--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -137,6 +137,22 @@ struct AstStatement {
 struct AstUpstreamDecl {
     Span span{};
     Str name{};
+    // Optional backend address. Two syntactic forms produce the same
+    // fields, distinguished only by what the parser saw after the name:
+    //   A. `upstream backend at "127.0.0.1:8080"`
+    //      → host_lit = "127.0.0.1:8080", port_is_set = false.
+    //   C. `upstream backend { host: "127.0.0.1", port: 8080 }`
+    //      → host_lit = "127.0.0.1", port_lit = 8080, port_is_set = true.
+    // Analyze parses host_lit + port_lit into (ip u32, port u16) and
+    // stores the result on HirUpstream. has_address == false means no
+    // address was declared in the DSL (runtime must supply one via
+    // add_upstream()). Both forms require an IPv4 literal today;
+    // DNS/IPv6 are future work.
+    bool has_address = false;
+    Str host_lit{};    // raw string from `at "..."` or `host: "..."`
+    Span addr_span{};  // points at the address site for diagnostics
+    bool port_is_set = false;
+    u32 port_lit = 0;  // u32 to fit any parsed IntLit before range check
 };
 
 struct AstFunctionDecl {

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -141,7 +141,7 @@ struct AstUpstreamDecl {
     // fields, distinguished only by what the parser saw after the name:
     //   A. `upstream backend at "127.0.0.1:8080"`
     //      → host_lit = "127.0.0.1:8080", port_is_set = false.
-    //   C. `upstream backend { host: "127.0.0.1", port: 8080 }`
+    //   B. `upstream backend { host: "127.0.0.1", port: 8080 }`
     //      → host_lit = "127.0.0.1", port_lit = 8080, port_is_set = true.
     // Analyze parses host_lit + port_lit into (ip u32, port u16) and
     // stores the result on HirUpstream. has_address == false means no

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -18,6 +18,16 @@ struct HirUpstream {
     Span span{};
     Str name{};
     u16 id = 0;
+    // Address declared in the DSL via `upstream X at "..."` or
+    // `upstream X { host: "...", port: N }`. `has_address == false`
+    // means the runtime must bind this upstream via add_upstream();
+    // analyze doesn't force an address on every upstream, to stay
+    // compatible with test configs that register upstreams manually.
+    // ip is in host byte order (RouteConfig::add_upstream expects
+    // the same).
+    bool has_address = false;
+    u32 ip = 0;
+    u16 port = 0;
 };
 struct HirImport {
     Span span{};

--- a/include/rut/compiler/lexer.h
+++ b/include/rut/compiler/lexer.h
@@ -38,7 +38,6 @@ enum class TokenType : u8 {
     KwIn,
     KwReturn,
     KwUpstream,
-    KwAt,
     KwListen,
     KwTls,
     KwDefaults,

--- a/include/rut/compiler/lexer.h
+++ b/include/rut/compiler/lexer.h
@@ -38,6 +38,7 @@ enum class TokenType : u8 {
     KwIn,
     KwReturn,
     KwUpstream,
+    KwAt,
     KwListen,
     KwTls,
     KwDefaults,

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -317,6 +317,13 @@ struct MirUpstream {
     Span span{};
     Str name{};
     u16 id = 0;
+    // Address copied from HIR. has_address == false → the runtime
+    // must bind this upstream via add_upstream(); addresses declared
+    // in the DSL live here in host byte order (matching
+    // RouteConfig::add_upstream's expected layout).
+    bool has_address = false;
+    u32 ip = 0;
+    u16 port = 0;
 };
 
 struct MirModule {

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -411,6 +411,21 @@ struct Module {
     HeaderSetRef header_sets[kMaxHeaderSets];
     u32 header_set_count = 0;
 
+    // Upstream declarations carried verbatim from the DSL so a
+    // compile→config helper can translate them into
+    // RouteConfig::add_upstream calls without re-parsing addresses.
+    // has_address == false means the DSL declared the name only; the
+    // runtime must bind it separately. ip is host byte order.
+    struct Upstream {
+        Str name;
+        bool has_address;
+        u32 ip;
+        u16 port;
+    };
+    static constexpr u32 kMaxUpstreams = 32;
+    Upstream upstreams[kMaxUpstreams];
+    u32 upstream_count = 0;
+
     // Arena that owns all IR memory (mmap-backed, compiler use).
     MmapArena* arena;
 };

--- a/include/rut/runtime/compile_to_config.h
+++ b/include/rut/runtime/compile_to_config.h
@@ -75,6 +75,11 @@ inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
         // small fixed buffer matching UpstreamTarget::kMaxUpstreamNameLen
         // so the underlying strncpy-equivalent sees a terminator.
         char name_buf[UpstreamTarget::kMaxUpstreamNameLen];
+        // Defensive null guard: a hand-built rir::Module could set
+        // len > 0 with a null ptr; the copy below would segfault.
+        // lower_rir never produces this shape, but the helper is
+        // reachable from arbitrary callers so fail closed.
+        if (up.name.len > 0 && up.name.ptr == nullptr) return false;
         if (up.name.len + 1 > sizeof(name_buf)) return false;  // name too long
         for (u32 j = 0; j < up.name.len; j++) name_buf[j] = up.name.ptr[j];
         name_buf[up.name.len] = '\0';

--- a/include/rut/runtime/compile_to_config.h
+++ b/include/rut/runtime/compile_to_config.h
@@ -14,6 +14,29 @@
 //      header sets
 //   4. cfg.add_jit_handler(path, method, fn) per route
 //
+// Two supported preconditions on `cfg`:
+//
+//   1. FULLY EMPTY (no routes / upstreams / bodies / header sets).
+//      Helper populates every upstream from the module. Requires every
+//      DSL upstream to have an address (`upstream X at "..."` or
+//      `upstream X { host, port }`). Name-only upstreams cause a
+//      fail-fast return because the helper has no address to bind.
+//
+//   2. PRE-BOUND UPSTREAMS (cfg.upstream_count == mod.upstream_count,
+//      bodies / header sets / routes still empty). Helper skips the
+//      upstream loop and only populates bodies + header sets. The
+//      caller is responsible for having added upstreams in DSL
+//      declaration order — the helper verifies each cfg.upstreams[i]
+//      name matches mod.upstreams[i] under ASCII case-sensitive
+//      compare, so mis-ordered or mis-named entries are caught before
+//      the compile-time `upstream_index` resolves to the wrong
+//      backend. This is the workflow to use when some or all
+//      upstreams are name-only in the DSL and bound at runtime (from
+//      a config file, env var, CLI flag, service discovery, etc.).
+//
+// Any other shape — partial routes / bodies / header sets already in
+// cfg, or upstream_count mismatching mod.upstream_count — is rejected.
+//
 // Returns true on full success. On any partial failure (capacity
 // exceeded, validation rejected) the function stops and returns false;
 // `cfg` may have been partially populated, so callers should discard
@@ -25,16 +48,22 @@
 namespace rut {
 
 inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
-    // Helper assumes cfg starts empty — otherwise newly-added slots
-    // would not begin at index 0, breaking the compiler's
-    // declaration-order upstream_id / body_idx / headers_idx
-    // invariant. Refuse rather than silently produce a mis-aligned
-    // config. Callers that need to start from a partially-populated
-    // cfg should wire things up manually.
-    if (cfg.route_count != 0 || cfg.upstream_count != 0 || cfg.response_body_count != 0 ||
+    // Bodies / header sets / routes must always start empty — there's
+    // no "merge" semantics for those tables, and a non-zero count
+    // would break the compile-time body_idx / headers_idx invariants.
+    if (cfg.route_count != 0 || cfg.response_body_count != 0 ||
         cfg.response_header_set_count != 0) {
         return false;
     }
+
+    // Upstreams admit one of two shapes (see file docstring):
+    //   - Fully empty: helper adds every upstream itself.
+    //   - Pre-bound: caller already populated exactly mod.upstream_count
+    //     upstream slots in DSL declaration order. Helper verifies
+    //     names match and skips the add loop.
+    const bool upstreams_pre_bound = cfg.upstream_count == mod.upstream_count;
+    const bool upstreams_empty = cfg.upstream_count == 0;
+    if (!upstreams_empty && !upstreams_pre_bound) return false;
 
     // Defensive bounds-checks against malformed modules (e.g. a
     // hand-built rir::Module with inconsistent counts). Refuse before
@@ -52,53 +81,56 @@ inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
     // Upstreams: the compiler emits `forward(name)` as a 0-based index
     // into the declaration order (0 = first `upstream` decl, 1 = second,
     // …). `RouteConfig::upstreams` is also declaration-order (add_upstream
-    // appends). So for the indices to stay aligned, we either add an
-    // entry per DSL upstream OR refuse to populate at all.
-    //
-    // Refusing to skip name-only upstreams: if any upstream in the
-    // module lacks an address, we fail-fast. Mixing DSL-addressed and
-    // name-only upstreams would desync compile-time `upstream_index`
-    // from cfg slot, sending `forward(a)` to whichever backend happened
-    // to occupy slot 0 after compaction. Callers with name-only
-    // upstreams should wire them up manually, in DSL declaration order.
-    // (Mixed-mode support would need an in-place RouteConfig::
-    // bind_upstream_at(idx, ip, port) API — not worth adding until a
-    // concrete use case motivates it.)
-    for (u32 i = 0; i < mod.upstream_count; i++) {
-        if (!mod.upstreams[i].has_address) return false;
-    }
-    for (u32 i = 0; i < mod.upstream_count; i++) {
-        const auto& up = mod.upstreams[i];
-        // add_upstream's name parameter is a NUL-terminated C string;
-        // rir::Module stores Str (ptr + len) where the bytes may not
-        // be NUL-terminated (arena-allocated slices). Copy into a
-        // small fixed buffer matching UpstreamTarget::kMaxUpstreamNameLen
-        // so the underlying set_name sees a terminator. Truncate
-        // names that exceed the buffer — matches the silent-truncate
-        // behavior of UpstreamTarget::set_name so the helper doesn't
-        // introduce a new runtime-only failure mode. (A hard limit
-        // should be enforced at the frontend with a compile-time
-        // diagnostic, not here.)
-        char name_buf[UpstreamTarget::kMaxUpstreamNameLen];
-        // Defensive null guard: a hand-built rir::Module could set
-        // len > 0 with a null ptr; the copy below would segfault.
-        // lower_rir never produces this shape, but the helper is
-        // reachable from arbitrary callers so fail closed.
-        if (up.name.len > 0 && up.name.ptr == nullptr) return false;
-        // Compute copy_len as min(len, cap-1) with no `len + 1`
-        // arithmetic — that expression would wrap for a hand-built
-        // module with len == 0xffffffff, making the subsequent copy
-        // loop run far past name_buf.
-        u32 copy_len = up.name.len;
-        if (copy_len >= sizeof(name_buf)) copy_len = sizeof(name_buf) - 1;
-        for (u32 j = 0; j < copy_len; j++) name_buf[j] = up.name.ptr[j];
-        name_buf[copy_len] = '\0';
-        auto r = cfg.add_upstream(name_buf, up.ip, up.port);
-        if (!r.has_value()) return false;
-        // The helper only makes sense when cfg starts empty — assert
-        // that the newly-added slot matches the DSL's compile-time
-        // index i, so forward() resolves correctly at runtime.
-        if (r.value() != i) return false;
+    // appends). So for the indices to stay aligned we need one cfg slot
+    // per DSL upstream, in the same order.
+    if (upstreams_empty) {
+        // Name-only upstreams have no address to bind, so fail-fast.
+        // Callers who have them should either declare addresses in the
+        // DSL (`upstream X at "..."` / `{ host, port }`) or use the
+        // pre-bound mode: add_upstream manually in DSL order, then
+        // call the helper just for bodies / headers.
+        for (u32 i = 0; i < mod.upstream_count; i++) {
+            if (!mod.upstreams[i].has_address) return false;
+        }
+        for (u32 i = 0; i < mod.upstream_count; i++) {
+            const auto& up = mod.upstreams[i];
+            // add_upstream's name parameter is a NUL-terminated C
+            // string; rir::Module stores Str (ptr + len) where the
+            // bytes may not be NUL-terminated. Copy into a buffer
+            // matching UpstreamTarget::kMaxUpstreamNameLen. Truncate
+            // over-long names to match set_name's silent-truncate —
+            // a hard limit belongs as a frontend diagnostic, not here.
+            char name_buf[UpstreamTarget::kMaxUpstreamNameLen];
+            if (up.name.len > 0 && up.name.ptr == nullptr) return false;
+            u32 copy_len = up.name.len;
+            if (copy_len >= sizeof(name_buf)) copy_len = sizeof(name_buf) - 1;
+            for (u32 j = 0; j < copy_len; j++) name_buf[j] = up.name.ptr[j];
+            name_buf[copy_len] = '\0';
+            auto r = cfg.add_upstream(name_buf, up.ip, up.port);
+            if (!r.has_value()) return false;
+            if (r.value() != i) return false;
+        }
+    } else {
+        // Pre-bound mode: verify the caller added upstreams in DSL
+        // declaration order. A mismatch here would send forward(a) to
+        // the backend at slot a's index but with a different name —
+        // silent misconfiguration we'd rather catch up front.
+        for (u32 i = 0; i < mod.upstream_count; i++) {
+            const auto& up = mod.upstreams[i];
+            if (up.name.len > 0 && up.name.ptr == nullptr) return false;
+            // Compare against cfg.upstreams[i].name (NUL-terminated,
+            // at most kMaxUpstreamNameLen-1 chars). set_name truncates
+            // silently, so the comparison uses the truncated length
+            // on the cfg side for consistency.
+            u32 expected_len = up.name.len;
+            if (expected_len >= UpstreamTarget::kMaxUpstreamNameLen) {
+                expected_len = UpstreamTarget::kMaxUpstreamNameLen - 1;
+            }
+            if (cfg.upstreams[i].name_len != expected_len) return false;
+            for (u32 j = 0; j < expected_len; j++) {
+                if (cfg.upstreams[i].name[j] != up.name.ptr[j]) return false;
+            }
+        }
     }
 
     // Response bodies (1-based index preserved). Empty bodies don't

--- a/include/rut/runtime/compile_to_config.h
+++ b/include/rut/runtime/compile_to_config.h
@@ -1,0 +1,86 @@
+#pragma once
+
+// Bridge header: copy the RIR module's declarative content (upstreams
+// with addresses, response bodies, response header sets) into a
+// RouteConfig so the runtime can serve the compiled handlers.
+//
+// This helper intentionally does NOT register route entries — those
+// require the JitEngine to have compiled and looked up each handler
+// function, which is orthogonal to the declarative content here.
+// Callers typically:
+//   1. jit::codegen(rir.module) → LLVM IR module
+//   2. engine.compile(...); engine.lookup("handler_route_N") for each
+//   3. populate_route_config(cfg, rir.module) for upstreams / bodies /
+//      header sets
+//   4. cfg.add_jit_handler(path, method, fn) per route
+//
+// Returns true on full success. On any partial failure (capacity
+// exceeded, validation rejected) the function stops and returns false;
+// `cfg` may have been partially populated, so callers should discard
+// it rather than try to reuse it.
+
+#include "rut/compiler/rir.h"
+#include "rut/runtime/route_table.h"
+
+namespace rut {
+
+inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
+    // Upstreams: skip entries without an address (those are declared
+    // name-only in the DSL and bound by the runtime via an explicit
+    // add_upstream() from a config file / env / CLI flag). Entries
+    // with an address go straight in.
+    for (u32 i = 0; i < mod.upstream_count; i++) {
+        const auto& up = mod.upstreams[i];
+        if (!up.has_address) continue;
+        // add_upstream's name parameter is a NUL-terminated C string;
+        // rir::Module stores Str (ptr + len) where the bytes may not
+        // be NUL-terminated (arena-allocated slices). Copy into a
+        // small fixed buffer matching UpstreamTarget::kMaxUpstreamNameLen
+        // so the underlying strncpy-equivalent sees a terminator.
+        char name_buf[UpstreamTarget::kMaxUpstreamNameLen];
+        if (up.name.len + 1 > sizeof(name_buf)) return false;  // name too long
+        for (u32 j = 0; j < up.name.len; j++) name_buf[j] = up.name.ptr[j];
+        name_buf[up.name.len] = '\0';
+        auto r = cfg.add_upstream(name_buf, up.ip, up.port);
+        if (!r.has_value()) return false;
+    }
+
+    // Response bodies (1-based index preserved). Empty bodies don't
+    // appear in the module table (lower_rir skips them), so we can
+    // feed the bytes straight through.
+    for (u32 i = 0; i < mod.response_body_count; i++) {
+        const auto& body = mod.response_bodies[i];
+        u16 idx = cfg.add_response_body(body.ptr, body.len);
+        if (idx == 0) return false;
+        // Belt-and-suspenders: the 1-based index must match i+1 so
+        // callers that packed body_idx at compile time still resolve
+        // correctly. add_response_body assigns sequentially, so this
+        // invariant holds iff we start from an empty cfg.
+        if (idx != i + 1) return false;
+    }
+
+    // Response header sets (1-based index preserved). Materialise the
+    // (key, value) pointer tables add_response_header_set expects.
+    for (u32 i = 0; i < mod.header_set_count; i++) {
+        const auto& ref = mod.header_sets[i];
+        const char* keys[RouteConfig::kMaxHeadersPerSet];
+        u32 key_lens[RouteConfig::kMaxHeadersPerSet];
+        const char* vals[RouteConfig::kMaxHeadersPerSet];
+        u32 val_lens[RouteConfig::kMaxHeadersPerSet];
+        if (ref.count > RouteConfig::kMaxHeadersPerSet) return false;
+        for (u16 j = 0; j < ref.count; j++) {
+            const auto& k = mod.header_keys[ref.offset + j];
+            const auto& v = mod.header_values[ref.offset + j];
+            keys[j] = k.ptr;
+            key_lens[j] = k.len;
+            vals[j] = v.ptr;
+            val_lens[j] = v.len;
+        }
+        u16 idx = cfg.add_response_header_set(keys, key_lens, vals, val_lens, ref.count);
+        if (idx == 0) return false;
+        if (idx != i + 1) return false;
+    }
+    return true;
+}
+
+}  // namespace rut

--- a/include/rut/runtime/compile_to_config.h
+++ b/include/rut/runtime/compile_to_config.h
@@ -73,16 +73,26 @@ inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
         // rir::Module stores Str (ptr + len) where the bytes may not
         // be NUL-terminated (arena-allocated slices). Copy into a
         // small fixed buffer matching UpstreamTarget::kMaxUpstreamNameLen
-        // so the underlying strncpy-equivalent sees a terminator.
+        // so the underlying set_name sees a terminator. Truncate
+        // names that exceed the buffer — matches the silent-truncate
+        // behavior of UpstreamTarget::set_name so the helper doesn't
+        // introduce a new runtime-only failure mode. (A hard limit
+        // should be enforced at the frontend with a compile-time
+        // diagnostic, not here.)
         char name_buf[UpstreamTarget::kMaxUpstreamNameLen];
         // Defensive null guard: a hand-built rir::Module could set
         // len > 0 with a null ptr; the copy below would segfault.
         // lower_rir never produces this shape, but the helper is
         // reachable from arbitrary callers so fail closed.
         if (up.name.len > 0 && up.name.ptr == nullptr) return false;
-        if (up.name.len + 1 > sizeof(name_buf)) return false;  // name too long
-        for (u32 j = 0; j < up.name.len; j++) name_buf[j] = up.name.ptr[j];
-        name_buf[up.name.len] = '\0';
+        // Compute copy_len as min(len, cap-1) with no `len + 1`
+        // arithmetic — that expression would wrap for a hand-built
+        // module with len == 0xffffffff, making the subsequent copy
+        // loop run far past name_buf.
+        u32 copy_len = up.name.len;
+        if (copy_len >= sizeof(name_buf)) copy_len = sizeof(name_buf) - 1;
+        for (u32 j = 0; j < copy_len; j++) name_buf[j] = up.name.ptr[j];
+        name_buf[copy_len] = '\0';
         auto r = cfg.add_upstream(name_buf, up.ip, up.port);
         if (!r.has_value()) return false;
         // The helper only makes sense when cfg starts empty — assert

--- a/include/rut/runtime/compile_to_config.h
+++ b/include/rut/runtime/compile_to_config.h
@@ -25,13 +25,23 @@
 namespace rut {
 
 inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
-    // Upstreams: skip entries without an address (those are declared
-    // name-only in the DSL and bound by the runtime via an explicit
-    // add_upstream() from a config file / env / CLI flag). Entries
-    // with an address go straight in.
+    // Upstreams: the compiler emits `forward(name)` as a 0-based index
+    // into the declaration order (0 = first `upstream` decl, 1 = second,
+    // …). `RouteConfig::upstreams` is also declaration-order (add_upstream
+    // appends). So for the indices to stay aligned, we either add an
+    // entry per DSL upstream OR refuse to populate at all.
+    //
+    // Refusing to skip name-only upstreams: if any upstream in the
+    // module lacks an address, we fail-fast. Mixing DSL-addressed and
+    // name-only upstreams would desync compile-time `upstream_index`
+    // from cfg slot, sending `forward(a)` to whichever backend happened
+    // to occupy slot 0 after compaction. Callers with name-only
+    // upstreams should wire them up manually, in DSL declaration order.
+    for (u32 i = 0; i < mod.upstream_count; i++) {
+        if (!mod.upstreams[i].has_address) return false;
+    }
     for (u32 i = 0; i < mod.upstream_count; i++) {
         const auto& up = mod.upstreams[i];
-        if (!up.has_address) continue;
         // add_upstream's name parameter is a NUL-terminated C string;
         // rir::Module stores Str (ptr + len) where the bytes may not
         // be NUL-terminated (arena-allocated slices). Copy into a
@@ -43,6 +53,10 @@ inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
         name_buf[up.name.len] = '\0';
         auto r = cfg.add_upstream(name_buf, up.ip, up.port);
         if (!r.has_value()) return false;
+        // The helper only makes sense when cfg starts empty — assert
+        // that the newly-added slot matches the DSL's compile-time
+        // index i, so forward() resolves correctly at runtime.
+        if (r.value() != i) return false;
     }
 
     // Response bodies (1-based index preserved). Empty bodies don't

--- a/include/rut/runtime/compile_to_config.h
+++ b/include/rut/runtime/compile_to_config.h
@@ -25,6 +25,30 @@
 namespace rut {
 
 inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
+    // Helper assumes cfg starts empty — otherwise newly-added slots
+    // would not begin at index 0, breaking the compiler's
+    // declaration-order upstream_id / body_idx / headers_idx
+    // invariant. Refuse rather than silently produce a mis-aligned
+    // config. Callers that need to start from a partially-populated
+    // cfg should wire things up manually.
+    if (cfg.route_count != 0 || cfg.upstream_count != 0 || cfg.response_body_count != 0 ||
+        cfg.response_header_set_count != 0) {
+        return false;
+    }
+
+    // Defensive bounds-checks against malformed modules (e.g. a
+    // hand-built rir::Module with inconsistent counts). Refuse before
+    // we dereference anything out of range.
+    if (mod.upstream_count > rir::Module::kMaxUpstreams) return false;
+    if (mod.response_body_count > rir::Module::kMaxResponseBodies) return false;
+    if (mod.header_set_count > rir::Module::kMaxHeaderSets) return false;
+    if (mod.header_pool_used > rir::Module::kMaxHeaderPoolEntries) return false;
+    for (u32 i = 0; i < mod.header_set_count; i++) {
+        const auto& ref = mod.header_sets[i];
+        if (static_cast<u32>(ref.offset) + ref.count > mod.header_pool_used) return false;
+        if (ref.count > RouteConfig::kMaxHeadersPerSet) return false;
+    }
+
     // Upstreams: the compiler emits `forward(name)` as a 0-based index
     // into the declaration order (0 = first `upstream` decl, 1 = second,
     // …). `RouteConfig::upstreams` is also declaration-order (add_upstream
@@ -37,6 +61,9 @@ inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
     // from cfg slot, sending `forward(a)` to whichever backend happened
     // to occupy slot 0 after compaction. Callers with name-only
     // upstreams should wire them up manually, in DSL declaration order.
+    // (Mixed-mode support would need an in-place RouteConfig::
+    // bind_upstream_at(idx, ip, port) API — not worth adding until a
+    // concrete use case motivates it.)
     for (u32 i = 0; i < mod.upstream_count; i++) {
         if (!mod.upstreams[i].has_address) return false;
     }

--- a/include/rut/runtime/compile_to_config.h
+++ b/include/rut/runtime/compile_to_config.h
@@ -115,19 +115,22 @@ inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
         // declaration order. A mismatch here would send forward(a) to
         // the backend at slot a's index but with a different name —
         // silent misconfiguration we'd rather catch up front.
+        //
+        // The match MUST be exact, so reject any module name that
+        // wouldn't round-trip through the 31-byte cfg.upstreams name
+        // buffer. If we truncated both sides before comparing, two
+        // DSL names with identical first 31 bytes but different
+        // suffixes would compare equal, and a caller who pre-bound
+        // them in the wrong order could slip past the verification.
+        // The empty-cfg branch above can tolerate truncation (it's
+        // the one doing the bind, and forward() resolves by index,
+        // not by name) but this branch can't.
         for (u32 i = 0; i < mod.upstream_count; i++) {
             const auto& up = mod.upstreams[i];
             if (up.name.len > 0 && up.name.ptr == nullptr) return false;
-            // Compare against cfg.upstreams[i].name (NUL-terminated,
-            // at most kMaxUpstreamNameLen-1 chars). set_name truncates
-            // silently, so the comparison uses the truncated length
-            // on the cfg side for consistency.
-            u32 expected_len = up.name.len;
-            if (expected_len >= UpstreamTarget::kMaxUpstreamNameLen) {
-                expected_len = UpstreamTarget::kMaxUpstreamNameLen - 1;
-            }
-            if (cfg.upstreams[i].name_len != expected_len) return false;
-            for (u32 j = 0; j < expected_len; j++) {
+            if (up.name.len >= UpstreamTarget::kMaxUpstreamNameLen) return false;
+            if (cfg.upstreams[i].name_len != up.name.len) return false;
+            for (u32 j = 0; j < up.name.len; j++) {
                 if (cfg.upstreams[i].name[j] != up.name.ptr[j]) return false;
             }
         }

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -7058,6 +7058,36 @@ static FrontendResult<HirModule*> analyze_file_internal(
         import_stack.push_back(normalized_source);
     }
 
+    // Parse an IPv4 dotted-quad into a u32 in host byte order. Returns
+    // false on any malformed input (non-digit, octet > 255, missing
+    // dot, empty octet). `len` is the number of bytes at `s` to
+    // consider (does NOT need to be NUL-terminated).
+    auto parse_ipv4 = [](const char* s, u32 len, u32& out_ip) -> bool {
+        u32 octets[4] = {0, 0, 0, 0};
+        u32 octet_idx = 0;
+        u32 digit_count = 0;
+        u32 cur = 0;
+        for (u32 i = 0; i < len; i++) {
+            const char c = s[i];
+            if (c == '.') {
+                if (digit_count == 0 || octet_idx >= 3) return false;
+                octets[octet_idx++] = cur;
+                cur = 0;
+                digit_count = 0;
+                continue;
+            }
+            if (c < '0' || c > '9') return false;
+            cur = cur * 10 + static_cast<u32>(c - '0');
+            if (cur > 255) return false;
+            digit_count++;
+            if (digit_count > 3) return false;
+        }
+        if (digit_count == 0 || octet_idx != 3) return false;
+        octets[3] = cur;
+        out_ip = (octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3];
+        return true;
+    };
+
     for (u32 i = 0; i < file.items.len; i++) {
         const auto& item = file.items[i];
         if (item.kind != AstItemKind::Upstream) continue;
@@ -7070,6 +7100,53 @@ static FrontendResult<HirModule*> analyze_file_internal(
         up.span = item.upstream.span;
         up.name = item.upstream.name;
         up.id = static_cast<u16>(mod.upstreams.len + 1);
+        // Resolve the parsed address (if any) into concrete (ip, port).
+        // Two AST shapes produce this: `at "host:port"` packs both
+        // into host_lit; dict form separates host_lit and port_lit.
+        if (item.upstream.has_address) {
+            const Str lit = item.upstream.host_lit;
+            Str host_part = lit;
+            u32 port_value = item.upstream.port_lit;
+            if (!item.upstream.port_is_set) {
+                // `at "host:port"` form — split on the LAST colon so a
+                // future IPv6 literal (`[::1]:8080`) can replace this
+                // without refactoring the field layout.
+                u32 colon_idx = 0xffffffffu;
+                for (u32 k = 0; k < lit.len; k++) {
+                    if (lit.ptr[k] == ':') colon_idx = k;
+                }
+                if (colon_idx == 0xffffffffu || colon_idx + 1 == lit.len) {
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, item.upstream.addr_span, lit);
+                }
+                host_part = {lit.ptr, colon_idx};
+                port_value = 0;
+                for (u32 k = colon_idx + 1; k < lit.len; k++) {
+                    const char c = lit.ptr[k];
+                    if (c < '0' || c > '9') {
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, item.upstream.addr_span, lit);
+                    }
+                    port_value = port_value * 10 + static_cast<u32>(c - '0');
+                    if (port_value > 0xffffu) {
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax, item.upstream.addr_span, lit);
+                    }
+                }
+            }
+            if (port_value == 0 || port_value > 0xffffu) {
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.upstream.addr_span, lit);
+            }
+            u32 ip = 0;
+            if (!parse_ipv4(host_part.ptr, host_part.len, ip)) {
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.upstream.addr_span, host_part);
+            }
+            up.has_address = true;
+            up.ip = ip;
+            up.port = static_cast<u16>(port_value);
+        }
         if (!mod.upstreams.push(up))
             return frontend_error(FrontendError::TooManyItems, item.upstream.span);
     }

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -7149,8 +7149,16 @@ static FrontendResult<HirModule*> analyze_file_internal(
             }
             u32 ip = 0;
             if (!parse_ipv4(host_part.ptr, host_part.len, ip)) {
+                // Keep the detail informative when host_part is
+                // empty (`":8080"` in at-form, `{ host: "" }` in dict
+                // form). An empty detail prints nothing and hides
+                // what went wrong. Falls back to the full at-form
+                // literal or to "host" for dict form.
+                const Str host_detail = host_part.len != 0
+                                            ? host_part
+                                            : (item.upstream.port_is_set ? Str{"host", 4} : lit);
                 return frontend_error(
-                    FrontendError::UnsupportedSyntax, item.upstream.addr_span, host_part);
+                    FrontendError::UnsupportedSyntax, item.upstream.addr_span, host_detail);
             }
             up.has_address = true;
             up.ip = ip;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -7099,7 +7099,11 @@ static FrontendResult<HirModule*> analyze_file_internal(
         HirUpstream up{};
         up.span = item.upstream.span;
         up.name = item.upstream.name;
-        up.id = static_cast<u16>(mod.upstreams.len + 1);
+        // 0-based index so compiler-emitted upstream IDs align
+        // directly with RouteConfig::upstreams[] slots — the runtime
+        // dispatch does `if (upstream_id < cfg->upstream_count)`
+        // without adjustment.
+        up.id = static_cast<u16>(mod.upstreams.len);
         // Resolve the parsed address (if any) into concrete (ip, port).
         // Two AST shapes produce this: `at "host:port"` packs both
         // into host_lit; dict form separates host_lit and port_lit.
@@ -7135,8 +7139,13 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 }
             }
             if (port_value == 0 || port_value > 0xffffu) {
+                // Point the detail at "port" when dict-form made the
+                // port its own token — pointing at host_lit would be
+                // misleading. `at "..."` packs both into host_lit, so
+                // the whole literal is the right detail there.
+                const Str port_detail = item.upstream.port_is_set ? Str{"port", 4} : lit;
                 return frontend_error(
-                    FrontendError::UnsupportedSyntax, item.upstream.addr_span, lit);
+                    FrontendError::UnsupportedSyntax, item.upstream.addr_span, port_detail);
             }
             u32 ip = 0;
             if (!parse_ipv4(host_part.ptr, host_part.len, ip)) {

--- a/src/compiler/lexer.cc
+++ b/src/compiler/lexer.cc
@@ -42,6 +42,7 @@ static TokenType keyword_type(Str text) {
     if (text.eq({"or", 2})) return TokenType::KwOr;
     if (text.eq({"nil", 3})) return TokenType::KwNil;
     if (text.eq({"upstream", 8})) return TokenType::KwUpstream;
+    if (text.eq({"at", 2})) return TokenType::KwAt;
     if (text.eq({"route", 5})) return TokenType::KwRoute;
     if (text.eq({"return", 6})) return TokenType::KwReturn;
     if (text.eq({"forward", 7})) return TokenType::KwForward;

--- a/src/compiler/lexer.cc
+++ b/src/compiler/lexer.cc
@@ -42,7 +42,10 @@ static TokenType keyword_type(Str text) {
     if (text.eq({"or", 2})) return TokenType::KwOr;
     if (text.eq({"nil", 3})) return TokenType::KwNil;
     if (text.eq({"upstream", 8})) return TokenType::KwUpstream;
-    if (text.eq({"at", 2})) return TokenType::KwAt;
+    // `at` is deliberately NOT reserved globally — only
+    // `parse_upstream` treats the identifier specially, matching the
+    // `response()` / `forward()` builder pattern. This keeps `at`
+    // available as a regular identifier in user code.
     if (text.eq({"route", 5})) return TokenType::KwRoute;
     if (text.eq({"return", 6})) return TokenType::KwReturn;
     if (text.eq({"forward", 7})) return TokenType::KwForward;

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2466,6 +2466,21 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
     rir::Builder b;
     b.init(&out.module);
 
+    // Carry upstream declarations (name + optional address) verbatim
+    // into the RIR module so a compile→config helper can translate
+    // them into RouteConfig::add_upstream calls without re-parsing.
+    if (mir.upstreams.len > rir::Module::kMaxUpstreams) {
+        return frontend_error(FrontendError::TooManyItems,
+                              mir.upstreams.len > 0 ? mir.upstreams[0].span : Span{});
+    }
+    for (u32 i = 0; i < mir.upstreams.len; i++) {
+        out.module.upstreams[i].name = mir.upstreams[i].name;
+        out.module.upstreams[i].has_address = mir.upstreams[i].has_address;
+        out.module.upstreams[i].ip = mir.upstreams[i].ip;
+        out.module.upstreams[i].port = mir.upstreams[i].port;
+    }
+    out.module.upstream_count = mir.upstreams.len;
+
     VariantLoweringInfo variant_infos[MirModule::kMaxVariants]{};
     TupleLoweringInfo tuple_infos[64]{};
     u32 tuple_info_count = 0;

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2469,12 +2469,24 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
     // Carry upstream declarations (name + optional address) verbatim
     // into the RIR module so a compile→config helper can translate
     // them into RouteConfig::add_upstream calls without re-parsing.
+    // Names must be copied into the RIR arena — MIR's name Str points
+    // at the caller's (possibly transient) source buffer; when that
+    // goes away before populate_route_config runs, the pointer would
+    // dangle. Response bodies and header sets already do this copy
+    // via intern_response_body / intern_response_headers.
     if (mir.upstreams.len > rir::Module::kMaxUpstreams) {
         return frontend_error(FrontendError::TooManyItems,
                               mir.upstreams.len > 0 ? mir.upstreams[0].span : Span{});
     }
     for (u32 i = 0; i < mir.upstreams.len; i++) {
-        out.module.upstreams[i].name = mir.upstreams[i].name;
+        const Str src_name = mir.upstreams[i].name;
+        char* name_buf = nullptr;
+        if (src_name.len > 0) {
+            name_buf = out.module.arena->alloc_array<char>(src_name.len);
+            if (!name_buf) return frontend_error(FrontendError::OutOfMemory, mir.upstreams[i].span);
+            for (u32 k = 0; k < src_name.len; k++) name_buf[k] = src_name.ptr[k];
+        }
+        out.module.upstreams[i].name = {name_buf, src_name.len};
         out.module.upstreams[i].has_address = mir.upstreams[i].has_address;
         out.module.upstreams[i].ip = mir.upstreams[i].ip;
         out.module.upstreams[i].port = mir.upstreams[i].port;

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -566,6 +566,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         up.span = module.upstreams[i].span;
         up.name = module.upstreams[i].name;
         up.id = module.upstreams[i].id;
+        up.has_address = module.upstreams[i].has_address;
+        up.ip = module.upstreams[i].ip;
+        up.port = module.upstreams[i].port;
         if (!mir->upstreams.push(up)) return frontend_error(FrontendError::TooManyItems, up.span);
     }
 

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1115,7 +1115,16 @@ struct Parser {
             auto rbrace = expect(TokenType::RBrace);
             if (!rbrace) return core::make_unexpected(rbrace.error());
             if (!seen_host || !seen_port) {
-                return frontend_error(FrontendError::UnsupportedSyntax, span_from(*rbrace.value()));
+                // Name the specific missing field in the detail so the
+                // diagnostic tells the user what to add. Point the
+                // span at the address block (the `{` we captured),
+                // not the closing brace. If both are missing, call
+                // out "host" first since order in the dict is
+                // host-then-port; the user will see "port" missing
+                // after fixing the host.
+                const Str detail = !seen_host ? Str{"host", 4} : Str{"port", 4};
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.upstream.addr_span, detail);
             }
             end_off = rbrace.value()->end;
             // Stretch the addr_span to cover the full `{ ... }` block

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1033,7 +1033,14 @@ struct Parser {
         //   `at "<host>:<port>"`          — single string literal
         //   `{ host: "...", port: N }`    — dict form; order-independent,
         //                                    both fields required
-        if (take(TokenType::KwAt)) {
+        // `at` is a contextual keyword — we peek for an Ident with
+        // exactly that text rather than reserving it globally. Keeps
+        // `at` available as a user identifier elsewhere.
+        const Token& after_name = cur();
+        const bool is_at_keyword =
+            after_name.type == TokenType::Ident && after_name.text.eq({"at", 2});
+        if (is_at_keyword) {
+            pos++;  // consume `at`
             auto lit = expect(TokenType::StringLit);
             if (!lit) return core::make_unexpected(lit.error());
             item.upstream.has_address = true;

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1027,9 +1027,82 @@ struct Parser {
         if (!name) return core::make_unexpected(name.error());
         AstItem item{};
         item.kind = AstItemKind::Upstream;
-        item.span = Span{kw.value()->start, name.value()->end, kw.value()->line, kw.value()->col};
-        item.upstream.span = item.span;
         item.upstream.name = name.value()->text;
+        u32 end_off = name.value()->end;
+        // Optional address after the name. Two forms:
+        //   `at "<host>:<port>"`          — single string literal
+        //   `{ host: "...", port: N }`    — dict form; order-independent,
+        //                                    both fields required
+        if (take(TokenType::KwAt)) {
+            auto lit = expect(TokenType::StringLit);
+            if (!lit) return core::make_unexpected(lit.error());
+            item.upstream.has_address = true;
+            item.upstream.host_lit = lit.value()->text;
+            item.upstream.addr_span = span_from(*lit.value());
+            // port_is_set stays false — analyze splits host_lit into
+            // (ip, port) for the `at "..."` form.
+            end_off = lit.value()->end;
+        } else if (take(TokenType::LBrace)) {
+            item.upstream.has_address = true;
+            item.upstream.addr_span =
+                Span{name.value()->end, name.value()->end, name.value()->line, name.value()->col};
+            bool seen_host = false;
+            bool seen_port = false;
+            // Empty dict (`upstream foo {}`) is a parse error — omit
+            // the braces entirely if no address is being declared.
+            if (cur().type == TokenType::RBrace) {
+                return frontend_error(FrontendError::UnsupportedSyntax, span_from(cur()));
+            }
+            while (true) {
+                auto field = expect(TokenType::Ident);
+                if (!field) return core::make_unexpected(field.error());
+                const Str field_name = field.value()->text;
+                auto colon = expect(TokenType::Colon);
+                if (!colon) return core::make_unexpected(colon.error());
+                if (field_name.eq({"host", 4})) {
+                    if (seen_host)
+                        return frontend_error(
+                            FrontendError::UnexpectedToken, span_from(*field.value()), field_name);
+                    auto lit = expect(TokenType::StringLit);
+                    if (!lit) return core::make_unexpected(lit.error());
+                    item.upstream.host_lit = lit.value()->text;
+                    seen_host = true;
+                } else if (field_name.eq({"port", 4})) {
+                    if (seen_port)
+                        return frontend_error(
+                            FrontendError::UnexpectedToken, span_from(*field.value()), field_name);
+                    auto lit = expect(TokenType::IntLit);
+                    if (!lit) return core::make_unexpected(lit.error());
+                    // Parse digits into u32; analyze range-checks to
+                    // 1..65535 with a friendlier diagnostic.
+                    u64 v = 0;
+                    for (u32 i = 0; i < lit.value()->text.len; i++) {
+                        v = v * 10 + static_cast<u64>(lit.value()->text.ptr[i] - '0');
+                        if (v > 0xffffffffu) {
+                            return frontend_error(FrontendError::InvalidInteger,
+                                                  span_from(*lit.value()),
+                                                  lit.value()->text);
+                        }
+                    }
+                    item.upstream.port_lit = static_cast<u32>(v);
+                    item.upstream.port_is_set = true;
+                    seen_port = true;
+                } else {
+                    return frontend_error(
+                        FrontendError::UnexpectedToken, span_from(*field.value()), field_name);
+                }
+                if (!take(TokenType::Comma)) break;
+                if (cur().type == TokenType::RBrace) break;  // trailing comma
+            }
+            auto rbrace = expect(TokenType::RBrace);
+            if (!rbrace) return core::make_unexpected(rbrace.error());
+            if (!seen_host || !seen_port) {
+                return frontend_error(FrontendError::UnsupportedSyntax, span_from(*rbrace.value()));
+            }
+            end_off = rbrace.value()->end;
+        }
+        item.span = Span{kw.value()->start, end_off, kw.value()->line, kw.value()->col};
+        item.upstream.span = item.span;
         return item;
     }
 

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1087,15 +1087,20 @@ struct Parser {
                     auto lit = expect(TokenType::IntLit);
                     if (!lit) return core::make_unexpected(lit.error());
                     // Parse digits into u32; analyze range-checks to
-                    // 1..65535 with a friendlier diagnostic.
+                    // 1..65535 with a friendlier diagnostic. Pre-multiply
+                    // overflow check prevents long literals (20+ digits
+                    // with the right leading byte) from silently
+                    // wrapping past 2^64 and landing below 0xffffffff —
+                    // the post-multiply guard alone isn't enough.
                     u64 v = 0;
                     for (u32 i = 0; i < lit.value()->text.len; i++) {
-                        v = v * 10 + static_cast<u64>(lit.value()->text.ptr[i] - '0');
-                        if (v > 0xffffffffu) {
+                        const u64 digit = static_cast<u64>(lit.value()->text.ptr[i] - '0');
+                        if (v > (static_cast<u64>(0xffffffffu) - digit) / 10u) {
                             return frontend_error(FrontendError::InvalidInteger,
                                                   span_from(*lit.value()),
                                                   lit.value()->text);
                         }
+                        v = v * 10 + digit;
                     }
                     item.upstream.port_lit = static_cast<u32>(v);
                     item.upstream.port_is_set = true;

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1042,10 +1042,16 @@ struct Parser {
             // port_is_set stays false — analyze splits host_lit into
             // (ip, port) for the `at "..."` form.
             end_off = lit.value()->end;
-        } else if (take(TokenType::LBrace)) {
+        } else if (cur().type == TokenType::LBrace) {
+            auto lbrace = expect(TokenType::LBrace);
+            if (!lbrace) return core::make_unexpected(lbrace.error());
             item.upstream.has_address = true;
-            item.upstream.addr_span =
-                Span{name.value()->end, name.value()->end, name.value()->line, name.value()->col};
+            // Span the whole `{ ... }` block so analyze-time
+            // diagnostics (bad host, missing field, out-of-range port)
+            // highlight the address site rather than the bare name.
+            // We extend addr_span.end to the closing brace below once
+            // we've consumed it.
+            item.upstream.addr_span = span_from(*lbrace.value());
             bool seen_host = false;
             bool seen_port = false;
             // Empty dict (`upstream foo {}`) is a parse error — omit
@@ -1100,6 +1106,9 @@ struct Parser {
                 return frontend_error(FrontendError::UnsupportedSyntax, span_from(*rbrace.value()));
             }
             end_off = rbrace.value()->end;
+            // Stretch the addr_span to cover the full `{ ... }` block
+            // so analyze diagnostics point at the whole address site.
+            item.upstream.addr_span.end = rbrace.value()->end;
         }
         item.span = Span{kw.value()->start, end_off, kw.value()->line, kw.value()->col};
         item.upstream.span = item.span;

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -411,6 +411,24 @@ TEST(frontend, parse_upstream_rejects_port_zero_and_overflow) {
     }
 }
 
+TEST(frontend, parse_upstream_dict_port_range_diagnostic_mentions_port) {
+    // `at "host:port"` form: the whole host_lit is the natural detail
+    // (the full bad string). But dict form gave port its own token, so
+    // pointing the error at host_lit would be misleading — use "port"
+    // as the detail instead.
+    const char* src =
+        "upstream api { host: \"127.0.0.1\", port: 65536 }\n"
+        "route GET \"/u\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+    CHECK(hir.error().detail.eq(lit("port")));
+}
+
 TEST(frontend, parse_upstream_dict_rejects_missing_field) {
     // Both host and port are required in dict form.
     for (const char* src : {
@@ -6584,7 +6602,9 @@ TEST(frontend, lower_forward_route_to_rir) {
     REQUIRE(hir);
     REQUIRE_EQ(hir->upstreams.len, 1u);
     REQUIRE_EQ(hir->routes.len, 1u);
-    CHECK_EQ(hir->upstreams[0].id, 1u);
+    // Upstream IDs are 0-based so they index RouteConfig::upstreams
+    // directly. The first declared upstream gets id 0, not 1.
+    CHECK_EQ(hir->upstreams[0].id, 0u);
     CHECK_EQ(static_cast<u8>(hir->routes[0].control.direct_term.kind),
              static_cast<u8>(HirTerminatorKind::ForwardUpstream));
     auto mir = build_mir_heap(hir.value());
@@ -6601,7 +6621,7 @@ TEST(frontend, lower_forward_route_to_rir) {
     REQUIRE_EQ(fn.block_count, 1u);
     REQUIRE_EQ(fn.blocks[0].inst_count, 2u);
     CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ConstI32));
-    CHECK_EQ(fn.blocks[0].insts[0].imm.i32_val, 1);
+    CHECK_EQ(fn.blocks[0].insts[0].imm.i32_val, 0);
     CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[1].op), static_cast<u8>(rir::Opcode::RetForward));
     rir.destroy();
 }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -495,17 +495,29 @@ TEST(frontend, parse_upstream_empty_host_diagnostic_has_nonempty_detail) {
 }
 
 TEST(frontend, parse_upstream_dict_rejects_missing_field) {
-    // Both host and port are required in dict form.
-    for (const char* src : {
-             "upstream api { host: \"127.0.0.1\" }\nroute GET \"/u\" { return 200 }\n",
-             "upstream api { port: 8080 }\nroute GET \"/u\" { return 200 }\n",
-             "upstream api {}\nroute GET \"/u\" { return 200 }\n",
-         }) {
-        auto lexed = lex(lit(src));
+    // Both host and port are required in dict form. The diagnostic
+    // detail must name the missing field so the user knows what to
+    // add — an empty detail made the error uninformative.
+    struct Case {
+        const char* src;
+        const char* missing;  // expected detail, or nullptr for the empty-dict case
+    };
+    const Case kCases[] = {
+        {"upstream api { host: \"127.0.0.1\" }\nroute GET \"/u\" { return 200 }\n", "port"},
+        {"upstream api { port: 8080 }\nroute GET \"/u\" { return 200 }\n", "host"},
+        // Empty `{}` is rejected by the earlier empty-dict branch
+        // (no specific missing field to name).
+        {"upstream api {}\nroute GET \"/u\" { return 200 }\n", nullptr},
+    };
+    for (const auto& tc : kCases) {
+        auto lexed = lex(lit(tc.src));
         REQUIRE(lexed);
         auto ast = parse_file_heap(lexed.value());
         REQUIRE(!ast);
         CHECK_EQ(ast.error().code, FrontendError::UnsupportedSyntax);
+        if (tc.missing != nullptr) {
+            CHECK(ast.error().detail.eq(lit(tc.missing)));
+        }
     }
 }
 

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -429,6 +429,22 @@ TEST(frontend, parse_upstream_dict_port_range_diagnostic_mentions_port) {
     CHECK(hir.error().detail.eq(lit("port")));
 }
 
+TEST(frontend, parse_upstream_dict_port_overflow_safe) {
+    // A dict-form port literal with enough leading digits to wrap u64
+    // past 2^64 must still be rejected as InvalidInteger, not
+    // accidentally accepted after wraparound. Uses 20+ digits —
+    // 10^20 > 2^64 so the accumulator would wrap without the
+    // pre-multiply overflow check.
+    const char* src =
+        "upstream api { host: \"127.0.0.1\", port: 99999999999999999999 }\n"
+        "route GET \"/u\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::InvalidInteger);
+}
+
 TEST(frontend, parse_upstream_empty_host_diagnostic_has_nonempty_detail) {
     // An empty host (`:8080` in at-form, `{ host: "" }` in dict form)
     // previously produced a zero-length detail, hiding what went

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -429,6 +429,38 @@ TEST(frontend, parse_upstream_dict_port_range_diagnostic_mentions_port) {
     CHECK(hir.error().detail.eq(lit("port")));
 }
 
+TEST(frontend, parse_upstream_empty_host_diagnostic_has_nonempty_detail) {
+    // An empty host (`:8080` in at-form, `{ host: "" }` in dict form)
+    // previously produced a zero-length detail, hiding what went
+    // wrong in diagnostics. The fallback now surfaces the full at-
+    // form literal or "host" for dict form so the user can see which
+    // part tripped the check.
+    {
+        const char* src = "upstream api at \":8080\"\nroute GET \"/u\" { return 200 }\n";
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(!hir);
+        CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+        CHECK(hir.error().detail.eq(lit(":8080")));
+    }
+    {
+        const char* src =
+            "upstream api { host: \"\", port: 80 }\n"
+            "route GET \"/u\" { return 200 }\n";
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(!hir);
+        CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+        CHECK(hir.error().detail.eq(lit("host")));
+    }
+}
+
 TEST(frontend, parse_upstream_dict_rejects_missing_field) {
     // Both host and port are required in dict form.
     for (const char* src : {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -296,6 +296,159 @@ TEST(frontend, parse_return_forward_rejects_missing_parens) {
     CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
 }
 
+TEST(frontend, parse_upstream_at_form) {
+    // `upstream NAME at "host:port"` packs both into a single string
+    // that analyze splits at the last colon. Result: HirUpstream has
+    // has_address=true and host-byte-order ip + port.
+    const char* src = "upstream api at \"127.0.0.1:8080\"\nroute GET \"/u\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    const auto& up = ast->items[0].upstream;
+    CHECK(up.has_address);
+    CHECK(up.host_lit.eq(lit("127.0.0.1:8080")));
+    CHECK(!up.port_is_set);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->upstreams.len, 1u);
+    const auto& u = hir->upstreams[0];
+    CHECK(u.has_address);
+    CHECK_EQ(u.ip, 0x7F000001u);
+    CHECK_EQ(u.port, 8080u);
+}
+
+TEST(frontend, parse_upstream_dict_form) {
+    // Dict form `{ host: "...", port: N }` — same analyze output,
+    // order-independent, both fields required.
+    const char* src_host_first =
+        "upstream api { host: \"10.0.0.1\", port: 9090 }\n"
+        "route GET \"/u\" { return 200 }\n";
+    const char* src_port_first =
+        "upstream api { port: 9090, host: \"10.0.0.1\" }\n"
+        "route GET \"/u\" { return 200 }\n";
+    for (const char* src : {src_host_first, src_port_first}) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(hir);
+        REQUIRE_EQ(hir->upstreams.len, 1u);
+        const auto& u = hir->upstreams[0];
+        CHECK(u.has_address);
+        CHECK_EQ(u.ip, 0x0A000001u);
+        CHECK_EQ(u.port, 9090u);
+    }
+}
+
+TEST(frontend, parse_upstream_no_address_still_works) {
+    // Backwards-compat: `upstream NAME` (no address) stays legal.
+    // HirUpstream.has_address == false means the runtime must bind
+    // this upstream via add_upstream() itself.
+    const char* src = "upstream api\nroute GET \"/u\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->upstreams.len, 1u);
+    CHECK(!hir->upstreams[0].has_address);
+}
+
+TEST(frontend, parse_upstream_rejects_malformed_ip) {
+    // IPv4 dotted-quad with an out-of-range octet → analyze rejects.
+    const char* src = "upstream api at \"256.0.0.1:8080\"\nroute GET \"/u\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, parse_upstream_rejects_hostname) {
+    // DNS names aren't supported yet — only IPv4 dotted-quad literals.
+    const char* src = "upstream api at \"example.com:8080\"\nroute GET \"/u\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, parse_upstream_rejects_missing_port) {
+    // `at "127.0.0.1"` without `:port` is rejected at analyze.
+    const char* src = "upstream api at \"127.0.0.1\"\nroute GET \"/u\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, parse_upstream_rejects_port_zero_and_overflow) {
+    // Port must be 1..65535 — 0 is reserved, and anything > 65535 is
+    // rejected at parse time (IntLit overflow) or at analyze.
+    for (const char* src : {
+             "upstream api at \"127.0.0.1:0\"\nroute GET \"/u\" { return 200 }\n",
+             "upstream api at \"127.0.0.1:65536\"\nroute GET \"/u\" { return 200 }\n",
+         }) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(!hir);
+        CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+    }
+}
+
+TEST(frontend, parse_upstream_dict_rejects_missing_field) {
+    // Both host and port are required in dict form.
+    for (const char* src : {
+             "upstream api { host: \"127.0.0.1\" }\nroute GET \"/u\" { return 200 }\n",
+             "upstream api { port: 8080 }\nroute GET \"/u\" { return 200 }\n",
+             "upstream api {}\nroute GET \"/u\" { return 200 }\n",
+         }) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(!ast);
+        CHECK_EQ(ast.error().code, FrontendError::UnsupportedSyntax);
+    }
+}
+
+TEST(frontend, parse_upstream_dict_rejects_duplicate_field) {
+    const char* src =
+        "upstream api { host: \"127.0.0.1\", host: \"10.0.0.1\", port: 80 }\n"
+        "route GET \"/u\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(frontend, parse_upstream_dict_rejects_unknown_field) {
+    const char* src =
+        "upstream api { host: \"127.0.0.1\", port: 80, weight: 3 }\n"
+        "route GET \"/u\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+    CHECK(ast.error().detail.eq(lit("weight")));
+}
+
 TEST(frontend, parse_return_response_with_headers) {
     // Headers dict carries through parser → HIR → MIR → RIR:
     // intern_response_headers writes one set into rir::Module's flat

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -437,6 +437,25 @@ TEST(frontend, parse_upstream_dict_rejects_duplicate_field) {
     CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
 }
 
+TEST(frontend, parse_upstream_at_is_contextual_not_reserved) {
+    // `at` is a contextual keyword recognised only after an upstream
+    // name. Using `at` as a regular identifier elsewhere — here as a
+    // route-path literal substring and as a header key — must parse
+    // without the lexer reserving the word. Regression guard against
+    // accidentally promoting `at` to a global keyword.
+    const char* src =
+        "upstream api at \"127.0.0.1:80\"\n"
+        "route GET \"/at\" { return response(200, headers: { \"at\": \"ok\" }) }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->upstreams.len, 1u);
+    CHECK(hir->upstreams[0].has_address);
+}
+
 TEST(frontend, parse_upstream_dict_rejects_unknown_field) {
     const char* src =
         "upstream api { host: \"127.0.0.1\", port: 80, weight: 3 }\n"

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -411,6 +411,23 @@ TEST(frontend, parse_upstream_rejects_port_zero_and_overflow) {
     }
 }
 
+TEST(frontend, parse_upstream_dict_rejects_port_zero) {
+    // At-form `:0` is covered by parse_upstream_rejects_port_zero_and_
+    // overflow, but dict form hits a different diagnostic path (port
+    // is a separate token, detail == "port"). Cover that branch too.
+    const char* src =
+        "upstream api { host: \"127.0.0.1\", port: 0 }\n"
+        "route GET \"/u\" { return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+    CHECK(hir.error().detail.eq(lit("port")));
+}
+
 TEST(frontend, parse_upstream_dict_port_range_diagnostic_mentions_port) {
     // `at "host:port"` form: the whole host_lit is the natural detail
     // (the full bad string). But dict form gave port its own token, so

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -7,6 +7,7 @@
 #include "rut/compiler/parser.h"
 #include "rut/jit/codegen.h"
 #include "rut/jit/jit_engine.h"
+#include "rut/runtime/compile_to_config.h"
 #include "rut/runtime/epoll_event_loop.h"
 #include "rut/runtime/io_uring_backend.h"
 #include "rut/runtime/shard.h"
@@ -3446,6 +3447,101 @@ TEST(route, dsl_return_forward_enters_proxy_state) {
     // a header value, or a body byte pattern. Locking in "HTTP/1.1 502"
     // makes the assertion about the status line specifically.
     CHECK(has("HTTP/1.1 502", 12));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+// End-to-end: compile DSL with an address-carrying `upstream` decl and
+// let populate_route_config bind the RouteConfig. Since no real backend
+// is listening on the compiled port, the forward will ECONNREFUSED and
+// the client will get 502 — which proves:
+//   1. `upstream X at "127.0.0.1:NNN"` parses + validates + lowers.
+//   2. populate_route_config called add_upstream with the compiled
+//      (ip, port) — otherwise the runtime would have had no upstream
+//      entry and returned some other error.
+TEST(route, populate_route_config_binds_upstream_from_dsl) {
+    using namespace rut;
+
+    const char* src =
+        "upstream backend at \"127.0.0.1:9999\"\n"
+        "route GET \"/api\" { return forward(backend) }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+    // RIR module carries the declared upstream with its address.
+    REQUIRE_EQ(rir.module.upstream_count, 1u);
+    CHECK(rir.module.upstreams[0].has_address);
+    CHECK_EQ(rir.module.upstreams[0].ip, 0x7F000001u);
+    CHECK_EQ(rir.module.upstreams[0].port, 9999u);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler_fn = reinterpret_cast<jit::HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler_fn != nullptr);
+
+    RouteConfig cfg{};
+    // The helper walks mod.upstreams / response_bodies / header_sets
+    // and calls the corresponding cfg.add_* methods. For this test
+    // only the upstream gets populated; routes still need to be
+    // registered explicitly (they depend on the JIT-compiled fn).
+    REQUIRE(populate_route_config(cfg, rir.module));
+    CHECK_EQ(cfg.upstream_count, 1u);
+    REQUIRE(cfg.add_jit_handler("/api", 'G', handler_fn));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 100};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    const char kReq[] = "GET /api HTTP/1.1\r\nHost: x\r\n\r\n";
+    send_all(c, kReq, sizeof(kReq) - 1);
+    char buf[1024];
+    i32 total = 0;
+    while (total < static_cast<i32>(sizeof(buf))) {
+        i32 n = recv_timeout(c, buf + total, sizeof(buf) - total, 500);
+        if (n <= 0) break;
+        total += n;
+        if (buf_contains(buf, static_cast<u32>(total), "\r\n", 2)) break;
+    }
+    CHECK_GT(total, 0);
+    const Str response{buf, static_cast<u32>(total)};
+    // The connect to 127.0.0.1:9999 fails (nothing listening) → 502.
+    // If populate_route_config had NOT populated the upstream, the
+    // runtime's upstream_id lookup would have failed earlier and the
+    // error shape would differ (still 502 today, but the branch is
+    // different). We rely on upstream_count == 1 above as the
+    // strong evidence that the DSL-compiled address reached cfg.
+    CHECK(buf_contains(
+        reinterpret_cast<const char*>(response.ptr), response.len, "HTTP/1.1 502", 12));
 
     close(c);
     lt.stop();

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -3495,10 +3495,37 @@ TEST(route, populate_route_config_rejects_non_empty_cfg) {
 TEST(route, populate_route_config_binds_upstream_from_dsl) {
     using namespace rut;
 
-    const char* src =
-        "upstream backend at \"127.0.0.1:9999\"\n"
-        "route GET \"/api\" { return forward(backend) }\n";
-    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    // Reserve an ephemeral port for the "unreachable backend". Hard-
+    // coding 9999 would be flaky: if the CI runner already has
+    // something listening there, the test would behave differently.
+    // Bind (but don't listen) on 127.0.0.1:0 so the kernel picks a
+    // free port, capture it, keep the socket open for the duration
+    // of the test so no other process can steal it, and feed the
+    // number into the DSL source. Connect attempts during the test
+    // get ECONNREFUSED — exactly the "no backend is listening"
+    // behaviour we want to drive.
+    const i32 reserve_fd = socket(AF_INET, SOCK_STREAM, 0);
+    REQUIRE_GE(reserve_fd, 0);
+    struct sockaddr_in reserve_addr{};
+    reserve_addr.sin_family = AF_INET;
+    reserve_addr.sin_addr.s_addr = __builtin_bswap32(0x7F000001u);
+    reserve_addr.sin_port = 0;
+    REQUIRE_EQ(
+        bind(reserve_fd, reinterpret_cast<struct sockaddr*>(&reserve_addr), sizeof(reserve_addr)),
+        0);
+    struct sockaddr_in got{};
+    socklen_t got_len = sizeof(got);
+    REQUIRE_EQ(getsockname(reserve_fd, reinterpret_cast<struct sockaddr*>(&got), &got_len), 0);
+    const u16 upstream_port = __builtin_bswap16(got.sin_port);
+
+    char src_buf[256];
+    const int src_len = snprintf(src_buf,
+                                 sizeof(src_buf),
+                                 "upstream backend at \"127.0.0.1:%u\"\n"
+                                 "route GET \"/api\" { return forward(backend) }\n",
+                                 upstream_port);
+    REQUIRE(src_len > 0 && src_len < static_cast<int>(sizeof(src_buf)));
+    auto lexed = lex(Str{src_buf, static_cast<u32>(src_len)});
     REQUIRE(lexed);
     auto ast = parse_file(lexed.value());
     REQUIRE(ast);
@@ -3516,7 +3543,7 @@ TEST(route, populate_route_config_binds_upstream_from_dsl) {
     REQUIRE_EQ(rir.module.upstream_count, 1u);
     CHECK(rir.module.upstreams[0].has_address);
     CHECK_EQ(rir.module.upstreams[0].ip, 0x7F000001u);
-    CHECK_EQ(rir.module.upstreams[0].port, 9999u);
+    CHECK_EQ(rir.module.upstreams[0].port, upstream_port);
 
     auto cg = jit::codegen(rir.module);
     REQUIRE(cg.ok);
@@ -3542,7 +3569,7 @@ TEST(route, populate_route_config_binds_upstream_from_dsl) {
     const Str actual_name{cfg.upstreams[0].name, 7u};
     const Str expected_name{"backend", 7u};
     CHECK(actual_name.eq(expected_name));
-    CHECK_EQ(cfg.upstreams[0].addr.sin_port, __builtin_bswap16(9999));
+    CHECK_EQ(cfg.upstreams[0].addr.sin_port, __builtin_bswap16(upstream_port));
     CHECK_EQ(cfg.upstreams[0].addr.sin_addr.s_addr, __builtin_bswap32(0x7F000001));
     REQUIRE(cfg.add_jit_handler("/api", 'G', handler_fn));
     const RouteConfig* active = &cfg;
@@ -3572,16 +3599,19 @@ TEST(route, populate_route_config_binds_upstream_from_dsl) {
     }
     CHECK_GT(total, 0);
     const Str response{buf, static_cast<u32>(total)};
-    // The connect to 127.0.0.1:9999 fails (nothing listening) → 502.
-    // If populate_route_config had NOT populated the upstream, the
-    // runtime's upstream_id lookup would have failed earlier and the
-    // error shape would differ (still 502 today, but the branch is
-    // different). We rely on upstream_count == 1 above as the
-    // strong evidence that the DSL-compiled address reached cfg.
+    // Connect to 127.0.0.1:<reserved port> fails with ECONNREFUSED
+    // (nothing listening because reserve_fd never called listen()) →
+    // 502. If populate_route_config had NOT populated the upstream,
+    // the runtime's upstream_id lookup would have failed earlier and
+    // the error shape would differ (still 502 today, but the branch
+    // is different). The upstream_count / name / (ip, port) asserts
+    // above are the strong evidence that the DSL-compiled address
+    // reached cfg.
     CHECK(buf_contains(
         reinterpret_cast<const char*>(response.ptr), response.len, "HTTP/1.1 502", 12));
 
     close(c);
+    close(reserve_fd);
     lt.stop();
     loop->shutdown();
     close(lfd);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -3554,6 +3554,7 @@ TEST(route, populate_route_config_rejects_pre_bound_name_mismatch) {
     // so the shape check passes, but the per-slot name compare fails.
     REQUIRE(cfg.add_upstream("other", 0x7F000001, 8080).has_value());
     CHECK(!populate_route_config(cfg, rir.module));
+    rir.destroy();
 }
 
 // End-to-end: compile DSL with an address-carrying `upstream` decl and

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -3457,24 +3457,23 @@ TEST(route, dsl_return_forward_enters_proxy_state) {
     rir.destroy();
 }
 
-// populate_route_config requires an empty RouteConfig so newly-added
-// slots line up with declaration order from the compiled module. Any
-// partially-populated config would silently mis-align indices across
-// upstreams / bodies / header sets, so the helper fail-fast rejects.
-TEST(route, populate_route_config_rejects_non_empty_cfg) {
+// populate_route_config requires bodies / header sets / routes to
+// start empty (there's no merge semantics). Upstreams are more
+// flexible: either empty (helper binds from the module) or exactly
+// mod.upstream_count (caller pre-bound, helper verifies + just
+// populates bodies/headers). Anything else — partial bodies, partial
+// routes, partial header sets, or upstream_count mismatch — rejects.
+TEST(route, populate_route_config_rejects_partial_cfg) {
     using namespace rut;
-    // The helper relies on cfg starting empty so newly-added slots
-    // match declaration order. A pre-populated cfg would silently
-    // mis-align indices; refuse instead of corrupting. Covers all
-    // four "partially populated" cases.
     FrontendRirModule rir{};
     REQUIRE(rir.init(1, 8));
     RouteConfig cfg_with_route{};
     REQUIRE(cfg_with_route.add_static("/x", 0, 200));
     CHECK(!populate_route_config(cfg_with_route, rir.module));
-    RouteConfig cfg_with_upstream{};
-    REQUIRE(cfg_with_upstream.add_upstream("x", 0x7F000001, 1).has_value());
-    CHECK(!populate_route_config(cfg_with_upstream, rir.module));
+    // upstream_count == 1 but module has 0 → mismatch, reject.
+    RouteConfig cfg_upstream_mismatch{};
+    REQUIRE(cfg_upstream_mismatch.add_upstream("x", 0x7F000001, 1).has_value());
+    CHECK(!populate_route_config(cfg_upstream_mismatch, rir.module));
     RouteConfig cfg_with_body{};
     REQUIRE_EQ(cfg_with_body.add_response_body("hi", 2), 1u);
     CHECK(!populate_route_config(cfg_with_body, rir.module));
@@ -3486,6 +3485,75 @@ TEST(route, populate_route_config_rejects_non_empty_cfg) {
     REQUIRE_EQ(cfg_with_headers.add_response_header_set(keys, klens, vals, vlens, 1), 1u);
     CHECK(!populate_route_config(cfg_with_headers, rir.module));
     rir.destroy();
+}
+
+// Pre-bound upstream mode: caller registers upstreams manually (e.g.
+// because the DSL declared them name-only, addresses come from a
+// runtime config file), then the helper fills in bodies / header
+// sets only. This is the workflow the reviewer called out as a
+// first-class use case.
+TEST(route, populate_route_config_accepts_pre_bound_upstreams) {
+    using namespace rut;
+    const char* src =
+        "upstream backend\n"
+        "route GET \"/api\" { return forward(backend) }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.upstream_count, 1u);
+    CHECK(!rir.module.upstreams[0].has_address);  // name-only
+
+    RouteConfig cfg{};
+    // Caller binds the upstream manually — same name, in DSL order.
+    REQUIRE(cfg.add_upstream("backend", 0x7F000001, 8080).has_value());
+    // Helper accepts the pre-bound cfg (upstream_count matches) and
+    // returns true even though the module had a name-only upstream.
+    CHECK(populate_route_config(cfg, rir.module));
+    // The manually-bound address is untouched.
+    CHECK_EQ(cfg.upstreams[0].addr.sin_port, __builtin_bswap16(8080));
+    rir.destroy();
+}
+
+// Pre-bound mode with a name mismatch: caller populated cfg in the
+// wrong order / with wrong names. Helper verifies name-for-name
+// (ASCII case-sensitive) and rejects so forward() can't resolve to
+// the wrong backend silently.
+TEST(route, populate_route_config_rejects_pre_bound_name_mismatch) {
+    using namespace rut;
+    const char* src =
+        "upstream backend\n"
+        "route GET \"/api\" { return forward(backend) }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    RouteConfig cfg{};
+    // Wrong name ("other" vs DSL's "backend"). upstream_count matches,
+    // so the shape check passes, but the per-slot name compare fails.
+    REQUIRE(cfg.add_upstream("other", 0x7F000001, 8080).has_value());
+    CHECK(!populate_route_config(cfg, rir.module));
 }
 
 // End-to-end: compile DSL with an address-carrying `upstream` decl and

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -3465,6 +3465,33 @@ TEST(route, dsl_return_forward_enters_proxy_state) {
 //   2. populate_route_config called add_upstream with the compiled
 //      (ip, port) — otherwise the runtime would have had no upstream
 //      entry and returned some other error.
+TEST(route, populate_route_config_rejects_non_empty_cfg) {
+    using namespace rut;
+    // The helper relies on cfg starting empty so newly-added slots
+    // match declaration order. A pre-populated cfg would silently
+    // mis-align indices; refuse instead of corrupting. Covers all
+    // four "partially populated" cases.
+    FrontendRirModule rir{};
+    REQUIRE(rir.init(1, 8));
+    RouteConfig cfg_with_route{};
+    REQUIRE(cfg_with_route.add_static("/x", 0, 200));
+    CHECK(!populate_route_config(cfg_with_route, rir.module));
+    RouteConfig cfg_with_upstream{};
+    REQUIRE(cfg_with_upstream.add_upstream("x", 0x7F000001, 1).has_value());
+    CHECK(!populate_route_config(cfg_with_upstream, rir.module));
+    RouteConfig cfg_with_body{};
+    REQUIRE_EQ(cfg_with_body.add_response_body("hi", 2), 1u);
+    CHECK(!populate_route_config(cfg_with_body, rir.module));
+    RouteConfig cfg_with_headers{};
+    const char* keys[1] = {"X-Foo"};
+    u32 klens[1] = {5};
+    const char* vals[1] = {"v"};
+    u32 vlens[1] = {1};
+    REQUIRE_EQ(cfg_with_headers.add_response_header_set(keys, klens, vals, vlens, 1), 1u);
+    CHECK(!populate_route_config(cfg_with_headers, rir.module));
+    rir.destroy();
+}
+
 TEST(route, populate_route_config_binds_upstream_from_dsl) {
     using namespace rut;
 

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -3557,6 +3557,50 @@ TEST(route, populate_route_config_rejects_pre_bound_name_mismatch) {
     rir.destroy();
 }
 
+// Pre-bound mode: a module upstream with a name longer than the cfg
+// can hold (kMaxUpstreamNameLen - 1 = 31 bytes) can't round-trip
+// through set_name without truncation. Two such names with the same
+// first 31 bytes would compare equal after truncation, letting a
+// caller pre-bind in the wrong order and slip past the verification.
+// Helper rejects over-long names up front in pre-bound mode to close
+// that gap.
+TEST(route, populate_route_config_rejects_pre_bound_over_long_name) {
+    using namespace rut;
+    // 32 bytes — one past the 31-byte cap. Build at compile time so
+    // the DSL source is deterministic.
+    const char* src =
+        "upstream "
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"  // 32 'a's
+        "route GET \"/api\" { return forward(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.upstream_count, 1u);
+    REQUIRE_EQ(rir.module.upstreams[0].name.len, 32u);
+
+    RouteConfig cfg{};
+    // Caller pre-binds using the truncated name (what set_name would
+    // store anyway). Under the old comparison this would have matched
+    // the truncated module name and incorrectly accepted the config.
+    REQUIRE(cfg.add_upstream("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",  // 31 'a's
+                             0x7F000001,
+                             8080)
+                .has_value());
+    CHECK(!populate_route_config(cfg, rir.module));
+    rir.destroy();
+}
+
 // End-to-end: compile DSL with an address-carrying `upstream` decl and
 // let populate_route_config bind the RouteConfig. Since no real backend
 // is listening on the compiled port, the forward will ECONNREFUSED and

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -3505,7 +3505,18 @@ TEST(route, populate_route_config_binds_upstream_from_dsl) {
     // only the upstream gets populated; routes still need to be
     // registered explicitly (they depend on the JIT-compiled fn).
     REQUIRE(populate_route_config(cfg, rir.module));
-    CHECK_EQ(cfg.upstream_count, 1u);
+    // Strong assertion that the helper actually bound the DSL upstream:
+    // the slot must exist, be at the same index the compiler emits,
+    // carry the DSL name verbatim, and resolve to the declared address.
+    // Without these, a "not-found → 502" could masquerade as the
+    // "connect refused → 502" below and let this test pass spuriously.
+    REQUIRE_EQ(cfg.upstream_count, 1u);
+    CHECK_EQ(cfg.upstreams[0].name_len, 7u);
+    const Str actual_name{cfg.upstreams[0].name, 7u};
+    const Str expected_name{"backend", 7u};
+    CHECK(actual_name.eq(expected_name));
+    CHECK_EQ(cfg.upstreams[0].addr.sin_port, __builtin_bswap16(9999));
+    CHECK_EQ(cfg.upstreams[0].addr.sin_addr.s_addr, __builtin_bswap32(0x7F000001));
     REQUIRE(cfg.add_jit_handler("/api", 'G', handler_fn));
     const RouteConfig* active = &cfg;
 

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -3457,14 +3457,10 @@ TEST(route, dsl_return_forward_enters_proxy_state) {
     rir.destroy();
 }
 
-// End-to-end: compile DSL with an address-carrying `upstream` decl and
-// let populate_route_config bind the RouteConfig. Since no real backend
-// is listening on the compiled port, the forward will ECONNREFUSED and
-// the client will get 502 — which proves:
-//   1. `upstream X at "127.0.0.1:NNN"` parses + validates + lowers.
-//   2. populate_route_config called add_upstream with the compiled
-//      (ip, port) — otherwise the runtime would have had no upstream
-//      entry and returned some other error.
+// populate_route_config requires an empty RouteConfig so newly-added
+// slots line up with declaration order from the compiled module. Any
+// partially-populated config would silently mis-align indices across
+// upstreams / bodies / header sets, so the helper fail-fast rejects.
 TEST(route, populate_route_config_rejects_non_empty_cfg) {
     using namespace rut;
     // The helper relies on cfg starting empty so newly-added slots
@@ -3492,6 +3488,14 @@ TEST(route, populate_route_config_rejects_non_empty_cfg) {
     rir.destroy();
 }
 
+// End-to-end: compile DSL with an address-carrying `upstream` decl and
+// let populate_route_config bind the RouteConfig. Since no real backend
+// is listening on the compiled port, the forward will ECONNREFUSED and
+// the client will get 502 — which proves:
+//   1. `upstream X at "127.0.0.1:NNN"` parses + validates + lowers.
+//   2. populate_route_config called add_upstream with the compiled
+//      (ip, port) — otherwise the runtime would have had no upstream
+//      entry and returned some other error.
 TEST(route, populate_route_config_binds_upstream_from_dsl) {
     using namespace rut;
 
@@ -3504,8 +3508,19 @@ TEST(route, populate_route_config_binds_upstream_from_dsl) {
     // number into the DSL source. Connect attempts during the test
     // get ECONNREFUSED — exactly the "no backend is listening"
     // behaviour we want to drive.
-    const i32 reserve_fd = socket(AF_INET, SOCK_STREAM, 0);
-    REQUIRE_GE(reserve_fd, 0);
+    //
+    // Guard closes the fd on scope exit so an early REQUIRE failure
+    // (before the explicit close at the bottom) doesn't leak the
+    // reserved socket and starve subsequent tests of ephemeral ports.
+    struct FdGuard {
+        i32 fd;
+        ~FdGuard() {
+            if (fd >= 0) close(fd);
+        }
+    };
+    FdGuard reserve{socket(AF_INET, SOCK_STREAM, 0)};
+    REQUIRE_GE(reserve.fd, 0);
+    const i32 reserve_fd = reserve.fd;
     struct sockaddr_in reserve_addr{};
     reserve_addr.sin_family = AF_INET;
     reserve_addr.sin_addr.s_addr = __builtin_bswap32(0x7F000001u);
@@ -3611,7 +3626,7 @@ TEST(route, populate_route_config_binds_upstream_from_dsl) {
         reinterpret_cast<const char*>(response.ptr), response.len, "HTTP/1.1 502", 12));
 
     close(c);
-    close(reserve_fd);
+    // reserve_fd is closed by FdGuard at scope exit.
     lt.stop();
     loop->shutdown();
     close(lfd);


### PR DESCRIPTION
## Summary

- Extend `upstream <name>` to optionally declare a backend address in two forms: `at "127.0.0.1:8080"` (single string) or `{ host: "127.0.0.1", port: 8080 }` (dict).
- Thread the parsed (ip, port) through HIR/MIR/RIR onto `rir::Module::upstreams[]`.
- Add a `populate_route_config(cfg, mod)` bridge helper in `include/rut/runtime/compile_to_config.h` that copies declarative module content (upstreams / bodies / header sets) into a `RouteConfig` so consumers don't write that loop by hand.

## Scope decisions

- **IPv4 only** for now. DNS names / IPv6 literals rejected with a clear diagnostic. Async DNS (getaddrinfo) + IPv6 bracket syntax is a separate feature.
- **`upstream <name>` without address still works** — tests that wire upstreams manually via `add_upstream()` keep working. `has_address == false` means the runtime binds separately.
- **Helper does declarative data only** — route registration still needs `cfg.add_jit_handler(path, method, fn)` per route since `fn` requires the JitEngine.

## Test plan

- [x] 10 new frontend tests: both syntactic forms, order-independent dict, no-address backward-compat, malformed IP, hostname rejection, missing port, port 0 / overflow, dict missing / duplicate / unknown fields.
- [x] 1 new integration test: full DSL source with `at "127.0.0.1:9999"`, `populate_route_config`, request through gateway → 502 (nothing listening). Asserts `cfg.upstream_count == 1` as strong evidence the compiled address reached the runtime.
- [x] `./dev.sh build`, `./dev.sh test` (40/40 test suites), `./dev.sh format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)