### PR TITLE
testing/bench: nanobench-style perf counters + MAD + env warnings

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -28,3 +28,9 @@ target_include_directories(bench_connection PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/testing
 )
+
+add_executable(bench_bench_demo bench_bench_demo.cc)
+target_include_directories(bench_bench_demo PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+)

--- a/bench/bench_bench_demo.cc
+++ b/bench/bench_bench_demo.cc
@@ -1,0 +1,58 @@
+// Demo: exercise the nanobench-style additions (environment warnings,
+// perf counters, MAD / err% reporting) so the commit ships a visible
+// proof-of-life. Measures two trivially-different workloads — a warm
+// memory scan vs. a random-access scan — and prints the perf counter
+// numbers that explain their cycle-count difference.
+//
+// Build:  ninja -C build bench_bench_demo
+// Run:    taskset -c 0 ./build/bench/bench_bench_demo
+
+#include "bench.h"
+
+using namespace rut;
+
+static constexpr u32 kBufSize = 256 * 1024;  // 256 KB — fits in L2, not L1
+alignas(64) static u8 g_buf[kBufSize];
+alignas(64) static u32 g_indices[kBufSize / 64];
+
+int main() {
+    bench::print_environment_warnings();
+
+    // Prep buffers. Sequential buf, shuffled cacheline-granular indices.
+    for (u32 i = 0; i < kBufSize; i++) g_buf[i] = static_cast<u8>(i & 0xff);
+    const u32 n_cls = kBufSize / 64;
+    for (u32 i = 0; i < n_cls; i++) g_indices[i] = i * 64;
+    // Fisher-Yates shuffle.
+    u64 rnd = 0x9E3779B97F4A7C15ULL;
+    for (u32 i = n_cls - 1; i > 0; i--) {
+        rnd = rnd * 6364136223846793005ULL + 1442695040888963407ULL;
+        const u32 j = static_cast<u32>(rnd >> 32) % (i + 1);
+        u32 t = g_indices[i];
+        g_indices[i] = g_indices[j];
+        g_indices[j] = t;
+    }
+
+    bench::Bench b;
+    b.title("bench infra sanity check");
+    b.min_iterations(200000);
+    b.warmup(5000);
+    b.epochs(7);
+    b.perf_counters(true);
+    b.print_header();
+
+    b.run("sequential_scan", [&] {
+        u64 acc = 0;
+        for (u32 i = 0; i < kBufSize; i += 64) acc += g_buf[i];
+        bench::do_not_optimize(&acc);
+    });
+
+    b.run("random_cacheline_scan", [&] {
+        u64 acc = 0;
+        for (u32 i = 0; i < n_cls; i++) acc += g_buf[g_indices[i]];
+        bench::do_not_optimize(&acc);
+    });
+
+    b.compare();
+    bench::out("\n");
+    return 0;
+}

