### PR TITLE
DSL: arrays + for-loop frontend (Phase 1-3b, MIR unroll deferred)

### DIFF
--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -111,10 +111,13 @@ struct AstExpr {
     AstExpr* rhs = nullptr;
     static constexpr u32 kMaxFieldInits = 8;
     // Shared capacity for tuple elements, call arguments, field inits, and
-    // array literals. 8 was historically too tight for array literals (DSL
-    // allowlists / upstream pools routinely exceed 8); 32 covers the common
-    // case with bounded per-AstExpr footprint (~192 bytes extra vs 8).
-    static constexpr u32 kMaxArgs = 32;
+    // array literals. HirExpr::kMaxArgs must stay at 8 (HirRoute stack
+    // budget — see the comment there), so keeping AstExpr at 8 too means
+    // ArrayLit with > 8 elements fails at parse with TooManyItems at the
+    // 9th element's span, instead of parsing successfully and then failing
+    // ambiguously in analyze. Once HIR gets an out-of-line element pool
+    // for arrays, both caps can rise together.
+    static constexpr u32 kMaxArgs = 8;
     FixedVec<FieldInit, kMaxFieldInits> field_inits;
     FixedVec<AstTypeRef, kMaxTypeArgs> type_args;
     FixedVec<AstExpr*, kMaxArgs> args;

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -33,8 +33,11 @@ enum class AstStmtKind : u8 {
     //   - then_stmt   = body block (via parse_braced_stmt_body; may be a single
     //                   stmt if the block contained exactly one stmt)
     // No break / continue / else / labels (spec §3.3.9: every iteration runs
-    // to completion). Analyze (Phase 3) enforces iteration source is array-typed
-    // and compile-time-sized; MIR (Phase 4) fully unrolls the loop.
+    // to completion). Analyze (Phase 3b) enforces the iteration source is
+    // array-typed and compile-time-sized and builds a HirForLoop. MIR build
+    // currently rejects any route carrying for_loops (Phase 4a) — the full
+    // unroll (loop-var substitution + per-iteration guard blocks) lands in
+    // Phase 4b.
     For,
 };
 

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -27,6 +27,15 @@ enum class AstStmtKind : u8 {
     Match,
     Block,
     Wait,  // `wait(N)` — suspend handler for N milliseconds (v1: IntLit only)
+    // `for <name> in <expr> { <body> }`. Fields reused from AstStatement:
+    //   - name        = loop variable identifier (e.g., "item" in `for item in xs`)
+    //   - expr        = iteration source expression (must type-check as Array<T>)
+    //   - then_stmt   = body block (via parse_braced_stmt_body; may be a single
+    //                   stmt if the block contained exactly one stmt)
+    // No break / continue / else / labels (spec §3.3.9: every iteration runs
+    // to completion). Analyze (Phase 3) enforces iteration source is array-typed
+    // and compile-time-sized; MIR (Phase 4) fully unrolls the loop.
+    For,
 };
 
 // Single response header key/value pair, used by `response(N, headers: {...})`.
@@ -41,6 +50,12 @@ enum class AstExprKind : u8 {
     IntLit,
     StrLit,
     Tuple,
+    // Array literal `[e1, e2, ...]` — elements stored in `args`.
+    // Parser accepts empty `[]`; analyze enforces "empty requires type annotation"
+    // since Rutlang has no push/append and all sizes are compile-time known.
+    // Surface `[T]` type syntax desugars to `AstTypeRef{name="Array", type_args=[T]}`
+    // in parse_func_type_ref.
+    ArrayLit,
     StructInit,
     Placeholder,
     VariantCase,
@@ -93,7 +108,11 @@ struct AstExpr {
     AstExpr* lhs = nullptr;
     AstExpr* rhs = nullptr;
     static constexpr u32 kMaxFieldInits = 8;
-    static constexpr u32 kMaxArgs = 8;
+    // Shared capacity for tuple elements, call arguments, field inits, and
+    // array literals. 8 was historically too tight for array literals (DSL
+    // allowlists / upstream pools routinely exceed 8); 32 covers the common
+    // case with bounded per-AstExpr footprint (~192 bytes extra vs 8).
+    static constexpr u32 kMaxArgs = 32;
     FixedVec<FieldInit, kMaxFieldInits> field_inits;
     FixedVec<AstTypeRef, kMaxTypeArgs> type_args;
     FixedVec<AstExpr*, kMaxArgs> args;

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -51,10 +51,12 @@ enum class AstExprKind : u8 {
     StrLit,
     Tuple,
     // Array literal `[e1, e2, ...]` — elements stored in `args`.
-    // Parser accepts empty `[]`; analyze enforces "empty requires type annotation"
-    // since Rutlang has no push/append and all sizes are compile-time known.
-    // Surface `[T]` type syntax desugars to `AstTypeRef{name="Array", type_args=[T]}`
-    // in parse_func_type_ref.
+    // Parser accepts empty `[]`; analyze currently rejects empty array
+    // literals unconditionally (Rutlang has no push/append so the element
+    // type can't be inferred later). Contextual inference from a surrounding
+    // type annotation is deferred; until then `let xs: [i32] = []` also
+    // errors.  Surface `[T]` type syntax desugars to
+    // `AstTypeRef{name="Array", type_args=[T]}` in parse_func_type_ref.
     ArrayLit,
     StructInit,
     Placeholder,

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -53,9 +53,11 @@ enum class HirExprKind : u8 {
     StrLit,
     Tuple,
     // Array literal: elements stored in `args`. analyze rejects heterogeneous
-    // arrays and empty `[]` without a type annotation (Rutlang has no
-    // push/append so size + element type must be compile-time known). The
-    // result's HirTypeShape carries array_len + array_elem_shape_index.
+    // arrays and empty `[]` (Rutlang has no push/append so size + element
+    // type must be compile-time known; contextual inference from annotations
+    // is deferred — empty literals currently error even with an annotation).
+    // Element count is a value property on `HirExpr.array_len`, not a type
+    // property; the result's HirTypeShape carries only `array_elem_shape_index`.
     ArrayLit,
     TupleSlot,
     VariantCase,
@@ -95,10 +97,12 @@ enum class HirTypeKind : u8 {
     Struct,
     Method,
     // Homogeneous fixed-size sequence. Carrier for `for x in <arr>` iteration.
-    // Complete type info lives in HirTypeShape via (array_len,
-    // array_elem_shape_index) — composite-type host structures (HirLocal,
-    // HirExpr, etc.) reference it through their existing `shape_index`
-    // rather than mirroring inline fields.
+    // Type-shape info lives in HirTypeShape via `array_elem_shape_index`
+    // alone; length is a *value* property on `HirExpr.array_len` so two
+    // arrays with the same element type but different lengths share one
+    // shape. Composite-type host structures (HirLocal, HirExpr, etc.)
+    // reference the shape through their existing `shape_index` rather than
+    // mirroring inline fields.
     Array,
 };
 
@@ -320,7 +324,14 @@ struct HirExpr {
     HirExpr* lhs = nullptr;
     HirExpr* rhs = nullptr;
     static constexpr u32 kMaxFieldInits = 8;
-    static constexpr u32 kMaxArgs = 32;  // shared w/ AstExpr::kMaxArgs (Phase 1)
+    // HIR-level cap stays at 8 even though AstExpr::kMaxArgs = 32: HirRoute
+    // sits at ~300 KB on stack and is copied on each recursive
+    // analyze_file_internal call (via `HirRoute scratch{}`). A 32-wide cap
+    // here inflates the exprs / locals / for_loops pools enough to blow the
+    // 8 MB thread stack during cyclic-import tests. Phase 3a's ArrayLit
+    // analyze catches > kMaxArgs element arrays cleanly; a larger HIR cap
+    // can land when we introduce an out-of-line array-element pool.
+    static constexpr u32 kMaxArgs = 8;
     FixedVec<FieldInit, kMaxFieldInits> field_inits;
     FixedVec<HirExpr*, kMaxArgs> args;
 };
@@ -680,7 +691,11 @@ struct HirControl {
 // body's guards/terminator point into the parent HirRoute::exprs pool — so
 // HirRoute::rebase_from must walk this substructure too.
 struct HirForLoopBody {
-    static constexpr u32 kMaxGuards = 4;
+    // 2 guards cover the canonical DESIGN.md examples (1 guard short-circuits
+    // the request, rarely 2 for compound checks). Each HirGuard is ~4.5 KB
+    // inline, so raising this directly grows HirRoute on the stack — see
+    // HirExpr::kMaxArgs comment for the recursive-analyze stack budget.
+    static constexpr u32 kMaxGuards = 2;
     FixedVec<HirGuard, kMaxGuards> guards;
     HirTerminator term{};
     bool has_term = false;
@@ -724,7 +739,11 @@ struct HirRoute {
     static constexpr u32 kMaxExprs = 64;
     static constexpr u32 kMaxDecorators = 8;
     static constexpr u32 kMaxWaits = 4;
-    static constexpr u32 kMaxForLoops = 4;
+    // 2 for-loops per route covers realistic DSL patterns (one allowlist
+    // check + one server-pool iteration) while keeping HirRoute under the
+    // stack budget. Each HirForLoop is ~10 KB even at kMaxGuards=2; a
+    // larger cap would push HirRoute past the recursive-analyze budget.
+    static constexpr u32 kMaxForLoops = 2;
     FixedVec<HirExpr, kMaxExprs> exprs;
     FixedVec<HirLocal, kMaxLocals> locals;
     FixedVec<HirGuard, kMaxGuards> guards;

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -687,9 +687,11 @@ struct HirControl {
 
 // Body of a `for ... in` loop. Phase 3b MVP: body is `guard*` plus an
 // optional terminator (return / forward). Lets, nested for-loops, and
-// arbitrary if/match are deferred to later phases. All HirExpr* inside this
-// body's guards/terminator point into the parent HirRoute::exprs pool — so
-// HirRoute::rebase_from must walk this substructure too.
+// arbitrary if/match are deferred to later phases. The body's guards carry
+// inline HirExpr cond subtrees whose lhs/rhs/args* point into the parent
+// HirRoute::exprs pool; HirRoute::rebase_from must walk them. HirTerminator
+// has no HirExpr pointers (only status_code / upstream_index / response
+// strings), so it doesn't participate in rebase.
 struct HirForLoopBody {
     // 2 guards cover the canonical DESIGN.md examples (1 guard short-circuits
     // the request, rarely 2 for compound checks). Each HirGuard is ~4.5 KB
@@ -708,8 +710,11 @@ struct HirForLoop {
     // subfields point into HirRoute::exprs, so they need rebase too.
     HirExpr iter_expr{};
     // Loop variable (e.g., `item` in `for item in xs`). Scope is the body
-    // only; analyze pushes it into route.locals, analyzes the body, then
-    // rolls back route.locals.len so the name doesn't leak.
+    // only. analyze pushes it into route.locals so body HirExpr LocalRefs
+    // bind to a stable ref_index (required once MIR unroll substitutes per
+    // iteration), then *clears the name* after body analysis — Ident
+    // resolution scans locals by name so post-loop code can't reach the
+    // loop variable, and next_local_ref_index still won't reuse the slot.
     Str loop_var_name{};
     HirTypeKind loop_var_type = HirTypeKind::Unknown;
     u32 loop_var_variant_index = 0xffffffffu;

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -52,6 +52,11 @@ enum class HirExprKind : u8 {
     IntLit,
     StrLit,
     Tuple,
+    // Array literal: elements stored in `args`. analyze rejects heterogeneous
+    // arrays and empty `[]` without a type annotation (Rutlang has no
+    // push/append so size + element type must be compile-time known). The
+    // result's HirTypeShape carries array_len + array_elem_shape_index.
+    ArrayLit,
     TupleSlot,
     VariantCase,
     IfElse,
@@ -89,6 +94,12 @@ enum class HirTypeKind : u8 {
     Tuple,
     Struct,
     Method,
+    // Homogeneous fixed-size sequence. Carrier for `for x in <arr>` iteration.
+    // Complete type info lives in HirTypeShape via (array_len,
+    // array_elem_shape_index) — composite-type host structures (HirLocal,
+    // HirExpr, etc.) reference it through their existing `shape_index`
+    // rather than mirroring inline fields.
+    Array,
 };
 
 inline constexpr u32 kMaxTupleSlots = 10;
@@ -101,6 +112,13 @@ struct HirTypeShape {
     u32 struct_index = 0xffffffffu;
     u32 tuple_len = 0;
     u32 tuple_elem_shape_indices[kMaxTupleSlots]{};
+    // Array-typed shape: array_elem_shape_index points at another
+    // HirTypeShape in HirModule::type_shapes describing the element type.
+    // Length is a *value* property (lives on HirExpr.array_len, carried
+    // forward to MIR for unroll) — not a type property, so two arrays of
+    // the same element type with different lengths still share one shape.
+    // Sentinel: type != Array → array_elem_shape_index = 0xffffffffu.
+    u32 array_elem_shape_index = 0xffffffffu;
 };
 
 struct HirProtocol {
@@ -296,10 +314,13 @@ struct HirExpr {
     u32 error_struct_index = 0xffffffffu;
     u32 error_variant_index = 0xffffffffu;
     u32 error_case_index = 0xffffffffu;
+    // For HirExprKind::ArrayLit: compile-time-known element count. Elements
+    // themselves live in `args`. For non-Array exprs: 0.
+    u32 array_len = 0;
     HirExpr* lhs = nullptr;
     HirExpr* rhs = nullptr;
     static constexpr u32 kMaxFieldInits = 8;
-    static constexpr u32 kMaxArgs = 8;
+    static constexpr u32 kMaxArgs = 32;  // shared w/ AstExpr::kMaxArgs (Phase 1)
     FixedVec<FieldInit, kMaxFieldInits> field_inits;
     FixedVec<HirExpr*, kMaxArgs> args;
 };
@@ -653,6 +674,35 @@ struct HirControl {
     HirTerminator direct_term{};
 };
 
+// Body of a `for ... in` loop. Phase 3b MVP: body is `guard*` plus an
+// optional terminator (return / forward). Lets, nested for-loops, and
+// arbitrary if/match are deferred to later phases. All HirExpr* inside this
+// body's guards/terminator point into the parent HirRoute::exprs pool — so
+// HirRoute::rebase_from must walk this substructure too.
+struct HirForLoopBody {
+    static constexpr u32 kMaxGuards = 4;
+    FixedVec<HirGuard, kMaxGuards> guards;
+    HirTerminator term{};
+    bool has_term = false;
+};
+
+struct HirForLoop {
+    Span span{};
+    // Iteration source. Must type-check as Array<T>; the element type T
+    // binds the loop variable's HirTypeKind below. iter_expr's HirExpr*
+    // subfields point into HirRoute::exprs, so they need rebase too.
+    HirExpr iter_expr{};
+    // Loop variable (e.g., `item` in `for item in xs`). Scope is the body
+    // only; analyze pushes it into route.locals, analyzes the body, then
+    // rolls back route.locals.len so the name doesn't leak.
+    Str loop_var_name{};
+    HirTypeKind loop_var_type = HirTypeKind::Unknown;
+    u32 loop_var_variant_index = 0xffffffffu;
+    u32 loop_var_struct_index = 0xffffffffu;
+    u32 loop_var_shape_index = 0xffffffffu;
+    HirForLoopBody body{};
+};
+
 struct HirRoute {
     struct DecoratorRef {
         Span span{};
@@ -674,11 +724,13 @@ struct HirRoute {
     static constexpr u32 kMaxExprs = 64;
     static constexpr u32 kMaxDecorators = 8;
     static constexpr u32 kMaxWaits = 4;
+    static constexpr u32 kMaxForLoops = 4;
     FixedVec<HirExpr, kMaxExprs> exprs;
     FixedVec<HirLocal, kMaxLocals> locals;
     FixedVec<HirGuard, kMaxGuards> guards;
     FixedVec<DecoratorRef, kMaxDecorators> decorators;
     FixedVec<Wait, kMaxWaits> waits;
+    FixedVec<HirForLoop, kMaxForLoops> for_loops;
     HirControl control{};
     u32 error_variant_index = 0xffffffffu;
 
@@ -692,6 +744,7 @@ struct HirRoute {
           guards(other.guards),
           decorators(other.decorators),
           waits(other.waits),
+          for_loops(other.for_loops),
           control(other.control),
           error_variant_index(other.error_variant_index) {
         rebase_from(other);
@@ -706,6 +759,7 @@ struct HirRoute {
         guards = other.guards;
         decorators = other.decorators;
         waits = other.waits;
+        for_loops = other.for_loops;
         control = other.control;
         error_variant_index = other.error_variant_index;
         rebase_from(other);
@@ -720,6 +774,7 @@ struct HirRoute {
           guards(other.guards),
           decorators(other.decorators),
           waits(other.waits),
+          for_loops(other.for_loops),
           control(other.control),
           error_variant_index(other.error_variant_index) {
         rebase_from(other);
@@ -734,6 +789,7 @@ struct HirRoute {
         guards = other.guards;
         decorators = other.decorators;
         waits = other.waits;
+        for_loops = other.for_loops;
         control = other.control;
         error_variant_index = other.error_variant_index;
         rebase_from(other);
@@ -768,6 +824,16 @@ private:
             rebase_expr(guards[i].cond, other);
             rebase_expr(guards[i].fail_match_expr, other);
             rebase_expr(guards[i].fail_body.cond, other);
+        }
+        // For-loops: iter_expr and the body's guard conds all point into
+        // `exprs`, so rebase them the same way as top-level guards.
+        for (u32 i = 0; i < for_loops.len; i++) {
+            rebase_expr(for_loops[i].iter_expr, other);
+            for (u32 gi = 0; gi < for_loops[i].body.guards.len; gi++) {
+                rebase_expr(for_loops[i].body.guards[gi].cond, other);
+                rebase_expr(for_loops[i].body.guards[gi].fail_match_expr, other);
+                rebase_expr(for_loops[i].body.guards[gi].fail_body.cond, other);
+            }
         }
         rebase_expr(control.cond, other);
         rebase_expr(control.match_expr, other);

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -2288,6 +2288,11 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                             const HirLocal* locals,
                                             u32 local_count,
                                             const MatchPayloadBinding* binding);
+static FrontendResult<HirExpr> analyze_array_iter_expr(const AstExpr& expr,
+                                                       HirRoute* route,
+                                                       const HirModule& mod,
+                                                       const HirLocal* locals,
+                                                       u32 local_count);
 static FrontendResult<HirExpr> instantiate_function_expr(const HirExpr& expr,
                                                          HirRoute* route,
                                                          const HirModule& mod,
@@ -3903,12 +3908,13 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
 }
 
-static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
-                                            HirRoute* route,
-                                            const HirModule& mod,
-                                            const HirLocal* locals,
-                                            u32 local_count,
-                                            const MatchPayloadBinding* binding) {
+static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
+                                                 HirRoute* route,
+                                                 const HirModule& mod,
+                                                 const HirLocal* locals,
+                                                 u32 local_count,
+                                                 const MatchPayloadBinding* binding,
+                                                 bool allow_array_lit) {
     HirExpr out{};
     out.span = expr.span;
     if (expr.kind == AstExprKind::Placeholder)
@@ -4456,6 +4462,7 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         return out;
     }
     if (expr.kind == AstExprKind::ArrayLit) {
+        if (!allow_array_lit) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         // Empty array `[]` has no inferable element type; Rutlang has no
         // push/append so the element type can't be resolved later either.
         // Future: contextual inference from a declared type annotation can
@@ -4862,6 +4869,23 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         return out;
     }
     return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+}
+
+static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
+                                            HirRoute* route,
+                                            const HirModule& mod,
+                                            const HirLocal* locals,
+                                            u32 local_count,
+                                            const MatchPayloadBinding* binding) {
+    return analyze_expr_impl(expr, route, mod, locals, local_count, binding, false);
+}
+
+static FrontendResult<HirExpr> analyze_array_iter_expr(const AstExpr& expr,
+                                                       HirRoute* route,
+                                                       const HirModule& mod,
+                                                       const HirLocal* locals,
+                                                       u32 local_count) {
+    return analyze_expr_impl(expr, route, mod, locals, local_count, nullptr, true);
 }
 
 static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
@@ -9977,8 +10001,8 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 // get a stable ref_index, then has its *name* cleared once
                 // the body is analyzed (the block below) — so it stays
                 // out of later Ident resolution without freeing the slot.
-                auto iter = analyze_expr(
-                    stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
+                auto iter = analyze_array_iter_expr(
+                    stmt.expr, &route, mod, route.locals.data, route.locals.len);
                 if (!iter) return core::make_unexpected(iter.error());
                 if (iter->type != HirTypeKind::Array || iter->shape_index >= mod.type_shapes.len)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -89,6 +89,7 @@ static bool same_type_shape_node(const HirTypeShape& lhs, const HirTypeShape& rh
     for (u32 i = 0; i < lhs.tuple_len; i++) {
         if (lhs.tuple_elem_shape_indices[i] != rhs.tuple_elem_shape_indices[i]) return false;
     }
+    if (lhs.array_elem_shape_index != rhs.array_elem_shape_index) return false;
     return true;
 }
 
@@ -101,17 +102,35 @@ static FrontendResult<u32> intern_hir_type_shape(HirModule* mod,
                                                  const HirTypeKind* tuple_types,
                                                  const u32* tuple_variant_indices,
                                                  const u32* tuple_struct_indices,
-                                                 Span span) {
+                                                 Span span,
+                                                 u32 array_elem_shape_index = 0xffffffffu) {
+    // Normalize: HirExpr's variant_index defaults to 0 (not the 0xffffffffu
+    // sentinel), so callers that pass `out.variant_index` for a non-Variant
+    // type accidentally poison dedup. Force the index fields to sentinel
+    // for any kind that doesn't actually carry them. Same for struct/generic.
+    if (type != HirTypeKind::Variant) variant_index = 0xffffffffu;
+    if (type != HirTypeKind::Struct) struct_index = 0xffffffffu;
+    if (type != HirTypeKind::Generic) generic_index = 0xffffffffu;
     HirTypeShape shape{};
     shape.type = type;
     shape.generic_index = generic_index;
     shape.variant_index = variant_index;
     shape.struct_index = struct_index;
     shape.tuple_len = tuple_len;
+    shape.array_elem_shape_index =
+        type == HirTypeKind::Array ? array_elem_shape_index : 0xffffffffu;
     shape.is_concrete = type == HirTypeKind::Bool || type == HirTypeKind::I32 ||
                         type == HirTypeKind::Str || type == HirTypeKind::Method;
     if (type == HirTypeKind::Variant) shape.is_concrete = variant_index != 0xffffffffu;
     if (type == HirTypeKind::Struct) shape.is_concrete = struct_index != 0xffffffffu;
+    if (type == HirTypeKind::Array) {
+        // Array is concrete iff its element shape is concrete and the element
+        // shape is actually resolved. Element shape is already interned (the
+        // caller passed array_elem_shape_index), so just look it up.
+        shape.is_concrete =
+            array_elem_shape_index < mod->type_shapes.len &&
+            mod->type_shapes[array_elem_shape_index].is_concrete;
+    }
     if (type == HirTypeKind::Tuple) {
         shape.is_concrete = true;
         for (u32 i = 0; i < tuple_len; i++) {
@@ -1540,17 +1559,66 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(
     HirTypeKind* tuple_types,
     u32* tuple_variant_indices,
     u32* tuple_struct_indices,
-    Span span) {
+    Span span,
+    u32* array_elem_shape_index_out = nullptr) {
     if (generic_index) *generic_index = 0xffffffffu;
     variant_index = 0xffffffffu;
     struct_index = 0xffffffffu;
     tuple_len = 0;
+    if (array_elem_shape_index_out) *array_elem_shape_index_out = 0xffffffffu;
     if (!ref.is_tuple) {
         Str resolved_name = ref.name;
         if (ref.namespace_name.len != 0) {
             if (!resolve_import_namespace_type_name(
                     mod, ref.namespace_name, ref.name, resolved_name))
                 return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
+        }
+        // Array<T> detection — must come before the type-param / named-type
+        // checks because "Array" is a reserved builtin, not a user-defined
+        // struct or generic param. The element type is resolved recursively
+        // and interned so we can return a shape_index to the caller.
+        if (ref.namespace_name.len == 0 && resolved_name.eq(Str{"Array", 5})) {
+            if (ref.type_arg_names.len != 1)
+                return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
+            u32 elem_variant_index = 0xffffffffu;
+            u32 elem_struct_index = 0xffffffffu;
+            u32 elem_tuple_len = 0;
+            HirTypeKind elem_tuple_types[kMaxTupleSlots]{};
+            u32 elem_tuple_variant_indices[kMaxTupleSlots]{};
+            u32 elem_tuple_struct_indices[kMaxTupleSlots]{};
+            u32 elem_nested_array_shape = 0xffffffffu;
+            AstTypeRef elem_ref = get_ast_type_arg_ref(ref, 0);
+            auto elem_kind = resolve_func_type_ref(mod,
+                                                   elem_ref,
+                                                   type_params,
+                                                   nullptr,
+                                                   elem_variant_index,
+                                                   elem_struct_index,
+                                                   elem_tuple_len,
+                                                   elem_tuple_types,
+                                                   elem_tuple_variant_indices,
+                                                   elem_tuple_struct_indices,
+                                                   span,
+                                                   &elem_nested_array_shape);
+            if (!elem_kind) return core::make_unexpected(elem_kind.error());
+            // Nested arrays (`[[Int]]`): element kind is itself Array, and
+            // its element shape lives in elem_nested_array_shape. Pass that
+            // through so intern_hir_type_shape builds the right nested shape.
+            auto elem_shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                                    elem_kind.value(),
+                                                    0xffffffffu,
+                                                    elem_variant_index,
+                                                    elem_struct_index,
+                                                    elem_tuple_len,
+                                                    elem_tuple_types,
+                                                    elem_tuple_variant_indices,
+                                                    elem_tuple_struct_indices,
+                                                    span,
+                                                    elem_nested_array_shape);
+            if (!elem_shape) return core::make_unexpected(elem_shape.error());
+            if (array_elem_shape_index_out)
+                *array_elem_shape_index_out = elem_shape.value();
+            return HirTypeKind::Array;
         }
         if (type_params != nullptr && ref.namespace_name.len == 0) {
             const u32 type_param_index = find_generic_param_index(*type_params, resolved_name);
@@ -1718,6 +1786,14 @@ static bool same_hir_type_shape(const HirExpr& lhs, const HirExpr& rhs) {
                 return false;
         }
     }
+    // Array element type lives in HirTypeShape via shape_index (no inline
+    // mirror on HirExpr). Shape interning makes equal types share the same
+    // index, so a mismatch here = genuinely different element types or
+    // lengths. Callers that want mod-aware comparison use the 3-arg overload.
+    if (lhs.type == HirTypeKind::Array) {
+        if (lhs.shape_index == 0xffffffffu || rhs.shape_index == 0xffffffffu) return false;
+        return lhs.shape_index == rhs.shape_index;
+    }
     return true;
 }
 
@@ -1738,6 +1814,10 @@ static bool same_hir_shape_index(const HirModule& mod, u32 lhs_shape_index, u32 
                 mod, lhs.tuple_elem_shape_indices[i], rhs.tuple_elem_shape_indices[i])) {
             return false;
         }
+    }
+    if (lhs.array_elem_shape_index != 0xffffffffu || rhs.array_elem_shape_index != 0xffffffffu) {
+        if (!same_hir_shape_index(mod, lhs.array_elem_shape_index, rhs.array_elem_shape_index))
+            return false;
     }
     return true;
 }
@@ -2124,6 +2204,7 @@ static FrontendResult<void> apply_declared_type_to_expr(HirExpr* expr,
     HirTypeKind tuple_types[kMaxTupleSlots]{};
     u32 tuple_variant_indices[kMaxTupleSlots]{};
     u32 tuple_struct_indices[kMaxTupleSlots]{};
+    u32 array_elem_shape_index = 0xffffffffu;
     auto declared = resolve_func_type_ref(mod,
                                           stmt.type,
                                           nullptr,
@@ -2134,7 +2215,8 @@ static FrontendResult<void> apply_declared_type_to_expr(HirExpr* expr,
                                           tuple_types,
                                           tuple_variant_indices,
                                           tuple_struct_indices,
-                                          stmt.span);
+                                          stmt.span,
+                                          &array_elem_shape_index);
     if (!declared) return core::make_unexpected(declared.error());
     auto declared_shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
                                                 declared.value(),
@@ -2145,7 +2227,8 @@ static FrontendResult<void> apply_declared_type_to_expr(HirExpr* expr,
                                                 tuple_types,
                                                 tuple_variant_indices,
                                                 tuple_struct_indices,
-                                                stmt.span);
+                                                stmt.span,
+                                                array_elem_shape_index);
     if (!declared_shape) return core::make_unexpected(declared_shape.error());
     if (expr->type == HirTypeKind::Unknown && (expr->may_nil || expr->may_error)) {
         expr->type = declared.value();
@@ -4357,6 +4440,76 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                                    expr.span);
         if (!variant_shape) return core::make_unexpected(variant_shape.error());
         out.shape_index = variant_shape.value();
+        return out;
+    }
+    if (expr.kind == AstExprKind::ArrayLit) {
+        // Empty array `[]` has no inferable element type; Rutlang has no
+        // push/append so the element type can't be resolved later either.
+        // Future: contextual inference from a declared type annotation can
+        // relax this, but Phase 3a rejects it outright for clarity.
+        if (expr.args.len == 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        out.kind = HirExprKind::ArrayLit;
+        out.type = HirTypeKind::Array;
+        out.array_len = expr.args.len;
+        // Analyze each element and push into the route's expr pool. Keep the
+        // first element's metadata around so we can (a) enforce element-type
+        // uniformity across the array and (b) intern the element shape.
+        HirExpr first_elem_snapshot{};
+        u32 first_elem_shape_index = 0xffffffffu;
+        for (u32 i = 0; i < expr.args.len; i++) {
+            auto elem = analyze_expr(*expr.args[i], route, mod, locals, local_count, binding);
+            if (!elem) return core::make_unexpected(elem.error());
+            // Reject element kinds we don't support inside arrays for Phase 3a.
+            // Nested tuples and heterogeneous nil/error unions get a cleaner
+            // answer once contextual inference + smart widening land; for now
+            // the MVP is strict.
+            if (elem->type == HirTypeKind::Unknown || elem->may_error ||
+                elem->type == HirTypeKind::Tuple || elem->may_nil)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+            // First element defines the array's element type; subsequent
+            // elements must match its shape exactly.
+            if (i > 0 && !same_hir_type_shape(mod, first_elem_snapshot, elem.value()))
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
+            if (i == 0) {
+                first_elem_snapshot = elem.value();
+                first_elem_shape_index = elem->shape_index;
+            }
+            if (!route->exprs.push(elem.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            if (!out.args.push(&route->exprs[route->exprs.len - 1]))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+        }
+        // Element's shape_index is the canonical carrier. If the first
+        // element didn't have a shape interned (e.g., primitive that bypassed
+        // shape interning), intern it now to keep the array shape well-formed.
+        if (first_elem_shape_index == 0xffffffffu) {
+            auto elem_shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                                    first_elem_snapshot.type,
+                                                    first_elem_snapshot.generic_index,
+                                                    first_elem_snapshot.variant_index,
+                                                    first_elem_snapshot.struct_index,
+                                                    first_elem_snapshot.tuple_len,
+                                                    first_elem_snapshot.tuple_types,
+                                                    first_elem_snapshot.tuple_variant_indices,
+                                                    first_elem_snapshot.tuple_struct_indices,
+                                                    expr.span);
+            if (!elem_shape) return core::make_unexpected(elem_shape.error());
+            first_elem_shape_index = elem_shape.value();
+        }
+        auto array_shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                                 HirTypeKind::Array,
+                                                 0xffffffffu,
+                                                 0xffffffffu,
+                                                 0xffffffffu,
+                                                 0,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 expr.span,
+                                                 first_elem_shape_index);
+        if (!array_shape) return core::make_unexpected(array_shape.error());
+        out.shape_index = array_shape.value();
         return out;
     }
     if (expr.kind == AstExprKind::Tuple) {
@@ -9781,6 +9934,111 @@ static FrontendResult<HirModule*> analyze_file_internal(
                         return frontend_error(FrontendError::TooManyItems, stmt.span);
                 }
                 if (!route.guards.push(guard))
+                    return frontend_error(FrontendError::TooManyItems, stmt.span);
+                continue;
+            }
+            if (stmt.kind == AstStmtKind::For) {
+                // Phase 3b: analyze `for <var> in <iter> { <body> }` into a
+                // HirForLoop node. Body is restricted to `guard*` + optional
+                // terminator (return/forward) per Phase 3b MVP. Loop var is
+                // pushed into route.locals for body visibility, then rolled
+                // back after body analysis so it doesn't leak.
+                auto iter = analyze_expr(
+                    stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
+                if (!iter) return core::make_unexpected(iter.error());
+                if (iter->type != HirTypeKind::Array ||
+                    iter->shape_index >= mod.type_shapes.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                const auto& iter_shape = mod.type_shapes[iter->shape_index];
+                if (iter_shape.array_elem_shape_index >= mod.type_shapes.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                const auto& elem_shape = mod.type_shapes[iter_shape.array_elem_shape_index];
+
+                HirForLoop fl{};
+                fl.span = stmt.span;
+                fl.iter_expr = iter.value();
+                fl.loop_var_name = stmt.name;
+                fl.loop_var_type = elem_shape.type;
+                fl.loop_var_variant_index = elem_shape.variant_index;
+                fl.loop_var_struct_index = elem_shape.struct_index;
+                fl.loop_var_shape_index = iter_shape.array_elem_shape_index;
+
+                const u32 locals_saved = route.locals.len;
+                HirLocal loop_var{};
+                loop_var.span = stmt.span;
+                loop_var.name = stmt.name;
+                loop_var.ref_index =
+                    next_local_ref_index(&route, route.locals.data, route.locals.len);
+                loop_var.type = fl.loop_var_type;
+                loop_var.variant_index = fl.loop_var_variant_index;
+                loop_var.struct_index = fl.loop_var_struct_index;
+                loop_var.shape_index = fl.loop_var_shape_index;
+                // Synthetic init — MIR will substitute the per-iteration
+                // element value when unrolling. Shape/type must match so
+                // downstream same_hir_type_shape checks succeed.
+                loop_var.init.type = fl.loop_var_type;
+                loop_var.init.variant_index = fl.loop_var_variant_index;
+                loop_var.init.struct_index = fl.loop_var_struct_index;
+                loop_var.init.shape_index = fl.loop_var_shape_index;
+                loop_var.init.span = stmt.span;
+                if (!route.locals.push(loop_var))
+                    return frontend_error(FrontendError::TooManyItems, stmt.span);
+
+                // Walk the body. parse_braced_stmt_body collapses single-stmt
+                // blocks, so body is either a Block (n>=2) or a single stmt.
+                const AstStatement* body = stmt.then_stmt;
+                const u32 body_item_count =
+                    body->kind == AstStmtKind::Block ? body->block_stmts.len : 1u;
+                for (u32 bi = 0; bi < body_item_count; bi++) {
+                    const AstStatement& bstmt = (body->kind == AstStmtKind::Block)
+                                                    ? *body->block_stmts[bi]
+                                                    : *body;
+                    if (bstmt.kind == AstStmtKind::Guard) {
+                        // Phase 3b MVP: only `guard cond else { return N }` or
+                        // `guard cond else { return forward(...) }`. No
+                        // bind_value, no match arms, no non-terminator fail
+                        // body.
+                        if (bstmt.bind_value || bstmt.match_arms.len != 0)
+                            return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                        if (bstmt.else_stmt == nullptr ||
+                            (bstmt.else_stmt->kind != AstStmtKind::ReturnStatus &&
+                             bstmt.else_stmt->kind != AstStmtKind::ForwardUpstream))
+                            return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                        HirGuard guard{};
+                        guard.span = bstmt.span;
+                        auto cond = analyze_expr(bstmt.expr,
+                                                 &route,
+                                                 mod,
+                                                 route.locals.data,
+                                                 route.locals.len,
+                                                 nullptr);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        guard.cond = cond.value();
+                        auto fail = analyze_term(*bstmt.else_stmt, mod);
+                        if (!fail) return core::make_unexpected(fail.error());
+                        guard.fail_term = fail.value();
+                        if (!fl.body.guards.push(guard))
+                            return frontend_error(FrontendError::TooManyItems, bstmt.span);
+                        continue;
+                    }
+                    if (bstmt.kind == AstStmtKind::ReturnStatus ||
+                        bstmt.kind == AstStmtKind::ForwardUpstream) {
+                        if (fl.body.has_term)
+                            return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                        auto t = analyze_term(bstmt, mod);
+                        if (!t) return core::make_unexpected(t.error());
+                        fl.body.term = t.value();
+                        fl.body.has_term = true;
+                        continue;
+                    }
+                    // Reject let / nested for / if / match in Phase 3b MVP.
+                    return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                }
+
+                // Roll back loop_var scope. FixedVec doesn't expose a resize
+                // helper, so truncate by setting len directly.
+                route.locals.len = locals_saved;
+                if (!route.for_loops.push(fl))
                     return frontend_error(FrontendError::TooManyItems, stmt.span);
                 continue;
             }

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9820,6 +9820,15 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 auto init = analyze_expr(
                     stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!init) return core::make_unexpected(init.error());
+                // ArrayLit at let RHS fails at MIR because MIR has no
+                // ArrayLit → MirValue lowering (arrays are only consumed via
+                // for-loop unroll in Phase 4; indexing and const-folded
+                // array locals are future work). Reject at analyze so users
+                // get a clean diagnostic at the declaration site instead of
+                // a late MIR error. Inline form (`for x in [1,2,3]`) still
+                // works because for-loop unroll skips mir_value on iter_expr.
+                if (init->kind == HirExprKind::ArrayLit)
+                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, stmt);
                 if (!typed) return core::make_unexpected(typed.error());
                 local.type = init->type;
@@ -9969,6 +9978,19 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 fl.loop_var_variant_index = elem_shape.variant_index;
                 fl.loop_var_struct_index = elem_shape.struct_index;
                 fl.loop_var_shape_index = iter_shape.array_elem_shape_index;
+
+                // Reject shadowing of an outer local by the loop variable.
+                // Ident resolution scans locals by name from index 0 upward,
+                // so an earlier local with the same name would win over the
+                // per-iteration loop var (`let item = 1; for item in [2] { ... }`
+                // would bind `item` inside the body to the outer `1`).
+                // Making the collision a compile error is simpler than
+                // rewriting name lookup to prefer most-recent.
+                for (u32 li = 0; li < route.locals.len; li++) {
+                    if (route.locals[li].name.len != 0 &&
+                        route.locals[li].name.eq(stmt.name))
+                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                }
 
                 const u32 locals_saved = route.locals.len;
                 HirLocal loop_var{};

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -127,9 +127,8 @@ static FrontendResult<u32> intern_hir_type_shape(HirModule* mod,
         // Array is concrete iff its element shape is concrete and the element
         // shape is actually resolved. Element shape is already interned (the
         // caller passed array_elem_shape_index), so just look it up.
-        shape.is_concrete =
-            array_elem_shape_index < mod->type_shapes.len &&
-            mod->type_shapes[array_elem_shape_index].is_concrete;
+        shape.is_concrete = array_elem_shape_index < mod->type_shapes.len &&
+                            mod->type_shapes[array_elem_shape_index].is_concrete;
     }
     if (type == HirTypeKind::Tuple) {
         shape.is_concrete = true;
@@ -1577,7 +1576,15 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(
         // checks because "Array" is a reserved builtin, not a user-defined
         // struct or generic param. The element type is resolved recursively
         // and interned so we can return a shape_index to the caller.
+        //
+        // Callers that don't support arrays pass array_elem_shape_index_out
+        // == nullptr. Those positions (protocol / function params, struct /
+        // variant fields — all of Phase 5's scope) cannot carry the array
+        // element shape, so silently accepting Array there would lose type
+        // info. Reject so users get a clear error at the declaration site.
         if (ref.namespace_name.len == 0 && resolved_name.eq(Str{"Array", 5})) {
+            if (array_elem_shape_index_out == nullptr)
+                return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
             if (ref.type_arg_names.len != 1)
                 return frontend_error(FrontendError::UnsupportedSyntax, span, ref.name);
             u32 elem_variant_index = 0xffffffffu;
@@ -1616,8 +1623,7 @@ static FrontendResult<HirTypeKind> resolve_func_type_ref(
                                                     span,
                                                     elem_nested_array_shape);
             if (!elem_shape) return core::make_unexpected(elem_shape.error());
-            if (array_elem_shape_index_out)
-                *array_elem_shape_index_out = elem_shape.value();
+            if (array_elem_shape_index_out) *array_elem_shape_index_out = elem_shape.value();
             return HirTypeKind::Array;
         }
         if (type_params != nullptr && ref.namespace_name.len == 0) {
@@ -1787,9 +1793,12 @@ static bool same_hir_type_shape(const HirExpr& lhs, const HirExpr& rhs) {
         }
     }
     // Array element type lives in HirTypeShape via shape_index (no inline
-    // mirror on HirExpr). Shape interning makes equal types share the same
-    // index, so a mismatch here = genuinely different element types or
-    // lengths. Callers that want mod-aware comparison use the 3-arg overload.
+    // mirror on HirExpr). Length is a value property — not part of the
+    // shape — so two arrays of the same element type with different lengths
+    // share one shape_index. Shape interning makes equal element-type shapes
+    // share the same index, so a mismatch here means genuinely different
+    // element types. Callers that want mod-aware comparison use the 3-arg
+    // overload.
     if (lhs.type == HirTypeKind::Array) {
         if (lhs.shape_index == 0xffffffffu || rhs.shape_index == 0xffffffffu) return false;
         return lhs.shape_index == rhs.shape_index;
@@ -4447,8 +4456,7 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
         // push/append so the element type can't be resolved later either.
         // Future: contextual inference from a declared type annotation can
         // relax this, but Phase 3a rejects it outright for clarity.
-        if (expr.args.len == 0)
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (expr.args.len == 0) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         out.kind = HirExprKind::ArrayLit;
         out.type = HirTypeKind::Array;
         out.array_len = expr.args.len;
@@ -9946,8 +9954,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 auto iter = analyze_expr(
                     stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!iter) return core::make_unexpected(iter.error());
-                if (iter->type != HirTypeKind::Array ||
-                    iter->shape_index >= mod.type_shapes.len)
+                if (iter->type != HirTypeKind::Array || iter->shape_index >= mod.type_shapes.len)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
                 const auto& iter_shape = mod.type_shapes[iter->shape_index];
                 if (iter_shape.array_elem_shape_index >= mod.type_shapes.len)
@@ -9990,9 +9997,8 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 const u32 body_item_count =
                     body->kind == AstStmtKind::Block ? body->block_stmts.len : 1u;
                 for (u32 bi = 0; bi < body_item_count; bi++) {
-                    const AstStatement& bstmt = (body->kind == AstStmtKind::Block)
-                                                    ? *body->block_stmts[bi]
-                                                    : *body;
+                    const AstStatement& bstmt =
+                        (body->kind == AstStmtKind::Block) ? *body->block_stmts[bi] : *body;
                     if (bstmt.kind == AstStmtKind::Guard) {
                         // Phase 3b MVP: only `guard cond else { return N }` or
                         // `guard cond else { return forward(...) }`. No
@@ -10006,12 +10012,12 @@ static FrontendResult<HirModule*> analyze_file_internal(
                             return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
                         HirGuard guard{};
                         guard.span = bstmt.span;
-                        auto cond = analyze_expr(bstmt.expr,
-                                                 &route,
-                                                 mod,
-                                                 route.locals.data,
-                                                 route.locals.len,
-                                                 nullptr);
+                        // Use analyze_guard_cond (matches the top-level
+                        // guard dispatch at route scope): it enforces the
+                        // boolean predicate shape and rejects may_error /
+                        // may_nil conditions, unlike plain analyze_expr.
+                        auto cond = analyze_guard_cond(
+                            bstmt.expr, &route, mod, route.locals.data, route.locals.len);
                         if (!cond) return core::make_unexpected(cond.error());
                         guard.cond = cond.value();
                         auto fail = analyze_term(*bstmt.else_stmt, mod);
@@ -10035,9 +10041,21 @@ static FrontendResult<HirModule*> analyze_file_internal(
                     return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
                 }
 
-                // Roll back loop_var scope. FixedVec doesn't expose a resize
-                // helper, so truncate by setting len directly.
-                route.locals.len = locals_saved;
+                // Keep loop_var *in* route.locals so its ref_index stays
+                // stable for body HirExpr LocalRefs (MIR unroll will read
+                // those). Hide the *name* by clearing it — Ident resolution
+                // scans locals by name, so post-loop code that references
+                // the loop variable won't find it (scope semantics) while
+                // the ref_index itself is never reused by
+                // next_local_ref_index. Naive truncation would let later
+                // lets reuse the slot and collide with the body's LocalRefs.
+                //
+                // Note: `locals_saved` is retained in the debugger view via
+                // the assert below to catch accidental double-push of the
+                // loop_var (which would break the name-clearing trick).
+                if (route.locals.len != locals_saved + 1)
+                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                route.locals[locals_saved].name = {};
                 if (!route.for_loops.push(fl))
                     return frontend_error(FrontendError::TooManyItems, stmt.span);
                 continue;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9957,9 +9957,11 @@ static FrontendResult<HirModule*> analyze_file_internal(
             if (stmt.kind == AstStmtKind::For) {
                 // Phase 3b: analyze `for <var> in <iter> { <body> }` into a
                 // HirForLoop node. Body is restricted to `guard*` + optional
-                // terminator (return/forward) per Phase 3b MVP. Loop var is
-                // pushed into route.locals for body visibility, then rolled
-                // back after body analysis so it doesn't leak.
+                // terminator (return/forward) per Phase 3b MVP. The loop
+                // variable is pushed into route.locals so body LocalRefs
+                // get a stable ref_index, then has its *name* cleared once
+                // the body is analyzed (the block below) — so it stays
+                // out of later Ident resolution without freeing the slot.
                 auto iter = analyze_expr(
                     stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!iter) return core::make_unexpected(iter.error());
@@ -10001,9 +10003,17 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 loop_var.variant_index = fl.loop_var_variant_index;
                 loop_var.struct_index = fl.loop_var_struct_index;
                 loop_var.shape_index = fl.loop_var_shape_index;
-                // Synthetic init — MIR will substitute the per-iteration
-                // element value when unrolling. Shape/type must match so
-                // downstream same_hir_type_shape checks succeed.
+                // Synthetic init — MIR unroll (Phase 4b) substitutes the
+                // per-iteration element value when reaching a LocalRef to
+                // this slot, so init is never read at runtime. We still
+                // need a consistent HirExpr for downstream passes that
+                // inspect local.init.kind (const-fold, diagnostics) — use
+                // a self-referential LocalRef so the node reads as "look
+                // up my own slot", obviously synthetic. Leaving kind at
+                // the HirExpr default BoolLit would claim a false bool
+                // value while type says i32/str.
+                loop_var.init.kind = HirExprKind::LocalRef;
+                loop_var.init.local_index = loop_var.ref_index;
                 loop_var.init.type = fl.loop_var_type;
                 loop_var.init.variant_index = fl.loop_var_variant_index;
                 loop_var.init.struct_index = fl.loop_var_struct_index;
@@ -10025,6 +10035,15 @@ static FrontendResult<HirModule*> analyze_file_internal(
                         // `guard cond else { return forward(...) }`. No
                         // bind_value, no match arms, no non-terminator fail
                         // body.
+                        //
+                        // HirForLoopBody stores guards and the terminator in
+                        // separate fields rather than a single ordered stmt
+                        // list. If we accepted a guard after `has_term` was
+                        // already set, MIR unroll would silently reorder the
+                        // guard before the (already-fired) terminator —
+                        // miscompile. Reject so source order is preserved.
+                        if (fl.body.has_term)
+                            return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
                         if (bstmt.bind_value || bstmt.match_arms.len != 0)
                             return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
                         if (bstmt.else_stmt == nullptr ||

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3742,6 +3742,10 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 auto init =
                     analyze_expr(inner.expr, scratch, mod, cur_locals, cur_local_count, nullptr);
                 if (!init) return core::make_unexpected(init.error());
+                // Mirror the route-level let handler's ArrayLit-at-RHS gate
+                // (MIR has no ArrayLit lowering yet).
+                if (init->kind == HirExprKind::ArrayLit)
+                    return frontend_error(FrontendError::UnsupportedSyntax, inner.expr.span);
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, inner);
                 if (!typed) return core::make_unexpected(typed.error());
                 if (cur_local_count >= HirRoute::kMaxLocals)
@@ -5756,6 +5760,10 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
                 auto init = analyze_expr(
                     inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
                 if (!init) return core::make_unexpected(init.error());
+                // Mirror the route-level let handler's ArrayLit-at-RHS gate
+                // (MIR has no ArrayLit lowering yet).
+                if (init->kind == HirExprKind::ArrayLit)
+                    return frontend_error(FrontendError::UnsupportedSyntax, inner.expr.span);
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, inner);
                 if (!typed) return core::make_unexpected(typed.error());
                 local.type = init->type;
@@ -5948,6 +5956,10 @@ static FrontendResult<void> analyze_guard_fail_body(const AstStatement& stmt,
                 auto init = analyze_expr(
                     inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
                 if (!init) return core::make_unexpected(init.error());
+                // Mirror the route-level let handler's ArrayLit-at-RHS gate
+                // (MIR has no ArrayLit lowering yet).
+                if (init->kind == HirExprKind::ArrayLit)
+                    return frontend_error(FrontendError::UnsupportedSyntax, inner.expr.span);
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, inner);
                 if (!typed) return core::make_unexpected(typed.error());
                 local.type = init->type;
@@ -9821,12 +9833,15 @@ static FrontendResult<HirModule*> analyze_file_internal(
                     stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!init) return core::make_unexpected(init.error());
                 // ArrayLit at let RHS fails at MIR because MIR has no
-                // ArrayLit → MirValue lowering (arrays are only consumed via
-                // for-loop unroll in Phase 4; indexing and const-folded
-                // array locals are future work). Reject at analyze so users
+                // ArrayLit → MirValue lowering. Reject at analyze so users
                 // get a clean diagnostic at the declaration site instead of
-                // a late MIR error. Inline form (`for x in [1,2,3]`) still
-                // works because for-loop unroll skips mir_value on iter_expr.
+                // a later MIR error.
+                // Note: inline `for x in [1,2,3] { ... }` passes analyze
+                // (iter_expr is analyzed but not a let RHS), but Phase 4a's
+                // mir_build also rejects any route with for_loops.len > 0.
+                // End-to-end compilation of array-bearing programs lands
+                // once Phase 4b implements MIR unroll (and, separately,
+                // MIR gains array-constant lowering for let-RHS arrays).
                 if (init->kind == HirExprKind::ArrayLit)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, stmt);

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9987,8 +9987,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 // Making the collision a compile error is simpler than
                 // rewriting name lookup to prefer most-recent.
                 for (u32 li = 0; li < route.locals.len; li++) {
-                    if (route.locals[li].name.len != 0 &&
-                        route.locals[li].name.eq(stmt.name))
+                    if (route.locals[li].name.len != 0 && route.locals[li].name.eq(stmt.name))
                         return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 }
 

--- a/src/compiler/lexer.cc
+++ b/src/compiler/lexer.cc
@@ -39,6 +39,7 @@ static TokenType keyword_type(Str text) {
     if (text.eq({"if", 2})) return TokenType::KwIf;
     if (text.eq({"else", 4})) return TokenType::KwElse;
     if (text.eq({"for", 3})) return TokenType::KwFor;
+    if (text.eq({"in", 2})) return TokenType::KwIn;
     if (text.eq({"or", 2})) return TokenType::KwOr;
     if (text.eq({"nil", 3})) return TokenType::KwNil;
     if (text.eq({"upstream", 8})) return TokenType::KwUpstream;
@@ -249,6 +250,12 @@ LexResult lex(Str source) {
                 break;
             case ')':
                 tok.type = TokenType::RParen;
+                break;
+            case '[':
+                tok.type = TokenType::LBracket;
+                break;
+            case ']':
+                tok.type = TokenType::RBracket;
                 break;
             case ',':
                 tok.type = TokenType::Comma;

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -694,6 +694,16 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         fn.name = {"route", 5};
         fn.error_variant_index = module.routes[i].error_variant_index;
 
+        // Phase 4a: MIR doesn't yet unroll for-loops into its guard chain.
+        // Analyze (Phase 3b) populates route.for_loops; without the unroll
+        // pass the loop body is silently dropped and the route is compiled
+        // as if the loop never existed. Reject explicitly instead of
+        // miscompiling — Phase 4b will implement the unroll (loop-var
+        // substitution in mir_value + emit per-iteration guard blocks).
+        if (module.routes[i].for_loops.len != 0)
+            return frontend_error(FrontendError::UnsupportedSyntax,
+                                  module.routes[i].for_loops[0].span);
+
         // Propagate wait(ms) list 1:1. Codegen will turn each into a yield
         // boundary in the generated state machine.
         for (u32 wi = 0; wi < module.routes[i].waits.len; wi++) {

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -145,6 +145,23 @@ struct Parser {
     FrontendResult<AstExpr> parse_primary_atom() {
         const Token start = cur();
         AstExpr expr{};
+        if (take(TokenType::LBracket)) {
+            AstExpr arr{};
+            arr.kind = AstExprKind::ArrayLit;
+            while (!take(TokenType::RBracket)) {
+                auto elem = parse_expr();
+                if (!elem) return core::make_unexpected(elem.error());
+                auto elem_ptr = alloc_expr(elem.value());
+                if (!elem_ptr) return core::make_unexpected(elem_ptr.error());
+                if (!arr.args.push(elem_ptr.value()))
+                    return frontend_error(FrontendError::TooManyItems, elem->span);
+                if (take(TokenType::RBracket)) break;
+                auto comma = expect(TokenType::Comma);
+                if (!comma) return core::make_unexpected(comma.error());
+            }
+            arr.span = Span{start.start, prev().end, start.line, start.col};
+            return arr;
+        }
         if (take(TokenType::LParen)) {
             auto first = parse_expr();
             if (!first) return core::make_unexpected(first.error());
@@ -1009,6 +1026,27 @@ struct Parser {
             stmt.span = Span{start.start, else_stmt->span.end, start.line, start.col};
             return stmt;
         }
+        if (take(TokenType::KwFor)) {
+            auto var_name = expect(TokenType::Ident);
+            if (!var_name) return core::make_unexpected(var_name.error());
+            auto in_kw = expect(TokenType::KwIn);
+            if (!in_kw) return core::make_unexpected(in_kw.error());
+            auto iter_expr = parse_expr();
+            if (!iter_expr) return core::make_unexpected(iter_expr.error());
+            auto lbrace = expect(TokenType::LBrace);
+            if (!lbrace) return core::make_unexpected(lbrace.error());
+            auto body = parse_braced_stmt_body(*lbrace.value());
+            if (!body) return core::make_unexpected(body.error());
+            auto body_ptr = alloc_stmt(body.value());
+            if (!body_ptr) return core::make_unexpected(body_ptr.error());
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::For;
+            stmt.name = var_name.value()->text;
+            stmt.expr = iter_expr.value();
+            stmt.then_stmt = body_ptr.value();
+            stmt.span = Span{start.start, body->span.end, start.line, start.col};
+            return stmt;
+        }
         if (take(TokenType::KwMatch)) {
             const bool is_const = take(TokenType::KwConst) != nullptr;
             auto subject = parse_expr();
@@ -1325,6 +1363,26 @@ struct Parser {
 
     FrontendResult<AstTypeRef> parse_func_type_ref() {
         AstTypeRef out{};
+        // Surface sugar: `[T]` desugars to `Array<T>`. Recurses for nested
+        // forms like `[[Int]]` → `Array<Array<Int>>`. The "Array" name here
+        // uses a C-string literal with static storage duration, matching the
+        // pattern for other internal names (e.g., `Str{"Self", 4}`).
+        if (const Token* lbracket = take(TokenType::LBracket)) {
+            auto elem = parse_func_type_ref();
+            if (!elem) return core::make_unexpected(elem.error());
+            auto rbracket = expect(TokenType::RBracket);
+            if (!rbracket) return core::make_unexpected(rbracket.error());
+            out.name = Str{"Array", 5};
+            auto elem_ptr = alloc_type(elem.value());
+            if (!elem_ptr) return core::make_unexpected(elem_ptr.error());
+            if (!out.type_arg_namespaces.push(elem->namespace_name))
+                return frontend_error(FrontendError::TooManyItems, span_from(*lbracket));
+            if (!out.type_arg_names.push(elem->name))
+                return frontend_error(FrontendError::TooManyItems, span_from(*lbracket));
+            if (!out.type_args.push(elem_ptr.value()))
+                return frontend_error(FrontendError::TooManyItems, span_from(*lbracket));
+            return out;
+        }
         if (take(TokenType::LParen)) {
             out.is_tuple = true;
             while (true) {
@@ -1830,7 +1888,7 @@ struct Parser {
             if (!item.route.statements.push(stmt.value()))
                 return frontend_error(FrontendError::TooManyItems, stmt.value().span);
             if (stmt->kind != AstStmtKind::Let && stmt->kind != AstStmtKind::Guard &&
-                stmt->kind != AstStmtKind::Wait)
+                stmt->kind != AstStmtKind::Wait && stmt->kind != AstStmtKind::For)
                 break;
         }
         auto rbrace = expect(TokenType::RBrace);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13555,7 +13555,7 @@ TEST(frontend, parse_array_lit_trailing_comma) {
 }
 
 TEST(frontend, parse_array_lit_nested_type) {
-    // `[[i32]]` desugars recursively: outer [T] → Array<T>, inner [T] → Array<Int>.
+    // `[[i32]]` desugars recursively: outer [T] → Array<T>, inner [T] → Array<i32>.
     // Validates parse_func_type_ref's recursion on leading LBracket.
     const char* src = "route GET \"/x\" { let xss: [[i32]] = [] return 200 }\n";
     auto lexed = lex(lit(src));
@@ -13630,11 +13630,12 @@ TEST(frontend, parse_for_loop_multi_stmt_body) {
 }
 
 TEST(frontend, analyze_array_lit_at_let_rhs_rejected) {
-    // ArrayLit at let RHS is rejected because MIR cannot yet lower array
-    // values as constants (no indexing, no const-folded array locals).
-    // Inline `for x in [1,2,3] { ... }` still works — for-loop unroll
-    // skips mir_value on iter_expr. Phase 4+ may relax this once MIR
-    // gains array-constant lowering.
+    // ArrayLit at let RHS is rejected in analyze because MIR cannot yet
+    // lower array values as constants (no indexing, no const-folded array
+    // locals). Inline `for x in [1,2,3] { ... }` is allowed at analyze
+    // level, but Phase 4a's mir_build also rejects any route with
+    // `for_loops.len > 0` — so no for-loop-bearing program compiles end
+    // to end until Phase 4b implements MIR unroll.
     const char* src = "route GET \"/x\" { let xs: [i32] = [1, 2, 3] return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -13770,6 +13771,21 @@ TEST(frontend, mir_rejects_for_loop_until_phase_4b) {
     REQUIRE(hir);
     auto mir = build_mir_heap(hir.value());
     CHECK(!mir);
+}
+
+TEST(frontend, analyze_array_lit_at_nested_let_rhs_rejected) {
+    // ArrayLit rejection must fire at every let-analysis path, not just the
+    // route top-level handler. Exercises analyze_guard_fail_body (a let
+    // inside a guard's `else { ... }` block).
+    const char* src =
+        "route GET \"/x\" { guard true else { let xs: [i32] = [1, 2, 3] return 400 } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
 }
 
 TEST(frontend, analyze_for_loop_rejects_guard_after_terminator) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13629,30 +13629,19 @@ TEST(frontend, parse_for_loop_multi_stmt_body) {
              static_cast<u8>(AstStmtKind::Guard));
 }
 
-TEST(frontend, analyze_array_lit_int_roundtrip) {
-    // End-to-end: `let xs: [i32] = [1, 2, 3]` parses + type-checks. The
-    // annotation `[i32]` desugars to Array<Int>; the literal infers element
-    // type from the first I32 element; same_hir_type_shape accepts the match.
+TEST(frontend, analyze_array_lit_at_let_rhs_rejected) {
+    // ArrayLit at let RHS is rejected because MIR cannot yet lower array
+    // values as constants (no indexing, no const-folded array locals).
+    // Inline `for x in [1,2,3] { ... }` still works — for-loop unroll
+    // skips mir_value on iter_expr. Phase 4+ may relax this once MIR
+    // gains array-constant lowering.
     const char* src = "route GET \"/x\" { let xs: [i32] = [1, 2, 3] return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE(hir);
-    REQUIRE_EQ(hir->routes.len, 1u);
-    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
-    const auto& local = hir->routes[0].locals[0];
-    CHECK(local.name.eq(lit("xs")));
-    CHECK_EQ(static_cast<u8>(local.type), static_cast<u8>(HirTypeKind::Array));
-    REQUIRE(local.shape_index < hir->type_shapes.len);
-    const auto& shape = hir->type_shapes[local.shape_index];
-    CHECK_EQ(static_cast<u8>(shape.type), static_cast<u8>(HirTypeKind::Array));
-    REQUIRE(shape.array_elem_shape_index < hir->type_shapes.len);
-    CHECK_EQ(static_cast<u8>(hir->type_shapes[shape.array_elem_shape_index].type),
-             static_cast<u8>(HirTypeKind::I32));
-    // Length carried on the expr (not the shape), for MIR unroll in Phase 4.
-    CHECK_EQ(local.init.array_len, 3u);
+    CHECK(!hir);
 }
 
 TEST(frontend, analyze_array_lit_heterogeneous_rejected) {
@@ -13760,6 +13749,22 @@ TEST(frontend, analyze_for_loop_var_scoped_to_body) {
 TEST(frontend, analyze_for_loop_iter_not_array_rejected) {
     // Iter source must be Array<T>; iterating a scalar is a type error.
     const char* src = "route GET \"/x\" { for item in 42 { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_rejects_shadowing_outer_local) {
+    // Ident resolution scans route.locals by name from index 0 upward, so a
+    // loop var that shares its name with an outer local would let the outer
+    // binding win in the body — producing wrong guard behavior under MIR
+    // unroll. Analyze rejects the collision outright.
+    const char* src =
+        "route GET \"/x\" { let item = 1 for item in [2, 3] { guard item > 1 else "
+        "{ return 400 } } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13757,6 +13757,25 @@ TEST(frontend, analyze_for_loop_iter_not_array_rejected) {
     CHECK(!hir);
 }
 
+TEST(frontend, mir_rejects_for_loop_until_phase_4b) {
+    // Phase 4a: analyze accepts for-loops (Phase 3b), but MIR doesn't yet
+    // unroll them. Until Phase 4b lands the subst-aware mir_value + guard
+    // chain emission, MIR rejects any route with for_loops.len > 0 so
+    // users see a clean error at build time instead of a silent miscompile
+    // (loop body dropped, handler treats the loop as a no-op).
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    CHECK(!mir);
+}
+
 TEST(frontend, analyze_for_loop_rejects_shadowing_outer_local) {
     // Ident resolution scans route.locals by name from index 0 upward, so a
     // loop var that shares its name with an outer local would let the outer

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13496,10 +13496,11 @@ func keep(x: (i32, bool), y: (Box, i32)) -> (i32, bool) => x
 }
 
 TEST(frontend, parse_array_lit_basic) {
-    // `[i32]` in type position desugars to Array<Int> via parse_func_type_ref;
+    // `[i32]` in type position desugars to Array<i32> via parse_func_type_ref;
     // `[1, 2, 3]` in expression position produces AstExprKind::ArrayLit with
-    // three IntLit elements in `args`. Parser-only: analyze doesn't yet
-    // understand ArrayLit, so this test stops after parse_file_heap.
+    // three IntLit elements in `args`. Intentionally parse-only: stops after
+    // parse_file_heap to assert AST shape (the analyze_array_lit_int_roundtrip
+    // test below covers the full HIR pipeline for the same input).
     const char* src = "route GET \"/x\" { let xs: [i32] = [1, 2, 3] return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -13522,9 +13523,11 @@ TEST(frontend, parse_array_lit_basic) {
 }
 
 TEST(frontend, parse_array_lit_empty) {
-    // Empty `[]` is syntactically legal — analyze is expected to require a
-    // type annotation (Rutlang has no push/append so all array sizes are
-    // compile-time known). Parser accepts it as a zero-element ArrayLit.
+    // Empty `[]` is syntactically legal; the parser accepts it as a
+    // zero-element ArrayLit. analyze rejects it regardless of annotation
+    // in Phase 3a (contextual inference from annotation is future work) —
+    // see analyze_array_lit_empty_rejected below. This test only covers
+    // the parse shape.
     const char* src = "route GET \"/x\" { let xs: [i32] = [] return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -13569,8 +13572,9 @@ TEST(frontend, parse_array_lit_nested_type) {
 
 TEST(frontend, parse_for_loop_basic) {
     // `for item in xs { return 200 }` — loop variable stored in `name`,
-    // iteration source in `expr`, body block in `then_stmt`. Parser-only:
-    // analyze doesn't yet understand For/ArrayLit.
+    // iteration source in `expr`, body block in `then_stmt`. Intentionally
+    // parse-only: asserts AST shape independent of analyze (full-pipeline
+    // coverage lives in analyze_for_loop_* tests below).
     const char* src = "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -13586,8 +13590,7 @@ TEST(frontend, parse_for_loop_basic) {
     REQUIRE(for_stmt.then_stmt != nullptr);
     // Body is a single-stmt `return 200` (parse_braced_stmt_body collapses
     // one-stmt blocks to the stmt itself — not a Block wrapper).
-    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind),
-             static_cast<u8>(AstStmtKind::ReturnStatus));
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind), static_cast<u8>(AstStmtKind::ReturnStatus));
     CHECK_EQ(for_stmt.then_stmt->status_code, 200u);
 }
 
@@ -13709,8 +13712,7 @@ TEST(frontend, analyze_for_loop_terminator_body) {
     CHECK_EQ(static_cast<u8>(fl.iter_expr.type), static_cast<u8>(HirTypeKind::Array));
     CHECK_EQ(fl.iter_expr.array_len, 3u);
     CHECK(fl.body.has_term);
-    CHECK_EQ(static_cast<u8>(fl.body.term.kind),
-             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(static_cast<u8>(fl.body.term.kind), static_cast<u8>(HirTerminatorKind::ReturnStatus));
     CHECK_EQ(fl.body.term.status_code, 200);
     // route still needs a top-level terminator (after the for-loop).
     CHECK_EQ(static_cast<u8>(route.control.direct_term.kind),

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13495,6 +13495,300 @@ func keep(x: (i32, bool), y: (Box, i32)) -> (i32, bool) => x
     CHECK(mir->type_shapes[struct_tuple_shape].carrier_ready);
 }
 
+TEST(frontend, parse_array_lit_basic) {
+    // `[i32]` in type position desugars to Array<Int> via parse_func_type_ref;
+    // `[1, 2, 3]` in expression position produces AstExprKind::ArrayLit with
+    // three IntLit elements in `args`. Parser-only: analyze doesn't yet
+    // understand ArrayLit, so this test stops after parse_file_heap.
+    const char* src = "route GET \"/x\" { let xs: [i32] = [1, 2, 3] return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    const auto& route = ast->items[0].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    const auto& let_stmt = route.statements[0];
+    CHECK_EQ(static_cast<u8>(let_stmt.kind), static_cast<u8>(AstStmtKind::Let));
+    CHECK(let_stmt.type.name.eq(lit("Array")));
+    REQUIRE_EQ(let_stmt.type.type_args.len, 1u);
+    CHECK(let_stmt.type.type_args[0]->name.eq(lit("i32")));
+    CHECK_EQ(static_cast<u8>(let_stmt.expr.kind), static_cast<u8>(AstExprKind::ArrayLit));
+    REQUIRE_EQ(let_stmt.expr.args.len, 3u);
+    CHECK_EQ(static_cast<u8>(let_stmt.expr.args[0]->kind), static_cast<u8>(AstExprKind::IntLit));
+    CHECK_EQ(let_stmt.expr.args[0]->int_value, 1);
+    CHECK_EQ(let_stmt.expr.args[1]->int_value, 2);
+    CHECK_EQ(let_stmt.expr.args[2]->int_value, 3);
+}
+
+TEST(frontend, parse_array_lit_empty) {
+    // Empty `[]` is syntactically legal — analyze is expected to require a
+    // type annotation (Rutlang has no push/append so all array sizes are
+    // compile-time known). Parser accepts it as a zero-element ArrayLit.
+    const char* src = "route GET \"/x\" { let xs: [i32] = [] return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& let_stmt = ast->items[0].route.statements[0];
+    CHECK(let_stmt.type.name.eq(lit("Array")));
+    CHECK_EQ(static_cast<u8>(let_stmt.expr.kind), static_cast<u8>(AstExprKind::ArrayLit));
+    CHECK_EQ(let_stmt.expr.args.len, 0u);
+}
+
+TEST(frontend, parse_array_lit_trailing_comma) {
+    // `[1, 2, 3,]` — trailing comma accepted (Swift/Rust style) so diffs stay
+    // minimal when elements are appended. Element count matches the non-trailing
+    // form exactly; no phantom empty element.
+    const char* src = "route GET \"/x\" { let xs: [i32] = [1, 2, 3,] return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& let_stmt = ast->items[0].route.statements[0];
+    CHECK_EQ(static_cast<u8>(let_stmt.expr.kind), static_cast<u8>(AstExprKind::ArrayLit));
+    REQUIRE_EQ(let_stmt.expr.args.len, 3u);
+    CHECK_EQ(let_stmt.expr.args[2]->int_value, 3);
+}
+
+TEST(frontend, parse_array_lit_nested_type) {
+    // `[[i32]]` desugars recursively: outer [T] → Array<T>, inner [T] → Array<Int>.
+    // Validates parse_func_type_ref's recursion on leading LBracket.
+    const char* src = "route GET \"/x\" { let xss: [[i32]] = [] return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& let_stmt = ast->items[0].route.statements[0];
+    CHECK(let_stmt.type.name.eq(lit("Array")));
+    REQUIRE_EQ(let_stmt.type.type_args.len, 1u);
+    CHECK(let_stmt.type.type_args[0]->name.eq(lit("Array")));
+    REQUIRE_EQ(let_stmt.type.type_args[0]->type_args.len, 1u);
+    CHECK(let_stmt.type.type_args[0]->type_args[0]->name.eq(lit("i32")));
+}
+
+TEST(frontend, parse_for_loop_basic) {
+    // `for item in xs { return 200 }` — loop variable stored in `name`,
+    // iteration source in `expr`, body block in `then_stmt`. Parser-only:
+    // analyze doesn't yet understand For/ArrayLit.
+    const char* src = "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& route = ast->items[0].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    const auto& for_stmt = route.statements[0];
+    CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(for_stmt.name.eq(lit("item")));
+    CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::ArrayLit));
+    REQUIRE_EQ(for_stmt.expr.args.len, 3u);
+    REQUIRE(for_stmt.then_stmt != nullptr);
+    // Body is a single-stmt `return 200` (parse_braced_stmt_body collapses
+    // one-stmt blocks to the stmt itself — not a Block wrapper).
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind),
+             static_cast<u8>(AstStmtKind::ReturnStatus));
+    CHECK_EQ(for_stmt.then_stmt->status_code, 200u);
+}
+
+TEST(frontend, parse_for_loop_field_access_source) {
+    // `for server in up.servers` — iteration source is a field access expr,
+    // not a literal. Exercises parse_expr → parse_primary_expr → Field path
+    // inside the for's iter-expr slot.
+    const char* src = "route GET \"/x\" { for server in up.servers { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& for_stmt = ast->items[0].route.statements[0];
+    CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(for_stmt.name.eq(lit("server")));
+    CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::Field));
+}
+
+TEST(frontend, parse_for_loop_multi_stmt_body) {
+    // Body with multiple statements — parse_braced_stmt_body returns a Block
+    // wrapping them; then_stmt points to that Block.
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2] { let n = item guard n > 0 else { return 400 } } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& for_stmt = ast->items[0].route.statements[0];
+    REQUIRE(for_stmt.then_stmt != nullptr);
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind), static_cast<u8>(AstStmtKind::Block));
+    REQUIRE_EQ(for_stmt.then_stmt->block_stmts.len, 2u);
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->block_stmts[0]->kind),
+             static_cast<u8>(AstStmtKind::Let));
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->block_stmts[1]->kind),
+             static_cast<u8>(AstStmtKind::Guard));
+}
+
+TEST(frontend, analyze_array_lit_int_roundtrip) {
+    // End-to-end: `let xs: [i32] = [1, 2, 3]` parses + type-checks. The
+    // annotation `[i32]` desugars to Array<Int>; the literal infers element
+    // type from the first I32 element; same_hir_type_shape accepts the match.
+    const char* src = "route GET \"/x\" { let xs: [i32] = [1, 2, 3] return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    const auto& local = hir->routes[0].locals[0];
+    CHECK(local.name.eq(lit("xs")));
+    CHECK_EQ(static_cast<u8>(local.type), static_cast<u8>(HirTypeKind::Array));
+    REQUIRE(local.shape_index < hir->type_shapes.len);
+    const auto& shape = hir->type_shapes[local.shape_index];
+    CHECK_EQ(static_cast<u8>(shape.type), static_cast<u8>(HirTypeKind::Array));
+    REQUIRE(shape.array_elem_shape_index < hir->type_shapes.len);
+    CHECK_EQ(static_cast<u8>(hir->type_shapes[shape.array_elem_shape_index].type),
+             static_cast<u8>(HirTypeKind::I32));
+    // Length carried on the expr (not the shape), for MIR unroll in Phase 4.
+    CHECK_EQ(local.init.array_len, 3u);
+}
+
+TEST(frontend, analyze_array_lit_heterogeneous_rejected) {
+    // Mixed element types — analyze must reject. Phase 3a MVP is strict:
+    // first-element-is-truth, no widening.
+    const char* src = "route GET \"/x\" { let xs: [i32] = [1, \"two\", 3] return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_array_lit_empty_rejected) {
+    // `[]` leaves element type unresolvable with Rutlang's no-push rule.
+    // Contextual inference from annotation is future work; MVP rejects.
+    const char* src = "route GET \"/x\" { let xs: [i32] = [] return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_array_annotation_type_mismatch_rejected) {
+    // Annotation `[Str]` vs literal `[1, 2, 3]` (Array<I32>) — apply_declared_
+    // type_to_expr's same_hir_type_shape must reject. This exercises the
+    // mod-aware shape comparison path since Array info lives in shape_index.
+    const char* src = "route GET \"/x\" { let xs: [str] = [1, 2, 3] return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_terminator_body) {
+    // Phase 3b: body is a single `return` terminator. Analyze must produce a
+    // HirForLoop on route.for_loops with iter_expr typed Array<I32>, loop_var
+    // bound to I32, and body.term populated (has_term = true).
+    const char* src = "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    const auto& route = hir->routes[0];
+    REQUIRE_EQ(route.for_loops.len, 1u);
+    const auto& fl = route.for_loops[0];
+    CHECK(fl.loop_var_name.eq(lit("item")));
+    CHECK_EQ(static_cast<u8>(fl.loop_var_type), static_cast<u8>(HirTypeKind::I32));
+    CHECK_EQ(static_cast<u8>(fl.iter_expr.type), static_cast<u8>(HirTypeKind::Array));
+    CHECK_EQ(fl.iter_expr.array_len, 3u);
+    CHECK(fl.body.has_term);
+    CHECK_EQ(static_cast<u8>(fl.body.term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(fl.body.term.status_code, 200);
+    // route still needs a top-level terminator (after the for-loop).
+    CHECK_EQ(static_cast<u8>(route.control.direct_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+}
+
+TEST(frontend, analyze_for_loop_guard_body) {
+    // Canonical Phase 3b use: iterate an allowlist-style array with a guard
+    // that short-circuits the handler. The loop var (`n`) must be in scope
+    // inside the guard's condition.
+    const char* src =
+        "route GET \"/x\" { for n in [1, 2, 3] { guard n > 0 else { return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    const auto& route = hir->routes[0];
+    REQUIRE_EQ(route.for_loops.len, 1u);
+    const auto& fl = route.for_loops[0];
+    CHECK(fl.loop_var_name.eq(lit("n")));
+    REQUIRE_EQ(fl.body.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(fl.body.guards[0].fail_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(fl.body.guards[0].fail_term.status_code, 400);
+    // No body terminator — control falls through to the next iteration.
+    CHECK(!fl.body.has_term);
+}
+
+TEST(frontend, analyze_for_loop_var_scoped_to_body) {
+    // The loop variable must NOT leak to code after the for-loop. Writing
+    // `item` in a post-loop let should fail to resolve (Ident unknown).
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { return 200 } "
+        "let x = item return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_iter_not_array_rejected) {
+    // Iter source must be Array<T>; iterating a scalar is a type error.
+    const char* src = "route GET \"/x\" { for item in 42 { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_rejects_let_in_body) {
+    // Phase 3b MVP: body allows `guard*` + optional terminator. A nested let
+    // inside the body is an explicit scope restriction — future phases may
+    // relax this, but for now we fail loudly.
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { let y = 7 return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, parse_for_loop_rejects_missing_in) {
+    // `for item <missing in> [1, 2, 3]` — expect must see KwIn, else unexpected-token.
+    const char* src = "route GET \"/x\" { for item [1, 2, 3] { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    CHECK(!ast);
+}
+
 int main(int argc, char** argv) {
     return rut::test::run_all(argc, argv);
 }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13668,18 +13668,14 @@ TEST(frontend, analyze_array_lit_empty_rejected) {
     CHECK(!hir);
 }
 
-TEST(frontend, analyze_array_annotation_type_mismatch_rejected) {
-    // Annotation `[Str]` vs literal `[1, 2, 3]` (Array<I32>) — apply_declared_
-    // type_to_expr's same_hir_type_shape must reject. This exercises the
-    // mod-aware shape comparison path since Array info lives in shape_index.
-    const char* src = "route GET \"/x\" { let xs: [str] = [1, 2, 3] return 200 }\n";
-    auto lexed = lex(lit(src));
-    REQUIRE(lexed);
-    auto ast = parse_file_heap(lexed.value());
-    REQUIRE(ast);
-    auto hir = analyze_file_heap(ast.value());
-    CHECK(!hir);
-}
+// NOTE: a former `analyze_array_annotation_type_mismatch_rejected` test used
+// `let xs: [str] = [1, 2, 3]` to exercise `apply_declared_type_to_expr` /
+// `same_hir_type_shape` for Array. That path is unreachable in Phase 3a/3b
+// because any ArrayLit at a let RHS is rejected earlier (see
+// `analyze_array_lit_at_let_rhs_rejected`). The Array-shape comparison path
+// will regain test coverage once Phase 5 adds struct fields / function
+// params typed as `Array<T>`, which route `resolve_func_type_ref` through
+// positions where the ArrayLit-at-let gate doesn't fire first.
 
 TEST(frontend, analyze_for_loop_terminator_body) {
     // Phase 3b: body is a single `return` terminator. Analyze must produce a
@@ -13774,6 +13770,23 @@ TEST(frontend, mir_rejects_for_loop_until_phase_4b) {
     REQUIRE(hir);
     auto mir = build_mir_heap(hir.value());
     CHECK(!mir);
+}
+
+TEST(frontend, analyze_for_loop_rejects_guard_after_terminator) {
+    // HirForLoopBody stores guards and terminator in separate fields (no
+    // source-ordered stmt list), so accepting a guard after a terminator
+    // would let MIR unroll silently reorder an unreachable guard in front
+    // of the already-fired return. Analyze rejects to preserve source
+    // semantics until lowering is order-aware.
+    const char* src =
+        "route GET \"/x\" { for x in [1] { return 200 guard x > 0 else "
+        "{ return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
 }
 
 TEST(frontend, analyze_for_loop_rejects_shadowing_outer_local) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13788,6 +13788,19 @@ TEST(frontend, analyze_array_lit_at_nested_let_rhs_rejected) {
     CHECK(!hir);
 }
 
+TEST(frontend, analyze_array_lit_direct_function_body_rejected) {
+    // ArrayLit is only allowed as a for-loop iteration source until MIR can
+    // lower array constants. Direct expression bodies must reject in analyze
+    // instead of reaching mir_build as unsupported HirExprKind::ArrayLit.
+    const char* src = "func ids() => [1, 2, 3]\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
 TEST(frontend, analyze_for_loop_rejects_guard_after_terminator) {
     // HirForLoopBody stores guards and terminator in separate fields (no
     // source-ordered stmt list), so accepting a guard after a terminator


### PR DESCRIPTION
## Summary

Adds the frontend (parse + analyze) for two new language constructs reserved in CLAUDE.md's minimal keyword set but previously un-lexed / un-parsed:

- **Array literals and `[T]` type sugar**: `let blocked: [str] = [\"xss\", \"sql_injection\", \"path_traversal\"]`. `[T]` desugars to `Array<T>` at parse time; length is a value property (`HirExpr.array_len`) not a type property.
- **`for ... in` statements**: `for word in blocked { guard !input.contains(word) else { return 403 } }`. Body is restricted to `guard*` + optional `return/forward` terminator for the MVP — covers the canonical DESIGN.md examples.

Split across multiple commits for review ergonomics:

1. **`frontend: parse array literals [T] and for-loop statements`** — parser / lexer / AST only. Fixes two dead-declaration bugs (LBracket/RBracket and KwIn tokens existed in the enum but had no scanning logic).
2. **`analyze: HIR Array type + For stmt with unrolled-body prep`** — HirTypeKind::Array + HirExprKind::ArrayLit + HirForLoop + type resolution. Also fixes a latent dedup bug in `intern_hir_type_shape` where `HirExpr.variant_index` default (0) leaked into shape comparisons for non-Variant types.
3. Follow-up commits addressing review feedback: stack-budget tuning (HirRoute was 346 KB on stack → blew the 8 MB thread limit on clang Debug cyclic-import tests), P1/P2 bug fixes (ArrayLit at let RHS rejected, loop-var shadowing rejected), and **Phase 4a**: MIR now fails fast on routes with `for_loops.len > 0` rather than silently dropping the loop body.

## Why

- `for` / `in` / `[` / `]` are first-class in DESIGN.md §3.2.1's keyword set; until now the compiler accepted the keywords only as identifiers (or not at all).
- Array is the prerequisite substrate for Hash / LRU / Set / Bloom / Bitmap state types (CLAUDE.md §3.3.6). The shape-interning pattern introduced here (single `array_elem_shape_index` field vs Tuple's scattered `tuple_*` arrays) is the template for those.

## What's NOT in this PR (deferred)

- **Phase 4b: actual MIR unroll.** HirForLoop is built in HIR but MIR rejects it with a clean UnsupportedSyntax diagnostic (no silent miscompile). Phase 4b will thread a subst context through `mir_value` and emit N × body-guard-count guard blocks per for-loop.
- **Phase 5: Struct fields with array types.** `struct Foo { items: [Bar] }` is not yet parseable as a struct field type; this PR only handles arrays in `let`-RHS-rejected and for-iter-expr contexts.
- **Empty `[]` with contextual inference.** `let xs: [i32] = []` currently errors; the type annotation can't yet propagate element type into an empty literal.
- **Body-let / nested-for / body-if / body-match inside the for-body.** Phase 3b MVP restricts body to `guard*` + optional terminator. Guards after a body terminator are also rejected (source-order preservation).
- **`let xs = [1,2,3]`** at let RHS. MIR has no ArrayLit → MirValue lowering yet; the gate now lives in every let-analysis path (route top-level, guard fail-body, match arm body), so `let xs = [...]` compiles to a clean analyze error regardless of where it's written.
- **Arrays with > 8 elements.** Both `AstExpr::kMaxArgs` and `HirExpr::kMaxArgs` are at 8 (HirRoute stack budget caps the HIR side; AST matches to keep the diagnostic at parse-time on the 9th element's span). Both caps can rise once HIR gains an out-of-line array-element pool.

## Implementation notes

- `HirForLoopBody.has_term` distinguishes `for item in xs { return 200 }` from `for item in xs { guard ... }`.
- Loop variable scope: analyze pushes a synthetic `HirLocal` into `route.locals` for a stable ref_index and clears its name after body analysis — Ident resolution is name-based so post-loop code can't reach the loop variable. Confirmed by `analyze_for_loop_var_scoped_to_body`.
- Loop-variable name collision with an outer local is rejected at analyze time (covered by `analyze_for_loop_rejects_shadowing_outer_local`).
- Guards that appear after a body terminator are rejected (covered by `analyze_for_loop_rejects_guard_after_terminator`).

## Validation

- `./dev.sh build` — clean build on clang++ and gcc, Debug + Release.
- Full test suite: **1489/1489 pass** (600 frontend + 102 integration + 431 network + 317 jit + 40 simulate). Cyclic-import clang Debug run is stable (HirRoute stack-size regression fixed in 904695e).
- New coverage: ~22 tests (parse and analyze tests for both array literals and for-loops, plus negative tests for all rejection paths and the MIR placeholder).

## Test plan

- [ ] CI: clang-format, clang-tidy, build+test on clang + gcc × Debug + Release, code coverage
- [ ] Follow-up PR will add Phase 4b (MIR unroll) + integration tests that execute for-loops on a real socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)