### PR TITLE
runtime: add HashFullPath dispatch impl (PR-B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
           LLVM_PROFILE_FILE=build/test_traffic_replay.profraw ./build/tests/test_traffic_replay
           LLVM_PROFILE_FILE=build/test_sim.profraw ./build/tests/test_sim
           LLVM_PROFILE_FILE=build/test_route_trie.profraw ./build/tests/test_route_trie
+          LLVM_PROFILE_FILE=build/test_route_hash_full.profraw ./build/tests/test_route_hash_full
 
       - name: Generate coverage report
         run: |
@@ -178,4 +179,5 @@ jobs:
             build/tests/test_metrics \
             build/tests/test_chunked_parser \
             build/tests/test_rir \
-            build/tests/test_route_trie
+            build/tests/test_route_trie \
+            build/tests/test_route_hash_full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
           LLVM_PROFILE_FILE=build/test_traffic_capture.profraw ./build/tests/test_traffic_capture
           LLVM_PROFILE_FILE=build/test_traffic_replay.profraw ./build/tests/test_traffic_replay
           LLVM_PROFILE_FILE=build/test_sim.profraw ./build/tests/test_sim
+          LLVM_PROFILE_FILE=build/test_route_trie.profraw ./build/tests/test_route_trie
 
       - name: Generate coverage report
         run: |
@@ -176,4 +177,5 @@ jobs:
             build/tests/test_access_log \
             build/tests/test_metrics \
             build/tests/test_chunked_parser \
-            build/tests/test_rir
+            build/tests/test_rir \
+            build/tests/test_route_trie

--- a/include/rut/runtime/route_dispatch.h
+++ b/include/rut/runtime/route_dispatch.h
@@ -78,4 +78,12 @@ extern const RouteDispatch kLinearScanDispatch;
 // beats an "any" route at the same path.
 extern const RouteDispatch kSegmentTrieDispatch;
 
+// Exact-match hash table on the entire path
+// (RouteConfig::hash_full_state). Constant-time per match, but ONLY
+// admissible when no route is a prefix of another and no `:param`
+// segments are present — see route_hash_full.h. The selector
+// (follow-up PR) is responsible for never picking this dispatch when
+// those constraints don't hold.
+extern const RouteDispatch kHashFullPathDispatch;
+
 }  // namespace rut

--- a/include/rut/runtime/route_dispatch.h
+++ b/include/rut/runtime/route_dispatch.h
@@ -1,0 +1,81 @@
+#pragma once
+
+// RouteDispatch — vtable-style interface for route lookup.
+//
+// Why an interface?
+//   The hot path of every request is RouteConfig::match(). Different
+//   route-table shapes have very different ideal data structures (see
+//   bench/bench_route_trie.cc for the data behind that claim): a small
+//   flat config wins on a linear scan with early-exit; a wide exact-
+//   match config wins on a hash table; a deep prefix-shared config wins
+//   on a radix trie. Picking one structure for all configs leaves
+//   measurable performance on the table and forces every workload onto
+//   the same trade-off.
+//
+//   This file is the seam: a tiny vtable (one function pointer) that
+//   lets each impl live behind a uniform call. The compiler-side
+//   selector (a follow-up PR) inspects the parsed route set and picks
+//   the appropriate impl. The runtime path is one indirect call per
+//   match — branch predictor handles it cleanly because each
+//   CompiledConfig stays bound to a single dispatch for its lifetime.
+//
+// Why a function pointer instead of virtual dispatch?
+//   The codebase is `-fno-rtti`/no-stdlib by convention (see CLAUDE.md);
+//   virtual functions still work technically but sit oddly with the
+//   "compile-time backend selection via templates" pattern used
+//   elsewhere (e.g. EpollBackend / IoUringBackend). Function pointers
+//   are the smaller, more inspectable mechanism — `perf` reports the
+//   concrete impl's symbol name instead of an indirect-call target.
+//
+// State storage:
+//   For the linear-scan dispatch (this PR), the state is just the
+//   existing RouteConfig::routes[] array — no extra storage needed. The
+//   `match()` function takes a `const RouteConfig*` so impls can reach
+//   into RouteConfig fields directly. Future impls (HashFullPath,
+//   ByteRadix, …) will declare their own state structs and arrange for
+//   RouteConfig to hold them; the interface stays the same.
+
+#include "rut/common/types.h"
+
+namespace rut {
+
+struct RouteConfig;
+
+// Sentinel for "no match"; route indices are otherwise [0, kMaxRoutes).
+constexpr u16 kRouteIdxInvalid = 0xffffu;
+
+struct RouteDispatch {
+    // Look up the request-target `path` and resolve to a route index.
+    //
+    // Path bytes: `path` is the raw request-target as parsed (the bytes
+    // between method and HTTP/version). It MAY contain a '?' query
+    // string and/or '#' fragment — each impl is responsible for any
+    // stripping its matching policy needs. The default linear scan
+    // matches by byte prefix and so naturally handles "/api?q=1" via
+    // a route at "/api" (the route's bytes match the leading bytes of
+    // the request, regardless of what follows). The segment trie
+    // strips '?' / '#' explicitly before tokenizing. New impls should
+    // declare and uphold whichever policy is right for their shape.
+    //
+    // `method`: first byte of the HTTP method (G/P/D/H/O/C/T) or 0
+    // for "any". 0 in a route entry matches any request method.
+    //
+    // Returns the route index in RouteConfig::routes[], or
+    // kRouteIdxInvalid on no match. Callers (RouteConfig::match) turn
+    // that into a `const RouteEntry*` for downstream code.
+    u16 (*match)(const RouteConfig* cfg, Str path, u8 method);
+};
+
+// Linear byte-prefix scan over RouteConfig::routes[]. First-match-wins,
+// which means earlier-inserted routes shadow later ones at overlapping
+// prefixes — a behavior callers have relied on since the pre-trie days.
+extern const RouteDispatch kLinearScanDispatch;
+
+// Segment-aware radix trie (RouteConfig::trie). Longest-prefix match,
+// segment-boundary aware, normalizes consecutive '/' and trailing '/'.
+// Strips '?' / '#' from incoming requests before tokenizing. Reads
+// route_idx_by_method[] at every terminal so a method-specific route
+// beats an "any" route at the same path.
+extern const RouteDispatch kSegmentTrieDispatch;
+
+}  // namespace rut

--- a/include/rut/runtime/route_hash_full.h
+++ b/include/rut/runtime/route_hash_full.h
@@ -1,0 +1,110 @@
+#pragma once
+
+// HashFullPath — exact-match hash table on the entire route path.
+//
+// Defines the floor for "what's the fastest possible per-match dispatch
+// if you give up prefix semantics?" — at 128 routes on a realistic
+// SaaS gateway corpus it's ~1.93× over the linear scan baseline (see
+// the bench in feat/radix-trie-router for the data). Constant-time
+// regardless of distribution: one FNV-1a + open-addressing probe.
+//
+// Limitations the selector must respect:
+//   - NO PREFIX MATCHING. A route registered at "/api" doesn't match a
+//     request like "/api/v1/users" — only an exact-string request like
+//     "/api" hits. Configs that need longest-prefix semantics (anything
+//     with `:param` segments, anything where one route is a prefix of
+//     another) MUST stay on SegmentTrie.
+//   - Method dispatch: 0 in a route matches any request method. A
+//     specific method ('G', 'P', 'D', ...) only matches the same byte.
+//     Two routes at the same path with different methods both fit, via
+//     keying on (path, method). When a request method doesn't match the
+//     specific slot we fall back to the (path, any) slot.
+//   - kCap is fixed at 512 (= 4× kMaxRoutes for headroom against
+//     long-running open-address probe chains; load factor stays < 25%
+//     at the cap).
+//
+// Build cost: ~one FNV-1a per route on insert. Build is amortized
+// across the lifetime of a CompiledConfig (RCU swap reuses the table)
+// so insert speed is not on the hot path.
+
+#include "rut/common/types.h"
+#include "rut/runtime/route_dispatch.h"
+
+namespace rut {
+
+class HashFullPathTable {
+public:
+    static constexpr u32 kCap = 512;
+
+    HashFullPathTable() { clear(); }
+
+    void clear() {
+        for (u32 i = 0; i < kCap; i++) {
+            slots[i].path = Str{};
+            slots[i].method = 0;
+            slots[i].route_idx = kRouteIdxInvalid;
+        }
+        n_ = 0;
+    }
+
+    // Insert a (path, method, route_idx) triple. Returns false if the
+    // table is too full (load factor would exceed 50%) — callers in
+    // RouteConfig::add_* treat this as a hard route-rejection so the
+    // hash dispatch stays consistent with the linear-scan default.
+    //
+    // Duplicate (path, method) keys: first insert wins; subsequent
+    // calls return true without overwriting. Same shape as the trie's
+    // method-slot first-wins behavior.
+    //
+    // path must outlive this table — the slot stores a non-owning
+    // view. Callers in RouteConfig pass &routes[i].path which lives
+    // for the config's RCU lifetime.
+    bool insert(Str path, u8 method, u16 route_idx);
+
+    // Look up `path` + `method`. Returns kRouteIdxInvalid on miss.
+    // When the specific-method slot is empty but a same-path "any"
+    // (method 0) slot exists, returns the any slot — matching the
+    // first-match-wins fallback the linear scan provides.
+    u16 match(Str path, u8 method) const;
+
+    // Introspection for tests.
+    u32 size() const { return n_; }
+
+private:
+    struct Slot {
+        Str path;
+        u8 method;
+        u16 route_idx;
+    };
+    Slot slots[kCap];
+    u32 n_;
+
+    // FNV-1a + method byte folded in. method=0 ("any") and a specific
+    // method byte hash to different buckets, so two routes at the same
+    // path with different methods coexist without colliding on the
+    // hash key — just on the slot table when probing converges.
+    static u64 key_hash(Str path, u8 method);
+    static u32 bucket(u64 h) { return static_cast<u32>(h) & (kCap - 1); }
+
+    // Linear probe through `slots` from `start`, calling `pred` on
+    // each occupied slot. Returns the first index where `pred`
+    // returns true, or kCap on a sentinel-empty slot (`pred` not
+    // called for empty slots), or kCap when the whole table has
+    // been probed without a match (defensive — load factor cap
+    // makes this unreachable in practice).
+    template <typename Pred>
+    u32 probe(u32 start, Pred pred) const {
+        u32 i = start;
+        for (u32 step = 0; step < kCap; step++) {
+            if (slots[i].route_idx == kRouteIdxInvalid) return kCap;
+            if (pred(slots[i])) return i;
+            i = (i + 1) & (kCap - 1);
+        }
+        return kCap;
+    }
+};
+
+// kHashFullPathDispatch is declared in route_dispatch.h alongside the
+// other dispatch entries; see that header for the full vtable list.
+
+}  // namespace rut

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -5,6 +5,8 @@
 #include "rut/common/types.h"
 #include "rut/jit/handler_abi.h"
 #include "rut/runtime/error.h"
+#include "rut/runtime/route_dispatch.h"
+#include "rut/runtime/route_trie.h"
 
 #include <errno.h>
 #include <netinet/in.h>