--- a/testing/bench.h
+++ b/testing/bench.h
@@ -256,9 +256,17 @@ struct Bench {
                     // A short/interrupted read means this epoch's
                     // counters are zero rather than real. Rolling it
                     // into the totals would bias the per-iteration
-                    // averages; flip perf_ok off for the whole run
-                    // so the output section is suppressed instead.
+                    // averages; flip perf_ok off for the whole run so
+                    // the output section is suppressed, and zero out
+                    // any totals accumulated from earlier epochs so
+                    // the returned Result doesn't carry partial data
+                    // from an invalidated measurement window.
                     perf_ok = false;
+                    total_cycles = 0;
+                    total_inst = 0;
+                    total_bmiss = 0;
+                    total_cref = 0;
+                    total_cmiss = 0;
                 } else {
                     total_cycles += pc.cycles();
                     total_inst += pc.instructions();
@@ -293,8 +301,14 @@ struct Bench {
         }
         sort_u64(abs_dev, epochs_);
         r.mad_ns = abs_dev[epochs_ / 2];
+        // Widen to __int128 for the multiply so multi-second per-iter
+        // benchmarks (mad_ns above ~1.8e17) don't overflow u64 and
+        // wrap to a nonsense err_pct. __int128 is a compiler builtin
+        // on every x86_64 clang/gcc we target — no stdlib dep.
         r.err_pct = r.median_ns > 0
-                        ? static_cast<u32>((r.mad_ns * 100 + r.median_ns / 2) / r.median_ns)
+                        ? static_cast<u32>(((static_cast<unsigned __int128>(r.mad_ns) * 100) +
+                                            (static_cast<unsigned __int128>(r.median_ns) / 2)) /
+                                           static_cast<unsigned __int128>(r.median_ns))
                         : 0;
 
         r.iterations = iters_per_epoch * epochs_;
@@ -344,8 +358,14 @@ struct Bench {
             if (total_inst > 0) {
                 out("  inst/iter: ");
                 out_u64(total_inst / it);
+            }
+            // IPC requires cycles > 0; otherwise print nothing rather
+            // than dividing by a `? : 1` fallback that would emit a
+            // huge phantom IPC on an unsupported-event / read-failure
+            // edge case.
+            if (total_cycles > 0 && total_inst > 0) {
                 // IPC × 100 (fixed-point 2 decimals)
-                const u64 ipc100 = (total_inst * 100) / (total_cycles > 0 ? total_cycles : 1);
+                const u64 ipc100 = (total_inst * 100) / total_cycles;
                 out("  IPC: ");
                 out_u64(ipc100 / 100);
                 out(".");
@@ -438,14 +458,19 @@ struct Bench {
 // Environment checks
 // ============================================================================
 //
-// Microbenchmarks are only as reliable as the system they run on. These
-// helpers read /sys and /proc to flag the well-known foot-guns:
+// Microbenchmarks are only as reliable as the system they run on.
+// print_environment_warnings() reads /sys and /proc to flag the
+// well-known foot-guns it can actually detect from file state:
 //   - CPU governor != performance  (frequency varies during the run)
 //   - Intel turbo boost on         (same — amplified)
-//   - CPU unpinned (no taskset)    (scheduler migration flushes caches)
+//   - perf_event_paranoid > 2      (perf counters will be unavailable)
 //
-// Call print_environment_warnings() once at the start of main() so the
-// user sees the flags before reading numbers they might otherwise trust.
+// It also prints a `taskset -c N` hint so the user remembers to pin
+// the benchmark to one core, but it does NOT currently detect the
+// process's actual CPU affinity — that would need a sched_getaffinity
+// probe and is deferred. Call print_environment_warnings() once at
+// the start of main() so the user sees the flags before reading
+// numbers they might otherwise trust.
 
 // Read up to `cap-1` bytes from `path` into `buf`, zero-terminate. Returns
 // the count read, or 0 on any error. Trims a single trailing newline.

--- a/testing/bench.h
+++ b/testing/bench.h
@@ -247,8 +247,20 @@ struct Bench {
         // Per-run perf counters. If the user asked for them but the
         // kernel refuses (perf_event_paranoid too high), silently fall
         // back to wall-clock only — the measurement still happens.
+        // `perf_open` is sticky for the whole run: once we decide to
+        // run the enable/disable ioctls, we keep doing them in every
+        // epoch so the per-epoch ioctl overhead stays uniform across
+        // the timing sample. Mixing epochs that paid that overhead
+        // with epochs that didn't would skew median/MAD against runs
+        // where perf was invalidated mid-way.
+        // `perf_valid` controls whether we keep accumulating perf
+        // totals and report perf data in the Result. It can flip to
+        // false mid-run on a short/interrupted read, on a multiplexed
+        // group, or on an ioctl failure inside enable()/disable() —
+        // but the ioctls themselves keep firing.
         PerfCounters pc;
-        bool perf_ok = perf_counters_ && pc.open();
+        const bool perf_open = perf_counters_ && pc.open();
+        bool perf_valid = perf_open;
 
         // Collect epoch timings + cumulative perf totals.
         u64 epoch_ns[kMaxEpochs];
@@ -256,36 +268,39 @@ struct Bench {
         u64 total_cycles = 0, total_inst = 0, total_bmiss = 0, total_cref = 0, total_cmiss = 0;
 
         for (u32 e = 0; e < epochs_; e++) {
-            if (perf_ok) pc.enable();
+            if (perf_open) pc.enable();
             u64 t0 = now_ns();
             for (u64 i = 0; i < iters_per_epoch; i++) {
                 fn();
                 clobber();
             }
             u64 t1 = now_ns();
-            if (perf_ok) {
+            if (perf_open) {
                 pc.disable();
-                if (!pc.last_read_ok()) {
-                    // A short/interrupted read means this epoch's
-                    // counters are zero rather than real. Rolling it
-                    // into the totals would bias the per-iteration
-                    // averages; flip perf_ok off for the whole run so
-                    // the output section is suppressed, and zero out
-                    // any totals accumulated from earlier epochs so
-                    // the returned Result doesn't carry partial data
-                    // from an invalidated measurement window.
-                    perf_ok = false;
-                    total_cycles = 0;
-                    total_inst = 0;
-                    total_bmiss = 0;
-                    total_cref = 0;
-                    total_cmiss = 0;
-                } else {
-                    total_cycles += pc.cycles();
-                    total_inst += pc.instructions();
-                    total_bmiss += pc.branch_misses();
-                    total_cref += pc.cache_refs();
-                    total_cmiss += pc.cache_misses();
+                if (perf_valid) {
+                    if (!pc.last_read_ok()) {
+                        // A short/interrupted read or detected
+                        // multiplexing means this epoch's counters
+                        // are zero rather than real. Rolling that
+                        // into the totals would bias the per-
+                        // iteration averages; flip perf_valid off so
+                        // the output section is suppressed and zero
+                        // out any totals accumulated from earlier
+                        // epochs so the returned Result doesn't carry
+                        // partial data from an invalidated window.
+                        perf_valid = false;
+                        total_cycles = 0;
+                        total_inst = 0;
+                        total_bmiss = 0;
+                        total_cref = 0;
+                        total_cmiss = 0;
+                    } else {
+                        total_cycles += pc.cycles();
+                        total_inst += pc.instructions();
+                        total_bmiss += pc.branch_misses();
+                        total_cref += pc.cache_refs();
+                        total_cmiss += pc.cache_misses();
+                    }
                 }
             }
             epoch_ns[e] = (t1 - t0) / iters_per_epoch;  // ns per iteration
@@ -326,7 +341,7 @@ struct Bench {
 
         r.iterations = iters_per_epoch * epochs_;
         r.bytes_per_op = bytes_per_op_;
-        r.perf_valid = perf_ok;
+        r.perf_valid = perf_valid;
         r.perf_cycles = total_cycles;
         r.perf_instructions = total_inst;
         r.perf_branch_misses = total_bmiss;
@@ -336,7 +351,7 @@ struct Bench {
         // so a caller that only inspects the mask still sees "no
         // data", matching the zeroed totals.
         u32 available = 0;
-        if (perf_ok) {
+        if (perf_valid) {
             for (u32 i = 0; i < kPerfCounterCount; i++) {
                 if (pc.has(i)) available |= (1u << i);
             }
@@ -372,7 +387,7 @@ struct Bench {
         out_u64_comma(r.iterations);
         out(" iters)\n");
 
-        if (perf_ok) {
+        if (perf_valid) {
             // Per-iteration perf metrics — the numbers that actually
             // explain WHY something is faster or slower.
             // Gate each line on whether the underlying counter

--- a/testing/bench.h
+++ b/testing/bench.h
@@ -21,8 +21,10 @@
 //       b.run("llhttp_parse", [&] { ... });
 //   }
 
+#include "perf_counters.h"
 #include "rut/common/types.h"
 
+#include <fcntl.h>
 #include <time.h>    // clock_gettime, CLOCK_MONOTONIC
 #include <unistd.h>  // write
 
@@ -164,11 +166,26 @@ static constexpr u32 kMaxEpochs = 64;
 
 struct Result {
     const char* name;
-    u64 median_ns;     // median time per iteration
-    u64 min_ns;        // minimum time per iteration
-    u64 mean_ns;       // mean time per iteration
+    u64 median_ns;  // median time per iteration
+    u64 min_ns;     // minimum time per iteration
+    u64 mean_ns;    // mean time per iteration
+    // MAD = median of |epoch_ns - median_ns|. A robust-to-outliers
+    // dispersion measure (see nanobench). err_pct = MAD / median × 100
+    // — anything > 5% means the benchmark isn't measuring cleanly
+    // (CPU frequency scaling, thermal throttling, context switches,
+    // other cores touching shared caches).
+    u64 mad_ns;
+    u32 err_pct;       // MAD / median × 100, rounded
     u64 iterations;    // total iterations run
     u64 bytes_per_op;  // bytes processed per operation (for throughput)
+    // Hardware perf counters, totalled across all epochs. Zero when
+    // counters weren't enabled or when the kernel refused access.
+    u64 perf_cycles;
+    u64 perf_instructions;
+    u64 perf_branch_misses;
+    u64 perf_cache_refs;
+    u64 perf_cache_misses;
+    bool perf_valid;
 };
 
 struct Bench {
@@ -178,6 +195,7 @@ struct Bench {
     u32 epochs_ = 11;      // odd number for clean median
     u64 epoch_iters_ = 0;  // 0 = auto (min_iters / epochs)
     u64 bytes_per_op_ = 0;
+    bool perf_counters_ = false;
 
     Result results_[32];
     u32 result_count_ = 0;
@@ -190,6 +208,11 @@ struct Bench {
         if (epochs_ % 2 == 0) epochs_++;  // keep odd for clean median
     }
     void bytes_per_op(u64 n) { bytes_per_op_ = n; }
+    // Enable hardware perf counters (cycles, instructions, branch-misses,
+    // cache refs, cache misses) for each subsequent run(). No-op if the
+    // kernel refuses access (perf_event_paranoid too high); the benchmark
+    // still runs, just without PMU data.
+    void perf_counters(bool enable) { perf_counters_ = enable; }
 
     template <typename Fn>
     Result run(const char* name, Fn&& fn) {
@@ -202,17 +225,33 @@ struct Bench {
             clobber();
         }
 
-        // Collect epoch timings
+        // Per-run perf counters. If the user asked for them but the
+        // kernel refuses (perf_event_paranoid too high), silently fall
+        // back to wall-clock only — the measurement still happens.
+        PerfCounters pc;
+        const bool perf_ok = perf_counters_ && pc.open();
+
+        // Collect epoch timings + cumulative perf totals.
         u64 epoch_ns[kMaxEpochs];
         u64 total_ns = 0;
+        u64 total_cycles = 0, total_inst = 0, total_bmiss = 0, total_cref = 0, total_cmiss = 0;
 
         for (u32 e = 0; e < epochs_; e++) {
+            if (perf_ok) pc.enable();
             u64 t0 = now_ns();
             for (u64 i = 0; i < iters_per_epoch; i++) {
                 fn();
                 clobber();
             }
             u64 t1 = now_ns();
+            if (perf_ok) {
+                pc.disable();
+                total_cycles += pc.cycles();
+                total_inst += pc.instructions();
+                total_bmiss += pc.branch_misses();
+                total_cref += pc.cache_refs();
+                total_cmiss += pc.cache_misses();
+            }
             epoch_ns[e] = (t1 - t0) / iters_per_epoch;  // ns per iteration
             total_ns += (t1 - t0);
         }
@@ -227,8 +266,30 @@ struct Bench {
         r.min_ns = sorted[0];
         r.median_ns = sorted[epochs_ / 2];
         r.mean_ns = total_ns / (iters_per_epoch * epochs_);
+
+        // Median Absolute Deviation: median of |epoch - median|. More
+        // robust to outliers than stddev. err_pct is how noisy this
+        // run was; > 5% means the numbers probably can't be trusted
+        // for tight comparisons.
+        u64 abs_dev[kMaxEpochs];
+        for (u32 i = 0; i < epochs_; i++) {
+            const u64 v = sorted[i];
+            abs_dev[i] = v >= r.median_ns ? v - r.median_ns : r.median_ns - v;
+        }
+        sort_u64(abs_dev, epochs_);
+        r.mad_ns = abs_dev[epochs_ / 2];
+        r.err_pct = r.median_ns > 0
+                        ? static_cast<u32>((r.mad_ns * 100 + r.median_ns / 2) / r.median_ns)
+                        : 0;
+
         r.iterations = iters_per_epoch * epochs_;
         r.bytes_per_op = bytes_per_op_;
+        r.perf_valid = perf_ok;
+        r.perf_cycles = total_cycles;
+        r.perf_instructions = total_inst;
+        r.perf_branch_misses = total_bmiss;
+        r.perf_cache_refs = total_cref;
+        r.perf_cache_misses = total_cmiss;
 
         // Print result
         out("  ");
@@ -241,11 +302,13 @@ struct Bench {
         out("  median: ");
         out_duration_ns(r.median_ns);
 
+        out("  ±");
+        out_u64(r.err_pct);
+        out("%");
+        if (r.err_pct > 5) out("!");  // flag noisy measurements
+
         out("  min: ");
         out_duration_ns(r.min_ns);
-
-        out("  mean: ");
-        out_duration_ns(r.mean_ns);
 
         if (bytes_per_op_ > 0 && r.median_ns > 0) {
             u64 bytes_per_sec = (bytes_per_op_ * 1000000000ULL) / r.median_ns;
@@ -256,6 +319,40 @@ struct Bench {
         out("  (");
         out_u64_comma(r.iterations);
         out(" iters)\n");
+
+        if (perf_ok) {
+            // Per-iteration perf metrics — the numbers that actually
+            // explain WHY something is faster or slower.
+            const u64 it = r.iterations;
+            out("                              cycles/iter: ");
+            out_u64(total_cycles / it);
+            if (total_inst > 0) {
+                out("  inst/iter: ");
+                out_u64(total_inst / it);
+                // IPC × 100 (fixed-point 2 decimals)
+                const u64 ipc100 = (total_inst * 100) / (total_cycles > 0 ? total_cycles : 1);
+                out("  IPC: ");
+                out_u64(ipc100 / 100);
+                out(".");
+                const u64 frac = ipc100 % 100;
+                if (frac < 10) out("0");
+                out_u64(frac);
+            }
+            if (total_cref > 0) {
+                // Cache miss rate in ‰ (per-mille) for 1-decimal %
+                const u64 miss_thou = (total_cmiss * 1000) / total_cref;
+                out("  L1-miss: ");
+                out_u64(miss_thou / 10);
+                out(".");
+                out_u64(miss_thou % 10);
+                out("%");
+            }
+            if (total_bmiss > 0) {
+                out("  br-miss/iter: ");
+                out_u64(total_bmiss / it);
+            }
+            out("\n");
+        }
 
         if (result_count_ < 32) {
             results_[result_count_++] = r;
@@ -317,5 +414,80 @@ struct Bench {
         out(" ===\n");
     }
 };
+
+// ============================================================================
+// Environment checks
+// ============================================================================
+//
+// Microbenchmarks are only as reliable as the system they run on. These
+// helpers read /sys and /proc to flag the well-known foot-guns:
+//   - CPU governor != performance  (frequency varies during the run)
+//   - Intel turbo boost on         (same — amplified)
+//   - CPU unpinned (no taskset)    (scheduler migration flushes caches)
+//
+// Call print_environment_warnings() once at the start of main() so the
+// user sees the flags before reading numbers they might otherwise trust.
+
+// Read up to `cap-1` bytes from `path` into `buf`, zero-terminate. Returns
+// the count read, or 0 on any error. Trims a single trailing newline.
+inline u32 read_small_file(const char* path, char* buf, u32 cap) {
+    int fd = ::open(path, O_RDONLY);
+    if (fd < 0) return 0;
+    ssize_t n = ::read(fd, buf, cap - 1);
+    ::close(fd);
+    if (n <= 0) return 0;
+    u32 len = static_cast<u32>(n);
+    if (buf[len - 1] == '\n') len--;
+    buf[len] = '\0';
+    return len;
+}
+
+inline bool str_eq_cstr(const char* a, const char* b) {
+    u32 i = 0;
+    while (a[i] && b[i] && a[i] == b[i]) i++;
+    return a[i] == '\0' && b[i] == '\0';
+}
+
+inline void print_environment_warnings() {
+    char buf[128];
+
+    out("--- Environment ---\n");
+
+    // CPU governor.
+    if (read_small_file(
+            "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor", buf, sizeof(buf))) {
+        out("  governor: ");
+        out(buf);
+        if (!str_eq_cstr(buf, "performance")) {
+            out("  [!]  (expected 'performance' for stable measurements)");
+        }
+        out("\n");
+    }
+
+    // Intel no_turbo flag: "1" = turbo disabled (stable), "0" = turbo on.
+    if (read_small_file("/sys/devices/system/cpu/intel_pstate/no_turbo", buf, sizeof(buf))) {
+        out("  intel turbo: ");
+        if (str_eq_cstr(buf, "1")) {
+            out("OFF");
+        } else {
+            out("ON  [!]  (frequency will vary)");
+        }
+        out("\n");
+    }
+
+    // perf_event_paranoid — gate on PMU access.
+    if (read_small_file("/proc/sys/kernel/perf_event_paranoid", buf, sizeof(buf))) {
+        out("  perf_event_paranoid: ");
+        out(buf);
+        if (buf[0] != '0' && buf[0] != '1' && buf[0] != '2') {
+            out("  [!]  (perf counters will be unavailable; sudo sysctl "
+                "kernel.perf_event_paranoid=2)");
+        }
+        out("\n");
+    }
+
+    out("  suggestion: taskset -c 0 ./bench_...    # pin to one core\n");
+    out("\n");
+}
 
 }  // namespace rut::bench

--- a/testing/bench.h
+++ b/testing/bench.h
@@ -187,6 +187,19 @@ struct Result {
     u64 perf_cache_refs;
     u64 perf_cache_misses;
     bool perf_valid;
+    // Bitmask of PerfCounterIndex entries that the kernel actually
+    // granted. On a partial-PMU box the kernel may open cycles /
+    // instructions but refuse cache events (or vice versa); without
+    // this mask, a total of `0` in perf_cache_misses is ambiguous
+    // between "counter unavailable" and "legitimate zero" (a tiny
+    // hot dataset on a correctly opened counter). Downstream
+    // consumers should gate per-counter reads on has_perf_counter()
+    // rather than peeking at perf_valid alone.
+    u32 perf_available_mask;
+
+    bool has_perf_counter(u32 idx) const {
+        return perf_valid && idx < kPerfCounterCount && ((perf_available_mask >> idx) & 1u) != 0;
+    }
 };
 
 struct Bench {
@@ -319,6 +332,16 @@ struct Bench {
         r.perf_branch_misses = total_bmiss;
         r.perf_cache_refs = total_cref;
         r.perf_cache_misses = total_cmiss;
+        // Snapshot per-counter availability. Zero on invalidated runs
+        // so a caller that only inspects the mask still sees "no
+        // data", matching the zeroed totals.
+        u32 available = 0;
+        if (perf_ok) {
+            for (u32 i = 0; i < kPerfCounterCount; i++) {
+                if (pc.has(i)) available |= (1u << i);
+            }
+        }
+        r.perf_available_mask = available;
 
         // Print result
         out("  ");

--- a/testing/bench.h
+++ b/testing/bench.h
@@ -352,18 +352,24 @@ struct Bench {
         if (perf_ok) {
             // Per-iteration perf metrics — the numbers that actually
             // explain WHY something is faster or slower.
+            // Gate each line on whether the underlying counter
+            // actually opened — not just on "sum > 0". An unopened
+            // counter's value() returns 0, which is indistinguishable
+            // from a legitimate zero count, and on partial-PMU
+            // configurations (some kernels refuse cache events while
+            // granting cycles/instructions) we were printing
+            // "cache-miss: 0.0%" and "IPC: 0.00" as if they were real
+            // measurements (Codex P2 on #42).
             const u64 it = r.iterations;
-            out("                              cycles/iter: ");
-            out_u64(total_cycles / it);
-            if (total_inst > 0) {
+            if (pc.has(kPerfCycles)) {
+                out("                              cycles/iter: ");
+                out_u64(total_cycles / it);
+            }
+            if (pc.has(kPerfInstructions)) {
                 out("  inst/iter: ");
                 out_u64(total_inst / it);
             }
-            // IPC requires cycles > 0; otherwise print nothing rather
-            // than dividing by a `? : 1` fallback that would emit a
-            // huge phantom IPC on an unsupported-event / read-failure
-            // edge case.
-            if (total_cycles > 0 && total_inst > 0) {
+            if (pc.has(kPerfCycles) && pc.has(kPerfInstructions) && total_cycles > 0) {
                 // IPC × 100 (fixed-point 2 decimals)
                 const u64 ipc100 = (total_inst * 100) / total_cycles;
                 out("  IPC: ");
@@ -373,7 +379,7 @@ struct Bench {
                 if (frac < 10) out("0");
                 out_u64(frac);
             }
-            if (total_cref > 0) {
+            if (pc.has(kPerfCacheRefs) && pc.has(kPerfCacheMisses) && total_cref > 0) {
                 // PERF_COUNT_HW_CACHE_MISSES / _REFERENCES are the
                 // generic hardware cache events. On most x86 machines
                 // the kernel maps these to last-level-cache (LLC)
@@ -386,7 +392,7 @@ struct Bench {
                 out_u64(miss_thou % 10);
                 out("%");
             }
-            if (total_bmiss > 0) {
+            if (pc.has(kPerfBranchMisses)) {
                 out("  br-miss/iter: ");
                 out_u64(total_bmiss / it);
             }

--- a/testing/bench.h
+++ b/testing/bench.h
@@ -339,9 +339,13 @@ struct Bench {
                 out_u64(frac);
             }
             if (total_cref > 0) {
-                // Cache miss rate in ‰ (per-mille) for 1-decimal %
+                // PERF_COUNT_HW_CACHE_MISSES / _REFERENCES are the
+                // generic hardware cache events. On most x86 machines
+                // the kernel maps these to last-level-cache (LLC)
+                // counters, not L1 — label accordingly to avoid a
+                // misleading "L1-miss" attribution.
                 const u64 miss_thou = (total_cmiss * 1000) / total_cref;
-                out("  L1-miss: ");
+                out("  cache-miss: ");
                 out_u64(miss_thou / 10);
                 out(".");
                 out_u64(miss_thou % 10);
@@ -475,11 +479,24 @@ inline void print_environment_warnings() {
         out("\n");
     }
 
-    // perf_event_paranoid — gate on PMU access.
+    // perf_event_paranoid — gate on PMU access. `perf_event_open`
+    // allows unprivileged hardware-event counting up to and including
+    // paranoid=2; above that (newer kernels default to 4) the group
+    // open fails with EACCES. Parse as an integer so multi-digit
+    // values like "10" aren't misread via buf[0].
     if (read_small_file("/proc/sys/kernel/perf_event_paranoid", buf, sizeof(buf))) {
         out("  perf_event_paranoid: ");
         out(buf);
-        if (buf[0] != '0' && buf[0] != '1' && buf[0] != '2') {
+        // Accept a leading '-' for defensive parsing (kernel allows -1).
+        int paranoid = 0;
+        u32 i = (buf[0] == '-') ? 1 : 0;
+        bool valid = i < sizeof(buf) && buf[i] != '\0';
+        while (valid && buf[i] >= '0' && buf[i] <= '9') {
+            paranoid = paranoid * 10 + (buf[i] - '0');
+            i++;
+        }
+        if (buf[0] == '-') paranoid = -paranoid;
+        if (paranoid > 2) {
             out("  [!]  (perf counters will be unavailable; sudo sysctl "
                 "kernel.perf_event_paranoid=2)");
         }

--- a/testing/bench.h
+++ b/testing/bench.h
@@ -370,8 +370,12 @@ struct Bench {
                 out_u64(total_inst / it);
             }
             if (pc.has(kPerfCycles) && pc.has(kPerfInstructions) && total_cycles > 0) {
-                // IPC × 100 (fixed-point 2 decimals)
-                const u64 ipc100 = (total_inst * 100) / total_cycles;
+                // IPC × 100 (fixed-point 2 decimals). Widen to
+                // __int128 for the multiply so long benches where
+                // total_inst exceeds ~1.8e17 don't overflow u64 and
+                // wrap to a nonsense IPC. Same pattern as err_pct.
+                const u64 ipc100 = static_cast<u64>(
+                    (static_cast<unsigned __int128>(total_inst) * 100) / total_cycles);
                 out("  IPC: ");
                 out_u64(ipc100 / 100);
                 out(".");
@@ -385,7 +389,8 @@ struct Bench {
                 // the kernel maps these to last-level-cache (LLC)
                 // counters, not L1 — label accordingly to avoid a
                 // misleading "L1-miss" attribution.
-                const u64 miss_thou = (total_cmiss * 1000) / total_cref;
+                const u64 miss_thou = static_cast<u64>(
+                    (static_cast<unsigned __int128>(total_cmiss) * 1000) / total_cref);
                 out("  cache-miss: ");
                 out_u64(miss_thou / 10);
                 out(".");

--- a/testing/bench.h
+++ b/testing/bench.h
@@ -24,6 +24,7 @@
 #include "perf_counters.h"
 #include "rut/common/types.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <time.h>    // clock_gettime, CLOCK_MONOTONIC
 #include <unistd.h>  // write
@@ -205,7 +206,12 @@ struct Bench {
     void warmup(u64 n) { warmup_iters_ = n; }
     void epochs(u32 n) {
         epochs_ = n < 1 ? 1 : (n > kMaxEpochs ? kMaxEpochs : n);
-        if (epochs_ % 2 == 0) epochs_++;  // keep odd for clean median
+        if (epochs_ % 2 == 0) {
+            // Keep odd for clean median — but if we're already at the
+            // fixed-size array cap, stepping up would overrun
+            // epoch_ns[] / sorted[] / abs_dev[]. Step down instead.
+            epochs_ = (epochs_ == kMaxEpochs) ? (epochs_ - 1) : (epochs_ + 1);
+        }
     }
     void bytes_per_op(u64 n) { bytes_per_op_ = n; }
     // Enable hardware perf counters (cycles, instructions, branch-misses,
@@ -229,7 +235,7 @@ struct Bench {
         // kernel refuses (perf_event_paranoid too high), silently fall
         // back to wall-clock only — the measurement still happens.
         PerfCounters pc;
-        const bool perf_ok = perf_counters_ && pc.open();
+        bool perf_ok = perf_counters_ && pc.open();
 
         // Collect epoch timings + cumulative perf totals.
         u64 epoch_ns[kMaxEpochs];
@@ -246,11 +252,20 @@ struct Bench {
             u64 t1 = now_ns();
             if (perf_ok) {
                 pc.disable();
-                total_cycles += pc.cycles();
-                total_inst += pc.instructions();
-                total_bmiss += pc.branch_misses();
-                total_cref += pc.cache_refs();
-                total_cmiss += pc.cache_misses();
+                if (!pc.last_read_ok()) {
+                    // A short/interrupted read means this epoch's
+                    // counters are zero rather than real. Rolling it
+                    // into the totals would bias the per-iteration
+                    // averages; flip perf_ok off for the whole run
+                    // so the output section is suppressed instead.
+                    perf_ok = false;
+                } else {
+                    total_cycles += pc.cycles();
+                    total_inst += pc.instructions();
+                    total_bmiss += pc.branch_misses();
+                    total_cref += pc.cache_refs();
+                    total_cmiss += pc.cache_misses();
+                }
             }
             epoch_ns[e] = (t1 - t0) / iters_per_epoch;  // ns per iteration
             total_ns += (t1 - t0);
@@ -434,10 +449,17 @@ struct Bench {
 
 // Read up to `cap-1` bytes from `path` into `buf`, zero-terminate. Returns
 // the count read, or 0 on any error. Trims a single trailing newline.
+// Requires `cap >= 2` (one byte of payload + the trailing nul); smaller
+// caps are a caller bug and would underflow `cap - 1`. Retries `read()`
+// on EINTR so the env-warning path isn't silently defeated by a signal.
 inline u32 read_small_file(const char* path, char* buf, u32 cap) {
+    if (cap < 2) return 0;
     int fd = ::open(path, O_RDONLY);
     if (fd < 0) return 0;
-    ssize_t n = ::read(fd, buf, cap - 1);
+    ssize_t n;
+    do {
+        n = ::read(fd, buf, cap - 1);
+    } while (n < 0 && errno == EINTR);
     ::close(fd);
     if (n <= 0) return 0;
     u32 len = static_cast<u32>(n);

--- a/testing/perf_counters.h
+++ b/testing/perf_counters.h
@@ -196,7 +196,10 @@ private:
         attr.read_format = PERF_FORMAT_GROUP;
         // pid=0 → calling process. cpu=-1 → any CPU (the scheduler may
         // migrate us; caller should pin with taskset for stability).
-        long fd = perf_event_open_raw(&attr, 0, -1, group_fd, 0);
+        // PERF_FLAG_FD_CLOEXEC matches the rest of the codebase's
+        // policy of setting close-on-exec on every owned fd so perf
+        // handles don't leak into child processes across fork/exec.
+        long fd = perf_event_open_raw(&attr, 0, -1, group_fd, PERF_FLAG_FD_CLOEXEC);
         if (fd < 0) {
             fds_[idx] = -1;
             valid_[idx] = false;

--- a/testing/perf_counters.h
+++ b/testing/perf_counters.h
@@ -196,9 +196,9 @@ private:
         attr.read_format = PERF_FORMAT_GROUP;
         // pid=0 → calling process. cpu=-1 → any CPU (the scheduler may
         // migrate us; caller should pin with taskset for stability).
-        // PERF_FLAG_FD_CLOEXEC matches the rest of the codebase's
-        // policy of setting close-on-exec on every owned fd so perf
-        // handles don't leak into child processes across fork/exec.
+        // PERF_FLAG_FD_CLOEXEC sets close-on-exec on the perf fd so
+        // these handles don't leak into child processes across exec()
+        // — benchmarks often fork subprocesses for setup or warmup.
         long fd = perf_event_open_raw(&attr, 0, -1, group_fd, PERF_FLAG_FD_CLOEXEC);
         if (fd < 0) {
             fds_[idx] = -1;

--- a/testing/perf_counters.h
+++ b/testing/perf_counters.h
@@ -70,6 +70,7 @@ public:
             last_values_[i] = 0;
             valid_[i] = false;
         }
+        last_read_ok_ = true;
     }
 
     ~PerfCounters() { close_all(); }
@@ -124,6 +125,7 @@ public:
         if (fds_[kPerfCycles] < 0) return;
         ::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP);
         ::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
+        last_read_ok_ = true;
     }
 
     // Disable the group and pull the counter values. Subsequent has() /
@@ -133,6 +135,13 @@ public:
         ::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP);
         read_all();
     }
+
+    // True iff the most recent disable()'s read_all() returned a
+    // complete snapshot. False after a short / EINTR-final read —
+    // values in this case are zero rather than stale, but callers
+    // should suppress per-iteration perf output rather than print
+    // phantom zeros.
+    bool last_read_ok() const { return last_read_ok_; }
 
     // Whether the counter at `idx` was opened successfully. Secondary
     // counter opens can fail independently of the leader; callers that
@@ -167,6 +176,7 @@ private:
     int fds_[kPerfCounterCount];
     u64 last_values_[kPerfCounterCount];
     bool valid_[kPerfCounterCount];
+    bool last_read_ok_ = true;
 
     bool open_counter(u32 idx, u32 type, u64 config, int group_fd, bool disabled) {
         struct perf_event_attr attr;
@@ -211,16 +221,32 @@ private:
         for (u32 i = 0; i < kPerfCounterCount; i++) {
             if (valid_[i]) opened_count++;
         }
-        if (opened_count == 0) return;  // nothing to read
+        if (opened_count == 0) {
+            last_read_ok_ = false;
+            return;
+        }
 
         constexpr u32 kBufSlots = 1 + kPerfCounterCount;
         u64 buf[kBufSlots];
-        ssize_t n = ::read(fds_[kPerfCycles], buf, sizeof(buf));
+        ssize_t n;
+        do {
+            n = ::read(fds_[kPerfCycles], buf, sizeof(buf));
+        } while (n < 0 && errno == EINTR);
         const ssize_t expected = static_cast<ssize_t>((1 + opened_count) * sizeof(u64));
-        if (n < expected) return;  // short/failed read — values stay zero
+        if (n < expected) {
+            // Short or failed read. Values stay zero (already cleared
+            // above). Mark the snapshot invalid so Bench::run can
+            // suppress perf output for this epoch — printing "cycles/
+            // iter: 0" after a read failure would look like real data.
+            last_read_ok_ = false;
+            return;
+        }
 
         const u64 nr = buf[0];
-        if (nr < opened_count) return;  // kernel disagrees; bail safely
+        if (nr < opened_count) {
+            last_read_ok_ = false;
+            return;
+        }
 
         // Map read values back to the stable per-counter slots.
         u32 slot = 1;

--- a/testing/perf_counters.h
+++ b/testing/perf_counters.h
@@ -194,12 +194,28 @@ private:
         attr.exclude_kernel = 1;  // measure userspace only — kernel work is noise
         attr.exclude_hv = 1;      // skip hypervisor ticks
         attr.read_format = PERF_FORMAT_GROUP;
+        // Pin the group leader so the kernel either schedules all five
+        // counters together or refuses the open outright. Without
+        // pinning + multiplexing active, the kernel is free to
+        // time-slice counters in and out of hardware slots and
+        // PERF_FORMAT_GROUP alone gives us no way to tell (we'd need
+        // TOTAL_TIME_ENABLED / TOTAL_TIME_RUNNING to scale). Group
+        // members inherit the leader's pinning; `pinned = 1` is only
+        // valid on the leader (group_fd == -1). If pinning fails the
+        // leader open returns EINVAL — fall back to an unpinned open
+        // so benchmarks still run, just with the caveat that
+        // multiplexing (rare at only 5 counters) could bias numbers.
+        if (group_fd == -1) attr.pinned = 1;
         // pid=0 → calling process. cpu=-1 → any CPU (the scheduler may
         // migrate us; caller should pin with taskset for stability).
         // PERF_FLAG_FD_CLOEXEC sets close-on-exec on the perf fd so
         // these handles don't leak into child processes across exec()
         // — benchmarks often fork subprocesses for setup or warmup.
         long fd = perf_event_open_raw(&attr, 0, -1, group_fd, PERF_FLAG_FD_CLOEXEC);
+        if (fd < 0 && attr.pinned) {
+            attr.pinned = 0;
+            fd = perf_event_open_raw(&attr, 0, -1, group_fd, PERF_FLAG_FD_CLOEXEC);
+        }
         if (fd < 0) {
             fds_[idx] = -1;
             valid_[idx] = false;

--- a/testing/perf_counters.h
+++ b/testing/perf_counters.h
@@ -127,20 +127,40 @@ public:
     }
 
     // Reset and enable the whole group. Must be called after open();
-    // sampling starts immediately.
+    // sampling starts immediately. RESET / ENABLE ioctl failures are
+    // captured in ioctl_ok_ and folded into last_read_ok_ when
+    // disable() finishes, so callers can't be fooled into printing
+    // phantom zeros from a counter that never started: read() on a
+    // never-enabled group is `nr` zero values with no error, which
+    // would otherwise pass last_read_ok() with last_values_ all zero.
     void enable() {
         if (fds_[kPerfCycles] < 0) return;
-        ::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP);
-        ::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
         last_read_ok_ = true;
+        ioctl_ok_ = true;
+        if (::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP) < 0) {
+            ioctl_ok_ = false;
+        }
+        if (::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP) < 0) {
+            ioctl_ok_ = false;
+        }
     }
 
     // Disable the group and pull the counter values. Subsequent has() /
-    // cycles() / etc. reads see the snapshot taken here.
+    // cycles() / etc. reads see the snapshot taken here. If any of the
+    // RESET / ENABLE / DISABLE ioctls failed, last_read_ok_ is forced
+    // false and last_values_ are zeroed even when the read syscall
+    // itself succeeded — the read just reflects whatever (possibly
+    // stale, possibly never-counted) state the group was left in.
     void disable() {
         if (fds_[kPerfCycles] < 0) return;
-        ::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP);
+        if (::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP) < 0) {
+            ioctl_ok_ = false;
+        }
         read_all();
+        if (!ioctl_ok_) {
+            for (u32 i = 0; i < kPerfCounterCount; i++) last_values_[i] = 0;
+            last_read_ok_ = false;
+        }
     }
 
     // True iff the most recent disable()'s read_all() returned a
@@ -184,6 +204,10 @@ private:
     u64 last_values_[kPerfCounterCount];
     bool valid_[kPerfCounterCount];
     bool last_read_ok_ = true;
+    // Tracks whether the RESET/ENABLE/DISABLE ioctls in the most
+    // recent enable()/disable() pair all succeeded. Reset to true on
+    // each enable(); ANDed into last_read_ok_ at the end of disable().
+    bool ioctl_ok_ = true;
 
     bool open_counter(u32 idx, u32 type, u64 config, int group_fd, bool disabled) {
         struct perf_event_attr attr;

--- a/testing/perf_counters.h
+++ b/testing/perf_counters.h
@@ -193,18 +193,23 @@ private:
         attr.disabled = disabled ? 1 : 0;
         attr.exclude_kernel = 1;  // measure userspace only — kernel work is noise
         attr.exclude_hv = 1;      // skip hypervisor ticks
-        attr.read_format = PERF_FORMAT_GROUP;
+        // Request TIME_ENABLED / TIME_RUNNING alongside the grouped
+        // values so read_all() can detect when the kernel actually
+        // multiplexes the group (time_running < time_enabled) and
+        // invalidate the snapshot instead of reporting silently
+        // scaled-down counts. Codex P2 on #42 (round 7) flagged that
+        // the pinned-open fallback left the bench exposed to this.
+        attr.read_format =
+            PERF_FORMAT_GROUP | PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING;
         // Pin the group leader so the kernel either schedules all five
-        // counters together or refuses the open outright. Without
-        // pinning + multiplexing active, the kernel is free to
-        // time-slice counters in and out of hardware slots and
-        // PERF_FORMAT_GROUP alone gives us no way to tell (we'd need
-        // TOTAL_TIME_ENABLED / TOTAL_TIME_RUNNING to scale). Group
-        // members inherit the leader's pinning; `pinned = 1` is only
-        // valid on the leader (group_fd == -1). If pinning fails the
-        // leader open returns EINVAL — fall back to an unpinned open
-        // so benchmarks still run, just with the caveat that
-        // multiplexing (rare at only 5 counters) could bias numbers.
+        // counters together or refuses the open outright. Pinning
+        // avoids multiplexing in the first place whenever the system
+        // allows it; the TIME_ENABLED/RUNNING check is a safety net
+        // for the fallback case. Group members inherit the leader's
+        // pinning; `pinned = 1` is only valid on the leader
+        // (group_fd == -1). If pinning fails the leader open returns
+        // EINVAL — fall back to an unpinned open so benchmarks still
+        // run.
         if (group_fd == -1) attr.pinned = 1;
         // pid=0 → calling process. cpu=-1 → any CPU (the scheduler may
         // migrate us; caller should pin with taskset for stability).
@@ -227,24 +232,31 @@ private:
     }
 
     void read_all() {
-        // Layout with PERF_FORMAT_GROUP (no TIME_* / ID bits):
+        // Layout with PERF_FORMAT_GROUP |
+        //             PERF_FORMAT_TOTAL_TIME_ENABLED |
+        //             PERF_FORMAT_TOTAL_TIME_RUNNING:
         //   u64 nr;
+        //   u64 time_enabled;
+        //   u64 time_running;
         //   u64 values[nr];
         // where values[] is in the order group members were opened
         // (only successfully-opened counters appear).
+        //
+        // time_enabled ≥ time_running; when they differ, the kernel
+        // multiplexed the group off hardware slots for some of the
+        // window and the raw counts are proportionally under-reported.
+        // We refuse to "just scale them up" — multiplexed counts are
+        // a noisy proxy for the true rate, not a drop-in replacement
+        // — and instead flag the snapshot invalid so Bench::run
+        // suppresses the whole epoch.
         //
         // Zero the snapshot up front: on short/failed read the caller
         // must see zeros, not stale values from the previous epoch —
         // otherwise a silent read failure quietly poisons the next
         // accumulate() and the printed cycles-per-iter becomes a
-        // phantom from some prior run.
-        //
-        // Also re-optimize on success: start by assuming the read
-        // will succeed and only flip last_read_ok_ false on a
-        // concrete failure path. This way a successful read after a
-        // prior failure clears the sticky flag without requiring a
-        // matching enable() — otherwise a disable()-without-enable()
-        // would keep reporting stale "invalid snapshot".
+        // phantom from some prior run. Re-optimize on success: start
+        // by assuming the read will succeed and only flip
+        // last_read_ok_ false on a concrete failure path.
         for (u32 i = 0; i < kPerfCounterCount; i++) last_values_[i] = 0;
         last_read_ok_ = true;
 
@@ -259,31 +271,38 @@ private:
             return;
         }
 
-        constexpr u32 kBufSlots = 1 + kPerfCounterCount;
+        // Buffer: nr + time_enabled + time_running + values[nr].
+        constexpr u32 kBufSlots = 3 + kPerfCounterCount;
         u64 buf[kBufSlots];
         ssize_t n;
         do {
             n = ::read(fds_[kPerfCycles], buf, sizeof(buf));
         } while (n < 0 && errno == EINTR);
-        const ssize_t expected = static_cast<ssize_t>((1 + opened_count) * sizeof(u64));
+        const ssize_t expected = static_cast<ssize_t>((3 + opened_count) * sizeof(u64));
         if (n < expected) {
-            // Short or failed read. Values stay zero (already cleared
-            // above). Mark the snapshot invalid so Bench::run can
-            // suppress perf output for this epoch — printing "cycles/
-            // iter: 0" after a read failure would look like real data.
+            // Short or failed read.
             last_read_ok_ = false;
             return;
         }
 
         const u64 nr = buf[0];
+        const u64 time_enabled = buf[1];
+        const u64 time_running = buf[2];
         if (nr < opened_count) {
+            last_read_ok_ = false;
+            return;
+        }
+        // Multiplexing check: kernel only ran the counters for part
+        // of the enabled window. Don't trust the raw counts.
+        if (time_running < time_enabled) {
             last_read_ok_ = false;
             return;
         }
 
         // Map read values back to the stable per-counter slots.
-        u32 slot = 1;
-        for (u32 i = 0; i < kPerfCounterCount && slot < kBufSlots && slot - 1 < nr; i++) {
+        // Values start at buf[3] under this read_format.
+        u32 slot = 3;
+        for (u32 i = 0; i < kPerfCounterCount && slot < kBufSlots && slot - 3 < nr; i++) {
             if (!valid_[i]) continue;
             last_values_[i] = buf[slot++];
         }

--- a/testing/perf_counters.h
+++ b/testing/perf_counters.h
@@ -1,0 +1,216 @@
+#pragma once
+
+// PerfCounters — RAII wrapper around Linux perf_event_open for reading
+// hardware performance counters (cycles, instructions, branch-misses,
+// cache-references, cache-misses) during microbenchmarks.
+//
+// Modeled on nanobench's PerformanceCounters: a single event group so the
+// kernel schedules all counters together (all counted in the same time
+// window; no risk of counter A being descheduled while B runs). Leader is
+// cycles; other counters are added with `group_fd = leader_fd`.
+//
+// Usage:
+//   rut::bench::PerfCounters pc;
+//   if (pc.open()) {
+//       pc.enable();
+//       <work>
+//       pc.disable();
+//       u64 cycles = pc.cycles();
+//       u64 insts  = pc.instructions();
+//       ...
+//   } else {
+//       // perf_event_paranoid too high, or no hardware PMU, or similar.
+//       // Fall back to wall-clock only.
+//   }
+//
+// Common blockers and how to clear them:
+//   - /proc/sys/kernel/perf_event_paranoid > 2 prevents unprivileged
+//     access to hardware counters. Lower it (sudo sysctl
+//     kernel.perf_event_paranoid=0) or run under a user with CAP_PERFMON.
+//   - Containers / VMs often block PMU access entirely; open() returns
+//     EACCES or ENOENT.
+//   - Some kernels gate cache events behind extra permissions; those
+//     counters silently return zero if they fail — check validity bits.
+
+#include "rut/common/types.h"
+
+#include <errno.h>
+#include <linux/perf_event.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+namespace rut::bench {
+
+// Raw syscall wrapper — the glibc header doesn't provide one.
+inline long perf_event_open_raw(
+    struct perf_event_attr* attr, pid_t pid, int cpu, int group_fd, unsigned long flags) {
+    return syscall(__NR_perf_event_open, attr, pid, cpu, group_fd, flags);
+}
+
+// Keep these indexes stable — they match the order counters are opened
+// and the positions in the read buffer returned by read().
+enum PerfCounterIndex : u32 {
+    kPerfCycles = 0,
+    kPerfInstructions = 1,
+    kPerfBranchMisses = 2,
+    kPerfCacheRefs = 3,
+    kPerfCacheMisses = 4,
+    kPerfCounterCount = 5,
+};
+
+class PerfCounters {
+public:
+    PerfCounters() {
+        for (u32 i = 0; i < kPerfCounterCount; i++) {
+            fds_[i] = -1;
+            last_values_[i] = 0;
+            valid_[i] = false;
+        }
+    }
+
+    ~PerfCounters() { close_all(); }
+
+    // Non-copyable: fds are owned resources.
+    PerfCounters(const PerfCounters&) = delete;
+    PerfCounters& operator=(const PerfCounters&) = delete;
+
+    // Open the full counter group. Returns true if the leader (cycles)
+    // and at least one secondary counter opened successfully. Returns
+    // false if the leader itself failed — in that case the whole group
+    // is unusable; caller should fall back to wall-clock-only reporting.
+    //
+    // Individual secondary counters that fail to open are marked invalid
+    // and will report as zero via has(); the rest of the group still
+    // works.
+    bool open() {
+        // Leader = CPU cycles. Disabled at start; PERF_EVENT_IOC_ENABLE
+        // on the leader propagates to the whole group via
+        // PERF_IOC_FLAG_GROUP.
+        if (!open_counter(kPerfCycles,
+                          PERF_TYPE_HARDWARE,
+                          PERF_COUNT_HW_CPU_CYCLES,
+                          -1,
+                          /*disabled=*/true)) {
+            return false;
+        }
+        const int leader = fds_[kPerfCycles];
+        // Secondary counters join the group via group_fd = leader.
+        // attr.disabled = 0 for group members; they follow the leader.
+        open_counter(
+            kPerfInstructions, PERF_TYPE_HARDWARE, PERF_COUNT_HW_INSTRUCTIONS, leader, false);
+        open_counter(
+            kPerfBranchMisses, PERF_TYPE_HARDWARE, PERF_COUNT_HW_BRANCH_MISSES, leader, false);
+        open_counter(
+            kPerfCacheRefs, PERF_TYPE_HARDWARE, PERF_COUNT_HW_CACHE_REFERENCES, leader, false);
+        open_counter(
+            kPerfCacheMisses, PERF_TYPE_HARDWARE, PERF_COUNT_HW_CACHE_MISSES, leader, false);
+        return true;
+    }
+
+    // Reset and enable the whole group. Must be called after open();
+    // sampling starts immediately.
+    void enable() {
+        if (fds_[kPerfCycles] < 0) return;
+        ::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP);
+        ::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP);
+    }
+
+    // Disable the group and pull the counter values. Subsequent has() /
+    // cycles() / etc. reads see the snapshot taken here.
+    void disable() {
+        if (fds_[kPerfCycles] < 0) return;
+        ::ioctl(fds_[kPerfCycles], PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP);
+        read_all();
+    }
+
+    // Whether the counter at `idx` was opened successfully. Secondary
+    // counter opens can fail independently of the leader; callers that
+    // want IPC etc. should check has(kPerfCycles) && has(kPerfInstructions).
+    bool has(u32 idx) const { return idx < kPerfCounterCount && valid_[idx]; }
+
+    u64 value(u32 idx) const { return idx < kPerfCounterCount ? last_values_[idx] : 0; }
+
+    // Convenience accessors.
+    u64 cycles() const { return value(kPerfCycles); }
+    u64 instructions() const { return value(kPerfInstructions); }
+    u64 branch_misses() const { return value(kPerfBranchMisses); }
+    u64 cache_refs() const { return value(kPerfCacheRefs); }
+    u64 cache_misses() const { return value(kPerfCacheMisses); }
+
+    // Add counters from `other` into this one. Used to accumulate
+    // across epochs.
+    void accumulate(const PerfCounters& other) {
+        for (u32 i = 0; i < kPerfCounterCount; i++) {
+            if (other.valid_[i]) {
+                last_values_[i] += other.last_values_[i];
+                valid_[i] = valid_[i] || other.valid_[i];
+            }
+        }
+    }
+
+    void reset_values() {
+        for (u32 i = 0; i < kPerfCounterCount; i++) last_values_[i] = 0;
+    }
+
+private:
+    int fds_[kPerfCounterCount];
+    u64 last_values_[kPerfCounterCount];
+    bool valid_[kPerfCounterCount];
+
+    bool open_counter(u32 idx, u32 type, u64 config, int group_fd, bool disabled) {
+        struct perf_event_attr attr;
+        ::memset(&attr, 0, sizeof(attr));
+        attr.type = type;
+        attr.size = sizeof(attr);
+        attr.config = config;
+        attr.disabled = disabled ? 1 : 0;
+        attr.exclude_kernel = 1;  // measure userspace only — kernel work is noise
+        attr.exclude_hv = 1;      // skip hypervisor ticks
+        attr.read_format = PERF_FORMAT_GROUP;
+        // pid=0 → calling process. cpu=-1 → any CPU (the scheduler may
+        // migrate us; caller should pin with taskset for stability).
+        long fd = perf_event_open_raw(&attr, 0, -1, group_fd, 0);
+        if (fd < 0) {
+            fds_[idx] = -1;
+            valid_[idx] = false;
+            return false;
+        }
+        fds_[idx] = static_cast<int>(fd);
+        valid_[idx] = true;
+        return true;
+    }
+
+    void read_all() {
+        // Layout with PERF_FORMAT_GROUP (no TIME_* / ID bits):
+        //   u64 nr;
+        //   u64 values[nr];
+        // where values[] is in the order counters were opened.
+        constexpr u32 kBufSlots = 1 + kPerfCounterCount;
+        u64 buf[kBufSlots];
+        ssize_t n = ::read(fds_[kPerfCycles], buf, sizeof(buf));
+        if (n < static_cast<ssize_t>(sizeof(u64))) return;  // read failed; leave stale
+        const u64 nr = buf[0];
+        // The kernel only reports values for counters that actually
+        // opened (group members that failed to open aren't in the group
+        // at all). Map them back by walking valid_ in the same order.
+        u32 slot = 1;
+        for (u32 i = 0; i < kPerfCounterCount && slot < kBufSlots && slot - 1 < nr; i++) {
+            if (!valid_[i]) continue;
+            last_values_[i] = buf[slot++];
+        }
+    }
+
+    void close_all() {
+        for (u32 i = 0; i < kPerfCounterCount; i++) {
+            if (fds_[i] >= 0) {
+                ::close(fds_[i]);
+                fds_[i] = -1;
+            }
+        }
+    }
+};
+
+}  // namespace rut::bench

--- a/testing/perf_counters.h
+++ b/testing/perf_counters.h
@@ -25,8 +25,9 @@
 //
 // Common blockers and how to clear them:
 //   - /proc/sys/kernel/perf_event_paranoid > 2 prevents unprivileged
-//     access to hardware counters. Lower it (sudo sysctl
-//     kernel.perf_event_paranoid=0) or run under a user with CAP_PERFMON.
+//     access to hardware counters. Lower it (`sudo sysctl
+//     kernel.perf_event_paranoid=2`, matching the threshold the
+//     group open tolerates) or run under a user with CAP_PERFMON.
 //   - Containers / VMs often block PMU access entirely; open() returns
 //     EACCES or ENOENT.
 //   - Some kernels gate cache events behind extra permissions; those
@@ -77,15 +78,22 @@ public:
     PerfCounters(const PerfCounters&) = delete;
     PerfCounters& operator=(const PerfCounters&) = delete;
 
-    // Open the full counter group. Returns true if the leader (cycles)
-    // and at least one secondary counter opened successfully. Returns
-    // false if the leader itself failed — in that case the whole group
-    // is unusable; caller should fall back to wall-clock-only reporting.
+    // Open the full counter group. Returns true iff the leader (cycles)
+    // opens successfully — secondary counters are best-effort and may
+    // individually fail without affecting the return value (callers
+    // should use has() / value() defensively, e.g. check
+    // has(kPerfInstructions) before computing IPC).
     //
-    // Individual secondary counters that fail to open are marked invalid
-    // and will report as zero via has(); the rest of the group still
-    // works.
+    // Idempotent: calling open() on an already-open or partially-open
+    // instance first tears down the previous group so fds don't leak
+    // and stale valid_/last_values_ state can't carry over.
     bool open() {
+        close_all();  // safe no-op if no fds are open
+        for (u32 i = 0; i < kPerfCounterCount; i++) {
+            last_values_[i] = 0;
+            valid_[i] = false;
+        }
+
         // Leader = CPU cycles. Disabled at start; PERF_EVENT_IOC_ENABLE
         // on the leader propagates to the whole group via
         // PERF_IOC_FLAG_GROUP.
@@ -187,15 +195,34 @@ private:
         // Layout with PERF_FORMAT_GROUP (no TIME_* / ID bits):
         //   u64 nr;
         //   u64 values[nr];
-        // where values[] is in the order counters were opened.
+        // where values[] is in the order group members were opened
+        // (only successfully-opened counters appear).
+        //
+        // Zero the snapshot up front: on short/failed read the caller
+        // must see zeros, not stale values from the previous epoch —
+        // otherwise a silent read failure quietly poisons the next
+        // accumulate() and the printed cycles-per-iter becomes a
+        // phantom from some prior run.
+        for (u32 i = 0; i < kPerfCounterCount; i++) last_values_[i] = 0;
+
+        // Count how many group members were actually opened so we know
+        // the minimum correct read size.
+        u32 opened_count = 0;
+        for (u32 i = 0; i < kPerfCounterCount; i++) {
+            if (valid_[i]) opened_count++;
+        }
+        if (opened_count == 0) return;  // nothing to read
+
         constexpr u32 kBufSlots = 1 + kPerfCounterCount;
         u64 buf[kBufSlots];
         ssize_t n = ::read(fds_[kPerfCycles], buf, sizeof(buf));
-        if (n < static_cast<ssize_t>(sizeof(u64))) return;  // read failed; leave stale
+        const ssize_t expected = static_cast<ssize_t>((1 + opened_count) * sizeof(u64));
+        if (n < expected) return;  // short/failed read — values stay zero
+
         const u64 nr = buf[0];
-        // The kernel only reports values for counters that actually
-        // opened (group members that failed to open aren't in the group
-        // at all). Map them back by walking valid_ in the same order.
+        if (nr < opened_count) return;  // kernel disagrees; bail safely
+
+        // Map read values back to the stable per-counter slots.
         u32 slot = 1;
         for (u32 i = 0; i < kPerfCounterCount && slot < kBufSlots && slot - 1 < nr; i++) {
             if (!valid_[i]) continue;

--- a/testing/perf_counters.h
+++ b/testing/perf_counters.h
@@ -94,6 +94,12 @@ public:
             last_values_[i] = 0;
             valid_[i] = false;
         }
+        // Clear the snapshot-validity flag too so a failed read from
+        // a previous open/enable cycle can't leak into the new
+        // session. Callers inspecting last_read_ok() before the first
+        // enable() on the re-opened group should see `true`, not a
+        // stale `false` carried over from a prior teardown.
+        last_read_ok_ = true;
 
         // Leader = CPU cycles. Disabled at start; PERF_EVENT_IOC_ENABLE
         // on the leader propagates to the whole group via
@@ -213,7 +219,15 @@ private:
         // otherwise a silent read failure quietly poisons the next
         // accumulate() and the printed cycles-per-iter becomes a
         // phantom from some prior run.
+        //
+        // Also re-optimize on success: start by assuming the read
+        // will succeed and only flip last_read_ok_ false on a
+        // concrete failure path. This way a successful read after a
+        // prior failure clears the sticky flag without requiring a
+        // matching enable() — otherwise a disable()-without-enable()
+        // would keep reporting stale "invalid snapshot".
         for (u32 i = 0; i < kPerfCounterCount; i++) last_values_[i] = 0;
+        last_read_ok_ = true;
 
         // Count how many group members were actually opened so we know
         // the minimum correct read size.

--- a/testing/perf_counters.h
+++ b/testing/perf_counters.h
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/syscall.h>
+#include <sys/types.h>  // canonical home for pid_t, used below
 #include <unistd.h>
 
 namespace rut::bench {
@@ -211,8 +212,15 @@ private:
         // EINVAL — fall back to an unpinned open so benchmarks still
         // run.
         if (group_fd == -1) attr.pinned = 1;
-        // pid=0 → calling process. cpu=-1 → any CPU (the scheduler may
-        // migrate us; caller should pin with taskset for stability).
+        // pid=0 → calling *task* (thread), not the whole process. If a
+        // benchmark spawns worker threads, their cycles / inst /
+        // cache events are NOT counted here unless inheritance is
+        // enabled or separate perf fds are opened for each worker.
+        // Bench::run runs the measured code on the calling thread so
+        // this is fine in practice, but anyone extending to a
+        // multi-thread workload needs to know.
+        // cpu=-1 → any CPU (the scheduler may migrate us; caller
+        // should pin with taskset for stability).
         // PERF_FLAG_FD_CLOEXEC sets close-on-exec on the perf fd so
         // these handles don't leak into child processes across exec()
         // — benchmarks often fork subprocesses for setup or warmup.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,14 @@ target_include_directories(test_types PRIVATE
 add_test(NAME test_types COMMAND test_types)
 set_tests_properties(test_types PROPERTIES LABELS "unit")
 
+add_executable(test_perf_counters test_perf_counters.cc)
+target_include_directories(test_perf_counters PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+)
+add_test(NAME test_perf_counters COMMAND test_perf_counters)
+set_tests_properties(test_perf_counters PROPERTIES LABELS "unit")
+
 add_executable(test_rir test_rir.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
 target_link_libraries(test_rir rut_compiler)
 target_include_directories(test_rir PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -253,6 +253,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_traffic_replay>
     COMMAND $<TARGET_FILE:test_sim>
     COMMAND $<TARGET_FILE:test_simulate_engine>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine
+    COMMAND $<TARGET_FILE:test_perf_counters>
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_perf_counters
     COMMENT "Running all tests..."
 )

--- a/tests/test_perf_counters.cc
+++ b/tests/test_perf_counters.cc
@@ -40,6 +40,13 @@ TEST(perf_counters, enable_disable_cycles_nonzero) {
     u64 sink = busy_work(100000);
     pc.disable();
     asm volatile("" : : "r"(&sink) : "memory");
+    // If the read itself failed (EINTR-final, short read, kernel
+    // disagreement) the snapshot is all zeros regardless of which
+    // counters opened — asserting >0 here would be a phantom
+    // failure. Skip the nonzero checks in that case.
+    if (!pc.last_read_ok()) {
+        SKIP("perf read failed (signal / short read)");
+    }
 
     // Cycles should be well above zero for 100k iterations of busy work
     // (roughly 300k+ cycles on any modern core).
@@ -60,6 +67,9 @@ TEST(perf_counters, reset_between_measurements) {
     pc.enable();
     u64 s1 = busy_work(10000);
     pc.disable();
+    if (!pc.last_read_ok()) {
+        SKIP("perf read failed on first measurement");
+    }
     const u64 first_cycles = pc.cycles();
     asm volatile("" : : "r"(&s1) : "memory");
 
@@ -68,6 +78,9 @@ TEST(perf_counters, reset_between_measurements) {
     pc.enable();
     u64 s2 = busy_work(10000);
     pc.disable();
+    if (!pc.last_read_ok()) {
+        SKIP("perf read failed on second measurement");
+    }
     const u64 second_cycles = pc.cycles();
     asm volatile("" : : "r"(&s2) : "memory");
 

--- a/tests/test_perf_counters.cc
+++ b/tests/test_perf_counters.cc
@@ -1,0 +1,120 @@
+// Tests for testing/perf_counters.h — verifies the RAII wrapper around
+// perf_event_open works end-to-end. These tests gracefully skip the
+// substantive checks when perf_event_paranoid is too high (e.g., running
+// inside a default container or restricted CI), so the test binary
+// always passes but emits a clear "SKIPPED" note when the kernel refuses
+// access.
+
+#include "perf_counters.h"
+#include "test.h"
+
+using namespace rut;
+using namespace rut::bench;
+
+// Helper: some deterministic work so cycles / instructions should both
+// come back non-zero.
+__attribute__((noinline)) static u64 busy_work(u32 iters) {
+    u64 acc = 1;
+    for (u32 i = 0; i < iters; i++) {
+        acc = acc * 6364136223846793005ULL + 1442695040888963407ULL;
+        acc ^= acc >> 7;
+    }
+    return acc;
+}
+
+TEST(perf_counters, open_reports_capability) {
+    PerfCounters pc;
+    const bool opened = pc.open();
+    if (!opened) {
+        // Most likely perf_event_paranoid > 2 or we're in a container
+        // that blocks PMU access. Not a failure of the wrapper — the
+        // caller just needs to fall back to wall-clock-only reporting.
+        CHECK(true);
+        return;
+    }
+    // Leader must be valid if open() returned true; secondary counters
+    // are best-effort.
+    CHECK(pc.has(kPerfCycles));
+}
+
+TEST(perf_counters, enable_disable_cycles_nonzero) {
+    PerfCounters pc;
+    if (!pc.open()) {
+        CHECK(true);
+        return;
+    }
+    pc.enable();
+    u64 sink = busy_work(100000);
+    pc.disable();
+    asm volatile("" : : "r"(&sink) : "memory");
+
+    // Cycles should be well above zero for 100k iterations of busy work
+    // (roughly 300k+ cycles on any modern core).
+    if (pc.has(kPerfCycles)) {
+        CHECK_GT(pc.cycles(), 1000u);
+    }
+    if (pc.has(kPerfInstructions)) {
+        CHECK_GT(pc.instructions(), 1000u);
+    }
+}
+
+TEST(perf_counters, reset_between_measurements) {
+    PerfCounters pc;
+    if (!pc.open()) {
+        CHECK(true);
+        return;
+    }
+    // First measurement
+    pc.enable();
+    u64 s1 = busy_work(10000);
+    pc.disable();
+    const u64 first_cycles = pc.cycles();
+    asm volatile("" : : "r"(&s1) : "memory");
+
+    // Second measurement — enable() resets the group, so values should
+    // reflect only the new window, not accumulate from the first.
+    pc.enable();
+    u64 s2 = busy_work(10000);
+    pc.disable();
+    const u64 second_cycles = pc.cycles();
+    asm volatile("" : : "r"(&s2) : "memory");
+
+    if (pc.has(kPerfCycles)) {
+        // Both should be in the same order of magnitude — the second
+        // must not be an accumulation of both (which would put it
+        // meaningfully above first).
+        CHECK_GT(second_cycles, 0u);
+        // Allow generous slack (3x) for scheduler / frequency noise on
+        // an idle machine; we just want to catch "reset didn't happen
+        // and second is 2x first" class bugs.
+        CHECK(second_cycles < first_cycles * 3 + 100000);
+    }
+}
+
+TEST(perf_counters, accumulate_sums_values) {
+    PerfCounters a, b;
+    if (!a.open() || !b.open()) {
+        CHECK(true);
+        return;
+    }
+    a.enable();
+    u64 s1 = busy_work(5000);
+    a.disable();
+    asm volatile("" : : "r"(&s1) : "memory");
+
+    b.enable();
+    u64 s2 = busy_work(5000);
+    b.disable();
+    asm volatile("" : : "r"(&s2) : "memory");
+
+    const u64 a_cycles = a.cycles();
+    const u64 b_cycles = b.cycles();
+    a.accumulate(b);
+    if (a.has(kPerfCycles) && b.has(kPerfCycles)) {
+        CHECK_EQ(a.cycles(), a_cycles + b_cycles);
+    }
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}

--- a/tests/test_perf_counters.cc
+++ b/tests/test_perf_counters.cc
@@ -105,11 +105,17 @@ TEST(perf_counters, accumulate_sums_values) {
     u64 s1 = busy_work(5000);
     a.disable();
     asm volatile("" : : "r"(&s1) : "memory");
+    if (!a.last_read_ok()) {
+        SKIP("perf read failed on a");
+    }
 
     b.enable();
     u64 s2 = busy_work(5000);
     b.disable();
     asm volatile("" : : "r"(&s2) : "memory");
+    if (!b.last_read_ok()) {
+        SKIP("perf read failed on b");
+    }
 
     const u64 a_cycles = a.cycles();
     const u64 b_cycles = b.cycles();

--- a/tests/test_perf_counters.cc
+++ b/tests/test_perf_counters.cc
@@ -1,9 +1,8 @@
 // Tests for testing/perf_counters.h — verifies the RAII wrapper around
-// perf_event_open works end-to-end. These tests gracefully skip the
-// substantive checks when perf_event_paranoid is too high (e.g., running
-// inside a default container or restricted CI), so the test binary
-// always passes but emits a clear "SKIPPED" note when the kernel refuses
-// access.
+// perf_event_open works end-to-end. The tests SKIP (not silently pass)
+// when the kernel refuses PMU access, so restricted environments
+// (containers, perf_event_paranoid > 2, kernels without hardware
+// counters) show up as visible skip notes rather than fake green.
 
 #include "perf_counters.h"
 #include "test.h"
@@ -24,13 +23,8 @@ __attribute__((noinline)) static u64 busy_work(u32 iters) {
 
 TEST(perf_counters, open_reports_capability) {
     PerfCounters pc;
-    const bool opened = pc.open();
-    if (!opened) {
-        // Most likely perf_event_paranoid > 2 or we're in a container
-        // that blocks PMU access. Not a failure of the wrapper — the
-        // caller just needs to fall back to wall-clock-only reporting.
-        CHECK(true);
-        return;
+    if (!pc.open()) {
+        SKIP("PMU unavailable (perf_event_paranoid > 2 or no hardware counters)");
     }
     // Leader must be valid if open() returned true; secondary counters
     // are best-effort.
@@ -40,8 +34,7 @@ TEST(perf_counters, open_reports_capability) {
 TEST(perf_counters, enable_disable_cycles_nonzero) {
     PerfCounters pc;
     if (!pc.open()) {
-        CHECK(true);
-        return;
+        SKIP("PMU unavailable");
     }
     pc.enable();
     u64 sink = busy_work(100000);
@@ -61,8 +54,7 @@ TEST(perf_counters, enable_disable_cycles_nonzero) {
 TEST(perf_counters, reset_between_measurements) {
     PerfCounters pc;
     if (!pc.open()) {
-        CHECK(true);
-        return;
+        SKIP("PMU unavailable");
     }
     // First measurement
     pc.enable();
@@ -94,8 +86,7 @@ TEST(perf_counters, reset_between_measurements) {
 TEST(perf_counters, accumulate_sums_values) {
     PerfCounters a, b;
     if (!a.open() || !b.open()) {
-        CHECK(true);
-        return;
+        SKIP("PMU unavailable");
     }
     a.enable();
     u64 s1 = busy_work(5000);


### PR DESCRIPTION
## Summary

Three nanobench-inspired upgrades to `testing/bench.h` so microbench output can be interpreted rather than just trusted. Motivation: while working on #41 (radix trie router) we ran into the classic "is this measurement even signal?" problem — wall-clock numbers flipped order between runs, and we couldn't tell if algorithmic differences were real or measurement noise. This PR adds the infrastructure to answer that kind of question.

## What changes

### 1. Hardware perf counters (`testing/perf_counters.h`, new)

RAII wrapper around `perf_event_open` that opens a group of 5 counters (cycles, instructions, branch-misses, cache-refs, cache-misses) with `PERF_FORMAT_GROUP` so the kernel schedules them together. Degrades gracefully when `perf_event_paranoid` blocks access.

Opt-in per bench via `b.perf_counters(true)`. Output gains a second line per run:

```
  sequential_scan           median: 2.48 us  ±1%  min: 2.43 us  (199,997 iters)
                              cycles/iter: 11350  inst/iter: 9735  IPC: 0.85  cache-miss: 0.0%  br-miss/iter: 1
```

These are the numbers that actually explain *why* A is faster than B — we were previously debating folklore (e.g., "is the first-byte index slower because of more instructions, or more cache misses?") with no way to check.

Note: `cache-miss` reports the generic HW cache events (typically LLC on x86), not specifically L1.

### 2. Median Absolute Deviation (MAD) + err%

Every result line now shows `±N%` = `MAD / median × 100`. Values > 5% get a `!` marker so noisy measurements can't quietly poison comparisons. Robust-to-outliers dispersion measure (the same nanobench uses).

### 3. `print_environment_warnings()`

Reads `/sys` + `/proc` to flag the well-known foot-guns at bench startup:
- CPU governor != `performance` (frequency varies)
- Intel turbo ON (same — amplified)
- `perf_event_paranoid > 2` (PMU access blocked)

Plus surfaces the `taskset -c 0` suggestion. Opt-in — one call at the top of `main()`.

Example output on a default Fedora desktop:

```
--- Environment ---
  governor: powersave  [!]  (expected 'performance' for stable measurements)
  intel turbo: ON  [!]  (frequency will vary)
  perf_event_paranoid: 2
  suggestion: taskset -c 0 ./bench_...    # pin to one core
```

## Demo

`bench/bench_bench_demo.cc` runs two trivial workloads (sequential vs randomised cacheline scan) with all three features on, producing reference output future benches can copy.

## Scope discipline

Existing `bench_http_parser` and `bench_connection` pick up err% for free (it's an automatic addition to every result) and are otherwise untouched. Perf counter integration and env warnings are explicit opt-ins per bench — migrating them is a separate follow-up.

## Test plan
- [ ] `./dev.sh build` — compiles cleanly
- [ ] `./dev.sh test` — 1,500+ existing tests pass
- [ ] `./build/tests/test_perf_counters` — 4 tests covering open/enable/disable/reset/accumulate; skip substantive assertions gracefully when PMU access is denied or a snapshot read fails
- [ ] `taskset -c 0 ./build/bench/bench_bench_demo` — produces the reference output above
- [ ] Existing `./build/bench/bench_http_parser` still runs, now shows `±N%` on each line

## Follow-ups
- Migrate existing benches (`bench_http_parser`, `bench_connection`, `bench_route_trie` from #41) to opt in to perf counters + env warnings
- Time-adaptive iteration count (nanobench's `minbasetime`) — currently users set `min_iterations` manually
- JSON output for cross-commit regression tracking
- Clock-overhead subtraction (matters only for sub-100ns benches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)