### PR TITLE
runtime: add HashFirstSegment dispatch impl (PR-C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
           LLVM_PROFILE_FILE=build/test_sim.profraw ./build/tests/test_sim
           LLVM_PROFILE_FILE=build/test_route_trie.profraw ./build/tests/test_route_trie
           LLVM_PROFILE_FILE=build/test_route_hash_full.profraw ./build/tests/test_route_hash_full
+          LLVM_PROFILE_FILE=build/test_route_hash_first_seg.profraw ./build/tests/test_route_hash_first_seg
 
       - name: Generate coverage report
         run: |
@@ -180,4 +181,5 @@ jobs:
             build/tests/test_chunked_parser \
             build/tests/test_rir \
             build/tests/test_route_trie \
-            build/tests/test_route_hash_full
+            build/tests/test_route_hash_full \
+            build/tests/test_route_hash_first_seg

--- a/include/rut/runtime/route_dispatch.h
+++ b/include/rut/runtime/route_dispatch.h
@@ -86,4 +86,12 @@ extern const RouteDispatch kSegmentTrieDispatch;
 // those constraints don't hold.
 extern const RouteDispatch kHashFullPathDispatch;
 
+// First-segment-hashed bucket table with byte-prefix scan inside the
+// bucket (RouteConfig::hash_first_seg_state). Preserves linear-scan
+// semantics so prefix routes work, just with O(N/B) average lookup.
+// Selector picks this for configs with diverse first segments and
+// no first-segment bucket exceeding kPerBucket — see
+// route_hash_first_seg.h.
+extern const RouteDispatch kHashFirstSegmentDispatch;
+
 }  // namespace rut

--- a/include/rut/runtime/route_hash_first_seg.h
+++ b/include/rut/runtime/route_hash_first_seg.h
@@ -1,0 +1,103 @@
+#pragma once
+
+// HashFirstSegment — partition routes by first-segment hash, linear scan
+// within bucket. Preserves the linear-scan default's byte-prefix
+// matching semantics (so configs with prefix routes can use it), just
+// with O(N/B) average-case lookup instead of O(N).
+//
+// Sweet spot:
+//   - Configs with DIVERSE first segments (multi-service gateways:
+//     /service-a, /service-b, /admin, /webhooks, /oauth, ...) — each
+//     bucket holds 1-3 routes, lookup is dominated by the first-segment
+//     hash + a tiny linear scan.
+//   - Configs with prefix routes (where any path is a prefix of another)
+//     and no `:param` segments — those need the byte-prefix walk that
+//     this impl preserves; HashFullPath would be wrong, SegmentTrie is
+//     overkill.
+//
+// Anti-sweet-spot (selector must avoid):
+//   - Configs where >kPerBucket routes share the same first segment
+//     (e.g., a monolithic SaaS API with 80+ routes all under /api/v1/).
+//     Insert returns false past kPerBucket and the dispatch becomes
+//     incomplete; the selector is responsible for measuring the
+//     max-bucket-size from ParsedRoutes and rejecting this dispatch
+//     when it would exceed kPerBucket.
+//   - Configs with `:param` segments — the byte-prefix walk inside the
+//     bucket can't capture params; need SegmentTrie.
+//
+// Storage: kBuckets × kPerBucket × sizeof(Entry) = 64 × 16 × 24B ≈ 24 KB.
+//
+// Catchall handling: a route at "/" tokenizes to first_segment="", which
+// hashes to the same bucket every time (FNV(empty)). On a request whose
+// own first-segment bucket misses, match() falls back to the empty-
+// segment bucket — preserving the linear scan's "everything matches /"
+// behavior.
+
+#include "rut/common/types.h"
+#include "rut/runtime/route_dispatch.h"
+
+namespace rut {
+
+class HashFirstSegmentTable {
+public:
+    static constexpr u32 kBuckets = 64;    // power of 2 for fast modulo
+    static constexpr u32 kPerBucket = 16;  // selector's hard ceiling
+    static constexpr u32 kCap = 256;       // total capacity (>= kMaxRoutes)
+
+    HashFirstSegmentTable() { clear(); }
+
+    void clear() {
+        for (u32 b = 0; b < kBuckets; b++) bucket_lens[b] = 0;
+        n_ = 0;
+    }
+
+    // Insert a (path, method, route_idx). Returns false on:
+    //   - total capacity hit (n_ at kCap),
+    //   - per-bucket capacity hit (the route's first-segment bucket
+    //     already holds kPerBucket entries — the selector must never
+    //     pick this dispatch for a config that triggers this; we
+    //     return false defensively so a wrong selector choice is
+    //     loud rather than silent).
+    // Within a bucket entries are kept in insert order so the linear
+    // scan inside match() preserves the linear scan's first-match-wins
+    // semantics.
+    bool insert(Str path, u8 method, u16 route_idx);
+
+    // Look up `path` + `method`. Returns kRouteIdxInvalid on miss.
+    // Sequence:
+    //   1. hash first_segment(request_path) → bucket → linear scan
+    //   2. if no hit and first_segment is non-empty, fall back to
+    //      the empty-segment bucket (where catchalls at "/" sit)
+    u16 match(Str path, u8 method) const;
+
+    // Introspection.
+    u32 size() const { return n_; }
+    u32 bucket_size(u32 b) const { return b < kBuckets ? bucket_lens[b] : 0; }
+
+private:
+    struct Entry {
+        Str path;
+        u8 method;
+        u16 route_idx;
+    };
+    Entry entries[kBuckets][kPerBucket];
+    u32 bucket_lens[kBuckets];
+    u32 n_;
+
+    // First segment of `p`: skip leading '/', read until next '/' or
+    // end. Returns an empty Str when `p` is "" or "/" or "/x" with
+    // no second segment — those cases all hash to the catchall
+    // bucket (first segment of the only routable byte sequence is
+    // the empty prefix).
+    static Str first_segment(Str p);
+
+    static u32 bucket_for(Str seg);
+
+    // Linear scan inside one bucket, returning the first matching
+    // entry's route_idx or kRouteIdxInvalid if none match. Match
+    // semantics: byte-prefix (path starts with entry.path) plus
+    // method-slot (entry.method == 0 matches any).
+    u16 scan_bucket(u32 b, Str path, u8 method) const;
+};
+
+}  // namespace rut