@@ -95,11 +97,88 @@ struct RouteConfig {
     // by handle_jit_outcome in callbacks_impl.h.
     static constexpr u32 kMaxHeadersPerSet = 32;
 
+    // Non-copyable: the embedded `trie` stores non-owning Str views
+    // pointing into routes[].path. A by-value copy would leave the
+    // copy's trie referencing the original's path buffers — a use-
+    // after-free as soon as the original is modified or destroyed.
+    // RouteConfig is published via `const RouteConfig*` for RCU swap;
+    // there's no production codepath that needs to copy one.
+    RouteConfig() = default;
+    RouteConfig(const RouteConfig&) = delete;
+    RouteConfig& operator=(const RouteConfig&) = delete;
+
     RouteEntry routes[kMaxRoutes];
     u32 route_count = 0;
 
+    // Pluggable route lookup. Set BEFORE the first add_* call (ideally
+    // by the compiler-side selector at config-build time); the active
+    // dispatch determines which per-impl state add_* populates. Once
+    // any route has been added, set_dispatch() refuses to swap — the
+    // earlier routes wouldn't be in the new dispatch's data structure
+    // and lookups would silently miss them (Codex P1 caught this on
+    // #43). Build a fresh RouteConfig if you need a different dispatch.
+    //
+    // set_dispatch() also refuses any pointer that isn't one of the
+    // canonical static singletons declared in route_dispatch.h. The
+    // pointer is borrowed across the config's lifetime, so accepting
+    // an arbitrary `RouteDispatch*` would let a caller install an
+    // ephemeral / stack-local vtable that dangles once the caller's
+    // frame returns (Codex P2 on #43 round 3). Limiting the input to
+    // singletons whose addresses are stable for the program's
+    // lifetime closes the lifetime hazard at the gate.
+    const RouteDispatch* dispatch() const { return dispatch_; }
+    bool set_dispatch(const RouteDispatch* d) {
+        if (route_count > 0) return false;
+        if (!is_canonical_dispatch(d)) return false;
+        dispatch_ = d;
+        return true;
+    }
+
+    // Whitelist of canonical dispatch singletons. Each new impl PR
+    // adds its singleton here; a custom dispatch needs both an entry
+    // here AND a branch in populate_dispatch_state() — keeps the
+    // contract explicit at the two places that matter (install gate
+    // and state-build gate).
+    static bool is_canonical_dispatch(const RouteDispatch* d) {
+        return d == &kLinearScanDispatch || d == &kSegmentTrieDispatch;
+    }
+
+    // Segment-aware radix trie. Populated by add_* only when the
+    // active dispatch is kSegmentTrieDispatch. ~1.2 MB inline; sized
+    // to cover 128 routes × 32 distinct segments at the worst-case
+    // (no prefix sharing). When a different dispatch is selected this
+    // storage sits unused — a follow-up PR will move per-impl state
+    // into a tagged union so only the active impl pays its cost.
+    RouteTrie trie;
+    static_assert(kMaxRoutes == TrieNode::kMaxChildren,
+                  "RouteConfig::kMaxRoutes must equal TrieNode::kMaxChildren so a config "
+                  "whose routes all share a single parent fits the trie's per-node fan-out.");
+
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
+
+    // Reject route paths that aren't in origin-form. Required by the
+    // segment trie (which would otherwise silently mismatch malformed
+    // configs); the linear-scan default tolerates any string but
+    // applying the same gate uniformly keeps add_* semantics
+    // consistent across dispatch choices.
+    //   - Must be non-null, non-empty, and start with '/'. An empty
+    //     string and "api" without a leading slash are rejected
+    //     rather than implicitly normalized — the trie's root and
+    //     "/api" terminal would otherwise collide silently.
+    //   - Must not contain '?' or '#': those mark query/fragment in a
+    //     URI and routing doesn't match on them. RouteTrie::match()
+    //     strips them from incoming requests.
+    //   - Must terminate within kMaxPathLen.
+    static bool is_routable_path(const char* path) {
+        if (path == nullptr || path[0] != '/') return false;
+        for (u32 i = 0; i < RouteEntry::kMaxPathLen; i++) {
+            const char ch = path[i];
+            if (ch == '\0') return true;
+            if (ch == '?' || ch == '#') return false;
+        }
+        return false;
+    }
 
     // Body entries point into body_pool; pool is a bump-allocated char
     // buffer so body bytes live alongside the config and get reclaimed
@@ -134,11 +213,55 @@ struct RouteConfig {
     char header_bytes_pool[kResponseHeaderBytesPoolBytes];
     u32 header_bytes_pool_used = 0;
 
+    // Populate the active dispatch's state with a newly-written
+    // routes[route_count] entry. Returns false on:
+    //   - a structural capacity hit in that dispatch's data
+    //     structure (e.g., trie node-pool exhaustion),
+    //   - an unknown / non-canonical dispatch pointer.
+    //
+    // The fail-closed default is deliberate. Round-4 of #43
+    // tightened set_dispatch() to admit only canonical singleton
+    // dispatch pointers, so the "unknown dispatch" branch should
+    // not occur in normal use. We still reject it here as defense
+    // in depth: without explicit per-impl handling the auxiliary
+    // state for that dispatch would not be built, and match()
+    // would systematically miss. Refusing add_* keeps the failure
+    // loud rather than silent.
+    //
+    // Branches are narrow — body of each is exactly that impl's
+    // `insert`. New impls add a branch here; the rest of add_*
+    // doesn't change.
+    bool populate_dispatch_state(const RouteEntry& r) {
+        const Str path_view{r.path, r.path_len};
+        const u16 idx = static_cast<u16>(route_count);
+        if (dispatch_ == &kSegmentTrieDispatch) {
+            return trie.insert(path_view, r.method, idx);
+        }
+        if (dispatch_ == &kLinearScanDispatch) {
+            // routes[] IS the data — nothing else to populate.
+            return true;
+        }
+        return false;  // unknown dispatch — refuse so the misroute is loud
+    }
+
     // Add a proxy route: path prefix → upstream target.
-    // Returns false if table full, upstream_id invalid, or path too long.
+    // Returns false if:
+    //   - the route table is full,
+    //   - upstream_id is out of range,
+    //   - the path is malformed (see is_routable_path),
+    //   - the path is too long for RouteEntry::path,
+    //   - the active dispatch rejects the (path, method) pair while
+    //     populating its state — for example, the segment trie
+    //     refuses unrecognized method bytes. The default linear
+    //     scan accepts any method byte verbatim, so method
+    //     validation is effectively dispatch-dependent here.
+    //   - the active dispatch's state ran out of capacity,
+    //   - the active dispatch is not one of the canonical singletons
+    //     (see populate_dispatch_state).
     bool add_proxy(const char* path, u8 method, u16 upstream_id) {
         if (route_count >= kMaxRoutes) return false;
         if (upstream_id >= upstream_count) return false;
+        if (!is_routable_path(path)) return false;
         auto& r = routes[route_count];
         r.path_len = 0;
         while (path[r.path_len] && r.path_len < sizeof(r.path) - 1) {
@@ -152,13 +275,18 @@ struct RouteConfig {
         r.upstream_id = upstream_id;
         r.status_code = 0;
         r.fn = nullptr;
+        if (!populate_dispatch_state(r)) {
+            return false;  // active dispatch at capacity — fail loud
+        }
         route_count++;
         return true;
     }
 
-    // Add a static response route. Returns false if table full or path too long.
+    // Add a static response route. Same failure modes as add_proxy(),
+    // minus the upstream-id check that doesn't apply here.
     bool add_static(const char* path, u8 method, u16 status) {
         if (route_count >= kMaxRoutes) return false;
+        if (!is_routable_path(path)) return false;
         auto& r = routes[route_count];
         r.path_len = 0;
         while (path[r.path_len] && r.path_len < sizeof(r.path) - 1) {
@@ -172,16 +300,20 @@ struct RouteConfig {
         r.upstream_id = 0;
         r.status_code = status;
         r.fn = nullptr;
+        if (!populate_dispatch_state(r)) {
+            return false;
+        }
         route_count++;
         return true;
     }
 
     // Add a JIT-handler route. Handler is invoked on match; its HandlerResult
     // tells the runtime what to do next (return status, forward, or yield).
-    // Returns false if table full, path too long, or fn is null.
+    // Same failure modes as add_proxy() plus null-fn check.
     bool add_jit_handler(const char* path, u8 method, jit::HandlerFn fn) {
         if (route_count >= kMaxRoutes) return false;
         if (fn == nullptr) return false;
+        if (!is_routable_path(path)) return false;
         auto& r = routes[route_count];
         r.path_len = 0;
         while (path[r.path_len] && r.path_len < sizeof(r.path) - 1) {
@@ -195,6 +327,9 @@ struct RouteConfig {
         r.upstream_id = 0;
         r.status_code = 0;
         r.fn = fn;
+        if (!populate_dispatch_state(r)) {
+            return false;
+        }
         route_count++;
         return true;
     }
@@ -313,27 +448,28 @@ struct RouteConfig {
         return idx;
     }
 
-    // Match a request path (prefix match, first match wins).
-    // method_char: first char of HTTP method ('G'=GET, 'P'=POST, etc.), 0=any.
-    // Returns pointer to matching entry, or nullptr for no match (→ default 200 OK).
+    // Match a request path. Semantics depend on the chosen dispatch
+    // (`this->dispatch`), but the default linear-scan dispatch keeps
+    // the historical contract: first-match-wins byte-prefix scan,
+    // method 0 in a route entry matches any request method, and
+    // unmatched requests return nullptr (callers fall back to the
+    // default 200 OK handler).
+    //
+    // `method_char` is the first byte of the HTTP method ('G'=GET,
+    // 'P'=POST/PUT/PATCH, 'D'=DELETE, 'H'=HEAD, 'O'=OPTIONS,
+    // 'C'=CONNECT, 'T'=TRACE) or 0 for "any".
     const RouteEntry* match(const u8* path_data, u32 path_len, u8 method_char) const {
-        for (u32 i = 0; i < route_count; i++) {
-            auto& r = routes[i];
-            // Method filter: 0 = any
-            if (r.method != 0 && r.method != method_char) continue;
-            // Prefix match
-            if (path_len < r.path_len) continue;
-            bool matched = true;
-            for (u32 j = 0; j < r.path_len; j++) {
-                if (path_data[j] != static_cast<u8>(r.path[j])) {
-                    matched = false;
-                    break;
-                }
-            }
-            if (matched) return &r;
-        }
-        return nullptr;  // no match → default handler
+        const Str path{reinterpret_cast<const char*>(path_data), path_len};
+        const u16 idx = dispatch_->match(this, path, method_char);
+        if (idx >= route_count) return nullptr;  // covers kRouteIdxInvalid
+        return &routes[idx];
     }
+
+private:
+    // The active dispatch vtable, set via set_dispatch() and read via
+    // dispatch(). Private so callers can't assign past the route_count
+    // == 0 gate — see set_dispatch() doc.
+    const RouteDispatch* dispatch_ = &kLinearScanDispatch;
 };
 
 }  // namespace rut

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -141,7 +141,8 @@ struct RouteConfig {
     // contract explicit at the two places that matter (install gate
     // and state-build gate).
     static bool is_canonical_dispatch(const RouteDispatch* d) {
-        return d == &kLinearScanDispatch || d == &kSegmentTrieDispatch;
+        return d == &kLinearScanDispatch || d == &kSegmentTrieDispatch ||
+               d == &kHashFullPathDispatch;
     }
 
     // Segment-aware radix trie. Populated by add_* only when the

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -6,6 +6,7 @@
 #include "rut/jit/handler_abi.h"
 #include "rut/runtime/error.h"
 #include "rut/runtime/route_dispatch.h"
+#include "rut/runtime/route_hash_full.h"
 #include "rut/runtime/route_trie.h"
 
 #include <errno.h>
@@ -154,6 +155,15 @@ struct RouteConfig {
                   "RouteConfig::kMaxRoutes must equal TrieNode::kMaxChildren so a config "
                   "whose routes all share a single parent fits the trie's per-node fan-out.");
 
+    // Exact-match hash table over (path, method). Populated by every
+    // add_* method in lockstep with the trie. ~12 KB (512 slots ×
+    // 24 bytes); negligible next to the trie's 1.2 MB. Only consulted
+    // when dispatch == &kHashFullPathDispatch; the selector landing in
+    // a follow-up PR picks it for configs with no prefix routes
+    // (where exact-match is sufficient and beats the trie on every
+    // dimension we measure).
+    HashFullPathTable hash_full_state;
+
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
 
@@ -236,6 +246,9 @@ struct RouteConfig {
         const u16 idx = static_cast<u16>(route_count);
         if (dispatch_ == &kSegmentTrieDispatch) {
             return trie.insert(path_view, r.method, idx);
+        }
+        if (dispatch_ == &kHashFullPathDispatch) {
+            return hash_full_state.insert(path_view, r.method, idx);
         }
         if (dispatch_ == &kLinearScanDispatch) {
             // routes[] IS the data — nothing else to populate.

--- a/include/rut/runtime/route_trie.h
+++ b/include/rut/runtime/route_trie.h
@@ -1,0 +1,228 @@
+#pragma once
+
+#include "rut/common/types.h"
+
+namespace rut {
+
+// RouteTrie — segment-aware radix router for RouteConfig.
+//
+// Replaces the O(n) linear scan in RouteConfig::match() with a trie lookup
+// that gives O(segments × fanout) match time. At 128 routes the trie is
+// ~2.6× faster than the linear scan in hot-cache microbenchmarks (see
+// bench/bench_route_trie.cc). Crossover is around 32 routes; below that,
+// linear scan wins because tokenize() adds fixed per-lookup overhead that
+// the flat byte-compare doesn't pay.
+//
+// Child lookup is a plain linear scan over the children array with full
+// segment comparison. The benchmark also evaluated the common
+// httprouter / matchit "parallel u8 first-byte index" optimization: it is
+// within 1–3% of this simple layout at our segment-length distribution
+// (3–6 byte segments, small fan-outs), which is inside run-to-run noise
+// and well under the ~7–10% overhead of the translation-unit boundary
+// production calls cross anyway. We take the simpler design — fewer
+// bytes per node, less code to maintain — and leave the first-byte index
+// as an optimization that can be re-added if workloads change (longer segments,
+// larger fan-outs, or SIMD-ready eq).
+//
+// Semantics: segment-aware prefix match with longest-match-wins.
+//   - Path is split on '/' into segments.
+//   - Empty segments are dropped (so "/api//v1" == "/api/v1", "/api/" == "/api").
+//   - Matching is case-sensitive (per RFC 3986).
+//   - A route attached at the root ("/") acts as a catch-all for any request.
+//   - If multiple routes share a path, the first-inserted wins (build-order
+//     determinism for duplicate keys; the trie is built incrementally via
+//     add_* calls during RouteConfig construction, then treated as
+//     read-only once the RouteConfig is published via RCU swap).
+//
+// Method dispatch: each terminal node holds a small per-method slot table so
+// two routes with the same path but different HTTP methods both fit. Lookup
+// prefers a method-specific slot and falls back to the "any" slot. (This is
+// a semantic refinement over the old linear scan's first-match-wins across
+// method boundaries; see commit message for details.)
+
+// ---------------------------------------------------------------------------
+// Method slot encoding
+// ---------------------------------------------------------------------------
+// The runtime today uses the first byte of the HTTP method as its enum
+// ('G' = GET, 'P' = POST/PUT/PATCH, 'D' = DELETE, ...). That first-byte
+// scheme has a known ambiguity for POST/PUT/PATCH that we preserve here to
+// keep this PR scoped — a proper method enum is a separate change.
+//
+// method_slot() packs the handful of valid first-byte values into a
+// dense [0..kMethodSlots) index for use as an array subscript. Slot 0
+// = "any". Unsupported bytes (typos like 'g', future HTTP verbs, or
+// garbage on the wire) return kMethodSlotInvalid so callers can
+// reject them — an earlier revision mapped them to slot 0 ("any"),
+// which silently widened a method-specific route into all-methods
+// and/or conflated distinct method-specific routes. Codex flagged
+// the silent coalescence (#41 P2); keep failure explicit.
+static constexpr u32 kMethodSlots = 8;
+static constexpr u32 kMethodSlotInvalid = 0xffffffffu;
+inline u32 method_slot(u8 method_char) {
+    switch (method_char) {
+        case 0:
+            return 0;  // any
+        case 'G':
+            return 1;  // GET
+        case 'P':
+            return 2;  // POST/PUT/PATCH (ambiguous — matches current behavior)
+        case 'D':
+            return 3;  // DELETE
+        case 'H':
+            return 4;  // HEAD
+        case 'O':
+            return 5;  // OPTIONS
+        case 'C':
+            return 6;  // CONNECT
+        case 'T':
+            return 7;  // TRACE
+        default:
+            return kMethodSlotInvalid;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TrieNode
+// ---------------------------------------------------------------------------
+// Nodes live in a flat `RouteTrie::nodes` pool and reference each other via
+// u16 indices (not pointers) so the whole trie is a single contiguous region
+// safe to atomically swap under RCU.
+//
+// The root node (index 0) has an empty `segment`; every other node's
+// `segment` is the non-empty text of the path segment leading into it.
+
+struct TrieNode {
+    // Sized to match RouteConfig::kMaxRoutes exactly. A config that
+    // declares 128 routes all as distinct children of the same parent
+    // (e.g. 128 top-level paths under root) must not be rejected on
+    // topology alone — that would narrow the capacity contract the
+    // pre-trie linear scan already honored (Codex P1 on #41). Most
+    // inner nodes use very little of this (gateway routes rarely
+    // have wide fan-out past root); the wasted-slots memory is
+    // 128 × 2B − actual_children × 2B per node, tolerable at 512
+    // nodes total.
+    static constexpr u32 kMaxChildren = 128;
+
+    // Edge label: the path segment that leads INTO this node. Non-owning,
+    // points into the original RouteEntry::path buffer on RouteConfig.
+    Str segment{};
+
+    // Child node-pool indices. find_child scans these linearly with a full
+    // segment compare — see the comment at the top of this file for why
+    // we don't layer a separate first-byte index on top.
+    FixedVec<u16, kMaxChildren> children;
+
+    // Per-method route index at this terminal. kInvalidRoute means "this
+    // node is not terminal for that method". Slot 0 is "any"; other slots
+    // are per-method (see method_slot()).
+    static constexpr u16 kInvalidRoute = 0xffffu;
+    // "No child found" sentinel returned by find_child(). Numerically
+    // equal to kInvalidRoute (both are 0xffffu — u16's max value used
+    // as a "missing" sentinel) but kept as a distinct constant so
+    // call sites read clearly: a node-pool index lookup is not the
+    // same kind of thing as a route-table index lookup, even though
+    // u16 happens to carry both. Copilot caught the conflation on
+    // #43 round 4.
+    static constexpr u16 kInvalidNodeIdx = 0xffffu;
+    u16 route_idx_by_method[kMethodSlots] = {kInvalidRoute,
+                                             kInvalidRoute,
+                                             kInvalidRoute,
+                                             kInvalidRoute,
+                                             kInvalidRoute,
+                                             kInvalidRoute,
+                                             kInvalidRoute,
+                                             kInvalidRoute};
+};
+
+// ---------------------------------------------------------------------------
+// RouteTrie
+// ---------------------------------------------------------------------------
+// Owns the node pool. Built incrementally via insert() calls (RouteConfig
+// drives these from its add_* methods). Once the enclosing RouteConfig is
+// published, treat the trie as read-only — RCU-friendly.
+
+class RouteTrie {
+public:
+    // 128 routes × 32-segment distinct paths (no prefix sharing) need
+    // 1 + 128*32 = 4097 nodes — the +1 covers the root. Earlier
+    // values were off by one at the documented boundary: 2048
+    // rejected a valid 16-seg flat config (Codex P2 on #41 round 9),
+    // and 4096 then rejected the very 32-seg shape its own doc
+    // claimed to cover (Codex P2 on #41 round 13). 4097 is the exact
+    // worst-case for the advertised coverage; we deliberately don't
+    // round up further because deeper "pathological" configs (33-64
+    // segs per route, no sharing) are vanishingly rare and a smaller
+    // pool keeps the inline RouteConfig footprint near the existing
+    // ~1.2 MB. Memory cost: 4097 × ~290 B/node ≈ 1.2 MB per
+    // RouteConfig.
+    static constexpr u32 kMaxNodes = 4097;
+    // Sized so any legal request URI or registered route fits without
+    // truncation. RouteEntry::kMaxPathLen is 128 bytes, which at a
+    // minimum per-segment cost of 2 bytes ('/' + one content byte)
+    // gives 64 segments worst case; ConnectionBase::kMaxReqPathLen is
+    // 64 bytes (→ 32 segments). Pick the larger to cover route
+    // admission. Codex flagged #41 P2 where a 16-cap rejected valid
+    // 17-segment route configs.
+    static constexpr u32 kMaxPathSegments = 64;
+
+    RouteTrie() { clear(); }
+
+    // Wipe and re-seed with the root node.
+    void clear();
+
+    // Insert a route. `path` must be a RouteEntry::path view (persistent
+    // across the trie's lifetime — we store non-owning segment views into it).
+    // `method_char` is the first byte of the HTTP method (or 0 for any).
+    // `route_idx` is the position in RouteConfig::routes.
+    //
+    // Returns false if the trie is out of node-pool capacity or a node is
+    // out of child-slots — callers should treat either as a build-time
+    // "route table too complex" failure and refuse the config.
+    bool insert(Str path, u8 method_char, u16 route_idx);
+
+    // Look up `path` and return the route index of the longest-matching
+    // terminal whose method slot is compatible with `method_char`. Returns
+    // TrieNode::kInvalidRoute if nothing matches.
+    u16 match(Str path, u8 method_char) const;
+
+    // Introspection helpers (for tests / bench).
+    u32 node_count() const { return nodes.len; }
+
+private:
+    FixedVec<TrieNode, kMaxNodes> nodes;
+
+    // Split `path` into segments according to the normalization policy.
+    //   - Drop empty segments ("/api//v1" → ["api", "v1"], "/" → []).
+    //   - A trailing '/' produces an empty final segment that is then
+    //     dropped — so "/api/" and "/api" both yield ["api"].
+    //   - Match case-sensitively; preserve bytes verbatim (no tolower).
+    //
+    // Query and fragment stripping (the '?' / '#' bytes) is the
+    // caller's concern, not tokenize's. RouteConfig::add_* rejects
+    // route paths containing those bytes before we ever see them;
+    // match() shortens the incoming request path above the first '?'
+    // or '#' before calling tokenize. Keeping tokenize pure means
+    // the insert-vs-match round-trip always agrees on what counts
+    // as a segment.
+    //
+    // Returns the segment count on success, or kMaxPathSegments + 1 as
+    // a sentinel when the path would produce more segments than `out`
+    // can hold. `insert()` rejects sentinel results so a build-time
+    // config with too-deep paths fails cleanly; `match()` ignores the
+    // sentinel and runs with the (truncated) segments so deep request
+    // URIs still fall back to a catchall or prefix route.
+    //
+    // Does not allocate — `out` is caller-provided storage, emitted
+    // Str views point into the path portion of `path.ptr`.
+    static u32 tokenize_segments(Str path, FixedVec<Str, kMaxPathSegments>& out);
+
+    // Linear-scan child lookup: walks `children` and compares the full
+    // segment via Str::eq. Returns the child's node-pool index, or
+    // TrieNode::kInvalidNodeIdx if no child matches. See the comment
+    // at the top of this file for why we don't layer a u8 first-byte
+    // index on top — at our segment-length distribution it's a net
+    // cost, not a savings.
+    u16 find_child(u16 parent, Str segment) const;
+};
+
+}  // namespace rut

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(rut_runtime STATIC
     runtime/access_log.cc
     runtime/traffic_capture.cc
     runtime/route_dispatch.cc
+    runtime/route_hash_full.cc
     runtime/route_trie.cc
     ${SIMD_SOURCE}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,8 @@ add_library(rut_runtime STATIC
     runtime/chunked_parser.cc
     runtime/access_log.cc
     runtime/traffic_capture.cc
+    runtime/route_dispatch.cc
+    runtime/route_trie.cc
     ${SIMD_SOURCE}
 )
 

--- a/src/runtime/route_dispatch.cc
+++ b/src/runtime/route_dispatch.cc
@@ -1,0 +1,55 @@
+#include "rut/runtime/route_dispatch.h"
+
+#include "rut/runtime/route_table.h"
+
+namespace rut {
+
+namespace {
+
+// Linear scan — same algorithm as the pre-PR RouteConfig::match()
+// inline body. Pulled into a static function so the dispatch vtable
+// can hold a stable pointer to it.
+//
+// Semantics (preserved verbatim from the inline version):
+//   - First-match-wins across the routes[] array.
+//   - Method filter: r.method == 0 matches any request method.
+//   - Byte-prefix match: a route with path /api matches request
+//     paths /api, /api/v1, /api?q=1, etc.
+//   - No segment awareness — /api can match /apix as well, since
+//     this impl predates segment-aware routing. Configs that need
+//     segment semantics should be steered to a different dispatch
+//     by the selector.
+u16 linear_scan_match(const RouteConfig* cfg, Str path, u8 method) {
+    for (u32 i = 0; i < cfg->route_count; i++) {
+        const auto& r = cfg->routes[i];
+        if (r.method != 0 && r.method != method) continue;
+        if (path.len < r.path_len) continue;
+        bool matched = true;
+        for (u32 j = 0; j < r.path_len; j++) {
+            if (static_cast<u8>(path.ptr[j]) != static_cast<u8>(r.path[j])) {
+                matched = false;
+                break;
+            }
+        }
+        if (matched) return static_cast<u16>(i);
+    }
+    return kRouteIdxInvalid;
+}
+
+// Segment trie adapter — RouteConfig::trie has its own match() that
+// returns the route_idx, so this is a one-line forward through the
+// dispatch interface. The trie internally handles normalization
+// (collapse consecutive '/', strip trailing '/', strip '?' / '#'
+// from request paths) and longest-prefix selection with method-slot
+// tie-breaking — see route_trie.h for the full semantics.
+u16 segment_trie_match(const RouteConfig* cfg, Str path, u8 method) {
+    const u16 idx = cfg->trie.match(path, method);
+    return idx == TrieNode::kInvalidRoute ? kRouteIdxInvalid : idx;
+}
+
+}  // namespace
+
+const RouteDispatch kLinearScanDispatch = {&linear_scan_match};
+const RouteDispatch kSegmentTrieDispatch = {&segment_trie_match};
+
+}  // namespace rut

--- a/src/runtime/route_hash_full.cc
+++ b/src/runtime/route_hash_full.cc
@@ -1,0 +1,101 @@
+#include "rut/runtime/route_hash_full.h"
+
+#include "rut/runtime/route_table.h"
+
+namespace rut {
+
+namespace {
+
+// FNV-1a 64-bit basis + prime. Picked over a faster mixer because at
+// our key length (8-128 bytes) the FNV inner loop is already cheap and
+// FNV's bit dispersion is well-studied for the open-addressing case.
+constexpr u64 kFnvBasis = 0xcbf29ce484222325ULL;
+constexpr u64 kFnvPrime = 0x100000001b3ULL;
+
+}  // namespace
+
+u64 HashFullPathTable::key_hash(Str path, u8 method) {
+    u64 h = kFnvBasis;
+    for (u32 i = 0; i < path.len; i++) {
+        h ^= static_cast<u8>(path.ptr[i]);
+        h *= kFnvPrime;
+    }
+    // Fold method into a separate "byte position" so (path, 'G') and
+    // (path, 0) hash to different buckets even if FNV would land them
+    // adjacently — keeps the any-vs-specific fallback search predictable.
+    h ^= static_cast<u64>(method);
+    h *= kFnvPrime;
+    return h;
+}
+
+bool HashFullPathTable::insert(Str path, u8 method, u16 route_idx) {
+    if (n_ * 2 >= kCap) return false;  // load factor cap < 50%
+    const u64 h = key_hash(path, method);
+    const u32 start = bucket(h);
+    u32 i = start;
+    for (u32 step = 0; step < kCap; step++) {
+        if (slots[i].route_idx == kRouteIdxInvalid) {
+            slots[i].path = path;
+            slots[i].method = method;
+            slots[i].route_idx = route_idx;
+            n_++;
+            return true;
+        }
+        if (slots[i].method == method && slots[i].path.eq(path)) {
+            // First insert wins — duplicates are idempotent. This
+            // matches the trie's method-slot first-wins so the same
+            // input config produces the same observable routing
+            // decisions across dispatches.
+            return true;
+        }
+        i = (i + 1) & (kCap - 1);
+    }
+    return false;  // unreachable while load-factor cap holds
+}
+
+u16 HashFullPathTable::match(Str path, u8 method) const {
+    if (path.len == 0) return kRouteIdxInvalid;
+    // Strip query / fragment from the request before hashing — the
+    // raw request-target as parsed includes "?q=1" / "#frag" bytes,
+    // and a registered route at /health would otherwise miss when
+    // the request arrives as /health?check=1. Other dispatches do
+    // this too: SegmentTrie strips before tokenizing, linear scan
+    // matches by byte prefix so the trailing query bytes are
+    // ignored automatically. Codex P2 on #44.
+    u32 effective_len = 0;
+    while (effective_len < path.len && path.ptr[effective_len] != '?' &&
+           path.ptr[effective_len] != '#') {
+        effective_len++;
+    }
+    if (effective_len == 0) return kRouteIdxInvalid;
+    const Str key{path.ptr, effective_len};
+    // Try the specific-method bucket first. If the request asked for
+    // method 0 (any), this is the only lookup we do — no fallback
+    // needed because a method-0 route would have hashed into this
+    // same key.
+    const u64 h_specific = key_hash(key, method);
+    const u32 found_specific = probe(
+        bucket(h_specific), [&](const Slot& s) { return s.method == method && s.path.eq(key); });
+    if (found_specific != kCap) return slots[found_specific].route_idx;
+    if (method == 0) return kRouteIdxInvalid;
+    // Specific-method miss: fall back to the (path, any) slot, matching
+    // the linear scan's "method 0 in route matches any request"
+    // behavior.
+    const u64 h_any = key_hash(key, 0);
+    const u32 found_any =
+        probe(bucket(h_any), [&](const Slot& s) { return s.method == 0 && s.path.eq(key); });
+    if (found_any != kCap) return slots[found_any].route_idx;
+    return kRouteIdxInvalid;
+}
+
+namespace {
+
+u16 hash_full_path_match(const RouteConfig* cfg, Str path, u8 method) {
+    return cfg->hash_full_state.match(path, method);
+}
+
+}  // namespace
+
+const RouteDispatch kHashFullPathDispatch = {&hash_full_path_match};
+
+}  // namespace rut

--- a/src/runtime/route_trie.cc
+++ b/src/runtime/route_trie.cc
@@ -1,0 +1,218 @@
+#include "rut/runtime/route_trie.h"
+
+namespace rut {
+
+// ---------------------------------------------------------------------------
+// Path tokenization — encodes the normalization policies
+// ---------------------------------------------------------------------------
+//   P1a: drop empty segments (consecutive '/' collapse; leading '/' yields
+//        no segment)
+//   P2a: trailing '/' is equivalent to no trailing '/' — falls out of P1a
+//        once the trailing empty run is skipped
+//   P3a: case-sensitive — bytes are preserved verbatim, no tolower
+//
+// Returns the segment count, or kMaxPathSegments + 1 as a sentinel when the
+// path would produce more segments than `out` can hold. The two callers
+// treat the sentinel differently:
+//   - insert() rejects sentinel results at build time (registering a
+//     truncated path would land the route at the wrong depth relative
+//     to what the user wrote).
+//   - match() ignores the sentinel and routes using whatever segment
+//     prefix `out` does hold, so a request that exceeds the cap still
+//     hits the deepest applicable terminal — preserving catchall and
+//     longest-prefix semantics rather than failing-closed on input
+//     length alone (Codex P1 caught the earlier fail-closed match()).
+
+u32 RouteTrie::tokenize_segments(Str path, FixedVec<Str, kMaxPathSegments>& out) {
+    // Pure segment split — query/fragment stripping is the caller's
+    // job. Routes arrive here via RouteConfig::add_* which already
+    // rejected inputs containing '?' / '#', so insert() sees a clean
+    // path. Incoming requests go through match(), which shortens the
+    // Str above any '?' / '#' before calling tokenize. Keeping
+    // tokenize pure means the insert-vs-match round-trip always
+    // agrees on what a segment is: bytes between slashes.
+    u32 start = 0;
+    for (u32 i = 0; i <= path.len; i++) {
+        const bool at_sep = (i == path.len) || (path.ptr[i] == '/');
+        if (!at_sep) continue;
+        if (i > start) {
+            if (!out.push(Str{path.ptr + start, i - start})) return kMaxPathSegments + 1;
+        }
+        start = i + 1;
+    }
+    return out.len;
+}
+
+// ---------------------------------------------------------------------------
+// Trie storage and lookup helpers
+// ---------------------------------------------------------------------------
+
+void RouteTrie::clear() {
+    nodes.len = 0;
+    TrieNode root{};
+    [[maybe_unused]] bool ok = nodes.push(root);
+    // push cannot fail on a fresh FixedVec; nodes starts empty.
+}
+
+u16 RouteTrie::find_child(u16 parent, Str segment) const {
+    if (segment.len == 0) return TrieNode::kInvalidNodeIdx;
+    const auto& p = nodes[parent];
+    // Linear scan with full segment compare. Str::eq short-circuits on
+    // length mismatch (usually the common case for heterogeneous
+    // siblings) and then on first-byte mismatch if lengths coincide,
+    // giving the same "first-byte fast path" as a separate u8 index —
+    // but without the extra array and extra branch. Bench data confirms
+    // this is faster than the httprouter-style parallel index for our
+    // segment-length distribution.
+    for (u32 i = 0; i < p.children.len; i++) {
+        const u16 child_idx = p.children[i];
+        if (nodes[child_idx].segment.eq(segment)) return child_idx;
+    }
+    return TrieNode::kInvalidNodeIdx;
+}
+
+bool RouteTrie::insert(Str path, u8 method_char, u16 route_idx) {
+    // Reject unsupported method bytes up-front. An earlier revision
+    // fell back to slot 0 ("any") for unknown chars, which would
+    // silently broaden a route's method filter; fail fast instead so
+    // callers notice (Codex P2 on #41).
+    const u32 slot = method_slot(method_char);
+    if (slot == kMethodSlotInvalid) return false;
+
+    FixedVec<Str, kMaxPathSegments> segs{};
+    const u32 n = tokenize_segments(path, segs);
+    // Sentinel: a path with more segments than we can hold is rejected
+    // at insert time. Silently truncating would create a route
+    // registered at the wrong depth relative to what the user wrote.
+    if (n > kMaxPathSegments) return false;
+
+    // Snapshot state before any mutation so a mid-insert failure can
+    // fully undo everything we've done so far. Per-iteration
+    // pre-flights aren't sufficient on their own: a deep route that
+    // creates k-1 nodes successfully and then fails at segment k was
+    // still leaving k-1 ghost nodes (and the children-array pushes
+    // that pointed at them) in place, consuming capacity until the
+    // pool filled up and legitimate later routes got rejected. Codex
+    // P1 on #41.
+    const u32 saved_nodes_len = nodes.len;
+    // Parents whose children list grew during this insert, one entry
+    // per appended child. Rollback pops each parent's children list
+    // in reverse order so they return to their pre-insert length.
+    FixedVec<u16, kMaxPathSegments> pushed_parents{};
+
+    auto rollback = [&]() {
+        for (u32 r = pushed_parents.len; r > 0; r--) {
+            nodes[pushed_parents[r - 1]].children.len--;
+        }
+        nodes.len = saved_nodes_len;
+    };
+
+    u16 cur = 0;  // root
+    for (u32 i = 0; i < n; i++) {
+        u16 child = find_child(cur, segs[i]);
+        if (child == TrieNode::kInvalidNodeIdx) {
+            // Capacity pre-flight — no mutation if either cap would
+            // be exceeded. This avoids the usual "push succeeded,
+            // dangling node left behind" leak on a same-iteration
+            // failure.
+            if (nodes.len >= kMaxNodes || nodes[cur].children.full()) {
+                rollback();
+                return false;
+            }
+            TrieNode nn{};
+            nn.segment = segs[i];
+            if (!nodes.push(nn)) {
+                rollback();
+                return false;
+            }
+            child = static_cast<u16>(nodes.len - 1);
+            if (!nodes[cur].children.push(child)) {
+                // Pre-flight above rules this out, but if a future
+                // FixedVec invariant change makes it reachable, fall
+                // into the full rollback so the pool stays clean.
+                rollback();
+                return false;
+            }
+            if (!pushed_parents.push(cur)) {
+                // Unreachable: pushed_parents has the same cap as
+                // segs (kMaxPathSegments) and we push at most one
+                // entry per iteration. Roll back defensively anyway.
+                rollback();
+                return false;
+            }
+        }
+        cur = child;
+    }
+    // Record at the terminal. First-insert-wins on the same (path, method)
+    // pair — preserves the existing add-order semantics for duplicates.
+    if (nodes[cur].route_idx_by_method[slot] == TrieNode::kInvalidRoute) {
+        nodes[cur].route_idx_by_method[slot] = route_idx;
+    }
+    return true;
+}
+
+u16 RouteTrie::match(Str path, u8 method_char) const {
+    // Unsupported method bytes can't match anything — bail before
+    // touching the trie. Consistent with the insert-time rejection.
+    const u32 want_slot = method_slot(method_char);
+    if (want_slot == kMethodSlotInvalid) return TrieNode::kInvalidRoute;
+
+    // Shorten the request path above any '?' (query) or '#' (fragment)
+    // byte so routing uses only the path component (RFC 3986). We do
+    // this at the call site rather than inside tokenize_segments so
+    // insert() stays strict about the bytes it's tokenizing — a route
+    // registered as "/health" never tokenizes to the same key as one
+    // accidentally registered as "/health?x=1".
+    u32 end = path.len;
+    for (u32 i = 0; i < path.len; i++) {
+        if (path.ptr[i] == '?' || path.ptr[i] == '#') {
+            end = i;
+            break;
+        }
+    }
+    path.len = end;
+
+    // Require origin-form request target (begins with '/') before
+    // applying any route. Non-origin-form targets — OPTIONS `*`
+    // (asterisk-form), CONNECT `host:port` (authority-form), and
+    // absolute-form URLs — shouldn't route through path-based
+    // matching at all; the pre-trie byte-prefix matcher rejected
+    // them implicitly because pattern "/" failed to match their
+    // first byte. The trie's root-terminal seed was bypassing that
+    // and sending '*' / 'example:443' into a configured `/` catchall
+    // (Codex P2 on #41).
+    if (path.len == 0 || path.ptr[0] != '/') return TrieNode::kInvalidRoute;
+
+    FixedVec<Str, kMaxPathSegments> segs{};
+    // Ignore tokenize's return value on overflow: `segs` still holds
+    // the first kMaxPathSegments, and we want to walk the trie as deep
+    // as we have data for. Bailing out on overflow would let a request
+    // that's deeper than cap bypass a '/' catchall or a matching
+    // prefix route — insert() already rejects too-deep route configs,
+    // so the trie never contains a terminal we'd miss.
+    (void)tokenize_segments(path, segs);
+    u16 cur = 0;
+    // Track the deepest terminal we've seen that's compatible with the
+    // requested method. Initialize from the root so a route inserted at
+    // "/" acts as a catch-all even when the request has deeper segments
+    // not in the trie.
+    auto pick_terminal = [](const TrieNode& node, u32 slot) -> u16 {
+        // Prefer a method-specific slot; fall back to slot 0 ("any").
+        if (slot != 0 && node.route_idx_by_method[slot] != TrieNode::kInvalidRoute) {
+            return node.route_idx_by_method[slot];
+        }
+        return node.route_idx_by_method[0];
+    };
+    u16 best = pick_terminal(nodes[0], want_slot);
+
+    for (u32 i = 0; i < segs.len; i++) {
+        const u16 child = find_child(cur, segs[i]);
+        if (child == TrieNode::kInvalidNodeIdx) break;
+        cur = child;
+        const u16 candidate = pick_terminal(nodes[cur], want_slot);
+        if (candidate != TrieNode::kInvalidRoute) best = candidate;
+    }
+    return best;
+}
+
+}  // namespace rut

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,6 +111,15 @@ target_include_directories(test_types PRIVATE
 add_test(NAME test_types COMMAND test_types)
 set_tests_properties(test_types PROPERTIES LABELS "unit")
 
+add_executable(test_route_trie test_route_trie.cc)
+target_link_libraries(test_route_trie rut_runtime)
+target_include_directories(test_route_trie PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+)
+add_test(NAME test_route_trie COMMAND test_route_trie)
+set_tests_properties(test_route_trie PROPERTIES LABELS "unit")
+
 add_executable(test_rir test_rir.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
 target_link_libraries(test_rir rut_compiler)
 target_include_directories(test_rir PRIVATE
@@ -245,6 +254,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_traffic_replay>
     COMMAND $<TARGET_FILE:test_sim>
     COMMAND $<TARGET_FILE:test_simulate_engine>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine
+    COMMAND $<TARGET_FILE:test_route_trie>
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie
     COMMENT "Running all tests..."
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,15 @@ target_include_directories(test_route_trie PRIVATE
 add_test(NAME test_route_trie COMMAND test_route_trie)
 set_tests_properties(test_route_trie PROPERTIES LABELS "unit")
 
+add_executable(test_route_hash_full test_route_hash_full.cc)
+target_link_libraries(test_route_hash_full rut_runtime)
+target_include_directories(test_route_hash_full PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+)
+add_test(NAME test_route_hash_full COMMAND test_route_hash_full)
+set_tests_properties(test_route_hash_full PROPERTIES LABELS "unit")
+
 add_executable(test_rir test_rir.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
 target_link_libraries(test_rir rut_compiler)
 target_include_directories(test_rir PRIVATE
@@ -255,6 +264,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_sim>
     COMMAND $<TARGET_FILE:test_simulate_engine>
     COMMAND $<TARGET_FILE:test_route_trie>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie
+    COMMAND $<TARGET_FILE:test_route_hash_full>
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_hash_full
     COMMENT "Running all tests..."
 )

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -2392,9 +2392,11 @@ TEST(route, set_dispatch_accepts_canonical_singletons) {
     CHECK(a.set_dispatch(&kLinearScanDispatch));
     RouteConfig b;
     CHECK(b.set_dispatch(&kSegmentTrieDispatch));
-    // Null is still refused (no dispatch == no match).
     RouteConfig c;
-    CHECK(!c.set_dispatch(nullptr));
+    CHECK(c.set_dispatch(&kHashFullPathDispatch));
+    // Null is still refused (no dispatch == no match).
+    RouteConfig d;
+    CHECK(!d.set_dispatch(nullptr));
 }
 
 TEST(route, set_dispatch_refuses_after_first_add) {

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -2310,6 +2310,134 @@ TEST(route, add_upstream_at_capacity) {
     CHECK(!cfg.add_upstream("overflow", 0x7F000001, 9999).has_value());  // full
 }
 
+// ============================================================================
+// is_routable_path rejection — PR-A added a uniform path-validation gate
+// to add_*. These tests pin the rejected shapes so a regression doesn't
+// silently relax the contract.
+// ============================================================================
+
+TEST(route, add_rejects_null_path) {
+    RouteConfig cfg;
+    CHECK(!cfg.add_static(nullptr, 0, 200));
+    CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, add_rejects_empty_path) {
+    RouteConfig cfg;
+    CHECK(!cfg.add_static("", 0, 200));
+    CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, add_rejects_path_without_leading_slash) {
+    RouteConfig cfg;
+    CHECK(!cfg.add_static("api", 0, 200));
+    CHECK(!cfg.add_static("api/v1", 0, 200));
+    CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, add_rejects_path_with_query) {
+    // '?' belongs to the query component of a URI; matching is on path
+    // only. Routing on a path with '?' would be surprising — at match
+    // time the segment trie strips it from the request, so the route
+    // would be effectively unmatchable.
+    RouteConfig cfg;
+    (void)cfg.add_upstream("u", 0x7F000001, 80);
+    CHECK(!cfg.add_static("/api?foo=1", 0, 200));
+    CHECK(!cfg.add_proxy("/api?x", 0, 0));
+    CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, add_rejects_path_with_fragment) {
+    RouteConfig cfg;
+    CHECK(!cfg.add_static("/api#frag", 0, 200));
+    CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, add_accepts_well_formed_path_after_rejection) {
+    // A previous rejected add_* must not poison route_count or leave
+    // partial state — a follow-up valid add_* should succeed.
+    RouteConfig cfg;
+    CHECK(!cfg.add_static("api", 0, 200));    // missing leading '/'
+    CHECK(!cfg.add_static("/x?y", 0, 200));   // has '?'
+    CHECK(!cfg.add_static(nullptr, 0, 200));  // null
+    CHECK_EQ(cfg.route_count, 0u);
+    CHECK(cfg.add_static("/api", 0, 200));  // valid
+    CHECK_EQ(cfg.route_count, 1u);
+}
+
+TEST(route, set_dispatch_rejects_unknown_pointer) {
+    // Codex P2 on #43 round 3: set_dispatch() must refuse any pointer
+    // that isn't one of the canonical static singletons. Allowing an
+    // ephemeral / stack-local vtable to be installed lets the
+    // dispatch_ pointer dangle once the caller's frame returns; even
+    // a structural copy of a real singleton (the natural way a caller
+    // might "construct" one) would be a stack-local. Lifetime hazard
+    // closed at the install gate; populate_dispatch_state's fail-
+    // closed branch from round 3 stays as defense-in-depth.
+    RouteDispatch fake_vtable = kLinearScanDispatch;  // structural copy
+    RouteConfig cfg;
+    CHECK(!cfg.set_dispatch(&fake_vtable));          // refused
+    CHECK_EQ(cfg.dispatch(), &kLinearScanDispatch);  // unchanged
+    // The default dispatch still works — the failed install left the
+    // config in its initial state, not a half-broken one.
+    CHECK(cfg.add_static("/api", 0, 200));
+    CHECK_EQ(cfg.route_count, 1u);
+}
+
+TEST(route, set_dispatch_accepts_canonical_singletons) {
+    // Positive-path coverage of the whitelist: each canonical
+    // singleton known to this PR must be installable on a fresh
+    // config. Future impl PRs add their singleton + a line here.
+    RouteConfig a;
+    CHECK(a.set_dispatch(&kLinearScanDispatch));
+    RouteConfig b;
+    CHECK(b.set_dispatch(&kSegmentTrieDispatch));
+    // Null is still refused (no dispatch == no match).
+    RouteConfig c;
+    CHECK(!c.set_dispatch(nullptr));
+}
+
+TEST(route, set_dispatch_refuses_after_first_add) {
+    // Codex P1 on #43 round 2: flipping dispatch after add_* would
+    // leave earlier routes invisible to the new dispatch's data
+    // structure (e.g., trie empty / partial), causing silent misses.
+    // set_dispatch() pins the contract: dispatch is fixed at first
+    // add_*. Build a fresh RouteConfig if you need a different one.
+    RouteConfig cfg;
+    REQUIRE(cfg.set_dispatch(&kSegmentTrieDispatch));  // pre-add_* OK
+    REQUIRE_EQ(cfg.dispatch(), &kSegmentTrieDispatch);
+    REQUIRE(cfg.add_static("/a", 0, 200));
+    CHECK(!cfg.set_dispatch(&kLinearScanDispatch));   // post-add_* refused
+    CHECK_EQ(cfg.dispatch(), &kSegmentTrieDispatch);  // unchanged
+    CHECK(!cfg.set_dispatch(nullptr));                // null also refused
+}
+
+TEST(route, default_dispatch_admits_route_when_trie_would_fail) {
+    // The default linear-scan dispatch reads routes[] directly; a trie
+    // capacity exhaustion must NOT reject the route. The PR-A reviewer
+    // flagged that add_* used to gate on trie.insert() unconditionally,
+    // so configs whose paths are linear-scan-fine but trie-unfriendly
+    // would be wrongly rejected. This test pins the fix.
+    //
+    // We can't easily exhaust the trie at kMaxNodes=4097 in a unit
+    // test without making it absurdly long, so instead we verify the
+    // smaller observable: when dispatch == kLinearScanDispatch (the
+    // default), populate_dispatch_state is a no-op and add_* always
+    // succeeds for any well-formed path within RouteEntry::kMaxPathLen.
+    RouteConfig cfg;
+    REQUIRE(&kLinearScanDispatch == cfg.dispatch());
+    for (u32 i = 0; i < RouteConfig::kMaxRoutes; i++) {
+        char path[8];
+        path[0] = '/';
+        path[1] = static_cast<char>('a' + (i / 100) % 26);
+        path[2] = static_cast<char>('a' + (i / 10) % 26);
+        path[3] = static_cast<char>('a' + i % 26);
+        path[4] = '\0';
+        CHECK(cfg.add_static(path, 0, 200));
+    }
+    CHECK_EQ(cfg.route_count, RouteConfig::kMaxRoutes);
+}
+
 TEST(route, add_response_body_basic) {
     RouteConfig cfg;
     const u16 idx = cfg.add_response_body("Hello", 5);

--- a/tests/test_route_hash_full.cc
+++ b/tests/test_route_hash_full.cc
@@ -1,0 +1,184 @@
+// Tests for runtime/route_hash_full.h: exact-match hash dispatch.
+//
+// Covers the contract laid out at the top of the header:
+//   - exact-string matching (no prefix walking)
+//   - method-slot routing (specific beats any; any-fallback when
+//     specific misses)
+//   - capacity rejection at the load-factor cap
+//   - duplicate-key idempotence (first insert wins)
+//   - distinct hashing of (path, 0) vs (path, method) so they coexist
+//   - probe correctness under collision (open-addressing wraparound)
+
+#include "rut/runtime/route_hash_full.h"
+#include "test.h"
+
+using namespace rut;
+
+namespace {
+
+constexpr Str S(const char* s) {
+    u32 n = 0;
+    while (s[n]) n++;
+    return Str{s, n};
+}
+
+}  // namespace
+
+// ============================================================================
+// Basic match
+// ============================================================================
+
+TEST(route_hash_full, exact_match_single_route) {
+    HashFullPathTable t;
+    REQUIRE(t.insert(S("/health"), 0, 7));
+    CHECK_EQ(t.match(S("/health"), 0), 7u);
+}
+
+TEST(route_hash_full, no_match_returns_invalid) {
+    HashFullPathTable t;
+    REQUIRE(t.insert(S("/health"), 0, 7));
+    CHECK_EQ(t.match(S("/missing"), 0), kRouteIdxInvalid);
+    CHECK_EQ(t.match(S(""), 0), kRouteIdxInvalid);  // empty is never a route
+}
+
+TEST(route_hash_full, no_prefix_walking) {
+    // Crucial contract distinction from SegmentTrie: hash_full_path
+    // treats /api as STRICTLY EXACT — a request for /api/v1/users
+    // does NOT match a route registered at /api. The selector must
+    // never pick this dispatch for configs that need prefix semantics.
+    HashFullPathTable t;
+    REQUIRE(t.insert(S("/api"), 0, 1));
+    CHECK_EQ(t.match(S("/api"), 0), 1u);
+    CHECK_EQ(t.match(S("/api/v1"), 0), kRouteIdxInvalid);
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), kRouteIdxInvalid);
+    CHECK_EQ(t.match(S("/api/"), 0), kRouteIdxInvalid);  // trailing slash differs too
+}
+
+// ============================================================================
+// Method dispatch
+// ============================================================================
+
+TEST(route_hash_full, method_specific_beats_any_via_distinct_slots) {
+    // Two routes at the same path with different methods both fit; the
+    // hash function folds method into the key so they don't collide.
+    HashFullPathTable t;
+    REQUIRE(t.insert(S("/x"), 0, 10));
+    REQUIRE(t.insert(S("/x"), 'G', 20));
+    CHECK_EQ(t.match(S("/x"), 'G'), 20u);
+    CHECK_EQ(t.match(S("/x"), 0), 10u);    // direct hit on the any slot
+    CHECK_EQ(t.match(S("/x"), 'P'), 10u);  // POST → any-slot fallback
+    CHECK_EQ(t.match(S("/x"), 'D'), 10u);  // DELETE → any-slot fallback
+}
+
+TEST(route_hash_full, any_only_route_serves_every_method) {
+    HashFullPathTable t;
+    REQUIRE(t.insert(S("/wild"), 0, 99));
+    CHECK_EQ(t.match(S("/wild"), 'G'), 99u);
+    CHECK_EQ(t.match(S("/wild"), 'P'), 99u);
+    CHECK_EQ(t.match(S("/wild"), 'D'), 99u);
+    CHECK_EQ(t.match(S("/wild"), 0), 99u);
+}
+
+TEST(route_hash_full, specific_only_route_does_not_serve_other_methods) {
+    HashFullPathTable t;
+    REQUIRE(t.insert(S("/get-only"), 'G', 5));
+    CHECK_EQ(t.match(S("/get-only"), 'G'), 5u);
+    CHECK_EQ(t.match(S("/get-only"), 'P'), kRouteIdxInvalid);
+    CHECK_EQ(t.match(S("/get-only"), 0), kRouteIdxInvalid);
+}
+
+TEST(route_hash_full, method_first_insert_wins_on_exact_dup) {
+    HashFullPathTable t;
+    REQUIRE(t.insert(S("/x"), 'G', 1));
+    // Second insert at the same (path, method) is idempotent, not an
+    // overwrite. Same shape as the trie's first-wins.
+    REQUIRE(t.insert(S("/x"), 'G', 2));
+    CHECK_EQ(t.match(S("/x"), 'G'), 1u);
+}
+
+// ============================================================================
+// Capacity / build-time guards
+// ============================================================================
+
+TEST(route_hash_full, accepts_routes_up_to_load_factor_cap) {
+    // The load-factor cap is < 50% (n_*2 >= kCap rejects), so kCap/2
+    // = 256 inserts must all succeed at distinct paths.
+    HashFullPathTable t;
+    constexpr u32 kN = HashFullPathTable::kCap / 2;
+    char paths[kN][16];
+    for (u32 i = 0; i < kN; i++) {
+        // Construct distinct paths "/r0000".."/r0255".
+        paths[i][0] = '/';
+        paths[i][1] = 'r';
+        paths[i][2] = static_cast<char>('0' + (i / 100) % 10);
+        paths[i][3] = static_cast<char>('0' + (i / 10) % 10);
+        paths[i][4] = static_cast<char>('0' + i % 10);
+        paths[i][5] = '\0';
+        CHECK(t.insert(Str{paths[i], 5}, 0, static_cast<u16>(i)));
+    }
+    CHECK_EQ(t.size(), kN);
+    // The next insert must trip the load-factor cap.
+    CHECK(!t.insert(S("/overflow"), 0, 999));
+}
+
+TEST(route_hash_full, distinct_paths_dont_alias) {
+    // Non-trivial probe correctness: insert N distinct routes, look
+    // each one up, ensure we get the right index back. Catches any
+    // off-by-one in the wraparound or method-fold logic.
+    HashFullPathTable t;
+    constexpr u32 kN = 64;
+    char paths[kN][16];
+    for (u32 i = 0; i < kN; i++) {
+        paths[i][0] = '/';
+        paths[i][1] = 'p';
+        paths[i][2] = static_cast<char>('0' + (i / 10) % 10);
+        paths[i][3] = static_cast<char>('0' + i % 10);
+        paths[i][4] = '\0';
+        REQUIRE(t.insert(Str{paths[i], 4}, 0, static_cast<u16>(i)));
+    }
+    for (u32 i = 0; i < kN; i++) {
+        CHECK_EQ(t.match(Str{paths[i], 4}, 0), static_cast<u16>(i));
+    }
+}
+
+// ============================================================================
+// Adapter / dispatch interface integration
+// ============================================================================
+
+TEST(route_hash_full, clear_resets_state) {
+    HashFullPathTable t;
+    REQUIRE(t.insert(S("/a"), 0, 1));
+    REQUIRE(t.insert(S("/b"), 0, 2));
+    CHECK_EQ(t.size(), 2u);
+    t.clear();
+    CHECK_EQ(t.size(), 0u);
+    CHECK_EQ(t.match(S("/a"), 0), kRouteIdxInvalid);
+    // Reusing after clear() must work cleanly.
+    REQUIRE(t.insert(S("/c"), 0, 3));
+    CHECK_EQ(t.match(S("/c"), 0), 3u);
+    CHECK_EQ(t.match(S("/a"), 0), kRouteIdxInvalid);
+}
+
+TEST(route_hash_full, match_strips_query_and_fragment) {
+    // Codex P2 on #44: the runtime parser keeps the raw request-target
+    // in ParsedRequest.path, so "/health?check=1" arrives at match()
+    // verbatim. Without stripping, hash dispatch would miss /health
+    // routes that the linear scan and segment trie both find. Strip
+    // before hashing.
+    HashFullPathTable t;
+    REQUIRE(t.insert(S("/health"), 0, 7));
+    REQUIRE(t.insert(S("/api/users"), 0, 12));
+    CHECK_EQ(t.match(S("/health?check=1"), 0), 7u);
+    CHECK_EQ(t.match(S("/health?"), 0), 7u);
+    CHECK_EQ(t.match(S("/health#frag"), 0), 7u);
+    CHECK_EQ(t.match(S("/api/users?page=3&limit=10"), 0), 12u);
+    // After the strip the leading byte is still '/', so a request
+    // whose stripped path is empty (e.g., "?frag" alone, or "")
+    // falls through cleanly without aliasing into a registered key.
+    CHECK_EQ(t.match(S("?foo"), 0), kRouteIdxInvalid);
+    CHECK_EQ(t.match(S("#frag"), 0), kRouteIdxInvalid);
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}

--- a/tests/test_route_trie.cc
+++ b/tests/test_route_trie.cc
@@ -1,0 +1,465 @@
+// Tests for runtime/route_trie.h: segment tokenization + trie insert/match.
+//
+// Coverage strategy: the trie has four moving parts — tokenize_segments
+// (policy), find_child (linear scan with full segment compare), insert
+// (build), match (longest-match + method fallback). Tokenize is
+// covered by public observation: insert/match depend on it, so
+// asserting correct lookup behavior across the canonical edge-case
+// paths (multi-slash, trailing slash, case) exercises tokenize
+// indirectly, while dedicated tests below pin the policy at the
+// per-path level.
+
+#include "rut/runtime/route_trie.h"
+#include "test.h"
+
+using namespace rut;
+
+namespace {
+
+constexpr Str S(const char* s) {
+    u32 n = 0;
+    while (s[n]) n++;
+    return Str{s, n};
+}
+
+// Insert a (path, method, idx) tuple; a bool-returning helper so callers can
+// use REQUIRE in the test scope (the REQUIRE macro needs the `_tc` context
+// variable that only exists inside TEST macros).
+struct Insert {
+    const char* path;
+    u8 method;
+    u16 idx;
+};
+
+bool build_ok(RouteTrie& t, const Insert* items, u32 n) {
+    t.clear();
+    for (u32 i = 0; i < n; i++) {
+        if (!t.insert(S(items[i].path), items[i].method, items[i].idx)) return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+// ============================================================================
+// Basic match
+// ============================================================================
+
+TEST(route_trie, exact_match_single_route) {
+    RouteTrie t;
+    const Insert items[] = {{"/health", 0, 7}};
+    REQUIRE(build_ok(t, items, 1));
+    CHECK_EQ(t.match(S("/health"), 0), 7u);
+}
+
+TEST(route_trie, no_match_returns_sentinel_when_no_catchall) {
+    RouteTrie t;
+    const Insert items[] = {{"/health", 0, 7}};
+    REQUIRE(build_ok(t, items, 1));
+    CHECK_EQ(t.match(S("/missing"), 0), TrieNode::kInvalidRoute);
+    CHECK_EQ(t.match(S("/"), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_trie, rejects_non_origin_form_request_targets) {
+    // Codex P2 on #41: match() used to seed `best` from the root
+    // terminal unconditionally, so a configured "/" catchall would
+    // match HTTP/1.1 non-origin-form request targets like "*"
+    // (OPTIONS asterisk-form) or "example.com:443" (CONNECT
+    // authority-form). Path-based routing shouldn't apply to those;
+    // the pre-trie byte-prefix matcher rejected them implicitly.
+    RouteTrie t;
+    const Insert items[] = {{"/", 0, 99}};
+    REQUIRE(build_ok(t, items, 1));
+    // Origin-form paths still hit the catchall.
+    CHECK_EQ(t.match(S("/"), 0), 99u);
+    CHECK_EQ(t.match(S("/deep/path"), 0), 99u);
+    // Non-origin-form request targets — no leading '/', no match.
+    CHECK_EQ(t.match(S("*"), 0), TrieNode::kInvalidRoute);
+    CHECK_EQ(t.match(S("example.com:443"), 0), TrieNode::kInvalidRoute);
+    CHECK_EQ(t.match(S(""), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_trie, catchall_root_matches_unrouted_paths) {
+    RouteTrie t;
+    const Insert items[] = {{"/health", 0, 7}, {"/", 0, 99}};
+    REQUIRE(build_ok(t, items, 2));
+    CHECK_EQ(t.match(S("/health"), 0), 7u);    // specific wins over catchall
+    CHECK_EQ(t.match(S("/missing"), 0), 99u);  // falls through to catchall
+    CHECK_EQ(t.match(S("/"), 0), 99u);         // root path hits catchall
+}
+
+TEST(route_trie, longest_match_wins_regardless_of_insert_order) {
+    // Two orderings of the same routes must produce the same match — the
+    // whole point of moving off the linear first-match-wins scan.
+    const Insert forward[] = {{"/api", 0, 1}, {"/api/v1", 0, 2}, {"/api/v1/users", 0, 3}};
+    const Insert reverse[] = {{"/api/v1/users", 0, 3}, {"/api/v1", 0, 2}, {"/api", 0, 1}};
+    RouteTrie ta, tb;
+    REQUIRE(build_ok(ta, forward, 3));
+    REQUIRE(build_ok(tb, reverse, 3));
+    const char* reqs[] = {
+        "/api", "/api/", "/api/v2", "/api/v1", "/api/v1/users", "/api/v1/users/42"};
+    for (const char* req : reqs) {
+        const u16 a = ta.match(S(req), 0);
+        const u16 b = tb.match(S(req), 0);
+        CHECK_EQ(a, b);
+    }
+    // Spot-check expectations:
+    CHECK_EQ(ta.match(S("/api"), 0), 1u);
+    CHECK_EQ(ta.match(S("/api/"), 0), 1u);    // P2a: trailing slash ≡ no slash
+    CHECK_EQ(ta.match(S("/api/v2"), 0), 1u);  // deeper sibling not in trie → fall back
+    CHECK_EQ(ta.match(S("/api/v1"), 0), 2u);  // exact intermediate
+    CHECK_EQ(ta.match(S("/api/v1/users"), 0), 3u);
+    CHECK_EQ(ta.match(S("/api/v1/users/42"), 0), 3u);  // deeper request → longest prefix wins
+}
+
+// ============================================================================
+// Normalization policies (P1a, P2a, P3a)
+// ============================================================================
+
+TEST(route_trie, P1a_consecutive_slashes_collapse) {
+    RouteTrie t;
+    const Insert items[] = {{"/api/v1", 0, 10}};
+    REQUIRE(build_ok(t, items, 1));
+    CHECK_EQ(t.match(S("/api//v1"), 0), 10u);                 // client double-slash → normalize
+    CHECK_EQ(t.match(S("//api/v1"), 0), 10u);                 // leading double-slash
+    CHECK_EQ(t.match(S("/api///v1"), 0), 10u);                // triple
+    CHECK_EQ(t.match(S("///"), 0), TrieNode::kInvalidRoute);  // all-slash path has no segments
+}
+
+TEST(route_trie, P1a_insert_path_with_extra_slashes_normalizes) {
+    // Inserting "/api//v1" should be equivalent to inserting "/api/v1".
+    RouteTrie t;
+    const Insert items[] = {{"/api//v1", 0, 10}};
+    REQUIRE(build_ok(t, items, 1));
+    CHECK_EQ(t.match(S("/api/v1"), 0), 10u);
+    CHECK_EQ(t.match(S("/api//v1"), 0), 10u);
+}
+
+TEST(route_trie, P2a_trailing_slash_equivalent) {
+    RouteTrie t;
+    const Insert items[] = {{"/api", 0, 5}};
+    REQUIRE(build_ok(t, items, 1));
+    CHECK_EQ(t.match(S("/api"), 0), 5u);
+    CHECK_EQ(t.match(S("/api/"), 0), 5u);
+    CHECK_EQ(t.match(S("/api//"), 0), 5u);
+}
+
+TEST(route_trie, strips_query_string_before_matching) {
+    // Request paths from the HTTP parser include the raw request-target
+    // (path + query + fragment). Routing must run on the path component
+    // only, or GET /health?check=1 won't match a route registered as
+    // /health.
+    RouteTrie t;
+    const Insert items[] = {{"/health", 0, 1}, {"/api/users", 0, 2}};
+    REQUIRE(build_ok(t, items, 2));
+    CHECK_EQ(t.match(S("/health?check=1"), 0), 1u);
+    CHECK_EQ(t.match(S("/health?"), 0), 1u);
+    CHECK_EQ(t.match(S("/health#frag"), 0), 1u);
+    CHECK_EQ(t.match(S("/api/users?page=3&limit=10"), 0), 2u);
+    // Query on a miss still falls through cleanly (no match).
+    CHECK_EQ(t.match(S("/unknown?x=1"), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_trie, P3a_case_sensitive) {
+    RouteTrie t;
+    const Insert items[] = {{"/api", 0, 1}, {"/API", 0, 2}};
+    REQUIRE(build_ok(t, items, 2));
+    CHECK_EQ(t.match(S("/api"), 0), 1u);
+    CHECK_EQ(t.match(S("/API"), 0), 2u);
+    CHECK_EQ(t.match(S("/Api"), 0), TrieNode::kInvalidRoute);  // different case, different route
+}
+
+// ============================================================================
+// Method dispatch
+// ============================================================================
+
+TEST(route_trie, method_specific_beats_any_slot) {
+    // When a path has both a method-specific and an any-method route, the
+    // specific slot wins for matching methods, any wins for others.
+    RouteTrie t;
+    const Insert items[] = {{"/x", 0, 10}, {"/x", 'G', 20}};
+    REQUIRE(build_ok(t, items, 2));
+    CHECK_EQ(t.match(S("/x"), 'G'), 20u);
+    CHECK_EQ(t.match(S("/x"), 'P'), 10u);  // POST → any slot
+    CHECK_EQ(t.match(S("/x"), 'D'), 10u);  // DELETE → any slot
+}
+
+TEST(route_trie, match_strips_query_and_fragment) {
+    // Stripping '?' / '#' from the incoming request is match()'s job
+    // (tokenize_segments stays pure). A route registered at "/api"
+    // should match requests like "/api?x=1" or "/api#frag" despite
+    // the extra bytes after the path component. (Insert-time paths
+    // containing '?' / '#' are rejected earlier at RouteConfig::
+    // add_*, so insert() never sees such a path; the trie itself
+    // would happily store them as distinct bytes if it did.)
+    RouteTrie t;
+    const Insert items[] = {{"/api", 0, 1}};
+    REQUIRE(build_ok(t, items, 1));
+    CHECK_EQ(t.match(S("/api?x=1"), 0), 1u);
+    CHECK_EQ(t.match(S("/api#frag"), 0), 1u);
+}
+
+TEST(route_trie, rejects_unsupported_method_at_insert) {
+    // Codex P2 on #41: the earlier method_slot() mapped unknown method
+    // bytes to slot 0 (any), which would silently broaden a typoed
+    // route into an all-methods route. Now unknown bytes reject at
+    // insert() cleanly so callers see the failure.
+    RouteTrie t;
+    t.clear();
+    // Lowercase 'g' (typo for GET), uppercase 'X', or any unsupported
+    // first byte must fail.
+    CHECK(!t.insert(S("/x"), 'g', 1));
+    CHECK(!t.insert(S("/x"), 'X', 1));
+    CHECK(!t.insert(S("/x"), 'Z', 1));
+    // Known chars still work.
+    CHECK(t.insert(S("/x"), 'G', 1));
+    CHECK(t.insert(S("/y"), 0, 2));  // method=0 is "any", still valid
+}
+
+TEST(route_trie, rejects_unsupported_method_at_match) {
+    // Symmetric: a request with an unsupported method byte can't
+    // match anything, even routes at the same path.
+    RouteTrie t;
+    const Insert items[] = {{"/x", 0, 10}, {"/x", 'G', 20}};
+    REQUIRE(build_ok(t, items, 2));
+    CHECK_EQ(t.match(S("/x"), 'G'), 20u);
+    CHECK_EQ(t.match(S("/x"), 'g'), TrieNode::kInvalidRoute);  // typo
+    CHECK_EQ(t.match(S("/x"), 'X'), TrieNode::kInvalidRoute);  // unknown verb
+}
+
+TEST(route_trie, admits_routes_with_more_than_16_segments) {
+    // Codex P2 on #41: kMaxPathSegments was 16, which rejected valid
+    // route configs with 17+ segments even when the path fit within
+    // RouteEntry::kMaxPathLen. Bumped to 64 to cover the worst-case
+    // 128-byte path (= 64 two-byte segments). A 17-segment path must
+    // now insert and match.
+    RouteTrie t;
+    const char* deep = "/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q";  // 17 segments
+    CHECK(t.insert(S(deep), 0, 99));
+    CHECK_EQ(t.match(S(deep), 0), 99u);
+}
+
+TEST(route_trie, method_first_insert_wins_on_exact_dup) {
+    RouteTrie t;
+    const Insert items[] = {{"/x", 'G', 1}, {"/x", 'G', 2}};  // same method-slot, duplicate
+    REQUIRE(build_ok(t, items, 2));
+    CHECK_EQ(t.match(S("/x"), 'G'), 1u);  // first insert pins the slot
+}
+
+TEST(route_trie, method_post_put_patch_ambiguity_preserved) {
+    // The current first-char method scheme collapses POST/PUT/PATCH → 'P'.
+    // Preserve that here until a follow-up PR introduces a proper enum.
+    RouteTrie t;
+    const Insert items[] = {{"/x", 'P', 99}};
+    REQUIRE(build_ok(t, items, 1));
+    CHECK_EQ(t.match(S("/x"), 'P'), 99u);
+    CHECK_EQ(t.match(S("/x"), 'G'), TrieNode::kInvalidRoute);
+}
+
+// ============================================================================
+// Build-time guards
+// ============================================================================
+
+TEST(route_trie, empty_path_inserts_at_root) {
+    RouteTrie t;
+    const Insert items[] = {{"", 0, 42}};
+    REQUIRE(build_ok(t, items, 1));
+    // Inserting "" is semantically the same as inserting "/" — both
+    // tokenize to the empty-segment root terminal, so the slot is
+    // populated and origin-form requests hit it.
+    CHECK_EQ(t.match(S("/"), 0), 42u);          // "/" normalizes to root
+    CHECK_EQ(t.match(S("/anything"), 0), 42u);  // catchall
+    // An empty request target is NOT origin-form and must not match
+    // path-based routing (Codex P2 on #41 — don't let a catchall
+    // swallow asterisk-form / authority-form / empty targets).
+    CHECK_EQ(t.match(S(""), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_trie, node_count_shows_prefix_sharing) {
+    RouteTrie t;
+    const Insert items[] = {
+        {"/api/v1/users", 0, 1}, {"/api/v1/orders", 0, 2}, {"/api/v2/users", 0, 3}};
+    REQUIRE(build_ok(t, items, 3));
+    // Root + {"api"} + {"v1", "v2"} + {"users", "orders", "users"} = 1 + 1 + 2 + 3 = 7.
+    // If tokenize or insert accidentally didn't share the "api" prefix, we'd see 10.
+    CHECK_EQ(t.node_count(), 7u);
+}
+
+TEST(route_trie, deep_path_still_falls_through_to_catchall_or_prefix) {
+    // Regression guard (Codex P1): an earlier match() returned
+    // kInvalidRoute the moment tokenize reported segment-count
+    // overflow, letting requests with > kMaxPathSegments segments
+    // bypass a '/' catchall or a matching prefix route. match() must
+    // walk as deep as the trie has data for and return the longest-
+    // match terminal it saw, not bail when tokenize trips its cap.
+    //
+    // Although a real request hits ConnectionBase::kMaxReqPathLen
+    // (64 bytes → at most 32 segments) before the trie ever sees
+    // it, match() is also called from tests, replay capture, and
+    // future tooling that may legitimately feed paths past the
+    // segment cap; the contract here is robustness, not coverage of
+    // every wire shape. Build the over-cap path at runtime so the
+    // assertion remains tight as kMaxPathSegments evolves
+    // (Codex P2 on #41 round 14 — 17 segments stopped exercising
+    // the overflow path the moment kMaxPathSegments grew to 64).
+    RouteTrie t;
+    const Insert items[] = {{"/", 0, 42}, {"/api", 0, 7}};
+    REQUIRE(build_ok(t, items, 2));
+
+    // /api + (kMaxPathSegments + 1) "/a" segments = guaranteed
+    // overflow regardless of how the cap is retuned later. Buffer
+    // is sized statically since constexpr u32 mul is fine in this
+    // no-stdlib code; the path doesn't need a NUL terminator (Str
+    // carries length).
+    constexpr u32 kSegs = RouteTrie::kMaxPathSegments + 1;
+    char prefixed[4 + kSegs * 2];
+    u32 n = 0;
+    prefixed[n++] = '/';
+    prefixed[n++] = 'a';
+    prefixed[n++] = 'p';
+    prefixed[n++] = 'i';
+    for (u32 i = 0; i < kSegs; i++) {
+        prefixed[n++] = '/';
+        prefixed[n++] = 'a';
+    }
+    // Starts with /api — the /api terminal must win even though
+    // tokenize will overflow before reaching the deepest segment.
+    CHECK_EQ(t.match(Str{prefixed, n}, 0), 7u);
+
+    // Same depth, no /api prefix — catchall '/' must still fire
+    // instead of a spurious no-match.
+    char unprefixed[kSegs * 2];
+    n = 0;
+    for (u32 i = 0; i < kSegs; i++) {
+        unprefixed[n++] = '/';
+        unprefixed[n++] = 'a';
+    }
+    CHECK_EQ(t.match(Str{unprefixed, n}, 0), 42u);
+}
+
+TEST(route_trie, insert_atomic_on_node_pool_exhaustion_midpath) {
+    // Codex P1 regression: a deep path insert that creates k-1 nodes
+    // successfully and then hits kMaxNodes at segment k used to leave
+    // the k-1 ghost nodes in the pool. Repeated failures would eat
+    // capacity until legitimate shorter routes were rejected — the
+    // "bricked" route admission scenario.
+    //
+    // Setup: fill the pool to within `kDeepSegs - 1` of kMaxNodes so
+    // a kDeepSegs-segment insert is guaranteed to overflow partway
+    // through. Without rollback, the partial pushes would leak and
+    // the follow-up short insert would fail. kMaxNodes-agnostic: the
+    // exact fill shape is computed from the current cap.
+    RouteTrie t;
+    // kDeepSegs × 3-byte segments ("/zX") must fit in
+    // RouteEntry::kMaxPathLen=128. 40 segments × 3 = 120 bytes.
+    static constexpr u32 kDeepSegs = 40;
+    static_assert(kDeepSegs * 3 <= 128, "deep_path must fit RouteEntry::kMaxPathLen");
+
+    // Main 2-level fill: "/pNN/cMM" paths stay within
+    // TrieNode::kMaxChildren at every level. Target budget leaves a
+    // small margin; a top-up loop below tightens the headroom.
+    static constexpr u32 kParents = 40;
+    static constexpr u32 kChildren = (RouteTrie::kMaxNodes - 1 - kParents - kDeepSegs) / kParents;
+    static constexpr u32 kFillRoutes = kParents * kChildren;
+    static_assert(kChildren > 0 && kChildren <= TrieNode::kMaxChildren,
+                  "children count must stay within per-node cap");
+    static char fill_paths[kFillRoutes][12] = {};
+    for (u32 i = 0; i < kFillRoutes; i++) {
+        const u32 p = i / kChildren;
+        const u32 c = i % kChildren;
+        u32 n = 0;
+        fill_paths[i][n++] = '/';
+        fill_paths[i][n++] = 'p';
+        fill_paths[i][n++] = static_cast<char>('0' + p / 10);
+        fill_paths[i][n++] = static_cast<char>('0' + p % 10);
+        fill_paths[i][n++] = '/';
+        fill_paths[i][n++] = 'c';
+        if (c >= 100) fill_paths[i][n++] = static_cast<char>('0' + c / 100);
+        fill_paths[i][n++] = static_cast<char>('0' + (c / 10) % 10);
+        fill_paths[i][n++] = static_cast<char>('0' + c % 10);
+        REQUIRE(t.insert(Str{fill_paths[i], n}, 0, static_cast<u16>(i)));
+    }
+
+    // Top up with single-segment routes at root ("/tNN") to close
+    // the remaining slack below kDeepSegs. Each adds exactly one
+    // node (a new root child). Root has TrieNode::kMaxChildren=128
+    // total slots, of which kParents are already used.
+    static char topup_paths[128][6] = {};
+    u32 topup = 0;
+    while (t.node_count() + kDeepSegs <= RouteTrie::kMaxNodes) {
+        topup_paths[topup][0] = '/';
+        topup_paths[topup][1] = 't';
+        topup_paths[topup][2] = static_cast<char>('0' + topup / 10);
+        topup_paths[topup][3] = static_cast<char>('0' + topup % 10);
+        REQUIRE(t.insert(Str{topup_paths[topup], 4}, 0, 0));
+        topup++;
+        REQUIRE(topup < 128);  // guard against infinite loop
+    }
+    const u32 before = t.node_count();
+    // With this setup, a kDeepSegs insert needs more nodes than are
+    // actually free, so it MUST hit kMaxNodes partway through.
+    CHECK_GT(before + kDeepSegs, RouteTrie::kMaxNodes);
+
+    // Attempt the deep insert. With rollback, node_count returns to
+    // `before`. Without rollback, the partial pushes leak and
+    // node_count ends up at RouteTrie::kMaxNodes (or close to it).
+    char deep_path[kDeepSegs * 3];
+    u32 dpi = 0;
+    for (u32 i = 0; i < kDeepSegs; i++) {
+        deep_path[dpi++] = '/';
+        deep_path[dpi++] = 'z';
+        deep_path[dpi++] = static_cast<char>('a' + i % 26);
+    }
+    CHECK(!t.insert(Str{deep_path, dpi}, 0, 999));
+    CHECK_EQ(t.node_count(), before);
+
+    // A short route must still fit. If rollback leaked, we'd have
+    // burned through the remaining headroom and this would fail.
+    CHECK(t.insert(S("/ok"), 0, 500));
+    CHECK_EQ(t.match(S("/ok"), 0), 500u);
+}
+
+TEST(route_trie, insert_atomic_on_child_cap_overflow) {
+    // Regression guard (Copilot P1 + Codex P2): an earlier insert()
+    // could push a new node into the pool and then fail on the
+    // subsequent children.push(), leaving a dangling unreferenced
+    // node. Repeated overflow attempts used to leak pool capacity
+    // until legitimate inserts started failing. This test asserts
+    // the pool size stays stable across 100 failed inserts after
+    // saturating a parent's child cap.
+    //
+    // Important: TrieNode::segment is a non-owning Str view into the
+    // path buffer the caller provided. Use a 2D array so every
+    // inserted path keeps its own backing storage alive for the
+    // lifetime of the trie — a single scratch buffer would alias
+    // and all children would collapse onto the same segment.
+    RouteTrie t;
+    static constexpr u32 kN = TrieNode::kMaxChildren;
+    // 3-digit decimal encoding (/000../127) — fits kMaxChildren up to
+    // 999 and keeps every segment's bytes distinct so find_child can't
+    // coincidentally match two of our fill paths onto the same child.
+    char paths[kN][8] = {};
+    for (u32 i = 0; i < kN; i++) {
+        paths[i][0] = '/';
+        paths[i][1] = static_cast<char>('0' + (i / 100) % 10);
+        paths[i][2] = static_cast<char>('0' + (i / 10) % 10);
+        paths[i][3] = static_cast<char>('0' + i % 10);
+        REQUIRE(t.insert(Str{paths[i], 4}, 0, static_cast<u16>(i)));
+    }
+    const u32 saturated_count = t.node_count();
+    // Every insert from here on must hit root's child cap. None
+    // should grow node_count (what the old insert() used to leak).
+    // Use /zXX segments that can't collide with any /NNN above.
+    char overflow_paths[100][4] = {};
+    for (u32 i = 0; i < 100; i++) {
+        overflow_paths[i][0] = '/';
+        overflow_paths[i][1] = 'z';
+        overflow_paths[i][2] = static_cast<char>('a' + (i % 26));
+        CHECK(!t.insert(Str{overflow_paths[i], 3}, 0, 0));
+    }
+    CHECK_EQ(t.node_count(), saturated_count);
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}


### PR DESCRIPTION
## Summary
- New: `HashFullPathTable` — open-addressing hash table on (path, method), 512 slots, FNV-1a + load-factor cap < 50%.
- New: `kHashFullPathDispatch` vtable entry in `route_dispatch.h`.
- Wired into `RouteConfig`: `hash_full_state` embedded (~12 KB), populated in lockstep with `routes[]` and `trie` by every `add_*`.
- 10 new tests in `tests/test_route_hash_full.cc` (422 checks).

**Stacks on #43**. Base set to `feat/dispatch-interface` so the diff shows only this PR's changes.

## Why
[Bench data on the realistic SaaS corpus](https://github.com/hurricane1026/Rut/blob/feat/radix-trie-router/bench/bench_route_trie.cc) showed `hash_full_path` at 1.93× over linear scan at N=128 — the floor for exact-match dispatch when prefix semantics aren't required. Constant-time regardless of distribution: one FNV-1a + open-addressing probe.

## Critical contract: NO PREFIX MATCHING
This dispatch treats paths as strict exact-match strings. A request for `/api/v1/users` does NOT match a route registered at `/api`. The selector (a follow-up PR) MUST never pick this dispatch for configs where:
- Any registered route is a prefix of another, or
- Any route contains `:param` segments.

The header doc and the `no_prefix_walking` test pin this contract. The selector PR will gate it on a parsed-routes-side prefix-overlap check.

## Storage cost
12 KB embedded in `RouteConfig`, on top of the trie's 1.2 MB. When the linear-scan default dispatch is selected, this storage sits unused — the same trade-off this branch already accepts for the trie. A follow-up PR will move per-impl state into a tagged union so only the active impl pays its cost.

## Test plan
- [x] `./dev.sh test` — all 1700+ tests + 10 new hash_full tests pass
- [x] `clang-format` clean
- [ ] Reviewer eye on the hash function: FNV-1a + method-byte fold; method=0 vs method='G' must hash to distinct buckets so they don't probe-collide. The `method_specific_beats_any_via_distinct_slots` test exercises this.
- [ ] Reviewer eye on the probe loop: load-factor cap < 50% is the only thing keeping the bounded-probe defensive `return kCap` unreachable in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)