### PR TITLE
runtime: add ByteRadix dispatch impl (PR-D)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
           LLVM_PROFILE_FILE=build/test_route_trie.profraw ./build/tests/test_route_trie
           LLVM_PROFILE_FILE=build/test_route_hash_full.profraw ./build/tests/test_route_hash_full
           LLVM_PROFILE_FILE=build/test_route_hash_first_seg.profraw ./build/tests/test_route_hash_first_seg
+          LLVM_PROFILE_FILE=build/test_route_byte_radix.profraw ./build/tests/test_route_byte_radix
 
       - name: Generate coverage report
         run: |
@@ -182,4 +183,5 @@ jobs:
             build/tests/test_rir \
             build/tests/test_route_trie \
             build/tests/test_route_hash_full \
-            build/tests/test_route_hash_first_seg
+            build/tests/test_route_hash_first_seg \
+            build/tests/test_route_byte_radix

--- a/include/rut/runtime/route_byte_radix.h
+++ b/include/rut/runtime/route_byte_radix.h
@@ -1,0 +1,132 @@
+#pragma once
+
+// ByteRadix — byte-level edge-compressed radix trie.
+//
+// Each node holds an `edge` (a contiguous byte run from its parent).
+// Branching happens when prefixes diverge. Insertion may split an
+// existing edge when a new path shares some prefix with it; the lower
+// half of the edge moves into a new node and the original node's edge
+// shrinks to the shared prefix.
+//
+// Match semantics: longest-prefix-match in BYTES. A request for
+// "/api/v1/users" hits a route registered at "/api/v1" if it exists,
+// even when "/api" is also registered (longer wins). At each terminal
+// visited during descent we record the candidate route_idx; descent
+// stops at the first edge byte mismatch or path exhaustion, and we
+// return the deepest candidate seen.
+//
+// vs SegmentTrie:
+//   - Byte-aware, NOT segment-aware. "/api/v1" matches "/api/v1xyz"
+//     because there's no segment-boundary check. The selector picks
+//     this dispatch only for configs whose route paths don't depend
+//     on segment boundaries (no `:param` segments, no overlapping
+//     routes that need the segment-level distinction).
+//   - Edge compression typically yields fewer nodes for the same
+//     routes: "/api/v1/users" + "/api/v1/orders" share an
+//     "/api/v1/" edge of 9 bytes, then branch on 'u' vs 'o'. A
+//     segment trie would split into 4 segment nodes (api / v1 /
+//     users|orders).
+//
+// Bench data (closed #41 branch, realistic SaaS gateway, hot cache):
+//   N=128 routes:
+//     byte_radix:    0.91 us / match — fastest variant tested
+//     segment_trie:  1.76 us / match
+//     linear_scan:   2.00 us / match  (baseline)
+//   IPC 4.25 (highest in the table): the compressed edges fit more
+//   routes in fewer cache lines, descent is straight-line work.
+//
+// Storage: ~256 nodes × ~70 bytes/node ≈ 18 KB inline.
+//
+// Build-time canonicalization: insert strips a leading '/' and any
+// trailing '/'. The match path strips '?' / '#' suffix in addition,
+// so request bytes after the query/fragment marker don't participate.
+// Routes registered with '?' or '#' are rejected by
+// RouteConfig::is_routable_path before they reach insert().
+//
+// First-insert-wins on duplicate (path, method): the per-method
+// terminal slot is set only if currently kInvalidRoute. RouteConfig
+// guarantees route_idx is monotonic with insertion order, so older
+// terminals (smaller route_idx) shadow newer duplicates.
+
+#include "rut/common/types.h"
+#include "rut/runtime/route_dispatch.h"
+#include "rut/runtime/route_trie.h"  // for kMethodSlots, method_slot, TrieNode::kInvalidRoute
+
+namespace rut {
+
+struct ByteRadixNode {
+    // Per-node fan-out cap. Realistic configs branch <8 children at most
+    // points; 16 covers shared-byte-then-divergent-tail patterns common
+    // at the root (/, h, a, w, ...).
+    static constexpr u32 kMaxChildren = 16;
+
+    // Edge label: the byte run leading INTO this node. Non-owning view
+    // into RouteEntry::path; safe for the config's RCU lifetime.
+    Str edge{};
+
+    // Child node-pool indices, scanned linearly (find_child equivalent).
+    // Order is insertion order so first-byte-match returns the first
+    // registered child with that byte.
+    FixedVec<u16, kMaxChildren> children;
+
+    // Per-method route slot at this terminal. kInvalidRoute means "this
+    // node is not a terminal for that method". Slot 0 is "any".
+    u16 route_idx_by_method[kMethodSlots] = {TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute};
+};
+
+class ByteRadixTrie {
+public:
+    // 256 nodes covers 128 routes worst-case (no prefix sharing →
+    // 1 root + 128 leaves; even less with realistic byte-prefix
+    // overlap). Leaves room for edge splits during insert.
+    static constexpr u32 kMaxNodes = 256;
+
+    ByteRadixTrie() { clear(); }
+
+    // Wipe and re-seed with the empty root node.
+    void clear();
+
+    // Insert a (path, method, route_idx). Returns false if:
+    //   - method byte isn't recognized (mirrors trie/hash strict-method
+    //     contract — selector should pre-filter unsupported methods),
+    //   - the trie is out of node-pool / per-node-children capacity at
+    //     any step. Insert is atomic — any structural mutation is
+    //     rolled back to the pre-insert state on failure, so a partial
+    //     insert can never leave dangling nodes that future inserts
+    //     would inherit.
+    //
+    // CONTRACT: route_idx is assumed monotonic with insertion order
+    // (RouteConfig::add_* guarantees this via route_count++). First-
+    // insert-wins on duplicate (path, method) — the terminal slot is
+    // set only if currently empty.
+    bool insert(Str path, u8 method_char, u16 route_idx);
+
+    // Look up `path` — returns the longest-prefix terminal's route_idx
+    // for the matching method slot, or kInvalidRoute on no match.
+    // method_char == 0 ("any") looks at slot 0 directly; specific
+    // methods prefer their own slot but fall back to slot 0 at each
+    // candidate terminal.
+    u16 match(Str path, u8 method_char) const;
+
+    // Introspection (tests / bench).
+    u32 node_count() const { return nodes.len; }
+
+private:
+    FixedVec<ByteRadixNode, kMaxNodes> nodes;
+
+    // Pick a method slot at a terminal node, with the any-slot fallback.
+    static u16 pick_terminal(const ByteRadixNode& n, u32 slot);
+
+    // Find the child of `parent` whose edge starts with byte `b`.
+    // Returns TrieNode::kInvalidNodeIdx on no match.
+    u16 find_child_by_first_byte(u16 parent, u8 b) const;
+};
+
+}  // namespace rut

