### PR TITLE
mir: unroll for-loops (Phase 4b Scope A)

### DIFF
--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -35,9 +35,11 @@ enum class AstStmtKind : u8 {
     // No break / continue / else / labels (spec §3.3.9: every iteration runs
     // to completion). Analyze (Phase 3b) enforces the iteration source is
     // array-typed and compile-time-sized and builds a HirForLoop. MIR build
-    // currently rejects any route carrying for_loops (Phase 4a) — the full
-    // unroll (loop-var substitution + per-iteration guard blocks) lands in
-    // Phase 4b.
+    // unrolls for-loops in the Scope A pattern (one for-loop, body-guards
+    // only, Direct route control, no sibling route guards) — see
+    // mir_build.cc. Out-of-scope shapes (body terminator, if/match route
+    // control, interleaving with route guards, multiple for-loops) remain
+    // rejected here and are the target of Phase 4c/d.
     For,
 };
 

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -720,6 +720,10 @@ struct HirForLoop {
     u32 loop_var_variant_index = 0xffffffffu;
     u32 loop_var_struct_index = 0xffffffffu;
     u32 loop_var_shape_index = 0xffffffffu;
+    // Value that body LocalRefs carry in `local_index` when they refer to
+    // the loop variable. Set at analyze time from loop_var.ref_index; MIR
+    // unroll matches against this to substitute the per-iteration element.
+    u32 loop_var_ref_index = 0xffffffffu;
     HirForLoopBody body{};
 };
 

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9859,13 +9859,11 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 // ArrayLit at let RHS fails at MIR because MIR has no
                 // ArrayLit → MirValue lowering. Reject at analyze so users
                 // get a clean diagnostic at the declaration site instead of
-                // a later MIR error.
-                // Note: inline `for x in [1,2,3] { ... }` passes analyze
-                // (iter_expr is analyzed but not a let RHS), but Phase 4a's
-                // mir_build also rejects any route with for_loops.len > 0.
-                // End-to-end compilation of array-bearing programs lands
-                // once Phase 4b implements MIR unroll (and, separately,
-                // MIR gains array-constant lowering for let-RHS arrays).
+                // a later MIR error. Arrays only exist transiently as
+                // for-loop iterables today (MIR unroll lowers elements
+                // directly and never materializes the array as a MirValue);
+                // let-RHS arrays need a separate array-constant lowering
+                // pass before they can be supported.
                 if (init->kind == HirExprKind::ArrayLit)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, stmt);
@@ -10038,13 +10036,15 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 loop_var.name = stmt.name;
                 loop_var.ref_index =
                     next_local_ref_index(&route, route.locals.data, route.locals.len);
+                fl.loop_var_ref_index = loop_var.ref_index;
                 loop_var.type = fl.loop_var_type;
                 loop_var.variant_index = fl.loop_var_variant_index;
                 loop_var.struct_index = fl.loop_var_struct_index;
                 loop_var.shape_index = fl.loop_var_shape_index;
-                // Synthetic init — MIR unroll (Phase 4b) substitutes the
-                // per-iteration element value when reaching a LocalRef to
-                // this slot, so init is never read at runtime. We still
+                // Synthetic init — MIR unroll substitutes the per-iteration
+                // element value when reaching a LocalRef to this slot (via
+                // ForLoopCtx in mir_build.cc), so init is never read at
+                // runtime. We still
                 // need a consistent HirExpr for downstream passes that
                 // inspect local.init.kind (const-fold, diagnostics) — use
                 // a self-referential LocalRef so the node reads as "look

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -925,6 +925,20 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 return frontend_error(FrontendError::UnsupportedSyntax, fl.span);
             }
 
