### PR TITLE
DSL: req.method + method-literal expressions + bool guard passthrough

### DIFF
--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -48,10 +48,6 @@ enum class AstExprKind : u8 {
     MethodCall,
     Field,
     ReqHeader,
-    // Leaf for the magic `req` identifier. Followed by `.X` → Field
-    // access (e.g. req.method) or `.header("X")` → ReqHeader (the
-    // existing special form). Field-name resolution happens in analyze.
-    ReqObject,
     // HTTP method literal as expression. The concrete method (GET,
     // POST, …) is encoded in int_val using the HttpMethod enum
     // values from rut/runtime/http_parser.h. Lets `POST` etc. appear

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -48,6 +48,15 @@ enum class AstExprKind : u8 {
     MethodCall,
     Field,
     ReqHeader,
+    // Leaf for the magic `req` identifier. Followed by `.X` → Field
+    // access (e.g. req.method) or `.header("X")` → ReqHeader (the
+    // existing special form). Field-name resolution happens in analyze.
+    ReqObject,
+    // HTTP method literal as expression. The concrete method (GET,
+    // POST, …) is encoded in int_val using the HttpMethod enum
+    // values from rut/runtime/http_parser.h. Lets `POST` etc. appear
+    // in contexts like `guard req.method == POST else { ... }`.
+    LitMethod,
     Nil,
     Error,
     Ident,

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -49,7 +49,7 @@ enum class AstExprKind : u8 {
     Field,
     ReqHeader,
     // HTTP method literal as expression. The concrete method (GET,
-    // POST, …) is encoded in int_val using the HttpMethod enum
+    // POST, …) is encoded in int_value using the HttpMethod enum
     // values from rut/runtime/http_parser.h. Lets `POST` etc. appear
     // in contexts like `guard req.method == POST else { ... }`.
     LitMethod,

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -59,6 +59,11 @@ enum class HirExprKind : u8 {
     StructInit,
     Field,
     ReqHeader,
+    // HTTP method literal — int_value holds the HttpMethod enum
+    // value (0=GET, 1=POST, …, matching rut/runtime/http_parser.h).
+    ConstMethod,
+    // Read of the parsed request method from the current connection.
+    ReqMethod,
     Nil,
     Error,
     LocalRef,
@@ -83,6 +88,7 @@ enum class HirTypeKind : u8 {
     Variant,
     Tuple,
     Struct,
+    Method,
 };
 
 inline constexpr u32 kMaxTupleSlots = 10;

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -24,6 +24,10 @@ enum class MirValueKind : u8 {
     StructInit,
     Field,
     ReqHeader,
+    // HTTP method literal — int_value holds the HttpMethod enum value.
+    ConstMethod,
+    // Read of the parsed request method from the current connection.
+    ReqMethod,
     Nil,
     Error,
     LocalRef,
@@ -46,6 +50,7 @@ enum class MirTypeKind : u8 {
     Variant,
     Tuple,
     Struct,
+    Method,
 };
 
 struct MirTypeShape {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -108,8 +108,8 @@ static FrontendResult<u32> intern_hir_type_shape(HirModule* mod,
     shape.variant_index = variant_index;
     shape.struct_index = struct_index;
     shape.tuple_len = tuple_len;
-    shape.is_concrete =
-        type == HirTypeKind::Bool || type == HirTypeKind::I32 || type == HirTypeKind::Str;
+    shape.is_concrete = type == HirTypeKind::Bool || type == HirTypeKind::I32 ||
+                        type == HirTypeKind::Str || type == HirTypeKind::Method;
     if (type == HirTypeKind::Variant) shape.is_concrete = variant_index != 0xffffffffu;
     if (type == HirTypeKind::Struct) shape.is_concrete = struct_index != 0xffffffffu;
     if (type == HirTypeKind::Tuple) {
@@ -295,6 +295,7 @@ static bool hir_type_shape_satisfies_eq_constraint(const HirModule& mod,
         case HirTypeKind::Bool:
         case HirTypeKind::I32:
         case HirTypeKind::Str:
+        case HirTypeKind::Method:
             return true;
         case HirTypeKind::Tuple:
             for (u32 i = 0; i < tuple_len; i++) {
@@ -4025,21 +4026,36 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
     if (expr.kind == AstExprKind::MethodCall) {
         return analyze_method_call_expr(expr, route, mod, locals, local_count, binding);
     }
-    // Intercept `req.X` before the generic struct/variant/namespace
-    // Field handler below: the lhs is our magic ReqObject leaf, not a
-    // real value the general analyzer knows how to type-check.
+    // `req.X` is magic only when the name `req` isn't shadowed by a
+    // local in scope. A user who writes `let req = Foo(...); req.id`
+    // still gets normal struct-field access on their local. Otherwise
+    // the request object is not a first-class value, so we intercept
+    // before the generic Field handler (which would try to analyze
+    // `req` as an expression and fail for the unshadowed case).
     if (expr.kind == AstExprKind::Field && expr.lhs != nullptr &&
-        expr.lhs->kind == AstExprKind::ReqObject) {
-        // Known fields: method (HttpMethod). Future fields (path, …)
-        // add branches here. `header` isn't reached via this path —
-        // the parser captures `req.header("...")` as the dedicated
-        // ReqHeader special form before generic Field parsing runs.
-        if (expr.name.eq({"method", 6})) {
-            out.kind = HirExprKind::ReqMethod;
-            out.type = HirTypeKind::Method;
-            return out;
+        expr.lhs->kind == AstExprKind::Ident && expr.lhs->name.eq({"req", 3})) {
+        bool shadowed = false;
+        for (u32 i = 0; i < local_count; i++) {
+            if (locals[i].name.eq({"req", 3})) {
+                shadowed = true;
+                break;
+            }
         }
-        return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        if (!shadowed) {
+            // Known fields: method (HttpMethod). Future fields (path,
+            // …) add branches here. `header` isn't reached via this
+            // path — the parser captures `req.header("...")` as the
+            // dedicated ReqHeader special form before generic Field
+            // parsing runs.
+            if (expr.name.eq({"method", 6})) {
+                out.kind = HirExprKind::ReqMethod;
+                out.type = HirTypeKind::Method;
+                return out;
+            }
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        }
+        // Shadowed — fall through to the generic Field path so the
+        // user's local `req` resolves normally.
     }
     if (expr.kind == AstExprKind::Field) {
         if (expr.lhs == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
@@ -4376,13 +4392,6 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         out.type = HirTypeKind::Method;
         out.int_value = expr.int_value;
         return out;
-    }
-    // A bare `req` (not followed by `.`) parsed as ReqObject is a
-    // standalone identifier use — analyze rejects it because the
-    // request object isn't a first-class value today. The `req.X`
-    // Field form is handled earlier, before the generic Field path.
-    if (expr.kind == AstExprKind::ReqObject) {
-        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
     }
     if (expr.kind == AstExprKind::Nil) {
         out.kind = HirExprKind::Nil;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -4036,6 +4036,7 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
     if (expr.kind == AstExprKind::Field && expr.lhs != nullptr &&
         expr.lhs->kind == AstExprKind::Ident && expr.lhs->name.eq({"req", 3})) {
         bool user_bound = false;
+        if (binding && binding->subject && binding->name.eq({"req", 3})) user_bound = true;
         for (u32 i = 0; i < local_count; i++) {
             if (locals[i].name.eq({"req", 3})) {
                 user_bound = true;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5458,7 +5458,13 @@ static const HirExpr* known_error_expr(const HirExpr& expr,
 
 static bool const_eval_expr(
     const HirExpr& expr, const HirLocal* locals, u32 local_count, ConstValue* out, u32 depth) {
-    if (depth > local_count) return false;
+    // `depth` guards against LocalRef cycles. For any realistic
+    // program, local_count caps how many unique LocalRefs can be
+    // chained. A zero-local route with a nested expression (e.g.
+    // `if const POST == GET`) still needs a few levels of natural
+    // tree recursion, so we add a fixed headroom on top of
+    // local_count for the Eq/Lt/Gt descent.
+    if (depth > local_count + HirRoute::kMaxLocals) return false;
     if (expr.kind == HirExprKind::BoolLit) {
         out->type = HirTypeKind::Bool;
         out->bool_value = expr.bool_value;
@@ -5466,6 +5472,13 @@ static bool const_eval_expr(
     }
     if (expr.kind == HirExprKind::IntLit) {
         out->type = HirTypeKind::I32;
+        out->int_value = expr.int_value;
+        return true;
+    }
+    if (expr.kind == HirExprKind::ConstMethod) {
+        // Method literals (POST, GET, …) are compile-time constants;
+        // fold them so `if const POST == GET { ... }` works.
+        out->type = HirTypeKind::Method;
         out->int_value = expr.int_value;
         return true;
     }
@@ -5492,7 +5505,7 @@ static bool const_eval_expr(
                 out->bool_value = lhs.bool_value == rhs.bool_value;
                 return true;
             }
-            if (lhs.type == HirTypeKind::I32) {
+            if (lhs.type == HirTypeKind::I32 || lhs.type == HirTypeKind::Method) {
                 out->bool_value = lhs.int_value == rhs.int_value;
                 return true;
             }

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -4025,6 +4025,22 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
     if (expr.kind == AstExprKind::MethodCall) {
         return analyze_method_call_expr(expr, route, mod, locals, local_count, binding);
     }
+    // Intercept `req.X` before the generic struct/variant/namespace
+    // Field handler below: the lhs is our magic ReqObject leaf, not a
+    // real value the general analyzer knows how to type-check.
+    if (expr.kind == AstExprKind::Field && expr.lhs != nullptr &&
+        expr.lhs->kind == AstExprKind::ReqObject) {
+        // Known fields: method (HttpMethod). Future fields (path, …)
+        // add branches here. `header` isn't reached via this path —
+        // the parser captures `req.header("...")` as the dedicated
+        // ReqHeader special form before generic Field parsing runs.
+        if (expr.name.eq({"method", 6})) {
+            out.kind = HirExprKind::ReqMethod;
+            out.type = HirTypeKind::Method;
+            return out;
+        }
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+    }
     if (expr.kind == AstExprKind::Field) {
         if (expr.lhs == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         if (expr.lhs->kind == AstExprKind::Ident) {
@@ -4352,6 +4368,21 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         out.may_nil = true;
         out.str_value = expr.str_value;
         return out;
+    }
+    if (expr.kind == AstExprKind::LitMethod) {
+        // Method literal (POST / GET / …). int_value carries the
+        // HttpMethod enum value the parser decoded.
+        out.kind = HirExprKind::ConstMethod;
+        out.type = HirTypeKind::Method;
+        out.int_value = expr.int_value;
+        return out;
+    }
+    // A bare `req` (not followed by `.`) parsed as ReqObject is a
+    // standalone identifier use — analyze rejects it because the
+    // request object isn't a first-class value today. The `req.X`
+    // Field form is handled earlier, before the generic Field path.
+    if (expr.kind == AstExprKind::ReqObject) {
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
     }
     if (expr.kind == AstExprKind::Nil) {
         out.kind = HirExprKind::Nil;
@@ -5473,6 +5504,14 @@ static FrontendResult<HirExpr> analyze_guard_cond(const AstExpr& expr,
     cond.type = HirTypeKind::Bool;
 
     if (!analyzed->may_error) {
+        // Plain boolean — pass through so `guard <cond> else { ... }`
+        // rejects on falsy (Swift-style reject-or-continue). Without
+        // this, any non-errorable guard would fold to always-true.
+        if (analyzed->type == HirTypeKind::Bool && !analyzed->may_nil) {
+            if (!route->exprs.push(analyzed.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            return route->exprs[route->exprs.len - 1];
+        }
         cond.bool_value = true;
         return cond;
     }

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -4026,22 +4026,35 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
     if (expr.kind == AstExprKind::MethodCall) {
         return analyze_method_call_expr(expr, route, mod, locals, local_count, binding);
     }
-    // `req.X` is magic only when the name `req` isn't shadowed by a
-    // local in scope. A user who writes `let req = Foo(...); req.id`
-    // still gets normal struct-field access on their local. Otherwise
-    // the request object is not a first-class value, so we intercept
-    // before the generic Field handler (which would try to analyze
-    // `req` as an expression and fail for the unshadowed case).
+    // `req.X` is magic only when the name `req` doesn't already
+    // resolve to something the user declared: a local binding, a
+    // variant name, or an import namespace alias. Any of those wins
+    // and we fall through to the generic Field handler below, which
+    // knows how to route variant construction / namespace members /
+    // local field access. Only when `req` resolves to nothing does
+    // the magic request-object path take over.
     if (expr.kind == AstExprKind::Field && expr.lhs != nullptr &&
         expr.lhs->kind == AstExprKind::Ident && expr.lhs->name.eq({"req", 3})) {
-        bool shadowed = false;
+        bool user_bound = false;
         for (u32 i = 0; i < local_count; i++) {
             if (locals[i].name.eq({"req", 3})) {
-                shadowed = true;
+                user_bound = true;
                 break;
             }
         }
-        if (!shadowed) {
+        if (!user_bound) {
+            for (u32 i = 0; i < mod.variants.len; i++) {
+                if (mod.variants[i].name.eq({"req", 3})) {
+                    user_bound = true;
+                    break;
+                }
+            }
+        }
+        if (!user_bound) {
+            Str ignored_qualified{};
+            if (resolve_import_namespace_member(mod, expr, ignored_qualified)) user_bound = true;
+        }
+        if (!user_bound) {
             // Known fields: method (HttpMethod). Future fields (path,
             // …) add branches here. `header` isn't reached via this
             // path — the parser captures `req.header("...")` as the
@@ -4054,8 +4067,8 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
             }
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
         }
-        // Shadowed — fall through to the generic Field path so the
-        // user's local `req` resolves normally.
+        // Otherwise fall through to the generic Field path so the
+        // user's local / variant / namespace `req` resolves normally.
     }
     if (expr.kind == AstExprKind::Field) {
         if (expr.lhs == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -505,6 +505,11 @@ static FrontendResult<const rir::Type*> rir_type_for_shape(
         if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
         return ty.value();
     }
+    if (type == MirTypeKind::Method) {
+        auto ty = b.make_type(rir::TypeKind::Method);
+        if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+        return ty.value();
+    }
     if (type == MirTypeKind::Variant && variant_index != 0xffffffffu &&
         variant_infos[variant_index].struct_type != nullptr)
         return variant_infos[variant_index].struct_type;
@@ -648,7 +653,8 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
                                                       const rir::StructDef* const* user_struct_defs,
                                                       rir::Builder& b,
                                                       Span span) {
-    if (type == MirTypeKind::Bool || type == MirTypeKind::I32 || type == MirTypeKind::Str) {
+    if (type == MirTypeKind::Bool || type == MirTypeKind::I32 || type == MirTypeKind::Str ||
+        type == MirTypeKind::Method) {
         auto cmp = b.emit_cmp(rir::Opcode::CmpEq, lhs, rhs, {span.line, span.col});
         if (!cmp) return frontend_error(FrontendError::OutOfMemory, span);
         return cmp.value();
@@ -1354,6 +1360,16 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
     }
     if (value.kind == MirValueKind::ReqHeader) {
         auto v = b.emit_req_header(value.str_value, {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ConstMethod) {
+        auto v = b.emit_const_method(static_cast<u8>(value.int_value), {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqMethod) {
+        auto v = b.emit_req_method({span.line, span.col});
         if (!v) return frontend_error(FrontendError::OutOfMemory, span);
         return v.value();
     }

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -112,6 +112,30 @@ static bool shape_carrier_ready(const MirModule& mir,
     return true;
 }
 
+static bool shape_slot_carrier_ready(const MirModule& mir,
+                                     u32 shape_index,
+                                     const bool* struct_ready,
+                                     const bool* variant_ready) {
+    if (shape_index >= mir.type_shapes.len) return false;
+    const auto& shape = mir.type_shapes[shape_index];
+    if (!shape.is_concrete) return false;
+    if (shape.type == MirTypeKind::Method) return false;
+    if (shape.type == MirTypeKind::Bool || shape.type == MirTypeKind::I32 ||
+        shape.type == MirTypeKind::Str)
+        return true;
+    if (shape.type == MirTypeKind::Struct)
+        return shape.struct_index < mir.structs.len && struct_ready[shape.struct_index];
+    if (shape.type == MirTypeKind::Variant)
+        return shape.variant_index < mir.variants.len && variant_ready[shape.variant_index];
+    if (shape.type != MirTypeKind::Tuple) return false;
+    for (u32 i = 0; i < shape.tuple_len; i++) {
+        if (!shape_carrier_ready(
+                mir, shape.tuple_elem_shape_indices[i], struct_ready, variant_ready))
+            return false;
+    }
+    return true;
+}
+
 static bool instance_arg_concrete(const MirModule& mir, MirTypeKind type, u32 shape_index) {
     if (shape_index != 0xffffffffu) {
         if (shape_index >= mir.type_shapes.len) return false;
@@ -144,7 +168,7 @@ static bool field_carrier_ready(const MirModule& mir,
                                 const bool* variant_ready) {
     if (field.is_error_type) return true;
     if (field.shape_index != 0xffffffffu)
-        return shape_carrier_ready(mir, field.shape_index, struct_ready, variant_ready);
+        return shape_slot_carrier_ready(mir, field.shape_index, struct_ready, variant_ready);
     // Note: Method is intentionally omitted here (and in the variant
     // payload analog below). lower_rir's struct-field and variant-
     // payload builders don't yet have a Method carrier — a
@@ -172,7 +196,7 @@ static bool variant_payload_carrier_ready(const MirModule& mir,
                                           const bool* variant_ready) {
     if (!c.has_payload) return true;
     if (c.payload_shape_index != 0xffffffffu)
-        return shape_carrier_ready(mir, c.payload_shape_index, struct_ready, variant_ready);
+        return shape_slot_carrier_ready(mir, c.payload_shape_index, struct_ready, variant_ready);
     // See field_carrier_ready: Method payloads have no lower_rir
     // carrier yet, so don't claim they're ready.
     if (c.payload_type == MirTypeKind::Bool || c.payload_type == MirTypeKind::I32 ||

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -145,8 +145,19 @@ static bool field_carrier_ready(const MirModule& mir,
     if (field.is_error_type) return true;
     if (field.shape_index != 0xffffffffu)
         return shape_carrier_ready(mir, field.shape_index, struct_ready, variant_ready);
+    // Note: Method is intentionally omitted here (and in the variant
+    // payload analog below). lower_rir's struct-field and variant-
+    // payload builders don't yet have a Method carrier — a
+    // Method-typed struct field / payload would lower to an Optional
+    // <I32> slot and fail in emit_struct_create. Method as a plain
+    // value is fine (shape_carrier_ready accepts it) because it's
+    // lowered as a bare i8; these per-field helpers only run when
+    // there's no shape index to delegate to, so until someone wires
+    // Method into the carrier builders, reporting it as "ready"
+    // here would mislead the lowering pass. Today's surface DSL
+    // can't declare Method-typed struct fields anyway.
     if (field.type == MirTypeKind::Bool || field.type == MirTypeKind::I32 ||
-        field.type == MirTypeKind::Str || field.type == MirTypeKind::Method)
+        field.type == MirTypeKind::Str)
         return true;
     if (field.type == MirTypeKind::Struct)
         return field.struct_index < mir.structs.len && struct_ready[field.struct_index];
@@ -162,8 +173,10 @@ static bool variant_payload_carrier_ready(const MirModule& mir,
     if (!c.has_payload) return true;
     if (c.payload_shape_index != 0xffffffffu)
         return shape_carrier_ready(mir, c.payload_shape_index, struct_ready, variant_ready);
+    // See field_carrier_ready: Method payloads have no lower_rir
+    // carrier yet, so don't claim they're ready.
     if (c.payload_type == MirTypeKind::Bool || c.payload_type == MirTypeKind::I32 ||
-        c.payload_type == MirTypeKind::Str || c.payload_type == MirTypeKind::Method)
+        c.payload_type == MirTypeKind::Str)
         return true;
     if (c.payload_type == MirTypeKind::Struct)
         return c.payload_struct_index < mir.structs.len && struct_ready[c.payload_struct_index];

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -324,6 +324,17 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.str_value = expr.str_value;
         return v;
     }
+    if (expr.kind == HirExprKind::ConstMethod) {
+        v.kind = MirValueKind::ConstMethod;
+        v.type = MirTypeKind::Method;
+        v.int_value = expr.int_value;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqMethod) {
+        v.kind = MirValueKind::ReqMethod;
+        v.type = MirTypeKind::Method;
+        return v;
+    }
     if (expr.kind == HirExprKind::Nil) {
         v.kind = MirValueKind::Nil;
         v.type = MirTypeKind::Unknown;

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -40,6 +40,7 @@ static MirTypeKind mir_type_kind(HirTypeKind kind) {
     return kind == HirTypeKind::Bool      ? MirTypeKind::Bool
            : kind == HirTypeKind::I32     ? MirTypeKind::I32
            : kind == HirTypeKind::Str     ? MirTypeKind::Str
+           : kind == HirTypeKind::Method  ? MirTypeKind::Method
            : kind == HirTypeKind::Variant ? MirTypeKind::Variant
            : kind == HirTypeKind::Tuple   ? MirTypeKind::Tuple
            : kind == HirTypeKind::Struct  ? MirTypeKind::Struct
@@ -96,7 +97,7 @@ static bool shape_carrier_ready(const MirModule& mir,
     const auto& shape = mir.type_shapes[shape_index];
     if (!shape.is_concrete) return false;
     if (shape.type == MirTypeKind::Bool || shape.type == MirTypeKind::I32 ||
-        shape.type == MirTypeKind::Str)
+        shape.type == MirTypeKind::Str || shape.type == MirTypeKind::Method)
         return true;
     if (shape.type == MirTypeKind::Struct)
         return shape.struct_index < mir.structs.len && struct_ready[shape.struct_index];
@@ -145,7 +146,7 @@ static bool field_carrier_ready(const MirModule& mir,
     if (field.shape_index != 0xffffffffu)
         return shape_carrier_ready(mir, field.shape_index, struct_ready, variant_ready);
     if (field.type == MirTypeKind::Bool || field.type == MirTypeKind::I32 ||
-        field.type == MirTypeKind::Str)
+        field.type == MirTypeKind::Str || field.type == MirTypeKind::Method)
         return true;
     if (field.type == MirTypeKind::Struct)
         return field.struct_index < mir.structs.len && struct_ready[field.struct_index];
@@ -162,7 +163,7 @@ static bool variant_payload_carrier_ready(const MirModule& mir,
     if (c.payload_shape_index != 0xffffffffu)
         return shape_carrier_ready(mir, c.payload_shape_index, struct_ready, variant_ready);
     if (c.payload_type == MirTypeKind::Bool || c.payload_type == MirTypeKind::I32 ||
-        c.payload_type == MirTypeKind::Str)
+        c.payload_type == MirTypeKind::Str || c.payload_type == MirTypeKind::Method)
         return true;
     if (c.payload_type == MirTypeKind::Struct)
         return c.payload_struct_index < mir.structs.len && struct_ready[c.payload_struct_index];
@@ -536,13 +537,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
     }
     if (expr.kind == HirExprKind::LocalRef) {
         v.kind = MirValueKind::LocalRef;
-        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
-                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                     : MirTypeKind::Unknown;
+        v.type = mir_type_kind(expr.type);
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.local_index = expr.local_index;

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -202,12 +202,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.type = MirTypeKind::Tuple;
         v.tuple_len = expr.tuple_len;
         for (u32 i = 0; i < expr.tuple_len; i++) {
-            v.tuple_types[i] = expr.tuple_types[i] == HirTypeKind::Bool      ? MirTypeKind::Bool
-                               : expr.tuple_types[i] == HirTypeKind::I32     ? MirTypeKind::I32
-                               : expr.tuple_types[i] == HirTypeKind::Str     ? MirTypeKind::Str
-                               : expr.tuple_types[i] == HirTypeKind::Variant ? MirTypeKind::Variant
-                               : expr.tuple_types[i] == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                                             : MirTypeKind::Unknown;
+            v.tuple_types[i] = mir_type_kind(expr.tuple_types[i]);
             v.tuple_variant_indices[i] = expr.tuple_variant_indices[i];
             v.tuple_struct_indices[i] = expr.tuple_struct_indices[i];
         }
@@ -255,12 +250,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::TupleSlot;
-        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
-                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                     : MirTypeKind::Unknown;
+        v.type = mir_type_kind(expr.type);
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.int_value = expr.int_value;
@@ -292,25 +282,14 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::Field;
-        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
-                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                     : MirTypeKind::Unknown;
+        v.type = mir_type_kind(expr.type);
         v.str_value = expr.str_value;
         v.lhs = &fn->values[fn->values.len - 1];
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.tuple_len = expr.tuple_len;
         for (u32 i = 0; i < expr.tuple_len; i++) {
-            v.tuple_types[i] = expr.tuple_types[i] == HirTypeKind::Bool      ? MirTypeKind::Bool
-                               : expr.tuple_types[i] == HirTypeKind::I32     ? MirTypeKind::I32
-                               : expr.tuple_types[i] == HirTypeKind::Str     ? MirTypeKind::Str
-                               : expr.tuple_types[i] == HirTypeKind::Variant ? MirTypeKind::Variant
-                               : expr.tuple_types[i] == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                                             : MirTypeKind::Unknown;
+            v.tuple_types[i] = mir_type_kind(expr.tuple_types[i]);
             v.tuple_variant_indices[i] = expr.tuple_variant_indices[i];
             v.tuple_struct_indices[i] = expr.tuple_struct_indices[i];
         }
@@ -401,13 +380,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
             return frontend_error(FrontendError::TooManyItems, expr.span);
         MirValue* else_ptr = &fn->values[fn->values.len - 1];
         v.kind = MirValueKind::IfElse;
-        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
-                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                     : MirTypeKind::Unknown;
+        v.type = mir_type_kind(expr.type);
         v.lhs = cond_ptr;
         v.rhs = then_ptr;
         if (!v.args.push(else_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -430,13 +403,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
             return frontend_error(FrontendError::TooManyItems, expr.span);
         MirValue* rhs_ptr = &fn->values[fn->values.len - 1];
         v.kind = MirValueKind::Or;
-        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
-                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                     : MirTypeKind::Unknown;
+        v.type = mir_type_kind(expr.type);
         v.lhs = lhs_ptr;
         v.rhs = rhs_ptr;
         v.variant_index = expr.variant_index;
@@ -476,13 +443,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::ValueOf;
-        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
-                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                     : MirTypeKind::Unknown;
+        v.type = mir_type_kind(expr.type);
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.error_struct_index = expr.error_struct_index;
@@ -497,13 +458,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::MissingOf;
-        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
-                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                     : MirTypeKind::Unknown;
+        v.type = mir_type_kind(expr.type);
         v.may_nil = expr.may_nil;
         v.may_error = expr.may_error;
         v.variant_index = expr.variant_index;
@@ -520,13 +475,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
         v.kind = MirValueKind::MatchPayload;
-        v.type = expr.type == HirTypeKind::Bool      ? MirTypeKind::Bool
-                 : expr.type == HirTypeKind::I32     ? MirTypeKind::I32
-                 : expr.type == HirTypeKind::Str     ? MirTypeKind::Str
-                 : expr.type == HirTypeKind::Variant ? MirTypeKind::Variant
-                 : expr.type == HirTypeKind::Tuple   ? MirTypeKind::Tuple
-                 : expr.type == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                                     : MirTypeKind::Unknown;
+        v.type = mir_type_kind(expr.type);
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.case_index = expr.case_index;
@@ -587,17 +536,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         st.template_struct_index = module.structs[i].template_struct_index;
         st.instance_type_arg_count = module.structs[i].instance_type_arg_count;
         for (u32 ai = 0; ai < st.instance_type_arg_count; ai++) {
-            st.instance_type_args[ai] =
-                module.structs[i].instance_type_args[ai] == HirTypeKind::Bool  ? MirTypeKind::Bool
-                : module.structs[i].instance_type_args[ai] == HirTypeKind::I32 ? MirTypeKind::I32
-                : module.structs[i].instance_type_args[ai] == HirTypeKind::Str ? MirTypeKind::Str
-                : module.structs[i].instance_type_args[ai] == HirTypeKind::Variant
-                    ? MirTypeKind::Variant
-                : module.structs[i].instance_type_args[ai] == HirTypeKind::Struct
-                    ? MirTypeKind::Struct
-                : module.structs[i].instance_type_args[ai] == HirTypeKind::Tuple
-                    ? MirTypeKind::Tuple
-                    : MirTypeKind::Unknown;
+            st.instance_type_args[ai] = mir_type_kind(module.structs[i].instance_type_args[ai]);
             st.instance_generic_indices[ai] = module.structs[i].instance_generic_indices[ai];
             st.instance_shape_indices[ai] = module.structs[i].instance_shape_indices[ai];
         }
@@ -612,18 +551,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             field.struct_index = module.structs[i].fields[fi].struct_index;
             field.tuple_len = module.structs[i].fields[fi].tuple_len;
             for (u32 ti = 0; ti < field.tuple_len; ti++) {
-                field.tuple_types[ti] =
-                    module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Bool
-                        ? MirTypeKind::Bool
-                    : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::I32
-                        ? MirTypeKind::I32
-                    : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Str
-                        ? MirTypeKind::Str
-                    : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Variant
-                        ? MirTypeKind::Variant
-                    : module.structs[i].fields[fi].tuple_types[ti] == HirTypeKind::Struct
-                        ? MirTypeKind::Struct
-                        : MirTypeKind::Unknown;
+                field.tuple_types[ti] = mir_type_kind(module.structs[i].fields[fi].tuple_types[ti]);
                 field.tuple_variant_indices[ti] =
                     module.structs[i].fields[fi].tuple_variant_indices[ti];
                 field.tuple_struct_indices[ti] =
@@ -643,16 +571,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         variant.instance_type_arg_count = module.variants[i].instance_type_arg_count;
         for (u32 ai = 0; ai < variant.instance_type_arg_count; ai++) {
             variant.instance_type_args[ai] =
-                module.variants[i].instance_type_args[ai] == HirTypeKind::Bool  ? MirTypeKind::Bool
-                : module.variants[i].instance_type_args[ai] == HirTypeKind::I32 ? MirTypeKind::I32
-                : module.variants[i].instance_type_args[ai] == HirTypeKind::Str ? MirTypeKind::Str
-                : module.variants[i].instance_type_args[ai] == HirTypeKind::Variant
-                    ? MirTypeKind::Variant
-                : module.variants[i].instance_type_args[ai] == HirTypeKind::Struct
-                    ? MirTypeKind::Struct
-                : module.variants[i].instance_type_args[ai] == HirTypeKind::Tuple
-                    ? MirTypeKind::Tuple
-                    : MirTypeKind::Unknown;
+                mir_type_kind(module.variants[i].instance_type_args[ai]);
             variant.instance_generic_indices[ai] = module.variants[i].instance_generic_indices[ai];
             variant.instance_shape_indices[ai] = module.variants[i].instance_shape_indices[ai];
         }
@@ -667,17 +586,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             case_decl.payload_tuple_len = module.variants[i].cases[ci].payload_tuple_len;
             for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
                 case_decl.payload_tuple_types[ti] =
-                    module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Bool
-                        ? MirTypeKind::Bool
-                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::I32
-                        ? MirTypeKind::I32
-                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Str
-                        ? MirTypeKind::Str
-                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Variant
-                        ? MirTypeKind::Variant
-                    : module.variants[i].cases[ci].payload_tuple_types[ti] == HirTypeKind::Struct
-                        ? MirTypeKind::Struct
-                        : MirTypeKind::Unknown;
+                    mir_type_kind(module.variants[i].cases[ci].payload_tuple_types[ti]);
                 case_decl.payload_tuple_variant_indices[ti] =
                     module.variants[i].cases[ci].payload_tuple_variant_indices[ti];
                 case_decl.payload_tuple_struct_indices[ti] =
@@ -771,18 +680,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             local.struct_index = module.routes[i].locals[li].struct_index;
             local.tuple_len = module.routes[i].locals[li].tuple_len;
             for (u32 ti = 0; ti < local.tuple_len; ti++) {
-                local.tuple_types[ti] =
-                    module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Bool
-                        ? MirTypeKind::Bool
-                    : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::I32
-                        ? MirTypeKind::I32
-                    : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Str
-                        ? MirTypeKind::Str
-                    : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Variant
-                        ? MirTypeKind::Variant
-                    : module.routes[i].locals[li].tuple_types[ti] == HirTypeKind::Struct
-                        ? MirTypeKind::Struct
-                        : MirTypeKind::Unknown;
+                local.tuple_types[ti] = mir_type_kind(module.routes[i].locals[li].tuple_types[ti]);
                 local.tuple_variant_indices[ti] =
                     module.routes[i].locals[li].tuple_variant_indices[ti];
                 local.tuple_struct_indices[ti] =

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -320,19 +320,6 @@ struct Parser {
             expr.span = Span{start_tok.start, rparen.value()->end, start_tok.line, start_tok.col};
             return expr;
         }
-        // `req` as a leaf — only when followed by `.`, otherwise treat
-        // as a normal identifier so users can still bind a local
-        // called `req`. The trailer machinery in parse_primary_expr
-        // will turn `req.X` into Field{lhs=ReqObject, name="X"};
-        // analyze maps the specific field names to request opcodes.
-        if (cur().type == TokenType::Ident && cur().text.eq({"req", 3}) &&
-            peek().type == TokenType::Dot) {
-            const Token tok = cur();
-            pos++;
-            expr.kind = AstExprKind::ReqObject;
-            expr.span = span_from(tok);
-            return expr;
-        }
         // HTTP method literals as expressions (POST, GET, …). The
         // lexer already tokenizes these as KwGet/KwPost/etc.; until
         // now they were only consumed in route declarations. Map each

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -320,6 +320,57 @@ struct Parser {
             expr.span = Span{start_tok.start, rparen.value()->end, start_tok.line, start_tok.col};
             return expr;
         }
+        // `req` as a leaf — only when followed by `.`, otherwise treat
+        // as a normal identifier so users can still bind a local
+        // called `req`. The trailer machinery in parse_primary_expr
+        // will turn `req.X` into Field{lhs=ReqObject, name="X"};
+        // analyze maps the specific field names to request opcodes.
+        if (cur().type == TokenType::Ident && cur().text.eq({"req", 3}) &&
+            peek().type == TokenType::Dot) {
+            const Token tok = cur();
+            pos++;
+            expr.kind = AstExprKind::ReqObject;
+            expr.span = span_from(tok);
+            return expr;
+        }
+        // HTTP method literals as expressions (POST, GET, …). The
+        // lexer already tokenizes these as KwGet/KwPost/etc.; until
+        // now they were only consumed in route declarations. Map each
+        // keyword to the corresponding HttpMethod enum value (stored
+        // in int_value), letting `guard req.method == POST else { … }`
+        // compile. Values match HttpMethod in rut/runtime/http_parser.h.
+        if (is_method_keyword(cur().type)) {
+            const Token tok = cur();
+            pos++;
+            expr.kind = AstExprKind::LitMethod;
+            switch (tok.type) {
+                case TokenType::KwGet:
+                    expr.int_value = 0;
+                    break;
+                case TokenType::KwPost:
+                    expr.int_value = 1;
+                    break;
+                case TokenType::KwPut:
+                    expr.int_value = 2;
+                    break;
+                case TokenType::KwDelete:
+                    expr.int_value = 3;
+                    break;
+                case TokenType::KwPatch:
+                    expr.int_value = 4;
+                    break;
+                case TokenType::KwHead:
+                    expr.int_value = 5;
+                    break;
+                case TokenType::KwOptions:
+                    expr.int_value = 6;
+                    break;
+                default:
+                    return frontend_error(FrontendError::UnsupportedSyntax, span_from(tok));
+            }
+            expr.span = span_from(tok);
+            return expr;
+        }
         auto ident = expect(TokenType::Ident);
         if (!ident) return core::make_unexpected(ident.error());
         if (ident.value()->text.len >= 2 && ident.value()->text.ptr[0] == '_') {

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1,6 +1,7 @@
 #include "rut/compiler/parser.h"
 
 #include "rut/common/http_header_validation.h"
+#include "rut/runtime/http_parser.h"
 #include <memory>
 
 namespace rut {
@@ -322,35 +323,37 @@ struct Parser {
         }
         // HTTP method literals as expressions (POST, GET, …). The
         // lexer already tokenizes these as KwGet/KwPost/etc.; until
-        // now they were only consumed in route declarations. Map each
-        // keyword to the corresponding HttpMethod enum value (stored
-        // in int_value), letting `guard req.method == POST else { … }`
-        // compile. Values match HttpMethod in rut/runtime/http_parser.h.
+        // now they were only consumed in route declarations. Map
+        // each keyword to the HttpMethod enum value stored in
+        // int_value — sourcing from the runtime enum rather than
+        // hard-coded integers so the two stay in sync if the enum
+        // ever shifts. Lets `POST` etc. appear in contexts like
+        // `guard req.method == POST else { … }`.
         if (is_method_keyword(cur().type)) {
             const Token tok = cur();
             pos++;
             expr.kind = AstExprKind::LitMethod;
             switch (tok.type) {
                 case TokenType::KwGet:
-                    expr.int_value = 0;
+                    expr.int_value = static_cast<i32>(HttpMethod::GET);
                     break;
                 case TokenType::KwPost:
-                    expr.int_value = 1;
+                    expr.int_value = static_cast<i32>(HttpMethod::POST);
                     break;
                 case TokenType::KwPut:
-                    expr.int_value = 2;
+                    expr.int_value = static_cast<i32>(HttpMethod::PUT);
                     break;
                 case TokenType::KwDelete:
-                    expr.int_value = 3;
+                    expr.int_value = static_cast<i32>(HttpMethod::DELETE);
                     break;
                 case TokenType::KwPatch:
-                    expr.int_value = 4;
+                    expr.int_value = static_cast<i32>(HttpMethod::PATCH);
                     break;
                 case TokenType::KwHead:
-                    expr.int_value = 5;
+                    expr.int_value = static_cast<i32>(HttpMethod::HEAD);
                     break;
                 case TokenType::KwOptions:
-                    expr.int_value = 6;
+                    expr.int_value = static_cast<i32>(HttpMethod::OPTIONS);
                     break;
                 default:
                     return frontend_error(FrontendError::UnsupportedSyntax, span_from(tok));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -3271,6 +3271,33 @@ route GET "/users" {
     CHECK(shape.carrier_ready);
 }
 
+TEST(frontend, lower_to_rir_rejects_generic_variant_method_payload_carrier) {
+    // Generic variant payloads instantiated with Method currently
+    // have no dedicated lower_rir carrier. They should be rejected
+    // deterministically instead of being treated as carrier-ready
+    // through the payload shape index and failing later in struct
+    // creation with a type mismatch.
+    const auto src = R"rut(
+variant Box<T> { value(T) }
+func wrap<T>(x: T) -> Box<T> => Box.value(x)
+route GET "/users" {
+    let state = wrap(POST)
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(!lowered);
+}
+
 TEST(frontend, import_namespace_struct_init_is_supported) {
     const std::string dir = "/tmp/rut_import_namespace_struct_frontend";
     std::filesystem::create_directories(dir);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -811,6 +811,28 @@ route GET "/users" { if req.ping() == 200 { return 200 } else { return 500 } }
     REQUIRE(hir);
 }
 
+TEST(frontend, parse_match_payload_named_req_shadows_magic_path) {
+    // Match payload bindings named `req` must also win over the
+    // special request-object path. Otherwise `req.value` in a match
+    // arm would be intercepted as magic request access instead of
+    // field access on the bound payload.
+    const char* src = R"rut(
+struct Payload { value: i32 }
+variant Box { value(Payload) }
+route GET "/users" {
+    match Box.value(Payload(value: 42)) {
+        case .value(req): if req.value == 42 { return 200 } else { return 500 }
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
 TEST(frontend, parse_return_response_with_headers) {
     // Headers dict carries through parser → HIR → MIR → RIR:
     // intern_response_headers writes one set into rir::Module's flat

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -563,6 +563,90 @@ TEST(frontend, parse_upstream_dict_rejects_unknown_field) {
     CHECK(ast.error().detail.eq(lit("weight")));
 }
 
+TEST(frontend, parse_guard_req_method_eq_post) {
+    // `guard req.method == POST else { return 405 }` — the keystone
+    // use case. Parser yields LitMethod + Field(ReqObject, "method");
+    // analyze resolves both to typed HIR; MIR/RIR downstream carry
+    // the ConstMethod / ReqMethod opcodes. Codegen emits i8 constant
+    // and a helper-call to read the parsed method from the request.
+    const char* src =
+        "route GET \"/\" { guard req.method == POST else { return 405 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    // Lower fully through MIR → RIR so we know codegen gets the right
+    // inputs. The parser / analyzer paths are the ones that changed;
+    // downstream is reused machinery.
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, parse_method_keyword_as_expression) {
+    // POST / GET / PUT / DELETE / HEAD / OPTIONS / PATCH each need
+    // to parse as standalone expressions with distinct HttpMethod
+    // enum values (matching runtime/http_parser.h: GET=0, POST=1, ...).
+    struct Case {
+        const char* src;
+        i32 expected_value;
+    };
+    const Case kCases[] = {
+        {"route GET \"/\" { guard req.method == GET else { return 405 } return 200 }\n", 0},
+        {"route GET \"/\" { guard req.method == POST else { return 405 } return 200 }\n", 1},
+        {"route GET \"/\" { guard req.method == PUT else { return 405 } return 200 }\n", 2},
+        {"route GET \"/\" { guard req.method == DELETE else { return 405 } return 200 }\n", 3},
+        {"route GET \"/\" { guard req.method == PATCH else { return 405 } return 200 }\n", 4},
+        {"route GET \"/\" { guard req.method == HEAD else { return 405 } return 200 }\n", 5},
+        {"route GET \"/\" { guard req.method == OPTIONS else { return 405 } return 200 }\n", 6},
+    };
+    for (const auto& tc : kCases) {
+        auto lexed = lex(lit(tc.src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(hir);
+    }
+}
+
+TEST(frontend, parse_req_unknown_field_rejected) {
+    // `req.X` for a field name analyze doesn't recognize must reject
+    // at analyze time. `header` is accepted as a call form via the
+    // dedicated ReqHeader path, but `req.header` without parens falls
+    // into this path and is rejected (same as any other non-method
+    // field name).
+    const char* src = "route GET \"/\" { guard req.bogus == GET else { return 405 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+    CHECK(hir.error().detail.eq(lit("bogus")));
+}
+
+TEST(frontend, parse_method_vs_non_method_compare_rejected) {
+    // `req.method == 200` mixes Method and i32 — analyze enforces
+    // type-equality on the == operands and rejects.
+    const char* src =
+        "route GET \"/\" { guard req.method == 200 else { return 405 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
 TEST(frontend, parse_return_response_with_headers) {
     // Headers dict carries through parser → HIR → MIR → RIR:
     // intern_response_headers writes one set into rir::Module's flat

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -710,6 +710,49 @@ route GET "/users" {
     // surface as an "unknown req field" analyze error.
 }
 
+TEST(frontend, parse_user_variant_named_req_shadows_magic_path) {
+    // A variant literally named `req` must take precedence so
+    // `req.case` resolves as variant construction (VariantCase),
+    // not the magic request-object path. The parser would otherwise
+    // hijack every dotted `req.*` before variant/import resolution
+    // gets a turn.
+    const char* src = R"rut(
+variant req { case_a, case_b }
+route GET "/users" {
+    let x = req.case_a
+    if x == req.case_a { return 200 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
+TEST(frontend, parse_import_namespace_named_req_shadows_magic_path) {
+    // An import namespace alias `req` must also block the magic
+    // fast-path: `req.someFn()` should resolve to the imported
+    // function, not get rewritten into request-field access.
+    const std::string dir = "/tmp/rut_import_namespace_req_shadow_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/req.rut", std::ios::binary);
+        out << "func ping() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import "req.rut"
+route GET "/users" { if req.ping() == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+}
+
 TEST(frontend, parse_return_response_with_headers) {
     // Headers dict carries through parser → HIR → MIR → RIR:
     // intern_response_headers writes one set into rir::Module's flat

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -663,6 +663,34 @@ TEST(frontend, parse_method_vs_non_method_compare_rejected) {
     CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
+TEST(frontend, parse_generic_eq_function_accepts_method_instance) {
+    // Calling an `Eq`-constrained generic with Method operands
+    // binds T → Method. Exercises the HIR→MIR copy paths for
+    // struct / variant `instance_type_args` plus the Eq-constraint
+    // check in analyze (which must accept Method as an Eq-capable
+    // scalar). A regression would either fail analyze with
+    // "generic T missing Eq" or die in lower_to_rir when the
+    // Method-typed instance is downgraded to Unknown.
+    const char* src = R"rut(
+func same<T: Eq>(x: T, y: T) -> bool => x == y
+route POST "/x" {
+    if same(req.method, POST) { return 200 } else { return 405 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
 TEST(frontend, parse_method_let_binding_round_trips) {
     // `let m = req.method; guard m == POST else { ... }` — exercises
     // the HIR→MIR type-mapping and carrier-ready paths for Method.

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -663,6 +663,34 @@ TEST(frontend, parse_method_vs_non_method_compare_rejected) {
     CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
+TEST(frontend, parse_const_if_folds_method_eq) {
+    // `if const POST == GET` is a compile-time predicate — analyze
+    // folds the equality during const-eval and picks the else
+    // branch. Requires const_eval_expr to recognise ConstMethod and
+    // fold `==` over HirTypeKind::Method. Before this fix, analyze
+    // failed with UnsupportedSyntax because Method wasn't in the
+    // eval table.
+    const char* src = R"rut(
+route GET "/" {
+    if const POST == GET { return 500 } else { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    // Const-fold chose the else branch → direct return 200. Lower
+    // through MIR/RIR to confirm the whole pipeline stays happy.
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
 TEST(frontend, parse_generic_eq_function_accepts_method_instance) {
     // Calling an `Eq`-constrained generic with Method operands
     // binds T → Method. Exercises the HIR→MIR copy paths for

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -565,10 +565,12 @@ TEST(frontend, parse_upstream_dict_rejects_unknown_field) {
 
 TEST(frontend, parse_guard_req_method_eq_post) {
     // `guard req.method == POST else { return 405 }` — the keystone
-    // use case. Parser yields LitMethod + Field(ReqObject, "method");
-    // analyze resolves both to typed HIR; MIR/RIR downstream carry
-    // the ConstMethod / ReqMethod opcodes. Codegen emits i8 constant
-    // and a helper-call to read the parsed method from the request.
+    // use case. Parser yields LitMethod + Field(Ident("req"), "method");
+    // analyze routes the Field through the magic `req.X` path when
+    // `req` isn't shadowed by a local/variant/import, producing
+    // typed HIR ReqMethod / ConstMethod. MIR/RIR downstream carry
+    // those opcodes; codegen emits an i8 constant and a helper call
+    // that reads the parsed method from the request.
     const char* src =
         "route GET \"/\" { guard req.method == POST else { return 405 } return 200 }\n";
     auto lexed = lex(lit(src));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -593,6 +593,9 @@ TEST(frontend, parse_method_keyword_as_expression) {
     // POST / GET / PUT / DELETE / HEAD / OPTIONS / PATCH each need
     // to parse as standalone expressions with distinct HttpMethod
     // enum values (matching runtime/http_parser.h: GET=0, POST=1, ...).
+    // Asserts the rhs of `req.method == <KW>` is HIR ConstMethod
+    // with the matching enum value so a broken keyword→int mapping
+    // in the parser would fail here, not silently at runtime.
     struct Case {
         const char* src;
         i32 expected_value;
@@ -613,6 +616,17 @@ TEST(frontend, parse_method_keyword_as_expression) {
         REQUIRE(ast);
         auto hir = analyze_file_heap(ast.value());
         REQUIRE(hir);
+        REQUIRE_EQ(hir->routes.len, 1u);
+        REQUIRE_EQ(hir->routes[0].guards.len, 1u);
+        const auto& cond = hir->routes[0].guards[0].cond;
+        REQUIRE_EQ(static_cast<u8>(cond.kind), static_cast<u8>(HirExprKind::Eq));
+        REQUIRE(cond.rhs != nullptr);
+        REQUIRE_EQ(static_cast<u8>(cond.rhs->kind), static_cast<u8>(HirExprKind::ConstMethod));
+        CHECK_EQ(cond.rhs->int_value, tc.expected_value);
+        // Also verify the lhs is req.method (ReqMethod) so a broken
+        // parser that swapped operands wouldn't pass by coincidence.
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(HirExprKind::ReqMethod));
     }
 }
 
@@ -645,6 +659,55 @@ TEST(frontend, parse_method_vs_non_method_compare_rejected) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(!hir);
     CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, parse_method_let_binding_round_trips) {
+    // `let m = req.method; guard m == POST else { ... }` — exercises
+    // the HIR→MIR type-mapping and carrier-ready paths for Method.
+    // If mir_type_kind / shape_carrier_ready dropped Method to
+    // Unknown, the guard's == would see an unknown-shape lhs and
+    // fail in lower_to_rir. Full pipeline through RIR proves Method
+    // flows as a first-class scalar.
+    const char* src =
+        "route POST \"/x\" { let m = req.method guard m == POST else { return 405 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, parse_user_local_req_shadows_magic_path) {
+    // A user who writes `let req = SomeStruct(...); req.field` should
+    // get normal struct-field access on their local, not the magic
+    // request-object path. The magic `req.X` handler only fires when
+    // no local named `req` is in scope; the generic Field resolver
+    // takes over otherwise.
+    const char* src = R"rut(
+struct Box { value: i32 }
+route GET "/users" {
+    let req = Box(value: 42)
+    guard req.value == 42 else { return 500 }
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    // The local binding is the Box struct; req.value resolves to
+    // the struct's i32 field, so the guard compares two i32s rather
+    // than any Method value. Any regression to the magic path would
+    // surface as an "unknown req field" analyze error.
 }
 
 TEST(frontend, parse_return_response_with_headers) {

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -3748,6 +3748,94 @@ TEST(route, populate_route_config_binds_upstream_from_dsl) {
     rir.destroy();
 }
 
+// End-to-end: `guard req.method == POST else { return 405 }` inside a
+// DSL handler. Registers the handler with method=0 so both GET and
+// POST reach it — the guard (not RouteConfig's method filter) is what
+// discriminates. Asserts POST → 200, GET → 405.
+TEST(route, dsl_req_method_guard_real_socket) {
+    using namespace rut;
+
+    const char* src =
+        "route POST \"/x\" { "
+        "guard req.method == POST else { return 405 } "
+        "return 200 "
+        "}\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler_fn = reinterpret_cast<jit::HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler_fn != nullptr);
+
+    RouteConfig cfg{};
+    // method=0 means "any method" — both GET and POST requests reach
+    // the handler so the DSL-level guard is what we're actually
+    // exercising. The DSL's `route POST` token is irrelevant here.
+    REQUIRE(cfg.add_jit_handler("/x", 0, handler_fn));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 100};
+    lt.start();
+
+    // POST /x → guard passes → 200 OK.
+    {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        const char kReq[] = "POST /x HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n";
+        send_all(c, kReq, sizeof(kReq) - 1);
+        char buf[2048];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 1000);
+        close(c);
+        CHECK_GT(n, 0);
+        CHECK(buf_contains(buf, static_cast<u32>(n), "200 OK", 6));
+        CHECK(!buf_contains(buf, static_cast<u32>(n), "405", 3));
+    }
+
+    // GET /x → guard fails → 405.
+    {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        const char kReq[] = "GET /x HTTP/1.1\r\nHost: x\r\n\r\n";
+        send_all(c, kReq, sizeof(kReq) - 1);
+        char buf[2048];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 1000);
+        close(c);
+        CHECK_GT(n, 0);
+        CHECK(buf_contains(buf, static_cast<u32>(n), "405", 3));
+        CHECK(!buf_contains(buf, static_cast<u32>(n), "200 OK", 6));
+    }
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
 int main(int argc, char** argv) {
     return rut::test::run_all(argc, argv);
 }

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -3799,34 +3799,39 @@ TEST(route, dsl_req_method_guard_real_socket) {
     loop->config_ptr = &active;
     LoopThread lt = {loop, {}, 100};
     lt.start();
+    usleep(10000);  // let accept registration settle before the first client connect
+
+    // Helper: send one request and record response + pass/fail
+    // against expected substrings. Uses CHECK (not REQUIRE) and
+    // guards socket use behind fd >= 0 so lt.stop() still runs at
+    // the end — REQUIRE's early-return would leak the loop thread.
+    auto exercise = [&](const char* req,
+                        u32 req_len,
+                        const char* want,
+                        u32 want_len,
+                        const char* reject,
+                        u32 reject_len) {
+        const i32 c = connect_to(port);
+        CHECK_GE(c, 0);
+        if (c < 0) return;
+        send_all(c, req, req_len);
+        char buf[2048];
+        const i32 n = recv_timeout(c, buf, sizeof(buf), 1000);
+        close(c);
+        CHECK_GT(n, 0);
+        if (n <= 0) return;
+        const auto len = static_cast<u32>(n);
+        CHECK(buf_contains(buf, len, want, want_len));
+        CHECK(!buf_contains(buf, len, reject, reject_len));
+    };
 
     // POST /x → guard passes → 200 OK.
-    {
-        i32 c = connect_to(port);
-        REQUIRE(c >= 0);
-        const char kReq[] = "POST /x HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n";
-        send_all(c, kReq, sizeof(kReq) - 1);
-        char buf[2048];
-        i32 n = recv_timeout(c, buf, sizeof(buf), 1000);
-        close(c);
-        CHECK_GT(n, 0);
-        CHECK(buf_contains(buf, static_cast<u32>(n), "200 OK", 6));
-        CHECK(!buf_contains(buf, static_cast<u32>(n), "405", 3));
-    }
+    const char kPostReq[] = "POST /x HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n";
+    exercise(kPostReq, sizeof(kPostReq) - 1, "200 OK", 6, "405", 3);
 
     // GET /x → guard fails → 405.
-    {
-        i32 c = connect_to(port);
-        REQUIRE(c >= 0);
-        const char kReq[] = "GET /x HTTP/1.1\r\nHost: x\r\n\r\n";
-        send_all(c, kReq, sizeof(kReq) - 1);
-        char buf[2048];
-        i32 n = recv_timeout(c, buf, sizeof(buf), 1000);
-        close(c);
-        CHECK_GT(n, 0);
-        CHECK(buf_contains(buf, static_cast<u32>(n), "405", 3));
-        CHECK(!buf_contains(buf, static_cast<u32>(n), "200 OK", 6));
-    }
+    const char kGetReq[] = "GET /x HTTP/1.1\r\nHost: x\r\n\r\n";
+    exercise(kGetReq, sizeof(kGetReq) - 1, "405", 3, "200 OK", 6);
 
     lt.stop();
     loop->shutdown();


### PR DESCRIPTION
## Summary

Adds the `req.method` request access primitive and HTTP method keywords (GET, POST, …) as expressions so DSL can gate on method:

```rut
route POST "/x" {
    guard req.method == POST else { return 405 }
    return 200
}
```

- **Parser**: `req` is a leaf only when followed by `.` (falls back to plain identifier otherwise). Method keywords in expression position become `LitMethod` nodes carrying the HttpMethod enum value.
- **Analyze**: new `HirExprKind::ReqMethod` / `ConstMethod` + `HirTypeKind::Method`. `req.X` resolves before the generic Field path; bare `req` rejected.
- **MIR/RIR/codegen**: Method flows through as i8 via the existing `ConstMethod` / `ReqMethod` opcodes and `rut_helper_req_method` runtime helper — no codegen changes, just wiring.
- **Bool guard fix**: `analyze_guard_cond` was folding any non-errorable condition to `true`, silently turning `guard <bool> else { ... }` into a no-op. Plain Bool, non-nil, non-error expressions now pass through as the guard condition — matching the Swift-inspired reject-or-continue semantics documented in DESIGN.md §3.

## Test plan

- [x] `./dev.sh build` clean
- [x] `./dev.sh test` — all suites green (no regressions from the guard-cond fix)
- [x] `./dev.sh format` — clean
- [x] Frontend tests: full lex → MIR → RIR pipeline, all 7 method keywords (GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS), `req.bogus` rejected, Method-vs-non-Method `==` rejected
- [x] Integration test: real socket, `POST /x → 200` and `GET /x → 405` through the full lex → JIT → epoll loop path

🤖 Generated with [Claude Code](https://claude.com/claude-code)