--- a/include/rut/runtime/route_byte_radix.h
+++ b/include/rut/runtime/route_byte_radix.h
@@ -55,10 +55,20 @@
 namespace rut {
 
 struct ByteRadixNode {
-    // Per-node fan-out cap. Realistic configs branch <8 children at most
-    // points; 16 covers shared-byte-then-divergent-tail patterns common
-    // at the root (/, h, a, w, ...).
-    static constexpr u32 kMaxChildren = 16;
+    // Per-node fan-out cap. Sized to RouteConfig::kMaxRoutes (128) so
+    // a worst-case shape — 128 distinct routes that all branch at the
+    // same byte position (e.g., 128 single-byte tails under the same
+    // shared edge, which a `/` catchall plus 127 single-letter
+    // top-level paths would produce) — admits without RouteConfig::
+    // add_* failing partway through. Codex P1 on #46 round 2 caught
+    // an earlier 16-cap that turned 17-top-level-prefix configs into
+    // build failures even with kMaxRoutes headroom unused.
+    //
+    // Memory cost: 128 × u16 = 256 B per node × 256 nodes ≈ 64 KB
+    // total for the children arrays. The trie's overall footprint
+    // grows from ~18 KB to ~85 KB inline — still negligible next to
+    // the segment trie's 1.2 MB.
+    static constexpr u32 kMaxChildren = 128;
 
     // Edge label: the byte run leading INTO this node. Non-owning view
     // into RouteEntry::path; safe for the config's RCU lifetime.

--- a/include/rut/runtime/route_byte_radix.h
+++ b/include/rut/runtime/route_byte_radix.h
@@ -35,7 +35,11 @@
 //   IPC 4.25 (highest in the table): the compressed edges fit more
 //   routes in fewer cache lines, descent is straight-line work.
 //
-// Storage: ~256 nodes × ~70 bytes/node ≈ 18 KB inline.
+// Storage: ~256 nodes × ~290 bytes/node ≈ 75 KB inline. Each node
+// carries a 16-B Str edge view, a 260-B FixedVec<u16, 128> children
+// buffer (the post-#46-r3 fan-out cap that admits 128 distinct
+// next-bytes), and 16 B of per-method terminal slots. Still small
+// next to the segment trie's ~1.2 MB.
 //
 // Build-time canonicalization: insert strips a leading '/' and any
 // trailing '/'. The match path strips '?' / '#' suffix in addition,
@@ -64,10 +68,11 @@ struct ByteRadixNode {
     // an earlier 16-cap that turned 17-top-level-prefix configs into
     // build failures even with kMaxRoutes headroom unused.
     //
-    // Memory cost: 128 × u16 = 256 B per node × 256 nodes ≈ 64 KB
-    // total for the children arrays. The trie's overall footprint
-    // grows from ~18 KB to ~85 KB inline — still negligible next to
-    // the segment trie's 1.2 MB.
+    // Memory cost: 128 × u16 = 256 B per node for the children
+    // buffer alone × 256 nodes ≈ 64 KB just for fan-out arrays. The
+    // node-summary at the top of this header (~75 KB total) accounts
+    // for that plus the per-node Str + terminal slots. Still
+    // negligible next to the segment trie's ~1.2 MB.
     static constexpr u32 kMaxChildren = 128;
 
     // Edge label: the byte run leading INTO this node. Non-owning view

--- a/include/rut/runtime/route_dispatch.h
+++ b/include/rut/runtime/route_dispatch.h
@@ -94,4 +94,12 @@ extern const RouteDispatch kHashFullPathDispatch;
 // route_hash_first_seg.h.
 extern const RouteDispatch kHashFirstSegmentDispatch;
 
+// Byte-level edge-compressed radix trie (RouteConfig::byte_radix_state).
+// Longest-prefix-match in BYTES, not segments — so the selector picks
+// this only for configs without segment-boundary semantics (no
+// `:param`, no overlapping segment-distinguished routes). See
+// route_byte_radix.h for the contract and the bench data behind the
+// choice.
+extern const RouteDispatch kByteRadixDispatch;
+
 }  // namespace rut

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -5,6 +5,7 @@
 #include "rut/common/types.h"
 #include "rut/jit/handler_abi.h"
 #include "rut/runtime/error.h"
+#include "rut/runtime/route_byte_radix.h"
 #include "rut/runtime/route_dispatch.h"
 #include "rut/runtime/route_hash_first_seg.h"
 #include "rut/runtime/route_hash_full.h"
@@ -143,7 +144,8 @@ struct RouteConfig {
     // and state-build gate).
     static bool is_canonical_dispatch(const RouteDispatch* d) {
         return d == &kLinearScanDispatch || d == &kSegmentTrieDispatch ||
-               d == &kHashFullPathDispatch || d == &kHashFirstSegmentDispatch;
+               d == &kHashFullPathDispatch || d == &kHashFirstSegmentDispatch ||
+               d == &kByteRadixDispatch;
     }
 
     // Segment-aware radix trie. Populated by add_* only when the
@@ -175,6 +177,13 @@ struct RouteConfig {
     // a first segment with another (otherwise plain linear scan is
     // just as fast and uses no per-impl memory).
     HashFirstSegmentTable hash_first_seg_state;
+
+    // Byte-level edge-compressed radix trie. ~18 KB inline (256
+    // nodes × ~70 B). Selected by the picker when the route set
+    // benefits from byte-level prefix sharing AND doesn't depend
+    // on segment-boundary precedence — see route_byte_radix.h for
+    // the contract distinction from SegmentTrie.
+    ByteRadixTrie byte_radix_state;
 
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
@@ -264,6 +273,9 @@ struct RouteConfig {
         }
         if (dispatch_ == &kHashFirstSegmentDispatch) {
             return hash_first_seg_state.insert(path_view, r.method, idx);
+        }
+        if (dispatch_ == &kByteRadixDispatch) {
+            return byte_radix_state.insert(path_view, r.method, idx);
         }
         if (dispatch_ == &kLinearScanDispatch) {
             // routes[] IS the data — nothing else to populate.

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -178,11 +178,13 @@ struct RouteConfig {
     // just as fast and uses no per-impl memory).
     HashFirstSegmentTable hash_first_seg_state;
 
-    // Byte-level edge-compressed radix trie. ~18 KB inline (256
-    // nodes × ~70 B). Selected by the picker when the route set
-    // benefits from byte-level prefix sharing AND doesn't depend
-    // on segment-boundary precedence — see route_byte_radix.h for
-    // the contract distinction from SegmentTrie.
+    // Byte-level edge-compressed radix trie. ~75 KB inline (256
+    // nodes × ~290 B; per-node cost dominated by the 260-B children
+    // FixedVec sized to kMaxRoutes after the #46-r3 fan-out bump).
+    // Selected by the picker when the route set benefits from byte-
+    // level prefix sharing AND doesn't depend on segment-boundary
+    // precedence — see route_byte_radix.h for the contract
+    // distinction from SegmentTrie.
     ByteRadixTrie byte_radix_state;
 
     UpstreamTarget upstreams[kMaxUpstreams];

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,7 @@ add_library(rut_runtime STATIC
     runtime/chunked_parser.cc
     runtime/access_log.cc
     runtime/traffic_capture.cc
+    runtime/route_byte_radix.cc
     runtime/route_dispatch.cc
     runtime/route_hash_first_seg.cc
     runtime/route_hash_full.cc

--- a/src/runtime/route_byte_radix.cc
+++ b/src/runtime/route_byte_radix.cc
@@ -203,7 +203,16 @@ u16 ByteRadixTrie::match(Str path, u8 method_char) const {
 namespace {
 
 u16 byte_radix_match(const RouteConfig* cfg, Str path, u8 method) {
-    return cfg->byte_radix_state.match(path, method);
+    // Translate the impl's miss sentinel (TrieNode::kInvalidRoute,
+    // shared with SegmentTrie) into the dispatch interface's miss
+    // sentinel (kRouteIdxInvalid). Both are 0xffffu numerically today,
+    // but the names mean different things — the impl's is a route-
+    // table sentinel scoped to its own match() return; the
+    // interface's is a vtable contract. Codex on #46 caught the
+    // bare passthrough — segment_trie_match in route_dispatch.cc
+    // already does the same translation.
+    const u16 idx = cfg->byte_radix_state.match(path, method);
+    return idx == TrieNode::kInvalidRoute ? kRouteIdxInvalid : idx;
 }
 
 }  // namespace

--- a/src/runtime/route_byte_radix.cc
+++ b/src/runtime/route_byte_radix.cc
@@ -69,12 +69,19 @@ bool ByteRadixTrie::insert(Str path, u8 method_char, u16 route_idx) {
     // capacity failure rolls back to pre-insert state. Edge fields are
     // non-owning Str views (16 B each) and the FixedVec child arrays
     // are POD u16 buffers, so a memcpy-style snapshot is cheap. Worst
-    // case ~256 × ~70 B ≈ 18 KB copied, dwarfed by the trie's overall
-    // build cost on configs that even hit the pool cap.
+    // case after the #46-r3 fan-out bump (kMaxChildren=128): ~256 ×
+    // ~290 B ≈ 75 KB copied, plus the same on the stack as
+    // saved_nodes[]. The build cost is dominated by parser /
+    // RouteConfig::add_* setup at this scale, so the snapshot is
+    // still cheap; the stack draw fits easily under the default
+    // 8 MB pthread stack.
     //
     // Per-step pre-flight isn't sufficient on its own: a same-step
     // edge split allocates one node and would leave the parent's
     // edge truncated even if the subsequent leaf-allocation failed.
+    // A mutation-log rollback (reverse-apply each step on failure)
+    // would lower peak memory but adds bookkeeping; left for follow-up
+    // if profiles ever show this snapshot becoming a bottleneck.
     const u32 saved_len = nodes.len;
     ByteRadixNode saved_nodes[kMaxNodes];
     for (u32 i = 0; i < saved_len; i++) saved_nodes[i] = nodes[i];

--- a/src/runtime/route_byte_radix.cc
+++ b/src/runtime/route_byte_radix.cc
@@ -170,6 +170,15 @@ u16 ByteRadixTrie::match(Str path, u8 method_char) const {
     const u32 want_slot = method_slot(method_char);
     if (want_slot == kMethodSlotInvalid) return TrieNode::kInvalidRoute;
 
+    // Reject non-origin-form request targets BEFORE seeding `best`
+    // from the root terminal. Otherwise a configured "/" catchall
+    // would silently match HTTP/1.1 asterisk-form ("*"), authority-
+    // form ("host:port"), or empty targets — none of which are path-
+    // routable and the linear-scan dispatch never returns a route for
+    // them. RouteTrie::match applies the same guard (Codex P2 caught
+    // it there originally, P1 reapplied here on #46 round 1).
+    if (path.len == 0 || path.ptr[0] != '/') return TrieNode::kInvalidRoute;
+
     const Str p = canonicalize_request(path);
     u16 cur = 0;
     u16 best = pick_terminal(nodes[0], want_slot);

--- a/src/runtime/route_byte_radix.cc
+++ b/src/runtime/route_byte_radix.cc
@@ -1,0 +1,204 @@
+#include "rut/runtime/route_byte_radix.h"
+
+#include "rut/runtime/route_table.h"
+
+namespace rut {
+
+namespace {
+
+// Strip leading '/' and a trailing '/' run from `path`. insert() and
+// match() share this so a route registered as "/api" and a request for
+// "/api" tokenize to the same byte sequence ("api"); a trailing '/' on
+// either side is treated as no-trailing-'/' the same way SegmentTrie's
+// P2a normalization does.
+Str strip_slashes(Str path) {
+    u32 lo = 0;
+    if (lo < path.len && path.ptr[lo] == '/') lo++;
+    u32 hi = path.len;
+    while (hi > lo && path.ptr[hi - 1] == '/') hi--;
+    return Str{path.ptr + lo, hi - lo};
+}
+
+// Match-time-only: also stop at '?' / '#' so query / fragment bytes
+// don't participate in byte matching. Mirrors what SegmentTrie::match
+// does internally; insert() doesn't strip these because RouteConfig
+// already rejected paths containing them.
+Str canonicalize_request(Str path) {
+    u32 lo = 0;
+    if (lo < path.len && path.ptr[lo] == '/') lo++;
+    u32 hi = lo;
+    while (hi < path.len && path.ptr[hi] != '?' && path.ptr[hi] != '#') hi++;
+    while (hi > lo && path.ptr[hi - 1] == '/') hi--;
+    return Str{path.ptr + lo, hi - lo};
+}
+
+}  // namespace
+
+void ByteRadixTrie::clear() {
+    nodes.len = 0;
+    ByteRadixNode root{};
+    [[maybe_unused]] bool ok = nodes.push(root);
+    // push cannot fail on a fresh FixedVec; nodes starts empty.
+}
+
+u16 ByteRadixTrie::pick_terminal(const ByteRadixNode& n, u32 slot) {
+    if (slot != 0 && n.route_idx_by_method[slot] != TrieNode::kInvalidRoute) {
+        return n.route_idx_by_method[slot];
+    }
+    return n.route_idx_by_method[0];
+}
+
+u16 ByteRadixTrie::find_child_by_first_byte(u16 parent, u8 b) const {
+    const auto& p = nodes[parent];
+    for (u32 i = 0; i < p.children.len; i++) {
+        const u16 ci = p.children[i];
+        if (nodes[ci].edge.len > 0 && static_cast<u8>(nodes[ci].edge.ptr[0]) == b) {
+            return ci;
+        }
+    }
+    return TrieNode::kInvalidNodeIdx;
+}
+
+bool ByteRadixTrie::insert(Str path, u8 method_char, u16 route_idx) {
+    const u32 slot = method_slot(method_char);
+    if (slot == kMethodSlotInvalid) return false;
+
+    const Str p = strip_slashes(path);
+
+    // Atomic insert: snapshot the whole node pool so a mid-insert
+    // capacity failure rolls back to pre-insert state. Edge fields are
+    // non-owning Str views (16 B each) and the FixedVec child arrays
+    // are POD u16 buffers, so a memcpy-style snapshot is cheap. Worst
+    // case ~256 × ~70 B ≈ 18 KB copied, dwarfed by the trie's overall
+    // build cost on configs that even hit the pool cap.
+    //
+    // Per-step pre-flight isn't sufficient on its own: a same-step
+    // edge split allocates one node and would leave the parent's
+    // edge truncated even if the subsequent leaf-allocation failed.
+    const u32 saved_len = nodes.len;
+    ByteRadixNode saved_nodes[kMaxNodes];
+    for (u32 i = 0; i < saved_len; i++) saved_nodes[i] = nodes[i];
+
+    auto rollback = [&]() {
+        for (u32 i = 0; i < saved_len; i++) nodes[i] = saved_nodes[i];
+        nodes.len = saved_len;
+    };
+
+    u16 cur = 0;
+    u32 i = 0;
+    while (i < p.len) {
+        const u8 b = static_cast<u8>(p.ptr[i]);
+        const u16 child = find_child_by_first_byte(cur, b);
+        if (child == TrieNode::kInvalidNodeIdx) {
+            // No matching child — append a leaf with the rest of the
+            // path as its edge.
+            if (nodes.len >= kMaxNodes) {
+                rollback();
+                return false;
+            }
+            ByteRadixNode nn;
+            nn.edge = Str{p.ptr + i, p.len - i};
+            if (!nodes.push(nn)) {
+                rollback();
+                return false;
+            }
+            const u16 ni = static_cast<u16>(nodes.len - 1);
+            if (!nodes[cur].children.push(ni)) {
+                rollback();
+                return false;
+            }
+            cur = ni;
+            i = p.len;
+            break;
+        }
+        // Match as many bytes of the existing edge as possible.
+        const Str e = nodes[child].edge;
+        u32 k = 0;
+        while (k < e.len && i + k < p.len && e.ptr[k] == p.ptr[i + k]) k++;
+        if (k == e.len) {
+            // Full edge match — descend into child.
+            cur = child;
+            i += k;
+            continue;
+        }
+        // Partial match — split the edge at byte k. The original child
+        // now holds the shared prefix [0,k); a new node holds the old
+        // tail [k,e.len) with all of the original child's terminal
+        // slots and children moved to it.
+        if (nodes.len >= kMaxNodes) {
+            rollback();
+            return false;
+        }
+        ByteRadixNode tail;
+        tail.edge = Str{e.ptr + k, e.len - k};
+        for (u32 m = 0; m < kMethodSlots; m++) {
+            tail.route_idx_by_method[m] = nodes[child].route_idx_by_method[m];
+        }
+        tail.children = nodes[child].children;
+        if (!nodes.push(tail)) {
+            rollback();
+            return false;
+        }
+        const u16 tail_idx = static_cast<u16>(nodes.len - 1);
+        // Truncate child to shared prefix; clear its terminals/children
+        // (they moved to `tail`); install `tail` as its sole child.
+        nodes[child].edge = Str{e.ptr, k};
+        for (u32 m = 0; m < kMethodSlots; m++) {
+            nodes[child].route_idx_by_method[m] = TrieNode::kInvalidRoute;
+        }
+        nodes[child].children.len = 0;
+        if (!nodes[child].children.push(tail_idx)) {
+            rollback();
+            return false;
+        }
+        cur = child;
+        i += k;
+        // Loop continues — the new path either continues into a fresh
+        // sibling (next iteration's "no matching child" branch) or
+        // ends right at the split point (loop exits, terminal slot set
+        // on `cur`).
+    }
+
+    // First-insert-wins on duplicate (path, method).
+    if (nodes[cur].route_idx_by_method[slot] == TrieNode::kInvalidRoute) {
+        nodes[cur].route_idx_by_method[slot] = route_idx;
+    }
+    return true;
+}
+
+u16 ByteRadixTrie::match(Str path, u8 method_char) const {
+    const u32 want_slot = method_slot(method_char);
+    if (want_slot == kMethodSlotInvalid) return TrieNode::kInvalidRoute;
+
+    const Str p = canonicalize_request(path);
+    u16 cur = 0;
+    u16 best = pick_terminal(nodes[0], want_slot);
+    u32 i = 0;
+    while (i < p.len) {
+        const u8 b = static_cast<u8>(p.ptr[i]);
+        const u16 child = find_child_by_first_byte(cur, b);
+        if (child == TrieNode::kInvalidNodeIdx) break;
+        const Str e = nodes[child].edge;
+        if (i + e.len > p.len) break;  // request shorter than remaining edge
+        for (u32 k = 0; k < e.len; k++) {
+            if (e.ptr[k] != p.ptr[i + k]) return best;
+        }
+        cur = child;
+        i += e.len;
+        const u16 candidate = pick_terminal(nodes[cur], want_slot);
+        if (candidate != TrieNode::kInvalidRoute) best = candidate;
+    }
+    return best;
+}
+
+namespace {
+
+u16 byte_radix_match(const RouteConfig* cfg, Str path, u8 method) {
+    return cfg->byte_radix_state.match(path, method);
+}
+
+}  // namespace
+
+const RouteDispatch kByteRadixDispatch = {&byte_radix_match};
+
+}  // namespace rut

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,15 @@ target_include_directories(test_route_hash_first_seg PRIVATE
 add_test(NAME test_route_hash_first_seg COMMAND test_route_hash_first_seg)
 set_tests_properties(test_route_hash_first_seg PROPERTIES LABELS "unit")
 
+add_executable(test_route_byte_radix test_route_byte_radix.cc)
+target_link_libraries(test_route_byte_radix rut_runtime)
+target_include_directories(test_route_byte_radix PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+)
+add_test(NAME test_route_byte_radix COMMAND test_route_byte_radix)
+set_tests_properties(test_route_byte_radix PROPERTIES LABELS "unit")
+
 add_executable(test_rir test_rir.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
 target_link_libraries(test_rir rut_compiler)
 target_include_directories(test_rir PRIVATE
@@ -275,6 +284,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_route_trie>
     COMMAND $<TARGET_FILE:test_route_hash_full>
     COMMAND $<TARGET_FILE:test_route_hash_first_seg>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_hash_full test_route_hash_first_seg
+    COMMAND $<TARGET_FILE:test_route_byte_radix>
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_hash_full test_route_hash_first_seg test_route_byte_radix
     COMMENT "Running all tests..."
 )

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -2396,9 +2396,11 @@ TEST(route, set_dispatch_accepts_canonical_singletons) {
     CHECK(c.set_dispatch(&kHashFullPathDispatch));
     RouteConfig d;
     CHECK(d.set_dispatch(&kHashFirstSegmentDispatch));
-    // Null is still refused (no dispatch == no match).
     RouteConfig e;
-    CHECK(!e.set_dispatch(nullptr));
+    CHECK(e.set_dispatch(&kByteRadixDispatch));
+    // Null is still refused (no dispatch == no match).
+    RouteConfig f;
+    CHECK(!f.set_dispatch(nullptr));
 }
 
 TEST(route, set_dispatch_refuses_after_first_add) {

--- a/tests/test_route_byte_radix.cc
+++ b/tests/test_route_byte_radix.cc
@@ -185,44 +185,68 @@ TEST(route_byte_radix, rejects_unsupported_method_byte_at_match) {
 // ============================================================================
 
 TEST(route_byte_radix, atomic_insert_on_node_pool_exhaustion) {
-    // Fill the pool to within 1 of kMaxNodes with single-byte distinct
-    // routes (each takes ~1 node). The next insert that needs more
-    // than 1 node — a deeper distinct path — must fail and leave the
-    // pool unchanged.
+    // Drive the pool to exactly kMaxNodes - 1 with a deterministic
+    // sequence, then attempt an insert that demands 2 new nodes.
+    // With only 1 slot left the second allocation must fail and the
+    // rollback must restore the pre-insert pool exactly.
+    //
+    // The earlier shape used "if (!t.insert(...)) break;" plus a
+    // best-effort deep insert and accepted EITHER success or failure;
+    // Copilot on #46 round 3 flagged that the rollback path was
+    // never actually exercised. The new shape is fully deterministic.
     ByteRadixTrie t;
-    char paths[ByteRadixTrie::kMaxNodes][8];
-    u32 admitted = 0;
-    for (u32 i = 0; i + 2 < ByteRadixTrie::kMaxNodes; i++) {
-        paths[i][0] = '/';
-        paths[i][1] = static_cast<char>('a' + (i / 26 / 26) % 26);
-        paths[i][2] = static_cast<char>('a' + (i / 26) % 26);
-        paths[i][3] = static_cast<char>('a' + i % 26);
-        paths[i][4] = '\0';
-        if (!t.insert(Str{paths[i], 4}, 0, static_cast<u16>(i))) break;
-        admitted++;
+
+    // Phase 1 — fill root to kMaxChildren with 2-byte-edge leaves.
+    // Each insert: first byte unseen at root → add one leaf with a
+    // 2-byte edge. +1 node per insert. After kMaxChildren inserts:
+    // root + kMaxChildren leaves = 1 + kMaxChildren nodes.
+    //
+    // Each path needs its own backing buffer because the trie stores
+    // non-owning Str views into the path bytes; reusing one buffer
+    // across inserts would have every previously-inserted edge alias
+    // the latest write and collapse all leaves into one (subtle, and
+    // the in-place mutation of buffer contents would even change
+    // later find_child_by_first_byte lookups).
+    char p1_buf[ByteRadixNode::kMaxChildren][3];
+    for (u32 i = 0; i < ByteRadixNode::kMaxChildren; i++) {
+        p1_buf[i][0] = '/';
+        p1_buf[i][1] = static_cast<char>(0x40 + i);
+        p1_buf[i][2] = 'x';
+        REQUIRE(t.insert(Str{p1_buf[i], 3}, 0, static_cast<u16>(i)));
     }
-    REQUIRE(admitted > 4);
+    REQUIRE_EQ(t.node_count(), 1u + ByteRadixNode::kMaxChildren);
+
+    // Phase 2 — extend leaves with a 1-byte tail. Each descendant
+    // insert: full edge match on the 2-byte parent edge, then add
+    // one leaf for the trailing 'y'. +1 node per insert. Stop one
+    // short of kMaxNodes so phase 3 has exactly 1 free slot.
+    constexpr u32 phase2 =
+        ByteRadixTrie::kMaxNodes - 2u - ByteRadixNode::kMaxChildren;  // 126 with 256/128
+    static_assert(phase2 < ByteRadixNode::kMaxChildren,
+                  "phase2 must consume at most kMaxChildren leaves");
+    char p2_buf[phase2][4];
+    for (u32 i = 0; i < phase2; i++) {
+        p2_buf[i][0] = '/';
+        p2_buf[i][1] = static_cast<char>(0x40 + i);
+        p2_buf[i][2] = 'x';
+        p2_buf[i][3] = 'y';
+        REQUIRE(t.insert(Str{p2_buf[i], 4}, 0, static_cast<u16>(1000 + i)));
+    }
+    REQUIRE_EQ(t.node_count(), ByteRadixTrie::kMaxNodes - 1);
+
+    // Phase 3 — an insert that splits a 2-byte parent edge AND adds
+    // a sibling leaf. Needs 2 new nodes (split-tail + leaf); only 1
+    // slot remains, so rollback must fire. We split the edge of the
+    // 0th leaf ("/<0x40>x") with a fresh tail "z" via path "/<0x40>z".
+    const char split_path[3] = {'/', static_cast<char>(0x40), 'z'};
     const u32 nodes_before = t.node_count();
-    // Now insert a deep brand-new path that requires more nodes than
-    // are left. If the pre-flight allowed it to start, the rollback
-    // must restore the pool exactly.
-    char deep[64];
-    deep[0] = '/';
-    for (u32 i = 1; i < 60; i++) deep[i] = static_cast<char>('a' + i % 26);
-    deep[60] = '\0';
-    // The deep path may succeed or fail depending on remaining space;
-    // either way the post-state must be consistent — node_count is
-    // either unchanged (failure rolled back) or grew by exactly the
-    // number of new nodes the path actually allocated.
-    const bool ok = t.insert(Str{deep, 60}, 0, 9999);
-    if (!ok) {
-        CHECK_EQ(t.node_count(), nodes_before);  // rollback
-    } else {
-        CHECK(t.node_count() >= nodes_before);
-    }
-    // All previously-admitted routes still match correctly.
-    for (u32 i = 0; i < admitted; i++) {
-        CHECK_EQ(t.match(Str{paths[i], 4}, 0), static_cast<u16>(i));
+    CHECK(!t.insert(Str{split_path, 3}, 0, 9999));
+    CHECK_EQ(t.node_count(), nodes_before);  // rollback restored exactly
+
+    // All phase-1 routes still match correctly — rollback didn't
+    // corrupt their terminals or edges.
+    for (u32 i = 0; i < ByteRadixNode::kMaxChildren; i++) {
+        CHECK_EQ(t.match(Str{p1_buf[i], 3}, 0), static_cast<u16>(i));
     }
 }
 
@@ -269,24 +293,30 @@ TEST(route_byte_radix, accepts_kMaxRoutes_distinct_top_level_prefixes) {
     // fail at insert time even though kMaxRoutes is 128. Bumped to
     // 128 to cover the worst case.
     //
-    // Worst-case shape: 128 single-byte top-level paths, all sharing
-    // root as their parent. After this fix the trie accepts all of
-    // them.
+    // Worst-case shape: 128 paths whose first byte after the leading
+    // '/' is unique across the set, so they all become direct children
+    // of root and force the children FixedVec to its cap.
+    //
+    // Earlier r3 version used "/aa", "/ab", ... for 128 paths but
+    // collapsed all 128 to only 5 distinct first bytes — the root
+    // never actually grew past ~5 children, so the test passed even
+    // with the old kMaxChildren=16. Copilot on #46 round 3 caught
+    // it. We now use a contiguous run of 128 unique non-special
+    // bytes (0x40..0xbf, none of which are '/', '?', '#', or NUL).
     ByteRadixTrie t;
-    char paths[ByteRadixNode::kMaxChildren][4];
+    char paths[ByteRadixNode::kMaxChildren][2];
     for (u32 i = 0; i < ByteRadixNode::kMaxChildren; i++) {
-        // /<i>: encode i as 2 bytes (a-z + a-z) so each top-level
-        // path has a distinct first byte after the leading '/'.
         paths[i][0] = '/';
-        paths[i][1] = static_cast<char>('a' + i / 26);
-        paths[i][2] = static_cast<char>('a' + i % 26);
-        paths[i][3] = '\0';
-        REQUIRE(t.insert(Str{paths[i], 3}, 0, static_cast<u16>(i)));
+        paths[i][1] = static_cast<char>(0x40 + i);
+        REQUIRE(t.insert(Str{paths[i], 2}, 0, static_cast<u16>(i)));
     }
+    // Root must hold exactly kMaxChildren leaves now — verify via
+    // node_count (1 root + kMaxChildren leaves).
+    CHECK_EQ(t.node_count(), 1u + ByteRadixNode::kMaxChildren);
     // Spot-check a few — the first, the middle, and the last.
-    CHECK_EQ(t.match(Str{paths[0], 3}, 0), 0u);
-    CHECK_EQ(t.match(Str{paths[64], 3}, 0), 64u);
-    CHECK_EQ(t.match(Str{paths[ByteRadixNode::kMaxChildren - 1], 3}, 0),
+    CHECK_EQ(t.match(Str{paths[0], 2}, 0), 0u);
+    CHECK_EQ(t.match(Str{paths[64], 2}, 0), 64u);
+    CHECK_EQ(t.match(Str{paths[ByteRadixNode::kMaxChildren - 1], 2}, 0),
              static_cast<u16>(ByteRadixNode::kMaxChildren - 1));
 }
 

--- a/tests/test_route_byte_radix.cc
+++ b/tests/test_route_byte_radix.cc
@@ -1,0 +1,259 @@
+// Tests for runtime/route_byte_radix.h: byte-level edge-compressed
+// radix trie.
+//
+// Coverage:
+//   - basic exact match + miss
+//   - longest-prefix-match across edge splits
+//   - edge splitting on partial match (the canonical "shared prefix
+//     diverges later" pattern)
+//   - method-slot routing + first-insert-wins on duplicates
+//   - request-time '?' / '#' stripping
+//   - leading / trailing '/' canonicalization at insert and match
+//   - capacity rejection with atomic rollback
+//   - byte-aware (non-segment-aware) semantics — distinct from trie
+
+#include "rut/runtime/route_byte_radix.h"
+#include "test.h"
+
+using namespace rut;
+
+namespace {
+
+constexpr Str S(const char* s) {
+    u32 n = 0;
+    while (s[n]) n++;
+    return Str{s, n};
+}
+
+}  // namespace
+
+// ============================================================================
+// Basic match
+// ============================================================================
+
+TEST(route_byte_radix, exact_match_single_route) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/health"), 0, 7));
+    CHECK_EQ(t.match(S("/health"), 0), 7u);
+}
+
+TEST(route_byte_radix, no_match_when_no_routes) {
+    ByteRadixTrie t;
+    CHECK_EQ(t.match(S("/anything"), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_byte_radix, longest_prefix_match_wins) {
+    // Two registered routes: /api and /api/v1. A request for
+    // /api/v1/users hits /api/v1 (longer prefix) regardless of the
+    // insert order. Distinct from linear-scan first-match-wins —
+    // the selector picks byte_radix only for configs that don't
+    // depend on linear-scan precedence.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api"), 0, 0));
+    REQUIRE(t.insert(S("/api/v1"), 0, 1));
+    CHECK_EQ(t.match(S("/api"), 0), 0u);           // exact /api
+    CHECK_EQ(t.match(S("/api/v1"), 0), 1u);        // exact /api/v1
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), 1u);  // longer wins
+    CHECK_EQ(t.match(S("/api/other"), 0), 0u);     // /api wins (only /api fits)
+}
+
+TEST(route_byte_radix, longest_prefix_independent_of_insert_order) {
+    // Insert /api/v1 BEFORE /api — same outcome.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api/v1"), 0, 0));
+    REQUIRE(t.insert(S("/api"), 0, 1));
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), 0u);
+    CHECK_EQ(t.match(S("/api/other"), 0), 1u);
+}
+
+// ============================================================================
+// Edge splitting — the structurally interesting case
+// ============================================================================
+
+TEST(route_byte_radix, edge_split_on_partial_match) {
+    // Insert /api/v1 first (one edge "api/v1" from root). Then insert
+    // /api/v2 — the edge must split at "api/v" (5 bytes shared) into
+    //   root → "api/v" → {"1": old terminal, "2": new terminal}
+    // Both routes must remain matchable after the split.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api/v1"), 0, 0));
+    REQUIRE(t.insert(S("/api/v2"), 0, 1));
+    CHECK_EQ(t.match(S("/api/v1"), 0), 0u);
+    CHECK_EQ(t.match(S("/api/v2"), 0), 1u);
+    // Sibling that doesn't share the "api/v" stem must miss.
+    CHECK_EQ(t.match(S("/api/x"), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_byte_radix, multiple_splits_preserve_terminals) {
+    // /api/v1/users inserted first creates one long edge.
+    // /api/v1/orders splits at "api/v1/" → {users, orders}.
+    // /api/v2 splits at "api/v" → {"1/" → {users, orders}, "2"}.
+    // All four terminals (the three plus an /api shorter-prefix) must
+    // resolve to their original idx.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api/v1/users"), 0, 0));
+    REQUIRE(t.insert(S("/api/v1/orders"), 0, 1));
+    REQUIRE(t.insert(S("/api/v2"), 0, 2));
+    REQUIRE(t.insert(S("/api"), 0, 3));
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), 0u);
+    CHECK_EQ(t.match(S("/api/v1/orders"), 0), 1u);
+    CHECK_EQ(t.match(S("/api/v2"), 0), 2u);
+    CHECK_EQ(t.match(S("/api"), 0), 3u);
+    // Longest-prefix-match: /api/v1/anything hits /api (the only
+    // matching prefix of /api/v1/anything when v1's children diverge).
+    CHECK_EQ(t.match(S("/api/v1/x"), 0), 3u);
+    CHECK_EQ(t.match(S("/api/v3"), 0), 3u);
+}
+
+// ============================================================================
+// Byte-aware (NOT segment-aware) semantics
+// ============================================================================
+
+TEST(route_byte_radix, byte_match_crosses_segment_boundaries) {
+    // /api matches /apixyz because the trie is byte-aware. SegmentTrie
+    // would NOT match /apixyz against /api (segment boundary would
+    // have to align). This is the contract distinction the selector
+    // uses to choose between dispatches.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api"), 0, 0));
+    CHECK_EQ(t.match(S("/api"), 0), 0u);
+    CHECK_EQ(t.match(S("/apixyz"), 0), 0u);
+    CHECK_EQ(t.match(S("/apex"), 0), TrieNode::kInvalidRoute);  // diverges at 2nd byte
+}
+
+TEST(route_byte_radix, request_strips_query_and_fragment) {
+    // Request paths arrive raw from the parser; '?' / '#' must not
+    // participate in byte matching, otherwise /health?q=1 wouldn't hit
+    // a registered /health route.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/health"), 0, 0));
+    REQUIRE(t.insert(S("/api/users"), 0, 1));
+    CHECK_EQ(t.match(S("/health?check=1"), 0), 0u);
+    CHECK_EQ(t.match(S("/health?"), 0), 0u);
+    CHECK_EQ(t.match(S("/health#frag"), 0), 0u);
+    CHECK_EQ(t.match(S("/api/users?page=3"), 0), 1u);
+}
+
+TEST(route_byte_radix, trailing_slash_normalized) {
+    // P2a-style: a trailing '/' on the route at insert OR on the
+    // request at match is stripped to canonicalize to the same key.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api"), 0, 0));
+    CHECK_EQ(t.match(S("/api"), 0), 0u);
+    CHECK_EQ(t.match(S("/api/"), 0), 0u);   // trailing slash on request
+    REQUIRE(t.insert(S("/admin/"), 0, 1));  // trailing slash on route
+    CHECK_EQ(t.match(S("/admin"), 0), 1u);
+    CHECK_EQ(t.match(S("/admin/"), 0), 1u);
+}
+
+// ============================================================================
+// Method dispatch
+// ============================================================================
+
+TEST(route_byte_radix, method_specific_beats_any_at_same_path) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/x"), 0, 0));    // any
+    REQUIRE(t.insert(S("/x"), 'G', 1));  // GET-specific
+    CHECK_EQ(t.match(S("/x"), 'G'), 1u);
+    CHECK_EQ(t.match(S("/x"), 'P'), 0u);  // POST falls back to any
+    CHECK_EQ(t.match(S("/x"), 0), 0u);
+}
+
+TEST(route_byte_radix, first_insert_wins_on_dup_method_slot) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/x"), 'G', 0));
+    REQUIRE(t.insert(S("/x"), 'G', 1));  // duplicate (path, method)
+    CHECK_EQ(t.match(S("/x"), 'G'), 0u);
+}
+
+TEST(route_byte_radix, rejects_unsupported_method_byte_at_insert) {
+    ByteRadixTrie t;
+    // 'g' (lowercase) is not a recognized method byte.
+    CHECK(!t.insert(S("/x"), 'g', 0));
+    CHECK(!t.insert(S("/x"), 'X', 0));
+}
+
+TEST(route_byte_radix, rejects_unsupported_method_byte_at_match) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/x"), 'G', 0));
+    CHECK_EQ(t.match(S("/x"), 'g'), TrieNode::kInvalidRoute);
+    CHECK_EQ(t.match(S("/x"), 'X'), TrieNode::kInvalidRoute);
+}
+
+// ============================================================================
+// Capacity / atomic rollback
+// ============================================================================
+
+TEST(route_byte_radix, atomic_insert_on_node_pool_exhaustion) {
+    // Fill the pool to within 1 of kMaxNodes with single-byte distinct
+    // routes (each takes ~1 node). The next insert that needs more
+    // than 1 node — a deeper distinct path — must fail and leave the
+    // pool unchanged.
+    ByteRadixTrie t;
+    char paths[ByteRadixTrie::kMaxNodes][8];
+    u32 admitted = 0;
+    for (u32 i = 0; i + 2 < ByteRadixTrie::kMaxNodes; i++) {
+        paths[i][0] = '/';
+        paths[i][1] = static_cast<char>('a' + (i / 26 / 26) % 26);
+        paths[i][2] = static_cast<char>('a' + (i / 26) % 26);
+        paths[i][3] = static_cast<char>('a' + i % 26);
+        paths[i][4] = '\0';
+        if (!t.insert(Str{paths[i], 4}, 0, static_cast<u16>(i))) break;
+        admitted++;
+    }
+    REQUIRE(admitted > 4);
+    const u32 nodes_before = t.node_count();
+    // Now insert a deep brand-new path that requires more nodes than
+    // are left. If the pre-flight allowed it to start, the rollback
+    // must restore the pool exactly.
+    char deep[64];
+    deep[0] = '/';
+    for (u32 i = 1; i < 60; i++) deep[i] = static_cast<char>('a' + i % 26);
+    deep[60] = '\0';
+    // The deep path may succeed or fail depending on remaining space;
+    // either way the post-state must be consistent — node_count is
+    // either unchanged (failure rolled back) or grew by exactly the
+    // number of new nodes the path actually allocated.
+    const bool ok = t.insert(Str{deep, 60}, 0, 9999);
+    if (!ok) {
+        CHECK_EQ(t.node_count(), nodes_before);  // rollback
+    } else {
+        CHECK(t.node_count() >= nodes_before);
+    }
+    // All previously-admitted routes still match correctly.
+    for (u32 i = 0; i < admitted; i++) {
+        CHECK_EQ(t.match(Str{paths[i], 4}, 0), static_cast<u16>(i));
+    }
+}
+
+TEST(route_byte_radix, clear_resets_state) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/a"), 0, 0));
+    REQUIRE(t.insert(S("/b"), 0, 1));
+    const u32 nodes_after_inserts = t.node_count();
+    CHECK(nodes_after_inserts > 1u);
+    t.clear();
+    CHECK_EQ(t.node_count(), 1u);  // root only
+    CHECK_EQ(t.match(S("/a"), 0), TrieNode::kInvalidRoute);
+    REQUIRE(t.insert(S("/c"), 0, 0));
+    CHECK_EQ(t.match(S("/c"), 0), 0u);
+    CHECK_EQ(t.match(S("/a"), 0), TrieNode::kInvalidRoute);
+}
+
+// ============================================================================
+// Empty / root path
+// ============================================================================
+
+TEST(route_byte_radix, root_path_matches_root_terminal) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/"), 0, 42));
+    CHECK_EQ(t.match(S("/"), 0), 42u);
+    // Root is a "shorter-than-anything" prefix — every request that
+    // starts with '/' inherits the root terminal as a fallback.
+    CHECK_EQ(t.match(S("/anything"), 0), 42u);
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), 42u);
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}

--- a/tests/test_route_byte_radix.cc
+++ b/tests/test_route_byte_radix.cc
@@ -263,6 +263,33 @@ TEST(route_byte_radix, rejects_non_origin_form_request_targets) {
     CHECK_EQ(t.match(S(""), 0), TrieNode::kInvalidRoute);
 }
 
+TEST(route_byte_radix, accepts_kMaxRoutes_distinct_top_level_prefixes) {
+    // Codex P1 on #46 round 2: per-node fan-out was capped at 16,
+    // which made any config with 17+ distinct top-level prefixes
+    // fail at insert time even though kMaxRoutes is 128. Bumped to
+    // 128 to cover the worst case.
+    //
+    // Worst-case shape: 128 single-byte top-level paths, all sharing
+    // root as their parent. After this fix the trie accepts all of
+    // them.
+    ByteRadixTrie t;
+    char paths[ByteRadixNode::kMaxChildren][4];
+    for (u32 i = 0; i < ByteRadixNode::kMaxChildren; i++) {
+        // /<i>: encode i as 2 bytes (a-z + a-z) so each top-level
+        // path has a distinct first byte after the leading '/'.
+        paths[i][0] = '/';
+        paths[i][1] = static_cast<char>('a' + i / 26);
+        paths[i][2] = static_cast<char>('a' + i % 26);
+        paths[i][3] = '\0';
+        REQUIRE(t.insert(Str{paths[i], 3}, 0, static_cast<u16>(i)));
+    }
+    // Spot-check a few — the first, the middle, and the last.
+    CHECK_EQ(t.match(Str{paths[0], 3}, 0), 0u);
+    CHECK_EQ(t.match(Str{paths[64], 3}, 0), 64u);
+    CHECK_EQ(t.match(Str{paths[ByteRadixNode::kMaxChildren - 1], 3}, 0),
+             static_cast<u16>(ByteRadixNode::kMaxChildren - 1));
+}
+
 TEST(route_byte_radix, root_path_matches_root_terminal) {
     ByteRadixTrie t;
     REQUIRE(t.insert(S("/"), 0, 42));

--- a/tests/test_route_byte_radix.cc
+++ b/tests/test_route_byte_radix.cc
@@ -244,6 +244,25 @@ TEST(route_byte_radix, clear_resets_state) {
 // Empty / root path
 // ============================================================================
 
+TEST(route_byte_radix, rejects_non_origin_form_request_targets) {
+    // Codex P1 on #46: with a configured "/" catchall, match() seeded
+    // `best` from the root terminal regardless of whether the request
+    // was origin-form. Asterisk-form ("*"), authority-form ("host:port"),
+    // and empty targets must NOT match any route — the linear-scan
+    // dispatch never matches them either, and HTTP/1.1 doesn't define
+    // path routing for them.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/"), 0, 99));    // catchall
+    REQUIRE(t.insert(S("/api"), 0, 7));  // specific
+    // Origin-form still works.
+    CHECK_EQ(t.match(S("/api"), 0), 7u);
+    CHECK_EQ(t.match(S("/anything"), 0), 99u);
+    // Non-origin-form: NO match, even though "/" is registered.
+    CHECK_EQ(t.match(S("*"), 0), TrieNode::kInvalidRoute);
+    CHECK_EQ(t.match(S("example.com:443"), 0), TrieNode::kInvalidRoute);
+    CHECK_EQ(t.match(S(""), 0), TrieNode::kInvalidRoute);
+}
+
 TEST(route_byte_radix, root_path_matches_root_terminal) {
     ByteRadixTrie t;
     REQUIRE(t.insert(S("/"), 0, 42));


### PR DESCRIPTION
## Summary
- New: `ByteRadixTrie` — byte-level edge-compressed radix trie with longest-prefix-match semantics. 256-node inline pool (~18 KB), atomic-rollback insert.
- `kByteRadixDispatch` registered in `route_dispatch.h`, added to `RouteConfig`'s canonical-singleton whitelist + `populate_dispatch_state` branch list.
- 16 new tests in `tests/test_route_byte_radix.cc` (87 checks).

**Stacks on #45** (`feat/dispatch-hash-first-seg`).

## Why
[Bench on the closed #41 branch (realistic SaaS corpus, hot cache, N=128)](https://github.com/hurricane1026/Rut/blob/feat/radix-trie-router/bench/bench_route_trie.cc) showed `byte_radix` as the fastest dispatch tested:

| Variant | Wall time | IPC | Cache-miss% |
|---------|-----------|-----|-------------|
| **byte_radix** | **0.91 us** | **4.25** | 13.2% |
| hash_full_path | 1.03 us | 2.74 | 14.3% |
| hash_first_segment | 1.05 us | 3.59 | 10.9% |
| trie_simple_inlined | 1.76 us | 3.67 | 4.9% |
| linear_scan | 2.00 us | 3.47 | 13.1% |

Edge compression fits more routes in fewer cache lines and the descent is straight-line work — highest IPC in the table.

## Critical contract: byte-aware, NOT segment-aware
ByteRadix matches in BYTES, so `/api` matches `/apixyz`. SegmentTrie wouldn't (segment boundary check). The selector (PR-E) MUST NOT pick this dispatch for configs with:
- `:param` segments
- routes whose distinction depends on segment boundaries

The `byte_match_crosses_segment_boundaries` test pins this contract.

Other contracts (consistent with SegmentTrie):
- Longest-prefix wins. `/api/v1` shadows `/api` for requests under `/api/v1`.
- `?` / `#` stripped from request at match time (route paths reject these at insert via `is_routable_path`).
- Trailing `/` canonicalized at both insert and match.
- First-insert-wins on duplicate (path, method) — relies on monotonic `route_idx` from `RouteConfig::add_*`.
- Method byte validated; unrecognized bytes rejected at both insert and match.

## Storage
~18 KB inline. With #43 trie (1.2 MB), #44 hash_full (12 KB), and #45 hash_first_seg (24 KB), `RouteConfig` total inline state is now ~1.25 MB — same as before since trie dominates. The per-impl tagged-union refactor (PR-E) will reclaim per-impl storage so only the active dispatch's state lives in CompiledConfig.

## Test plan
- [x] All existing tests pass (#43-#45 + 1700+ baseline)
- [x] 16 new `route_byte_radix` tests pass (87 checks)
- [x] `clang-format` clean
- [ ] Reviewer eye on `insert()`'s edge-split path — when a partial match occurs, the original child's terminal slots and children move to a new "tail" node and the original is truncated to the shared prefix. The full-pool snapshot makes rollback trivial; without it, the split-then-leaf-fail sequence is hard to undo cleanly.
- [ ] Reviewer eye on `match()` — descent stops at the first edge-byte mismatch, returning the deepest terminal seen. The "request shorter than remaining edge" early break is the only edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)