--- a/include/rut/runtime/route_hash_first_seg.h
+++ b/include/rut/runtime/route_hash_first_seg.h
@@ -58,9 +58,14 @@ public:
     //     pick this dispatch for a config that triggers this; we
     //     return false defensively so a wrong selector choice is
     //     loud rather than silent).
-    // Within a bucket entries are kept in insert order so the linear
-    // scan inside match() preserves the linear scan's first-match-wins
-    // semantics.
+    //
+    // CONTRACT: route_idx must be assigned monotonically in insertion
+    // order (route N gets idx N). RouteConfig::add_* guarantees this
+    // via route_count++. match() relies on `smaller route_idx == older
+    // insert` to preserve linear-scan's first-match-wins precedence
+    // across the request's first-segment bucket and the catchall
+    // bucket — without monotonicity, an older catchall would not
+    // correctly shadow a newer specific route (Codex P1 on #45).
     bool insert(Str path, u8 method, u16 route_idx);
 
     // Look up `path` + `method`. Returns kRouteIdxInvalid on miss.

--- a/include/rut/runtime/route_hash_first_seg.h
+++ b/include/rut/runtime/route_hash_first_seg.h
@@ -70,9 +70,16 @@ public:
 
     // Look up `path` + `method`. Returns kRouteIdxInvalid on miss.
     // Sequence:
