### PR TITLE
docs: parse_array_lit_basic comment — drop reference to nonexistent test

### DIFF
--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13499,8 +13499,9 @@ TEST(frontend, parse_array_lit_basic) {
     // `[i32]` in type position desugars to Array<i32> via parse_func_type_ref;
     // `[1, 2, 3]` in expression position produces AstExprKind::ArrayLit with
     // three IntLit elements in `args`. Intentionally parse-only: stops after
-    // parse_file_heap to assert AST shape (the analyze_array_lit_int_roundtrip
-    // test below covers the full HIR pipeline for the same input).
+    // parse_file_heap to assert AST shape. Analyze coverage for array literals
+    // currently comes from for-loop iter-expression tests, not this let-RHS
+    // form.
     const char* src = "route GET \"/x\" { let xs: [i32] = [1, 2, 3] return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);


### PR DESCRIPTION
## Summary
- `tests/test_frontend.cc :: parse_array_lit_basic` referenced `analyze_array_lit_int_roundtrip` as covering the full HIR pipeline for the same input, but that test doesn't exist — and analyze currently rejects `ArrayLit` on a `let` RHS.
- Updated the comment to point at the for-loop iter-expression tests, which are where analyze coverage for `ArrayLit` actually lives post-#38.

## Context
Flagged by Copilot on PR #38 (https://github.com/hurricane1026/Rut/pull/38#pullrequestreview-4164041403). #38 merged without it, so this lands as a small follow-up.

## Test plan
- [ ] `./dev.sh build` succeeds (comment-only change, should be a no-op for compilation)
- [ ] `./dev.sh test` — the test body is unchanged, only the leading comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)