### PR TITLE
[codex] Add io_uring smoke coverage

### DIFF
--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1377,6 +1377,13 @@ TEST(uring, wait_copies_recv_into_conn_buffer) {
     tc.init(0, fds[0]);
     Connection& conn = tc.conn;
 
+    // Push the timerfd far out so the already-armed periodic tick can't race
+    // the recv CQE under scheduler stalls. The SUT here is the provided-buffer
+    // recv copy path, not timer/recv ordering.
+    struct itimerspec ts{};
+    ts.it_value.tv_sec = 60;
+    REQUIRE_EQ(timerfd_settime(backend.timer_fd, 0, &ts, nullptr), 0);
+
     REQUIRE(backend.add_recv(fds[0], conn.id));
     static const u8 kReq[] = "GET / HTTP/1.1\r\n\r\n";
     REQUIRE(send_all(fds[1], reinterpret_cast<const char*>(kReq), sizeof(kReq) - 1));

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1388,16 +1388,24 @@ TEST(uring, wait_copies_recv_into_conn_buffer) {
     static const u8 kReq[] = "GET / HTTP/1.1\r\n\r\n";
     REQUIRE(send_all(fds[1], reinterpret_cast<const char*>(kReq), sizeof(kReq) - 1));
 
+    // Defence in depth: the timerfd push above already removes the only
+    // competing CQE source, so one wait() should suffice. Still, bound-retry
+    // across up to 8 wait() calls so any unexpected non-Recv CQE (future
+    // backend changes, probe/cancel side effects) cannot flake the assertion.
     IoEvent events[4]{};
-    const u32 n = backend.wait(events, 4, &conn, 1);
-    REQUIRE_GE(n, 1u);
     const IoEvent* recv_ev = nullptr;
-    for (u32 i = 0; i < n; ++i) {
-        if (events[i].type == IoEventType::Recv) {
-            recv_ev = &events[i];
-            break;
+    bool saw_any_event = false;
+    for (u32 attempt = 0; attempt < 8 && recv_ev == nullptr; ++attempt) {
+        u32 n = backend.wait(events, 4, &conn, 1);
+        if (n > 0) saw_any_event = true;
+        for (u32 i = 0; i < n; ++i) {
+            if (events[i].type == IoEventType::Recv) {
+                recv_ev = &events[i];
+                break;
+            }
         }
     }
+    REQUIRE(saw_any_event);
     REQUIRE(recv_ev != nullptr);
     CHECK_EQ(recv_ev->conn_id, conn.id);
     CHECK_EQ(recv_ev->result, static_cast<i32>(sizeof(kReq) - 1));

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1377,25 +1377,20 @@ TEST(uring, wait_copies_recv_into_conn_buffer) {
     tc.init(0, fds[0]);
     Connection& conn = tc.conn;
 
-    // Push the timerfd far out so the already-armed periodic tick can't race
-    // the recv CQE under scheduler stalls. The SUT here is the provided-buffer
-    // recv copy path, not timer/recv ordering.
-    struct itimerspec ts{};
-    ts.it_value.tv_sec = 60;
-    REQUIRE_EQ(timerfd_settime(backend.timer_fd, 0, &ts, nullptr), 0);
-
     REQUIRE(backend.add_recv(fds[0], conn.id));
     static const u8 kReq[] = "GET / HTTP/1.1\r\n\r\n";
     static constexpr u32 kExpectedLen = sizeof(kReq) - 1;
     REQUIRE(send_all(fds[1], reinterpret_cast<const char*>(kReq), kExpectedLen));
 
-    // Defence in depth:
-    //   - the timerfd push above removes today's only competing CQE source
-    //   - POSIX permits SOCK_STREAM recv to return partial reads, so the
-    //     18 bytes could in principle arrive across multiple Recv CQEs
-    // Loop wait() up to 8 times accumulating Recv events until recv_buf
-    // holds the full request. add_recv uses IORING_RECV_MULTISHOT, so one
-    // SQE yields multiple CQEs without resubmission.
+    // Accumulate Recv CQEs across wait() calls until recv_buf holds the full
+    // request (POSIX permits SOCK_STREAM recv to split an 18-byte write across
+    // CQEs; non-Recv CQEs are skipped). add_recv uses IORING_RECV_MULTISHOT,
+    // so one SQE yields multiple CQEs without resubmission.
+    //
+    // The 8-attempt cap + init's default 1s periodic timerfd act together as
+    // a hang guard: if multishot recv is silently broken (error CQE, no
+    // buffer, etc.), timer CQEs wake wait() every 1s and the loop exits in
+    // ~8s with a clean REQUIRE failure instead of deadlocking.
     IoEvent events[4]{};
     bool saw_any_event = false;
     bool saw_recv_event = false;

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1289,7 +1289,7 @@ TEST(tls_state_machine, spurious_epollout_with_empty_tls_send_state_is_ignored) 
     backend.shutdown();
 }
 
-// === io_uring backend (TODO #3 + #4) ===
+// === io_uring backend smoke coverage ===
 
 // Verify IoUringBackend::init creates a timerfd
 TEST(uring, init_creates_timerfd) {
@@ -1326,6 +1326,69 @@ TEST(uring, return_buffer_no_crash) {
     backend.return_buffer(static_cast<u16>(kProvidedBufCount - 1));
     backend.shutdown();
     close(lfd);
+}
+
+// Verify wait() turns a timerfd expiration into a Timeout IoEvent.
+TEST(uring, wait_emits_timeout_tick) {
+    IoUringBackend backend;
+    i32 lfd = create_listen_socket(0).value_or(-1);
+    REQUIRE(lfd >= 0);
+    auto rc = backend.init(0, lfd);
+    if (!rc) {
+        close(lfd);
+        CHECK(true);
+        return;
+    }
+
+    // Override the default 1-second periodic tick with an immediate one-shot
+    // so the already-armed timer read completes on this wait().
+    struct itimerspec ts{};
+    ts.it_value.tv_nsec = 1;
+    REQUIRE_EQ(timerfd_settime(backend.timer_fd, 0, &ts, nullptr), 0);
+
+    IoEvent events[4]{};
+    const u32 n = backend.wait(events, 4, nullptr, 0);
+    REQUIRE_GE(n, 1u);
+    CHECK_EQ(events[0].type, IoEventType::Timeout);
+    CHECK_EQ(events[0].result, 1);
+    CHECK_EQ(events[0].has_buf, 0u);
+    CHECK_EQ(events[0].buf_id, 0u);
+
+    backend.shutdown();
+    close(lfd);
+}
+
+// Verify provided-buffer recv CQEs are copied into Connection.recv_buf and the
+// emitted IoEvent no longer owns a provided buffer.
+TEST(uring, wait_copies_recv_into_conn_buffer) {
+    i32 fds[2];
+    REQUIRE_EQ(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fds), 0);
+
+    IoUringBackend backend;
+    REQUIRE(backend.init(0, -1).has_value());
+
+    TestConn tc;
+    tc.init(0, fds[0]);
+    Connection& conn = tc.conn;
+
+    REQUIRE(backend.add_recv(fds[0], conn.id));
+    static const u8 kReq[] = "GET / HTTP/1.1\r\n\r\n";
+    REQUIRE(send_all(fds[1], reinterpret_cast<const char*>(kReq), sizeof(kReq) - 1));
+
+    IoEvent events[4]{};
+    const u32 n = backend.wait(events, 4, &conn, 1);
+    REQUIRE_GE(n, 1u);
+    CHECK_EQ(events[0].conn_id, conn.id);
+    CHECK_EQ(events[0].type, IoEventType::Recv);
+    CHECK_EQ(events[0].result, static_cast<i32>(sizeof(kReq) - 1));
+    CHECK_EQ(events[0].has_buf, 0u);
+    CHECK_EQ(events[0].buf_id, 0u);
+    REQUIRE_EQ(conn.recv_buf.len(), sizeof(kReq) - 1);
+    CHECK_EQ(memcmp(conn.recv_buf.data(), kReq, sizeof(kReq) - 1), 0);
+
+    close(fds[0]);
+    close(fds[1]);
+    backend.shutdown();
 }
 
 // === Shard lifecycle ===

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1350,7 +1350,7 @@ TEST(uring, wait_emits_timeout_tick) {
     const u32 n = backend.wait(events, 4, nullptr, 0);
     REQUIRE_GE(n, 1u);
     CHECK_EQ(events[0].type, IoEventType::Timeout);
-    CHECK_EQ(events[0].result, 1);
+    CHECK_GE(events[0].result, 1);
     CHECK_EQ(events[0].has_buf, 0u);
     CHECK_EQ(events[0].buf_id, 0u);
 
@@ -1365,7 +1365,13 @@ TEST(uring, wait_copies_recv_into_conn_buffer) {
     REQUIRE_EQ(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fds), 0);
 
     IoUringBackend backend;
-    REQUIRE(backend.init(0, -1).has_value());
+    auto init_rc = backend.init(0, -1);
+    if (!init_rc) {
+        close(fds[0]);
+        close(fds[1]);
+        CHECK(true);
+        return;
+    }
 
     TestConn tc;
     tc.init(0, fds[0]);
@@ -1378,11 +1384,18 @@ TEST(uring, wait_copies_recv_into_conn_buffer) {
     IoEvent events[4]{};
     const u32 n = backend.wait(events, 4, &conn, 1);
     REQUIRE_GE(n, 1u);
-    CHECK_EQ(events[0].conn_id, conn.id);
-    CHECK_EQ(events[0].type, IoEventType::Recv);
-    CHECK_EQ(events[0].result, static_cast<i32>(sizeof(kReq) - 1));
-    CHECK_EQ(events[0].has_buf, 0u);
-    CHECK_EQ(events[0].buf_id, 0u);
+    const IoEvent* recv_ev = nullptr;
+    for (u32 i = 0; i < n; ++i) {
+        if (events[i].type == IoEventType::Recv) {
+            recv_ev = &events[i];
+            break;
+        }
+    }
+    REQUIRE(recv_ev != nullptr);
+    CHECK_EQ(recv_ev->conn_id, conn.id);
+    CHECK_EQ(recv_ev->result, static_cast<i32>(sizeof(kReq) - 1));
+    CHECK_EQ(recv_ev->has_buf, 0u);
+    CHECK_EQ(recv_ev->buf_id, 0u);
     REQUIRE_EQ(conn.recv_buf.len(), sizeof(kReq) - 1);
     CHECK_EQ(memcmp(conn.recv_buf.data(), kReq, sizeof(kReq) - 1), 0);
 

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1347,7 +1347,7 @@ TEST(uring, wait_emits_timeout_tick) {
     REQUIRE_EQ(timerfd_settime(backend.timer_fd, 0, &ts, nullptr), 0);
 
     IoEvent events[4]{};
-    const u32 n = backend.wait(events, 4, nullptr, 0);
+    u32 n = backend.wait(events, 4, nullptr, 0);
     REQUIRE_GE(n, 1u);
     CHECK_EQ(events[0].type, IoEventType::Timeout);
     CHECK_GE(events[0].result, 1);
@@ -1386,33 +1386,35 @@ TEST(uring, wait_copies_recv_into_conn_buffer) {
 
     REQUIRE(backend.add_recv(fds[0], conn.id));
     static const u8 kReq[] = "GET / HTTP/1.1\r\n\r\n";
-    REQUIRE(send_all(fds[1], reinterpret_cast<const char*>(kReq), sizeof(kReq) - 1));
+    static constexpr u32 kExpectedLen = sizeof(kReq) - 1;
+    REQUIRE(send_all(fds[1], reinterpret_cast<const char*>(kReq), kExpectedLen));
 
-    // Defence in depth: the timerfd push above already removes the only
-    // competing CQE source, so one wait() should suffice. Still, bound-retry
-    // across up to 8 wait() calls so any unexpected non-Recv CQE (future
-    // backend changes, probe/cancel side effects) cannot flake the assertion.
+    // Defence in depth:
+    //   - the timerfd push above removes today's only competing CQE source
+    //   - POSIX permits SOCK_STREAM recv to return partial reads, so the
+    //     18 bytes could in principle arrive across multiple Recv CQEs
+    // Loop wait() up to 8 times accumulating Recv events until recv_buf
+    // holds the full request. add_recv uses IORING_RECV_MULTISHOT, so one
+    // SQE yields multiple CQEs without resubmission.
     IoEvent events[4]{};
-    const IoEvent* recv_ev = nullptr;
     bool saw_any_event = false;
-    for (u32 attempt = 0; attempt < 8 && recv_ev == nullptr; ++attempt) {
+    bool saw_recv_event = false;
+    for (u32 attempt = 0; attempt < 8 && conn.recv_buf.len() < kExpectedLen; ++attempt) {
         u32 n = backend.wait(events, 4, &conn, 1);
         if (n > 0) saw_any_event = true;
         for (u32 i = 0; i < n; ++i) {
-            if (events[i].type == IoEventType::Recv) {
-                recv_ev = &events[i];
-                break;
-            }
+            if (events[i].type != IoEventType::Recv) continue;
+            saw_recv_event = true;
+            CHECK_EQ(events[i].conn_id, conn.id);
+            CHECK_GT(events[i].result, 0);
+            CHECK_EQ(events[i].has_buf, 0u);
+            CHECK_EQ(events[i].buf_id, 0u);
         }
     }
     REQUIRE(saw_any_event);
-    REQUIRE(recv_ev != nullptr);
-    CHECK_EQ(recv_ev->conn_id, conn.id);
-    CHECK_EQ(recv_ev->result, static_cast<i32>(sizeof(kReq) - 1));
-    CHECK_EQ(recv_ev->has_buf, 0u);
-    CHECK_EQ(recv_ev->buf_id, 0u);
-    REQUIRE_EQ(conn.recv_buf.len(), sizeof(kReq) - 1);
-    CHECK_EQ(memcmp(conn.recv_buf.data(), kReq, sizeof(kReq) - 1), 0);
+    REQUIRE(saw_recv_event);
+    REQUIRE_EQ(conn.recv_buf.len(), kExpectedLen);
+    CHECK_EQ(memcmp(conn.recv_buf.data(), kReq, kExpectedLen), 0);
 
     close(fds[0]);
     close(fds[1]);

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -1426,7 +1426,7 @@ TEST(partial_send, backend_gets_correct_buffer) {
     CHECK_EQ(op->send_len, c->send_buf.len());
 }
 
-// === io_uring integration (TODO #3 + #4) ===
+// === io_uring dispatch semantics ===
 
 // Verify Timeout event with tick count is properly dispatched
 TEST(uring_timer, timeout_dispatches_tick) {


### PR DESCRIPTION
## Summary

- add real `IoUringBackend` smoke tests for timer tick delivery and provided-buffer recv copying
- update the old `TODO #3 + #4` section headers to describe the current io_uring coverage more accurately
- keep the change scoped to tests and coverage only; no runtime behavior changes

## Why

The io_uring backend already implements the timer tick and provided-buffer handling paths, but the nearby test grouping still read like unfinished TODO buckets. This PR adds backend-level smoke coverage that exercises the implemented `wait()` behavior directly and brings the test annotations back in sync with reality.

## Impact

- improves confidence that `IoUringBackend::wait()` emits `Timeout` events from `timer_fd`
- verifies provided-buffer recv completions are copied into `Connection.recv_buf` and released before dispatch
- reduces confusion around the remaining io_uring work by removing stale TODO wording from the test files

## Validation

- `build/tests/test_network --filter=uring_timer.*,uring_buf.*`
- `build/tests/test_integration --filter=uring.*`