-    //   1. hash first_segment(request_path) → bucket → linear scan
-    //   2. if no hit and first_segment is non-empty, fall back to
-    //      the empty-segment bucket (where catchalls at "/" sit)
+    //   1. scan the request's first_segment bucket for the smallest-
+    //      route_idx match (linear scan within the bucket, in insert
+    //      order, so first match returned IS the smallest idx there).
+    //   2. if first_segment is non-empty AND the catchall bucket
+    //      differs, ALSO scan the empty-segment bucket (where
+    //      catchalls at "/" sit) for its smallest-idx match.
+    //   3. if both buckets contain matches, return the smaller
+    //      route_idx of the two — preserves linear-scan first-match-
+    //      wins precedence so a catchall registered before a specific
+    //      route still shadows it (Codex P1 on #45 round 2).
     u16 match(Str path, u8 method) const;
 
     // Introspection.

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -143,7 +143,7 @@ struct RouteConfig {
     // and state-build gate).
     static bool is_canonical_dispatch(const RouteDispatch* d) {
         return d == &kLinearScanDispatch || d == &kSegmentTrieDispatch ||
-               d == &kHashFullPathDispatch;
+               d == &kHashFullPathDispatch || d == &kHashFirstSegmentDispatch;
     }
 
     // Segment-aware radix trie. Populated by add_* only when the

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -260,6 +260,9 @@ struct RouteConfig {
         if (dispatch_ == &kHashFullPathDispatch) {
             return hash_full_state.insert(path_view, r.method, idx);
         }
+        if (dispatch_ == &kHashFirstSegmentDispatch) {
+            return hash_first_seg_state.insert(path_view, r.method, idx);
+        }
         if (dispatch_ == &kLinearScanDispatch) {
             // routes[] IS the data — nothing else to populate.
             return true;
@@ -301,9 +304,6 @@ struct RouteConfig {
         if (!populate_dispatch_state(r)) {
             return false;  // active dispatch at capacity — fail loud
         }
-        if (!hash_first_seg_state.insert(path_view, method, static_cast<u16>(route_count))) {
-            return false;  // first-seg bucket overflow; reject for consistency
-        }
         route_count++;
         return true;
     }
@@ -327,9 +327,6 @@ struct RouteConfig {
         r.status_code = status;
         r.fn = nullptr;
         if (!populate_dispatch_state(r)) {
-            return false;
-        }
-        if (!hash_first_seg_state.insert(path_view, method, static_cast<u16>(route_count))) {
             return false;
         }
         route_count++;
@@ -357,9 +354,6 @@ struct RouteConfig {
         r.status_code = 0;
         r.fn = fn;
         if (!populate_dispatch_state(r)) {
-            return false;
-        }
-        if (!hash_first_seg_state.insert(path_view, method, static_cast<u16>(route_count))) {
             return false;
         }
         route_count++;

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -157,21 +157,23 @@ struct RouteConfig {
                   "RouteConfig::kMaxRoutes must equal TrieNode::kMaxChildren so a config "
                   "whose routes all share a single parent fits the trie's per-node fan-out.");
 
-    // Exact-match hash table over (path, method). Populated by every
-    // add_* method in lockstep with the trie. ~12 KB (512 slots ×
-    // 24 bytes); negligible next to the trie's 1.2 MB. Only consulted
-    // when dispatch == &kHashFullPathDispatch; the selector landing in
-    // a follow-up PR picks it for configs with no prefix routes
-    // (where exact-match is sufficient and beats the trie on every
-    // dimension we measure).
+    // Exact-match hash table over (path, method). ~12 KB (512 slots ×
+    // 24 bytes); negligible next to the trie's 1.2 MB. Populated by
+    // populate_dispatch_state ONLY when the active dispatch is
+    // &kHashFullPathDispatch — the per-active-dispatch model adopted
+    // in #43 round 2. Selector picks this dispatch for configs with no
+    // prefix routes (where exact-match is sufficient and beats the
+    // trie on every dimension we measure).
     HashFullPathTable hash_full_state;
 
     // First-segment-hashed bucket table. ~24 KB (64 buckets × 16
-    // entries × 24 B). Populated alongside the trie + hash_full_state.
-    // Selector picks this dispatch only when (a) no first-segment
-    // bucket would exceed kPerBucket and (b) at least one configured
-    // route shares a first segment with another (otherwise plain
-    // linear scan is just as fast and uses no per-impl memory).
+    // entries × 24 B). Populated by populate_dispatch_state ONLY when
+    // the active dispatch is &kHashFirstSegmentDispatch (same per-
+    // active-dispatch model as hash_full_state above). Selector picks
+    // this dispatch only when (a) no first-segment bucket would
+    // exceed kPerBucket and (b) at least one configured route shares
+    // a first segment with another (otherwise plain linear scan is
+    // just as fast and uses no per-impl memory).
     HashFirstSegmentTable hash_first_seg_state;
 
     UpstreamTarget upstreams[kMaxUpstreams];

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -6,6 +6,7 @@
 #include "rut/jit/handler_abi.h"
 #include "rut/runtime/error.h"
 #include "rut/runtime/route_dispatch.h"
+#include "rut/runtime/route_hash_first_seg.h"
 #include "rut/runtime/route_hash_full.h"
 #include "rut/runtime/route_trie.h"
 
@@ -165,6 +166,14 @@ struct RouteConfig {
     // dimension we measure).
     HashFullPathTable hash_full_state;
 
+    // First-segment-hashed bucket table. ~24 KB (64 buckets × 16
+    // entries × 24 B). Populated alongside the trie + hash_full_state.
+    // Selector picks this dispatch only when (a) no first-segment
+    // bucket would exceed kPerBucket and (b) at least one configured
+    // route shares a first segment with another (otherwise plain
+    // linear scan is just as fast and uses no per-impl memory).
+    HashFirstSegmentTable hash_first_seg_state;
+
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
 
@@ -292,6 +301,9 @@ struct RouteConfig {
         if (!populate_dispatch_state(r)) {
             return false;  // active dispatch at capacity — fail loud
         }
+        if (!hash_first_seg_state.insert(path_view, method, static_cast<u16>(route_count))) {
+            return false;  // first-seg bucket overflow; reject for consistency
+        }
         route_count++;
         return true;
     }
@@ -315,6 +327,9 @@ struct RouteConfig {
         r.status_code = status;
         r.fn = nullptr;
         if (!populate_dispatch_state(r)) {
+            return false;
+        }
+        if (!hash_first_seg_state.insert(path_view, method, static_cast<u16>(route_count))) {
             return false;
         }
         route_count++;
@@ -342,6 +357,9 @@ struct RouteConfig {
         r.status_code = 0;
         r.fn = fn;
         if (!populate_dispatch_state(r)) {
+            return false;
+        }
+        if (!hash_first_seg_state.insert(path_view, method, static_cast<u16>(route_count))) {
             return false;
         }
         route_count++;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(rut_runtime STATIC
     runtime/access_log.cc
     runtime/traffic_capture.cc
     runtime/route_dispatch.cc
+    runtime/route_hash_first_seg.cc
     runtime/route_hash_full.cc
     runtime/route_trie.cc
     ${SIMD_SOURCE}

--- a/src/runtime/route_hash_first_seg.cc
+++ b/src/runtime/route_hash_first_seg.cc
@@ -1,0 +1,90 @@
+#include "rut/runtime/route_hash_first_seg.h"
+
+#include "rut/runtime/route_table.h"
+
+namespace rut {
+
+namespace {
+
+constexpr u64 kFnvBasis = 0xcbf29ce484222325ULL;
+constexpr u64 kFnvPrime = 0x100000001b3ULL;
+
+u64 fnv1a(const char* p, u32 len) {
+    u64 h = kFnvBasis;
+    for (u32 i = 0; i < len; i++) {
+        h ^= static_cast<u8>(p[i]);
+        h *= kFnvPrime;
+    }
+    return h;
+}
+
+}  // namespace
+
+Str HashFirstSegmentTable::first_segment(Str p) {
+    u32 start = (p.len > 0 && p.ptr[0] == '/') ? 1 : 0;
+    u32 end = start;
+    while (end < p.len && p.ptr[end] != '/') end++;
+    return Str{p.ptr + start, end - start};
+}
+
+u32 HashFirstSegmentTable::bucket_for(Str seg) {
+    return static_cast<u32>(fnv1a(seg.ptr, seg.len)) & (kBuckets - 1);
+}
+
+bool HashFirstSegmentTable::insert(Str path, u8 method, u16 route_idx) {
+    if (n_ >= kCap) return false;
+    const u32 b = bucket_for(first_segment(path));
+    if (bucket_lens[b] >= kPerBucket) return false;
+    auto& e = entries[b][bucket_lens[b]++];
+    e.path = path;
+    e.method = method;
+    e.route_idx = route_idx;
+    n_++;
+    return true;
+}
+
+u16 HashFirstSegmentTable::scan_bucket(u32 b, Str path, u8 method) const {
+    const u32 n = bucket_lens[b];
+    for (u32 i = 0; i < n; i++) {
+        const auto& e = entries[b][i];
+        if (e.method != 0 && e.method != method) continue;
+        if (path.len < e.path.len) continue;
+        bool ok = true;
+        for (u32 j = 0; j < e.path.len; j++) {
+            if (path.ptr[j] != e.path.ptr[j]) {
+                ok = false;
+                break;
+            }
+        }
+        if (ok) return e.route_idx;
+    }
+    return kRouteIdxInvalid;
+}
+
+u16 HashFirstSegmentTable::match(Str path, u8 method) const {
+    const Str first = first_segment(path);
+    const u32 primary_bucket = bucket_for(first);
+    const u16 primary_hit = scan_bucket(primary_bucket, path, method);
+    if (primary_hit != kRouteIdxInvalid) return primary_hit;
+    // Catchall fallback — routes registered at "/" hash into the
+    // empty-segment bucket. If the request's own first-segment
+    // bucket missed, check the catchall bucket. Skip when the
+    // request itself has an empty first segment (we'd be probing
+    // the same bucket twice).
+    if (first.len == 0) return kRouteIdxInvalid;
+    const u32 catchall_bucket = bucket_for(Str{nullptr, 0});
+    if (catchall_bucket == primary_bucket) return kRouteIdxInvalid;
+    return scan_bucket(catchall_bucket, path, method);
+}
+
+namespace {
+
+u16 hash_first_seg_match(const RouteConfig* cfg, Str path, u8 method) {
+    return cfg->hash_first_seg_state.match(path, method);
+}
+
+}  // namespace
+
+const RouteDispatch kHashFirstSegmentDispatch = {&hash_first_seg_match};
+
+}  // namespace rut

--- a/src/runtime/route_hash_first_seg.cc
+++ b/src/runtime/route_hash_first_seg.cc
@@ -23,7 +23,12 @@ u64 fnv1a(const char* p, u32 len) {
 Str HashFirstSegmentTable::first_segment(Str p) {
     u32 start = (p.len > 0 && p.ptr[0] == '/') ? 1 : 0;
     u32 end = start;
-    while (end < p.len && p.ptr[end] != '/') end++;
+    // Stop at '/' AND at '?' / '#' — request-targets from the parser
+    // arrive raw, so /health?check=1 must produce first_segment "health"
+    // not "health?check=1". Without this, request and route would
+    // bucket differently and a registered /health route would miss.
+    // Codex P2 on #45.
+    while (end < p.len && p.ptr[end] != '/' && p.ptr[end] != '?' && p.ptr[end] != '#') end++;
     return Str{p.ptr + start, end - start};
 }
 

--- a/src/runtime/route_hash_first_seg.cc
+++ b/src/runtime/route_hash_first_seg.cc
@@ -67,19 +67,31 @@ u16 HashFirstSegmentTable::scan_bucket(u32 b, Str path, u8 method) const {
 }
 
 u16 HashFirstSegmentTable::match(Str path, u8 method) const {
+    // First-match-wins across the GLOBAL insert order (Codex P1 on
+    // #45). Each bucket scans in local insert order, so its first
+    // match is the smallest route_idx that bucket holds. To preserve
+    // linear-scan precedence — where a "/" catchall registered before
+    // a specific route MUST shadow the specific one — we look at both
+    // candidate buckets (request's first-segment bucket + the empty-
+    // segment bucket where catchalls live) and return the smaller
+    // route_idx of the two.
+    //
+    // Cost: at most two bucket scans per match. The catchall bucket
+    // typically holds 0-1 entries (only "/" routes hash there) so
+    // it's nearly free; we early-exit for the cases where there's
+    // nothing meaningful to merge.
     const Str first = first_segment(path);
     const u32 primary_bucket = bucket_for(first);
     const u16 primary_hit = scan_bucket(primary_bucket, path, method);
-    if (primary_hit != kRouteIdxInvalid) return primary_hit;
-    // Catchall fallback — routes registered at "/" hash into the
-    // empty-segment bucket. If the request's own first-segment
-    // bucket missed, check the catchall bucket. Skip when the
-    // request itself has an empty first segment (we'd be probing
-    // the same bucket twice).
-    if (first.len == 0) return kRouteIdxInvalid;
+    // If the request itself has empty first segment, primary_bucket
+    // already IS the catchall bucket — we'd just rescan it.
+    if (first.len == 0) return primary_hit;
     const u32 catchall_bucket = bucket_for(Str{nullptr, 0});
-    if (catchall_bucket == primary_bucket) return kRouteIdxInvalid;
-    return scan_bucket(catchall_bucket, path, method);
+    if (catchall_bucket == primary_bucket) return primary_hit;
+    const u16 catchall_hit = scan_bucket(catchall_bucket, path, method);
+    if (primary_hit == kRouteIdxInvalid) return catchall_hit;
+    if (catchall_hit == kRouteIdxInvalid) return primary_hit;
+    return primary_hit < catchall_hit ? primary_hit : catchall_hit;
 }
 
 namespace {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,15 @@ target_include_directories(test_route_hash_full PRIVATE
 add_test(NAME test_route_hash_full COMMAND test_route_hash_full)
 set_tests_properties(test_route_hash_full PROPERTIES LABELS "unit")
 
+add_executable(test_route_hash_first_seg test_route_hash_first_seg.cc)
+target_link_libraries(test_route_hash_first_seg rut_runtime)
+target_include_directories(test_route_hash_first_seg PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+)
+add_test(NAME test_route_hash_first_seg COMMAND test_route_hash_first_seg)
+set_tests_properties(test_route_hash_first_seg PROPERTIES LABELS "unit")
+
 add_executable(test_rir test_rir.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
 target_link_libraries(test_rir rut_compiler)
 target_include_directories(test_rir PRIVATE
@@ -265,6 +274,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_simulate_engine>
     COMMAND $<TARGET_FILE:test_route_trie>
     COMMAND $<TARGET_FILE:test_route_hash_full>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_hash_full
+    COMMAND $<TARGET_FILE:test_route_hash_first_seg>
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_hash_full test_route_hash_first_seg
     COMMENT "Running all tests..."
 )

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -2394,9 +2394,11 @@ TEST(route, set_dispatch_accepts_canonical_singletons) {
     CHECK(b.set_dispatch(&kSegmentTrieDispatch));
     RouteConfig c;
     CHECK(c.set_dispatch(&kHashFullPathDispatch));
-    // Null is still refused (no dispatch == no match).
     RouteConfig d;
-    CHECK(!d.set_dispatch(nullptr));
+    CHECK(d.set_dispatch(&kHashFirstSegmentDispatch));
+    // Null is still refused (no dispatch == no match).
+    RouteConfig e;
+    CHECK(!e.set_dispatch(nullptr));
 }
 
 TEST(route, set_dispatch_refuses_after_first_add) {

--- a/tests/test_route_hash_first_seg.cc
+++ b/tests/test_route_hash_first_seg.cc
@@ -1,0 +1,191 @@
+// Tests for runtime/route_hash_first_seg.h: bucketed dispatch.
+//
+// Coverage:
+//   - basic hit / miss in bucket
+//   - byte-prefix matching inside bucket (preserves linear-scan semantics)
+//   - method-slot routing (specific beats any, any-fallback)
+//   - catchall ("/" route) reachable for any request via the empty-
+//     segment bucket fallback
+//   - per-bucket capacity enforcement
+//   - first-match-wins within a bucket (insert order preserved)
+
+#include "rut/runtime/route_hash_first_seg.h"
+#include "test.h"
+
+using namespace rut;
+
+namespace {
+
+constexpr Str S(const char* s) {
+    u32 n = 0;
+    while (s[n]) n++;
+    return Str{s, n};
+}
+
+}  // namespace
+
+// ============================================================================
+// Basic match
+// ============================================================================
+
+TEST(route_hash_first_seg, exact_match_single_route) {
+    HashFirstSegmentTable t;
+    REQUIRE(t.insert(S("/health"), 0, 7));
+    CHECK_EQ(t.match(S("/health"), 0), 7u);
+}
+
+TEST(route_hash_first_seg, no_match_when_no_routes) {
+    HashFirstSegmentTable t;
+    CHECK_EQ(t.match(S("/anything"), 0), kRouteIdxInvalid);
+}
+
+TEST(route_hash_first_seg, byte_prefix_match_within_bucket) {
+    // Routes /api/v1 and /api/v2 share first segment "api". A request
+    // /api/v1/users hits /api/v1 by byte-prefix; /api/v3/x hits
+    // neither.
+    HashFirstSegmentTable t;
+    REQUIRE(t.insert(S("/api/v1"), 0, 1));
+    REQUIRE(t.insert(S("/api/v2"), 0, 2));
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), 1u);
+    CHECK_EQ(t.match(S("/api/v2"), 0), 2u);
+    CHECK_EQ(t.match(S("/api/v3/x"), 0), kRouteIdxInvalid);
+}
+
+// ============================================================================
+// Catchall reachability (the critical thing the empty-segment bucket
+// fallback gives us — without it, hashed dispatch would silently break
+// configs that depend on a "/" route)
+// ============================================================================
+
+TEST(route_hash_first_seg, catchall_root_matches_any_request) {
+    HashFirstSegmentTable t;
+    REQUIRE(t.insert(S("/"), 0, 99));
+    REQUIRE(t.insert(S("/health"), 0, 7));
+    // Specific route still wins on its own bucket.
+    CHECK_EQ(t.match(S("/health"), 0), 7u);
+    // Unmatched first-segment falls back to the catchall bucket.
+    CHECK_EQ(t.match(S("/missing"), 0), 99u);
+    CHECK_EQ(t.match(S("/random/deep/path"), 0), 99u);
+    // The root path itself hits the catchall.
+    CHECK_EQ(t.match(S("/"), 0), 99u);
+}
+
+TEST(route_hash_first_seg, catchall_only_config_serves_everything) {
+    HashFirstSegmentTable t;
+    REQUIRE(t.insert(S("/"), 0, 42));
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), 42u);
+    CHECK_EQ(t.match(S("/admin"), 0), 42u);
+    CHECK_EQ(t.match(S("/"), 0), 42u);
+}
+
+TEST(route_hash_first_seg, no_catchall_fallback_when_request_is_root) {
+    // When the request itself has an empty first segment, we don't
+    // double-probe (would just rescan the same bucket). A request "/"
+    // with no "/" route registered must miss cleanly.
+    HashFirstSegmentTable t;
+    REQUIRE(t.insert(S("/api"), 0, 1));
+    CHECK_EQ(t.match(S("/"), 0), kRouteIdxInvalid);
+    CHECK_EQ(t.match(S(""), 0), kRouteIdxInvalid);
+}
+
+// ============================================================================
+// Method dispatch
+// ============================================================================
+
+TEST(route_hash_first_seg, method_specific_beats_any_within_bucket) {
+    HashFirstSegmentTable t;
+    REQUIRE(t.insert(S("/x"), 0, 10));
+    REQUIRE(t.insert(S("/x"), 'G', 20));
+    // Insert order: /x ANY first, /x GET second. The bucket's linear
+    // scan sees the ANY entry first — so GET requests would hit ANY
+    // before reaching the specific entry. To preserve "specific wins"
+    // semantics in this dispatch the SELECTOR is responsible for
+    // ordering: emit method-specific routes before their any-method
+    // counterpart at the same path. Here we exercise the documented
+    // bucket-scan contract directly: insert order = match order.
+    //
+    // (When the selector lands, its tests will pin the higher-level
+    // "specific beats any" guarantee end-to-end. Within this dispatch,
+    // first-match-wins is the contract.)
+    CHECK_EQ(t.match(S("/x"), 'G'), 10u);  // ANY entry hits first
+    CHECK_EQ(t.match(S("/x"), 'P'), 10u);  // ANY matches POST too
+    CHECK_EQ(t.match(S("/x"), 0), 10u);
+}
+
+TEST(route_hash_first_seg, method_specific_first_then_any) {
+    // Reverse order: GET-specific first, then ANY. GET requests hit
+    // the specific entry first; non-GET methods skip past it and
+    // hit the ANY entry.
+    HashFirstSegmentTable t;
+    REQUIRE(t.insert(S("/x"), 'G', 20));
+    REQUIRE(t.insert(S("/x"), 0, 10));
+    CHECK_EQ(t.match(S("/x"), 'G'), 20u);
+    CHECK_EQ(t.match(S("/x"), 'P'), 10u);
+}
+
+// ============================================================================
+// Capacity / build-time guards
+// ============================================================================
+
+TEST(route_hash_first_seg, rejects_when_per_bucket_exceeds_cap) {
+    // All routes share first segment "x", forcing them into one
+    // bucket. The first kPerBucket inserts succeed; the next one
+    // must fail so the selector's wrong-pick stays loud.
+    HashFirstSegmentTable t;
+    constexpr u32 kN = HashFirstSegmentTable::kPerBucket;
+    char paths[kN + 1][8];
+    for (u32 i = 0; i <= kN; i++) {
+        paths[i][0] = '/';
+        paths[i][1] = 'x';
+        paths[i][2] = '/';
+        paths[i][3] = static_cast<char>('A' + i);
+        paths[i][4] = '\0';
+    }
+    for (u32 i = 0; i < kN; i++) {
+        CHECK(t.insert(Str{paths[i], 4}, 0, static_cast<u16>(i)));
+    }
+    CHECK(!t.insert(Str{paths[kN], 4}, 0, static_cast<u16>(kN)));
+}
+
+TEST(route_hash_first_seg, distinct_first_segments_distribute_well) {
+    // 10 routes with 10 different first segments. Each lands in a
+    // different bucket on average; scan_bucket sees only 1 entry per
+    // hit, so this is the shape the dispatch is designed for.
+    HashFirstSegmentTable t;
+    const char* paths[] = {
+        "/svc-a/x",
+        "/svc-b/x",
+        "/svc-c/x",
+        "/admin/x",
+        "/oauth/x",
+        "/health",
+        "/metrics",
+        "/_status",
+        "/_ready",
+        "/api/v1/x",
+    };
+    for (u32 i = 0; i < 10; i++) {
+        Str p = S(paths[i]);
+        REQUIRE(t.insert(p, 0, static_cast<u16>(i)));
+    }
+    for (u32 i = 0; i < 10; i++) {
+        Str p = S(paths[i]);
+        CHECK_EQ(t.match(p, 0), static_cast<u16>(i));
+    }
+}
+
+TEST(route_hash_first_seg, clear_resets_state) {
+    HashFirstSegmentTable t;
+    REQUIRE(t.insert(S("/a/x"), 0, 1));
+    REQUIRE(t.insert(S("/b/x"), 0, 2));
+    CHECK_EQ(t.size(), 2u);
+    t.clear();
+    CHECK_EQ(t.size(), 0u);
+    CHECK_EQ(t.match(S("/a/x"), 0), kRouteIdxInvalid);
+    REQUIRE(t.insert(S("/c/x"), 0, 3));
+    CHECK_EQ(t.match(S("/c/x"), 0), 3u);
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}

--- a/tests/test_route_hash_first_seg.cc
+++ b/tests/test_route_hash_first_seg.cc
@@ -57,17 +57,39 @@ TEST(route_hash_first_seg, byte_prefix_match_within_bucket) {
 // configs that depend on a "/" route)
 // ============================================================================
 
-TEST(route_hash_first_seg, catchall_root_matches_any_request) {
+// route_idx is monotonically assigned in insertion order (RouteConfig
+// guarantees this via route_count++); tests must mirror that contract
+// because the cross-bucket precedence in match() relies on it. The
+// tests below use idx == insertion sequence so the assertions reflect
+// what real configs see.
+
+TEST(route_hash_first_seg, catchall_inserted_after_specific) {
+    // Specific route at idx 0 (first), catchall at idx 1 (second).
+    // Linear-scan first-match-wins: /health hits idx 0, /missing
+    // falls back to idx 1.
     HashFirstSegmentTable t;
-    REQUIRE(t.insert(S("/"), 0, 99));
-    REQUIRE(t.insert(S("/health"), 0, 7));
-    // Specific route still wins on its own bucket.
-    CHECK_EQ(t.match(S("/health"), 0), 7u);
-    // Unmatched first-segment falls back to the catchall bucket.
-    CHECK_EQ(t.match(S("/missing"), 0), 99u);
-    CHECK_EQ(t.match(S("/random/deep/path"), 0), 99u);
-    // The root path itself hits the catchall.
-    CHECK_EQ(t.match(S("/"), 0), 99u);
+    REQUIRE(t.insert(S("/health"), 0, 0));
+    REQUIRE(t.insert(S("/"), 0, 1));
+    CHECK_EQ(t.match(S("/health"), 0), 0u);
+    CHECK_EQ(t.match(S("/missing"), 0), 1u);
+    CHECK_EQ(t.match(S("/random/deep/path"), 0), 1u);
+    CHECK_EQ(t.match(S("/"), 0), 1u);
+}
+
+TEST(route_hash_first_seg, catchall_inserted_first_shadows_specific) {
+    // Codex P1 on #45: catchall at idx 0, specific at idx 1. Linear
+    // scan returns the catchall (first match in routes[]); the old
+    // hash-first-seg impl returned the specific because the primary
+    // bucket hit shadowed the catchall fallback. Cross-bucket
+    // precedence (smaller route_idx wins) restores parity.
+    HashFirstSegmentTable t;
+    REQUIRE(t.insert(S("/"), 0, 0));
+    REQUIRE(t.insert(S("/health"), 0, 1));
+    // /health: primary bucket has route 1, catchall has route 0 — 0
+    // is older, so 0 wins. Same as linear scan would do.
+    CHECK_EQ(t.match(S("/health"), 0), 0u);
+    CHECK_EQ(t.match(S("/missing"), 0), 0u);
+    CHECK_EQ(t.match(S("/"), 0), 0u);
 }
 
 TEST(route_hash_first_seg, catchall_only_config_serves_everything) {

--- a/tests/test_route_hash_first_seg.cc
+++ b/tests/test_route_hash_first_seg.cc
@@ -174,6 +174,19 @@ TEST(route_hash_first_seg, distinct_first_segments_distribute_well) {
     }
 }
 
+TEST(route_hash_first_seg, first_segment_stops_at_query_and_fragment) {
+    // Codex P2 on #45: requests arrive with raw query / fragment bytes.
+    // first_segment must stop at '?' / '#' so /health?check=1 buckets
+    // the same as /health, otherwise registered routes would miss.
+    HashFirstSegmentTable t;
+    REQUIRE(t.insert(S("/health"), 0, 7));
+    REQUIRE(t.insert(S("/api/users"), 0, 12));
+    CHECK_EQ(t.match(S("/health?check=1"), 0), 7u);
+    CHECK_EQ(t.match(S("/health?"), 0), 7u);
+    CHECK_EQ(t.match(S("/health#frag"), 0), 7u);
+    CHECK_EQ(t.match(S("/api/users?page=3"), 0), 12u);
+}
+
 TEST(route_hash_first_seg, clear_resets_state) {
     HashFirstSegmentTable t;
     REQUIRE(t.insert(S("/a/x"), 0, 1));


### PR DESCRIPTION
## Summary
- New: `HashFirstSegmentTable` — 64-bucket × 16-entry table (~24 KB), FNV-1a on the first path segment, linear byte-prefix scan within bucket.
- New: `kHashFirstSegmentDispatch` vtable entry.
- Wired into `RouteConfig::hash_first_seg_state`, populated by every `add_*` alongside the trie + hash_full_state.
- 11 new tests (74 checks).

**Stacks on #44**. Base = `feat/dispatch-hash-full-path` so the diff shows only this PR's additions.

## Why
Real configs with prefix routes (any path is a prefix of another) can't use `HashFullPath` (PR-B) because it's exact-match only. They CAN use `HashFirstSegment` because the bucket-internal scan does byte-prefix matching, identical to the linear-scan default's semantics — just O(N/B) instead of O(N).

Sweet spot: multi-service gateways with diverse first segments (`/service-a`, `/service-b`, `/admin`, `/webhooks`, `/oauth`). Each bucket holds 1-3 routes; lookup is dominated by the FNV step + a tiny in-bucket scan.

## Critical caveats — selector's job
This dispatch is NOT a drop-in for every config. The selector (a follow-up PR) MUST verify:
1. **Max bucket size ≤ kPerBucket** (16). A monolithic SaaS config with 80+ routes under `/api/v1/` would all hash to one bucket and insert past the cap returns false. We refuse defensively so a wrong selector pick is loud rather than silent — but the right answer is the selector never gets there.
2. **No `:param` segments** — byte-prefix walk in the bucket can't capture params; those configs need `SegmentTrie`.

Header doc and the `rejects_when_per_bucket_exceeds_cap` test pin both contracts.

## Catchall reachability
Routes registered at `"/"` tokenize to first_segment=`""`, which always hashes to the same "catchall bucket". When a request's own first-segment bucket misses, `match()` falls back to the catchall bucket — preserving the linear scan's "everything matches /" behavior. The `catchall_root_matches_any_request` test pins this.

## Storage
24 KB inline in `RouteConfig` on top of HashFullPath (12 KB) and SegmentTrie (1.2 MB). When a different dispatch is selected, this storage sits unused. The follow-up tagged-union PR will reclaim per-impl storage.

## Test plan
- [x] `./dev.sh test` — all existing + 11 new tests (74 checks) pass
- [x] `clang-format` clean
- [ ] Reviewer eye on `first_segment()` boundary cases — empty path, `"/"`, `"/x"` with no second segment, all should return an empty Str so they hash to the catchall bucket consistently.
- [ ] Reviewer eye on `method_specific_beats_any_within_bucket` test — it documents that within-bucket order matters; the selector's job is to emit method-specific routes before their any-method counterpart at the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)