+            // Block budget pre-check. The unroll produces 2T+1 blocks
+            // (T virtual guards + 1 body + T fail blocks, T = N × M).
+            // MirFunction caps at kMaxBlocks, so worst-case shapes like
+            // N=8,M=1 or N=4,M=2 would push past the cap mid-emission.
+            // Reject up-front with a deterministic error at the for-loop
+            // span instead of a TooManyItems buried inside a later push.
+            {
+                const u64 total_guards =
+                    static_cast<u64>(fl.iter_expr.args.len) * fl.body.guards.len;
+                if (2 * total_guards + 1 > MirFunction::kMaxBlocks) {
+                    return frontend_error(FrontendError::TooManyItems, fl.span);
+                }
+            }
+
             // Unroll N × M virtual guards. Each entry pairs a body-guard
             // pointer with the ForLoopCtx that mir_value uses to substitute
             // the loop variable's LocalRef on the condition expression.

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -736,6 +736,18 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
 
         for (u32 li = 0; li < module.routes[i].locals.len; li++) {
             if (module.routes[i].locals[li].type == HirTypeKind::Tuple) continue;
+            // Skip synthetic name-cleared locals. Analyze keeps for-loop
+            // loop variables in HirRoute::locals so body LocalRefs bind to
+            // a stable ref_index, then blanks the name for scope-hiding
+            // (see analyze.cc:10137). MIR unroll substitutes every
+            // reference to the loop var with the per-iteration element
+            // (see ForLoopCtx in mir_value), so its MIR slot is never
+            // read. Emitting it anyway would push a MirLocal whose init
+            // is a self-referential LocalRef — lower_rir's
+            // materialize_local_init would resolve it to ValueId{0} since
+            // the slot is still being initialized, turning any future
+            // substitution regression into a silent miscompile.
+            if (module.routes[i].locals[li].name.len == 0) continue;
             MirLocal local{};
             local.span = module.routes[i].locals[li].span;
             local.name = module.routes[i].locals[li].name;

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -209,9 +209,22 @@ static bool variant_payload_carrier_ready(const MirModule& mir,
     return false;
 }
 
+// Context for MIR for-loop unrolling (Phase 4b). When lowering the body of
+// a HirForLoop iteration, the caller passes a non-null ctx so that any
+// LocalRef to the loop variable's ref_index is replaced with the current
+// iteration's element MirValue. External callers (route-level guards /
+// terminator / let init) pass nullptr: route-level code cannot reference
+// the loop variable because analyze clears its name after the body (see
+// analyze.cc:10123-10137), so substitution is never needed there.
+struct ForLoopCtx {
+    u32 loop_var_ref_index;    // matches HirExpr::local_index on LocalRef to loop var
+    MirValue current_element;  // value to substitute at that LocalRef
+};
+
 static FrontendResult<MirValue> mir_value(const HirExpr& expr,
                                           const HirModule& module,
-                                          MirFunction* fn) {
+                                          MirFunction* fn,
+                                          const ForLoopCtx* ctx = nullptr) {
     MirValue v{};
     v.shape_index = expr.shape_index;
     v.may_nil = expr.may_nil;
@@ -253,7 +266,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
                               v.tuple_variant_indices,
                               v.tuple_struct_indices);
         for (u32 i = 0; i < expr.args.len; i++) {
-            auto elem = mir_value(*expr.args[i], module, fn);
+            auto elem = mir_value(*expr.args[i], module, fn, ctx);
             if (!elem) return core::make_unexpected(elem.error());
             if (!fn->values.push(elem.value()))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -269,7 +282,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.str_value = expr.str_value;
         apply_expr_shape_if_available(module, expr, &v);
         for (u32 i = 0; i < expr.field_inits.len; i++) {
-            auto field_value = mir_value(*expr.field_inits[i].value, module, fn);
+            auto field_value = mir_value(*expr.field_inits[i].value, module, fn, ctx);
             if (!field_value) return core::make_unexpected(field_value.error());
             if (!fn->values.push(field_value.value()))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -282,7 +295,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::TupleSlot) {
-        auto lhs = mir_value(*expr.lhs, module, fn);
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -305,7 +318,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.int_value = expr.int_value;
         apply_expr_shape_if_available(module, expr, &v);
         if (expr.lhs != nullptr) {
-            auto payload = mir_value(*expr.lhs, module, fn);
+            auto payload = mir_value(*expr.lhs, module, fn, ctx);
             if (!payload) return core::make_unexpected(payload.error());
             if (!fn->values.push(payload.value()))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -314,7 +327,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::Field) {
-        auto lhs = mir_value(*expr.lhs, module, fn);
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -367,7 +380,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.error_case_index = expr.error_case_index;
         v.str_value = expr.str_value;
         for (u32 i = 0; i < expr.field_inits.len; i++) {
-            auto field_value = mir_value(*expr.field_inits[i].value, module, fn);
+            auto field_value = mir_value(*expr.field_inits[i].value, module, fn, ctx);
             if (!field_value) return core::make_unexpected(field_value.error());
             if (!fn->values.push(field_value.value()))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -381,9 +394,9 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
     }
     if (expr.kind == HirExprKind::Eq || expr.kind == HirExprKind::Lt ||
         expr.kind == HirExprKind::Gt) {
-        auto lhs = mir_value(*expr.lhs, module, fn);
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
         if (!lhs) return core::make_unexpected(lhs.error());
-        auto rhs = mir_value(*expr.rhs, module, fn);
+        auto rhs = mir_value(*expr.rhs, module, fn, ctx);
         if (!rhs) return core::make_unexpected(rhs.error());
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -401,11 +414,11 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::IfElse) {
-        auto cond = mir_value(*expr.lhs, module, fn);
+        auto cond = mir_value(*expr.lhs, module, fn, ctx);
         if (!cond) return core::make_unexpected(cond.error());
-        auto then_v = mir_value(*expr.rhs, module, fn);
+        auto then_v = mir_value(*expr.rhs, module, fn, ctx);
         if (!then_v) return core::make_unexpected(then_v.error());
-        auto else_v = mir_value(*expr.args[0], module, fn);
+        auto else_v = mir_value(*expr.args[0], module, fn, ctx);
         if (!else_v) return core::make_unexpected(else_v.error());
         if (!fn->values.push(cond.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -429,9 +442,9 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::Or) {
-        auto lhs = mir_value(*expr.lhs, module, fn);
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
         if (!lhs) return core::make_unexpected(lhs.error());
-        auto rhs = mir_value(*expr.rhs, module, fn);
+        auto rhs = mir_value(*expr.rhs, module, fn, ctx);
         if (!rhs) return core::make_unexpected(rhs.error());
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -450,7 +463,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::NoError) {
-        auto lhs = mir_value(*expr.lhs, module, fn);
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -461,7 +474,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::HasValue) {
-        auto lhs = mir_value(*expr.lhs, module, fn);
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -475,7 +488,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::ValueOf) {
-        auto lhs = mir_value(*expr.lhs, module, fn);
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -490,7 +503,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::MissingOf) {
-        auto lhs = mir_value(*expr.lhs, module, fn);
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -507,7 +520,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::MatchPayload) {
-        auto lhs = mir_value(*expr.lhs, module, fn);
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (!fn->values.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -522,6 +535,24 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::LocalRef) {
+        // For-loop unroll (Phase 4b): when lowering a body expression for
+        // iteration j, ctx carries the loop var's ref_index and the element
+        // MirValue for that iteration. A LocalRef whose local_index matches
+        // the loop var is replaced with the element directly; the element
+        // already carries its own shape / may_nil / may_error from having
+        // been lowered via mir_value() on the ArrayLit element expr, so no
+        // metadata merge is needed.
+        //
+        // LocalRefs to other locals (outer `let` bindings referenced from
+        // inside the loop body, e.g. `guard n > threshold`) fall through
+        // to the normal LocalRef lowering below — that path is exercised
+        // whenever ctx is null (route-level lowering) or the local_index
+        // doesn't match. The loop-var ref_index sentinel is validated once
+        // in the unroll driver, not here, to keep this hot path branchless
+        // for non-loop-var refs.
+        if (ctx != nullptr && expr.local_index == ctx->loop_var_ref_index) {
+            return ctx->current_element;
+        }
         v.kind = MirValueKind::LocalRef;
         v.type = mir_type_kind(expr.type);
         v.variant_index = expr.variant_index;
@@ -693,16 +724,6 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         fn.path = module.routes[i].path;
         fn.name = {"route", 5};
         fn.error_variant_index = module.routes[i].error_variant_index;
-
-        // Phase 4a: MIR doesn't yet unroll for-loops into its guard chain.
-        // Analyze (Phase 3b) populates route.for_loops; without the unroll
-        // pass the loop body is silently dropped and the route is compiled
-        // as if the loop never existed. Reject explicitly instead of
-        // miscompiling — Phase 4b will implement the unroll (loop-var
-        // substitution in mir_value + emit per-iteration guard blocks).
-        if (module.routes[i].for_loops.len != 0)
-            return frontend_error(FrontendError::UnsupportedSyntax,
-                                  module.routes[i].for_loops[0].span);
 
         // Propagate wait(ms) list 1:1. Codegen will turn each into a yield
         // boundary in the generated state machine.
@@ -879,6 +900,108 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             }
             return {};
         };
+
+        // Phase 4b Scope A for-loop unroll. A for-loop compiles to a flat
+        // chain of N × M virtual guards (N = iter_expr.args.len, M =
+        // body.guards.len), each branching to the next on pass and to its
+        // own fail block on failure. Pass of the final virtual guard falls
+        // into the route's direct terminator. This pass handles only the
+        // canonical allowlist-shaped pattern; other shapes remain rejected
+        // here until Phase 4c/d generalize the emission.
+        //
+        // Scope A preconditions (checked below): exactly one for-loop, no
+        // sibling route-level guards, route control is Direct, body has at
+        // least one guard and no body terminator. Rejected shapes (route
+        // guards mixed with for-loop, body terminator, if/match route
+        // control, multiple for-loops) get FrontendError::UnsupportedSyntax
+        // pointing at the for-loop span.
+        if (module.routes[i].for_loops.len != 0) {
+            const auto& fl = module.routes[i].for_loops[0];
+            const bool scope_a = module.routes[i].for_loops.len == 1 &&
+                                 module.routes[i].guards.len == 0 &&
+                                 module.routes[i].control.kind == HirControlKind::Direct &&
+                                 !fl.body.has_term && fl.body.guards.len != 0;
+            if (!scope_a || fl.loop_var_ref_index == 0xffffffffu) {
+                return frontend_error(FrontendError::UnsupportedSyntax, fl.span);
+            }
+
+            // Unroll N × M virtual guards. Each entry pairs a body-guard
+            // pointer with the ForLoopCtx that mir_value uses to substitute
+            // the loop variable's LocalRef on the condition expression.
+            // Phase 3b body guards are restricted to fail_kind == Term, so
+            // emit_guard_fail pushes exactly one fail block per guard.
+            struct UnrolledGuard {
+                const HirGuard* guard;
+                ForLoopCtx ctx;
+            };
+            constexpr u32 kMaxUnrolled = HirExpr::kMaxArgs * HirForLoopBody::kMaxGuards;
+            FixedVec<UnrolledGuard, kMaxUnrolled> expanded{};
+            for (u32 ai = 0; ai < fl.iter_expr.args.len; ai++) {
+                auto elem = mir_value(*fl.iter_expr.args[ai], module, &fn);
+                if (!elem) return core::make_unexpected(elem.error());
+                for (u32 gi = 0; gi < fl.body.guards.len; gi++) {
+                    UnrolledGuard u{};
+                    u.guard = &fl.body.guards[gi];
+                    u.ctx.loop_var_ref_index = fl.loop_var_ref_index;
+                    u.ctx.current_element = elem.value();
+                    if (!expanded.push(u))
+                        return frontend_error(FrontendError::TooManyItems, fl.span);
+                }
+            }
+
+            const u32 total = expanded.len;
+            const u32 body_index = total;
+            u32 guard_fail_index[kMaxUnrolled]{};
+            u32 fail_cursor = body_index + 1;
+            for (u32 gi = 0; gi < total; gi++) {
+                guard_fail_index[gi] = fail_cursor++;
+            }
+
+            // Entry block: test the first virtual guard's condition.
+            MirBlock entry_block{};
+            entry_block.label = entry_label();
+            entry_block.term.kind = MirTerminatorKind::Branch;
+            entry_block.term.span = expanded[0].guard->span;
+            auto cond0 = mir_value(expanded[0].guard->cond, module, &fn, &expanded[0].ctx);
+            if (!cond0) return core::make_unexpected(cond0.error());
+            entry_block.term.cond = cond0.value();
+            entry_block.term.then_block = total > 1 ? 1 : body_index;
+            entry_block.term.else_block = guard_fail_index[0];
+            if (!fn.blocks.push(entry_block))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+
+            // Subsequent virtual-guard blocks.
+            for (u32 gi = 1; gi < total; gi++) {
+                MirBlock guard_block{};
+                guard_block.label = cont_label();
+                guard_block.term.kind = MirTerminatorKind::Branch;
+                guard_block.term.span = expanded[gi].guard->span;
+                auto cond = mir_value(expanded[gi].guard->cond, module, &fn, &expanded[gi].ctx);
+                if (!cond) return core::make_unexpected(cond.error());
+                guard_block.term.cond = cond.value();
+                guard_block.term.then_block = gi + 1 < total ? gi + 1 : body_index;
+                guard_block.term.else_block = guard_fail_index[gi];
+                if (!fn.blocks.push(guard_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+            }
+
+            // Body block: the route's direct terminator.
+            MirBlock body_block{};
+            body_block.label = cont_label();
+            set_term_from_hir(&body_block.term, module.routes[i].control.direct_term);
+            if (!fn.blocks.push(body_block))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+
+            // Fail blocks, one per virtual guard.
+            for (u32 gi = 0; gi < total; gi++) {
+                auto emitted = emit_guard_fail(*expanded[gi].guard);
+                if (!emitted) return core::make_unexpected(emitted.error());
+            }
+
+            if (!mir->functions.push(fn))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+            continue;
+        }
 
         MirBlock block{};
         block.label = entry_label();

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -929,10 +929,19 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         // pointing at the for-loop span.
         if (module.routes[i].for_loops.len != 0) {
             const auto& fl = module.routes[i].for_loops[0];
-            const bool scope_a = module.routes[i].for_loops.len == 1 &&
-                                 module.routes[i].guards.len == 0 &&
-                                 module.routes[i].control.kind == HirControlKind::Direct &&
-                                 !fl.body.has_term && fl.body.guards.len != 0;
+            // Scope A also requires an inline array literal as the iter
+            // expression — the unroll reads elements from iter_expr.args
+            // which only ArrayLit populates. Today analyze only produces
+            // Array-typed HirExprs via the ArrayLit path (analyze.cc:4472
+            // is the sole producer), so this check is defensive against
+            // a future analyze change that admits other array-producing
+            // expressions (LocalRef/Field/call) — those would need a
+            // different MIR strategy since args.len would be 0 for them.
+            const bool scope_a =
+                module.routes[i].for_loops.len == 1 && module.routes[i].guards.len == 0 &&
+                module.routes[i].control.kind == HirControlKind::Direct && !fl.body.has_term &&
+                fl.body.guards.len != 0 && fl.iter_expr.kind == HirExprKind::ArrayLit &&
+                fl.iter_expr.args.len != 0;
             if (!scope_a || fl.loop_var_ref_index == 0xffffffffu) {
                 return frontend_error(FrontendError::UnsupportedSyntax, fl.span);
             }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13823,7 +13823,7 @@ TEST(frontend, mir_rejects_for_loop_with_body_terminator) {
     CHECK(!mir);
 }
 
-TEST(frontend, for_loop_lowers_through_rir_without_synthetic_local) {
+TEST(frontend, mir_for_loop_lowers_through_rir_without_synthetic_local) {
     // The loop variable is a synthetic HirLocal (analyze blanks its name
     // for scope-hiding) whose init is a self-referential LocalRef. MIR
     // must skip this slot so lower_rir's materialize_local_init doesn't

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13812,8 +13812,27 @@ TEST(frontend, mir_rejects_for_loop_with_body_terminator) {
     // unconditionally, making later iterations dead). Analyze accepts this
     // shape (Phase 3b), but MIR rejects until Scope B. Assertion: MIR fails
     // cleanly instead of silently dropping the loop.
+    const char* src = "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    CHECK(!mir);
+}
+
+TEST(frontend, mir_rejects_for_loop_exceeding_block_budget) {
+    // A Scope-A-shape program (one for-loop, body guards only, Direct
+    // control, no route guards) that unrolls to more than MirFunction::
+    // kMaxBlocks (16) blocks must reject cleanly at the for-loop span
+    // rather than fail mid-emission with a TooManyItems buried inside a
+    // later `fn.blocks.push`. N=8, M=1 → 2T+1 = 17 > 16. Analyze accepts
+    // this shape (kMaxArgs=8), so the reject must live in MIR's pre-check.
     const char* src =
-        "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 500 }\n";
+        "route GET \"/x\" { for n in [1, 2, 3, 4, 5, 6, 7, 8] { "
+        "guard n > 0 else { return 400 } } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13823,6 +13823,34 @@ TEST(frontend, mir_rejects_for_loop_with_body_terminator) {
     CHECK(!mir);
 }
 
+TEST(frontend, for_loop_lowers_through_rir_without_synthetic_local) {
+    // The loop variable is a synthetic HirLocal (analyze blanks its name
+    // for scope-hiding) whose init is a self-referential LocalRef. MIR
+    // must skip this slot so lower_rir's materialize_local_init doesn't
+    // resolve the self-ref to ValueId{0} on an unset slot. Regression
+    // guard: lower the canonical Scope A program end-to-end through RIR
+    // and confirm it succeeds. Also asserts that the MIR function has
+    // zero locals (the only HIR local was the loop var, which must have
+    // been skipped).
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
 TEST(frontend, mir_rejects_for_loop_exceeding_block_budget) {
     // A Scope-A-shape program (one for-loop, body guards only, Direct
     // control, no route guards) that unrolls to more than MirFunction::

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -13755,15 +13755,82 @@ TEST(frontend, analyze_for_loop_iter_not_array_rejected) {
     CHECK(!hir);
 }
 
-TEST(frontend, mir_rejects_for_loop_until_phase_4b) {
-    // Phase 4a: analyze accepts for-loops (Phase 3b), but MIR doesn't yet
-    // unroll them. Until Phase 4b lands the subst-aware mir_value + guard
-    // chain emission, MIR rejects any route with for_loops.len > 0 so
-    // users see a clean error at build time instead of a silent miscompile
-    // (loop body dropped, handler treats the loop as a no-op).
+TEST(frontend, mir_unrolls_for_loop_scope_a_basic) {
+    // Phase 4b Scope A: a for-loop with body-guards only, no sibling route
+    // guards, and a Direct route terminator unrolls to a flat guard chain.
+    // For N=3 elements × M=1 body guard, the route lowers to:
+    //   block[0..2] = guard-branch blocks (virtual guards, one per element)
+    //   block[3]    = body block (the route's `return 200`)
+    //   block[4..6] = fail blocks (`return 400` from the body guard's else)
+    // Total: 7 blocks.
     const char* src =
         "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else "
         "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].blocks.len, 7u);
+}
+
+TEST(frontend, mir_unrolls_for_loop_substitutes_element_in_cond) {
+    // The heart of the unroll: each iteration's virtual guard should test
+    // the element value directly, not a LocalRef to the loop variable.
+    // For `for item in [1, 2, 3] { guard item > 0 ...}`, block[0].term.cond
+    // must be Gt with lhs = IntConst(1), block[1] lhs = IntConst(2),
+    // block[2] lhs = IntConst(3). A regression that forgets to substitute
+    // would leave lhs as a LocalRef to the loop var's synthetic init.
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_rejects_for_loop_with_body_terminator) {
+    // Scope A excludes body terminators (iteration 0 would short-circuit
+    // unconditionally, making later iterations dead). Analyze accepts this
+    // shape (Phase 3b), but MIR rejects until Scope B. Assertion: MIR fails
+    // cleanly instead of silently dropping the loop.
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    CHECK(!mir);
+}
+
+TEST(frontend, mir_rejects_for_loop_with_route_level_guard) {
+    // Scope A excludes routes that mix for-loops with sibling route-level
+    // guards (span-ordered interleaving is deferred to Scope C).
+    const char* src =
+        "route GET \"/x\" { guard true else { return 403 } "
+        "for item in [1, 2, 3] { guard item > 0 else { return 400 } } "
+        "return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());


### PR DESCRIPTION
## Summary
Lifts the blanket MIR reject on routes carrying for-loops and emits a flat guard chain for the canonical allowlist pattern — one for-loop, body consists only of guards (no body terminator), route control is `Direct`, and no sibling route-level guards. `N × M` virtual guards with per-iteration loop-var substitution.

Follow-up to #38 which landed the AST/analyze/HIR plumbing with MIR deferred.

## Scope

**In scope (Scope A — this PR):**
```rutlang
route GET "/x" {
    for item in [1, 2, 3] {
        guard item > 0 else { return 400 }
    }
    return 200
}
```
→ 7 MIR blocks (3 guard branches + 1 body + 3 fail).

**Still rejected (Phase 4c/d):**
- for-loop with body terminator (`for n in [...] { return 200 }`)
- for-loop mixed with sibling route-level guards
- for-loop + `if`/`match` route control
- multiple for-loops per route

Out-of-scope shapes return `FrontendError::UnsupportedSyntax` pointing at the for-loop span.

## Implementation

1. **Loop-var identity**: `HirForLoop` gains `loop_var_ref_index`, set by analyze right where the ref_index is computed. This avoids name-based lookup at MIR time.
2. **Substitution plumbing**: `mir_value()` gets a `const ForLoopCtx* ctx = nullptr` default param; the 18 internal recursive calls forward it. The `LocalRef` case substitutes `ctx->current_element` when the ref_index matches; outer-local refs fall through to normal lowering.
3. **Unroll driver** in `mir_build.cc` builds `N × M` virtual guards, then emits entry-guard + cont-guard + body + fail blocks inline, reusing the existing `emit_guard_fail` lambda (which already handles the `FailKind::Term` branch that Phase 3b body guards are restricted to).
4. Old blanket reject at the top of the route-lowering loop deleted; narrower reject at the new scope check.

## Test plan
- [ ] `./dev.sh build` — compiles cleanly (verified locally, 0 new warnings)
- [ ] `./dev.sh test` — 603 frontend tests pass (+4 new), full suite passes
- [ ] `mir_unrolls_for_loop_scope_a_basic` asserts block count = `2T+1` for N=3, M=1 (T=3 → 7 blocks)
- [ ] `mir_unrolls_for_loop_substitutes_element_in_cond` asserts each unrolled guard's `cond.lhs` is `IntConst` with the element value (catches a substitution regression)
- [ ] `mir_rejects_for_loop_with_body_terminator` and `mir_rejects_for_loop_with_route_level_guard` verify out-of-scope shapes still fail cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)