### PR TITLE
runtime: pick_dispatch selector + RouteAnalysis (PR-E)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
           LLVM_PROFILE_FILE=build/test_route_trie.profraw ./build/tests/test_route_trie
           LLVM_PROFILE_FILE=build/test_route_hash_full.profraw ./build/tests/test_route_hash_full
           LLVM_PROFILE_FILE=build/test_route_hash_first_seg.profraw ./build/tests/test_route_hash_first_seg
+          LLVM_PROFILE_FILE=build/test_route_byte_radix.profraw ./build/tests/test_route_byte_radix
 
       - name: Generate coverage report
         run: |
@@ -182,4 +183,5 @@ jobs:
             build/tests/test_rir \
             build/tests/test_route_trie \
             build/tests/test_route_hash_full \
-            build/tests/test_route_hash_first_seg
+            build/tests/test_route_hash_first_seg \
+            build/tests/test_route_byte_radix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           LLVM_PROFILE_FILE=build/test_route_hash_full.profraw ./build/tests/test_route_hash_full
           LLVM_PROFILE_FILE=build/test_route_hash_first_seg.profraw ./build/tests/test_route_hash_first_seg
           LLVM_PROFILE_FILE=build/test_route_byte_radix.profraw ./build/tests/test_route_byte_radix
+          LLVM_PROFILE_FILE=build/test_route_select.profraw ./build/tests/test_route_select
 
       - name: Generate coverage report
         run: |
@@ -184,4 +185,5 @@ jobs:
             build/tests/test_route_trie \
             build/tests/test_route_hash_full \
             build/tests/test_route_hash_first_seg \
-            build/tests/test_route_byte_radix
+            build/tests/test_route_byte_radix \
+            build/tests/test_route_select

--- a/include/rut/runtime/route_byte_radix.h
+++ b/include/rut/runtime/route_byte_radix.h
@@ -1,0 +1,132 @@
+#pragma once
+
+// ByteRadix — byte-level edge-compressed radix trie.
+//
+// Each node holds an `edge` (a contiguous byte run from its parent).
+// Branching happens when prefixes diverge. Insertion may split an
+// existing edge when a new path shares some prefix with it; the lower
+// half of the edge moves into a new node and the original node's edge
+// shrinks to the shared prefix.
+//
+// Match semantics: longest-prefix-match in BYTES. A request for
+// "/api/v1/users" hits a route registered at "/api/v1" if it exists,
+// even when "/api" is also registered (longer wins). At each terminal
+// visited during descent we record the candidate route_idx; descent
+// stops at the first edge byte mismatch or path exhaustion, and we
+// return the deepest candidate seen.
+//
+// vs SegmentTrie:
+//   - Byte-aware, NOT segment-aware. "/api/v1" matches "/api/v1xyz"
+//     because there's no segment-boundary check. The selector picks
+//     this dispatch only for configs whose route paths don't depend
+//     on segment boundaries (no `:param` segments, no overlapping
+//     routes that need the segment-level distinction).
+//   - Edge compression typically yields fewer nodes for the same
+//     routes: "/api/v1/users" + "/api/v1/orders" share an
+//     "/api/v1/" edge of 9 bytes, then branch on 'u' vs 'o'. A
+//     segment trie would split into 4 segment nodes (api / v1 /
+//     users|orders).
+//
+// Bench data (closed #41 branch, realistic SaaS gateway, hot cache):
+//   N=128 routes:
+//     byte_radix:    0.91 us / match — fastest variant tested
+//     segment_trie:  1.76 us / match
+//     linear_scan:   2.00 us / match  (baseline)
+//   IPC 4.25 (highest in the table): the compressed edges fit more
+//   routes in fewer cache lines, descent is straight-line work.
+//
+// Storage: ~256 nodes × ~70 bytes/node ≈ 18 KB inline.
+//
+// Build-time canonicalization: insert strips a leading '/' and any
+// trailing '/'. The match path strips '?' / '#' suffix in addition,
+// so request bytes after the query/fragment marker don't participate.
+// Routes registered with '?' or '#' are rejected by
+// RouteConfig::is_routable_path before they reach insert().
+//
+// First-insert-wins on duplicate (path, method): the per-method
+// terminal slot is set only if currently kInvalidRoute. RouteConfig
+// guarantees route_idx is monotonic with insertion order, so older
+// terminals (smaller route_idx) shadow newer duplicates.
+
+#include "rut/common/types.h"
+#include "rut/runtime/route_dispatch.h"
+#include "rut/runtime/route_trie.h"  // for kMethodSlots, method_slot, TrieNode::kInvalidRoute
+
+namespace rut {
+
+struct ByteRadixNode {
+    // Per-node fan-out cap. Realistic configs branch <8 children at most
+    // points; 16 covers shared-byte-then-divergent-tail patterns common
+    // at the root (/, h, a, w, ...).
+    static constexpr u32 kMaxChildren = 16;
+
+    // Edge label: the byte run leading INTO this node. Non-owning view
+    // into RouteEntry::path; safe for the config's RCU lifetime.
+    Str edge{};
+
+    // Child node-pool indices, scanned linearly (find_child equivalent).
+    // Order is insertion order so first-byte-match returns the first
+    // registered child with that byte.
+    FixedVec<u16, kMaxChildren> children;
+
+    // Per-method route slot at this terminal. kInvalidRoute means "this
+    // node is not a terminal for that method". Slot 0 is "any".
+    u16 route_idx_by_method[kMethodSlots] = {TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute,
+                                             TrieNode::kInvalidRoute};
+};
+
+class ByteRadixTrie {
+public:
+    // 256 nodes covers 128 routes worst-case (no prefix sharing →
+    // 1 root + 128 leaves; even less with realistic byte-prefix
+    // overlap). Leaves room for edge splits during insert.
+    static constexpr u32 kMaxNodes = 256;
+
+    ByteRadixTrie() { clear(); }
+
+    // Wipe and re-seed with the empty root node.
+    void clear();
+
+    // Insert a (path, method, route_idx). Returns false if:
+    //   - method byte isn't recognized (mirrors trie/hash strict-method
+    //     contract — selector should pre-filter unsupported methods),
+    //   - the trie is out of node-pool / per-node-children capacity at
+    //     any step. Insert is atomic — any structural mutation is
+    //     rolled back to the pre-insert state on failure, so a partial
+    //     insert can never leave dangling nodes that future inserts
+    //     would inherit.
+    //
+    // CONTRACT: route_idx is assumed monotonic with insertion order
+    // (RouteConfig::add_* guarantees this via route_count++). First-
+    // insert-wins on duplicate (path, method) — the terminal slot is
+    // set only if currently empty.
+    bool insert(Str path, u8 method_char, u16 route_idx);
+
+    // Look up `path` — returns the longest-prefix terminal's route_idx
+    // for the matching method slot, or kInvalidRoute on no match.
+    // method_char == 0 ("any") looks at slot 0 directly; specific
+    // methods prefer their own slot but fall back to slot 0 at each
+    // candidate terminal.
+    u16 match(Str path, u8 method_char) const;
+
+    // Introspection (tests / bench).
+    u32 node_count() const { return nodes.len; }
+
+private:
+    FixedVec<ByteRadixNode, kMaxNodes> nodes;
+
+    // Pick a method slot at a terminal node, with the any-slot fallback.
+    static u16 pick_terminal(const ByteRadixNode& n, u32 slot);
+
+    // Find the child of `parent` whose edge starts with byte `b`.
+    // Returns TrieNode::kInvalidNodeIdx on no match.
+    u16 find_child_by_first_byte(u16 parent, u8 b) const;
+};
+
+}  // namespace rut

--- a/include/rut/runtime/route_byte_radix.h
+++ b/include/rut/runtime/route_byte_radix.h
@@ -55,10 +55,20 @@
 namespace rut {
 
 struct ByteRadixNode {
-    // Per-node fan-out cap. Realistic configs branch <8 children at most
-    // points; 16 covers shared-byte-then-divergent-tail patterns common
-    // at the root (/, h, a, w, ...).
-    static constexpr u32 kMaxChildren = 16;
+    // Per-node fan-out cap. Sized to RouteConfig::kMaxRoutes (128) so
+    // a worst-case shape — 128 distinct routes that all branch at the
+    // same byte position (e.g., 128 single-byte tails under the same
+    // shared edge, which a `/` catchall plus 127 single-letter
+    // top-level paths would produce) — admits without RouteConfig::
+    // add_* failing partway through. Codex P1 on #46 round 2 caught
+    // an earlier 16-cap that turned 17-top-level-prefix configs into
+    // build failures even with kMaxRoutes headroom unused.
+    //
+    // Memory cost: 128 × u16 = 256 B per node × 256 nodes ≈ 64 KB
+    // total for the children arrays. The trie's overall footprint
+    // grows from ~18 KB to ~85 KB inline — still negligible next to
+    // the segment trie's 1.2 MB.
+    static constexpr u32 kMaxChildren = 128;
 
     // Edge label: the byte run leading INTO this node. Non-owning view
     // into RouteEntry::path; safe for the config's RCU lifetime.

--- a/include/rut/runtime/route_byte_radix.h
+++ b/include/rut/runtime/route_byte_radix.h
@@ -35,7 +35,11 @@
 //   IPC 4.25 (highest in the table): the compressed edges fit more
 //   routes in fewer cache lines, descent is straight-line work.
 //
-// Storage: ~256 nodes × ~70 bytes/node ≈ 18 KB inline.
+// Storage: ~256 nodes × ~290 bytes/node ≈ 75 KB inline. Each node
+// carries a 16-B Str edge view, a 260-B FixedVec<u16, 128> children
+// buffer (the post-#46-r3 fan-out cap that admits 128 distinct
+// next-bytes), and 16 B of per-method terminal slots. Still small
+// next to the segment trie's ~1.2 MB.
 //
 // Build-time canonicalization: insert strips a leading '/' and any
 // trailing '/'. The match path strips '?' / '#' suffix in addition,
@@ -64,10 +68,11 @@ struct ByteRadixNode {
     // an earlier 16-cap that turned 17-top-level-prefix configs into
     // build failures even with kMaxRoutes headroom unused.
     //
-    // Memory cost: 128 × u16 = 256 B per node × 256 nodes ≈ 64 KB
-    // total for the children arrays. The trie's overall footprint
-    // grows from ~18 KB to ~85 KB inline — still negligible next to
-    // the segment trie's 1.2 MB.
+    // Memory cost: 128 × u16 = 256 B per node for the children
+    // buffer alone × 256 nodes ≈ 64 KB just for fan-out arrays. The
+    // node-summary at the top of this header (~75 KB total) accounts
+    // for that plus the per-node Str + terminal slots. Still
+    // negligible next to the segment trie's ~1.2 MB.
     static constexpr u32 kMaxChildren = 128;
 
     // Edge label: the byte run leading INTO this node. Non-owning view

--- a/include/rut/runtime/route_dispatch.h
+++ b/include/rut/runtime/route_dispatch.h
@@ -94,4 +94,12 @@ extern const RouteDispatch kHashFullPathDispatch;
 // route_hash_first_seg.h.
 extern const RouteDispatch kHashFirstSegmentDispatch;
 
+// Byte-level edge-compressed radix trie (RouteConfig::byte_radix_state).
+// Longest-prefix-match in BYTES, not segments — so the selector picks
+// this only for configs without segment-boundary semantics (no
+// `:param`, no overlapping segment-distinguished routes). See
+// route_byte_radix.h for the contract and the bench data behind the
+// choice.
+extern const RouteDispatch kByteRadixDispatch;
+
 }  // namespace rut

--- a/include/rut/runtime/route_select.h
+++ b/include/rut/runtime/route_select.h
@@ -38,19 +38,36 @@
 // Heuristics implemented (each justified by bench data; see
 // bench/bench_route_trie.cc on closed #41):
 //
-//   `:param` segments        → SegmentTrie (only impl that supports
-//                              segment-bound parameter capture; once
-//                              the .rut frontend grows :param syntax)
-//   route count ≤ 16         → LinearScan (early-exit on hot prefixes
-//                              + zero indirection wins at small N)
-//   prefix-overlap routes    → ByteRadix (longest-prefix in bytes;
-//                              hash variants give up prefix semantics)
+//   `:param` segments         → SegmentTrie (only impl that supports
+//                               segment-bound parameter capture; once
+//                               the .rut frontend grows :param syntax)
+//   route count ≤ 16          → LinearScan (early-exit on hot prefixes
+//                               + zero indirection wins at small N)
+//   segment-boundary-sensitive
+//     prefix overlap          → SegmentTrie (e.g., /api + /apix
+//                               registered together; ByteRadix's
+//                               byte-prefix semantics would mis-handle
+//                               request /apij — Copilot on #47 r1)
+//   segment-aligned prefix
+//     overlap, count fits     → ByteRadix (longest-prefix in bytes;
+//                               hash variants give up prefix semantics)
 //   diverse first segments
-//     + bucket-fit           → HashFirstSegment
-//   otherwise (exact-match)  → HashFullPath
+//     + bucket-fit, no
+//     prefix overlap          → HashFirstSegment (still byte-prefix
+//                               within a bucket, so /api/users matches
+//                               request /api/users/42)
+//   everything else           → SegmentTrie (unconditionally correct;
+//                               HashFullPath is intentionally NOT a
+//                               default fallback — it's exact-match
+//                               only and would silently turn prefix
+//                               hits into misses, Codex P1 on #47 r1)
 //
 // Out of scope here, deferred to follow-up PRs:
-//   - `:param` detection (the .rut DSL doesn't yet emit them)
+//   - `:param`-emitting frontend / parameter capture wired through to
+//     the runtime (RouteAnalysis already detects `:param`-shaped
+//     segments so the picker's branch is correct the moment the
+//     compiler starts emitting them; this bullet refers to the .rut
+//     DSL surface and capture extraction semantics)
 //   - Perfect-hash construction
 //   - Run-time recalibration based on observed traffic shape
 //
@@ -97,17 +114,32 @@ public:
 
     u32 count() const { return n_; }
 
-    // True iff any registered path is a strict prefix of another (in
-    // bytes). Hash variants (HashFullPath / HashFirstSegment exact
-    // mode) can't preserve linear-scan first-match-wins precedence
-    // across overlapping prefixes, so this flag steers the picker
-    // toward longest-prefix-capable impls (SegmentTrie, ByteRadix).
+    // True iff any registered path is a strict byte-prefix of another.
+    // Hash variants (HashFullPath / HashFirstSegment exact mode) can't
+    // preserve linear-scan first-match-wins precedence across
+    // overlapping prefixes, so this flag steers the picker toward
+    // longest-prefix-capable impls (SegmentTrie, ByteRadix).
     bool has_prefix_overlap() const { return has_prefix_overlap_; }
 
-    // True iff any path contains a `:param` segment marker. Currently
-    // always false — the .rut frontend doesn't emit them yet — but
-    // the picker hooks into it so the selector reads correctly when
-    // that work lands.
+    // True iff a strict byte-prefix overlap exists where the first
+    // byte BEYOND the shorter path (in the longer path) is not '/'.
+    // E.g., /api and /apix — the overlap doesn't respect segment
+    // boundaries. ByteRadix matches by bytes only, so for these
+    // configs it would route an intermediate request like /apij to
+    // /api silently — segment-aware tries treat the same request as
+    // a miss. The picker steers boundary-sensitive configs to
+    // SegmentTrie so dispatch behaviour matches segment intent.
+    // Implies has_prefix_overlap() — a config with this flag set
+    // necessarily has a strict prefix pair.
+    bool has_segment_boundary_sensitive_overlap() const {
+        return has_segment_boundary_sensitive_overlap_;
+    }
+
+    // True iff any path contains a `:param` segment marker. The
+    // detection is implemented (path_has_param_segment in the .cc),
+    // but the .rut DSL doesn't emit `:foo` syntax yet — so on real
+    // configs today this stays false. The picker's branch is in place
+    // for the day the frontend grows the syntax.
     bool has_param_segments() const { return has_param_segments_; }
 
     // Largest count of routes sharing a first-segment hash bucket
@@ -125,9 +157,9 @@ public:
 
 private:
     Str paths_[kMaxPaths];
-    u8 methods_[kMaxPaths];
     u32 n_ = 0;
     bool has_prefix_overlap_ = false;
+    bool has_segment_boundary_sensitive_overlap_ = false;
     bool has_param_segments_ = false;
     u32 bucket_counts_[HashFirstSegmentTable::kBuckets];
     // distinct first segments are reconstructed on demand from paths_

--- a/include/rut/runtime/route_select.h
+++ b/include/rut/runtime/route_select.h
@@ -1,0 +1,149 @@
+#pragma once
+
+// route_select — choose the right RouteDispatch for a given route set.
+//
+// The interface seam in route_dispatch.h gives us a vtable; each impl
+// (LinearScan, SegmentTrie, HashFullPath, HashFirstSegment, ByteRadix)
+// has its own sweet spot. Letting every config pay the same dispatch
+// leaves measurable performance on the table — bench data on the
+// closed #41 branch showed up to ~7× variance across impls at N=128
+// realistic, and the winner depends on the route set's shape.
+//
+// This file is the picker. Two pieces:
+//
+//   1. `RouteAnalysis` — a stateful builder that observes a config's
+//      routes one at a time and accumulates the shape signals the
+//      picker needs (count, prefix overlap, first-segment bucket
+//      distribution, presence of `:param` segments). Accumulation is
+//      the natural fit for callers like compile_to_config.h that
+//      already iterate parsed routes once on the way to add_*.
+//
+//   2. `pick_dispatch(const RouteAnalysis&)` — looks at the
+//      accumulated signals and returns one of the canonical
+//      `RouteDispatch*` singletons declared in route_dispatch.h.
+//
+// Caller flow:
+//   RouteAnalysis a;
+//   for (each route) a.note_route(path, method);
+//   RouteConfig cfg;
+//   cfg.set_dispatch(pick_dispatch(a));
+//   for (each route) cfg.add_*(path, method, ...);
+//
+// The two passes over the route list are intentional: the picker
+// needs the full set before deciding, and add_* needs the dispatch
+// chosen before the first call (RouteConfig refuses set_dispatch
+// after route_count > 0). The redundant work is fixed-cost per
+// config-build and has no impact on the runtime hot path.
+//
+// Heuristics implemented (each justified by bench data; see
+// bench/bench_route_trie.cc on closed #41):
+//
+//   `:param` segments        → SegmentTrie (only impl that supports
+//                              segment-bound parameter capture; once
+//                              the .rut frontend grows :param syntax)
+//   route count ≤ 16         → LinearScan (early-exit on hot prefixes
+//                              + zero indirection wins at small N)
+//   prefix-overlap routes    → ByteRadix (longest-prefix in bytes;
+//                              hash variants give up prefix semantics)
+//   diverse first segments
+//     + bucket-fit           → HashFirstSegment
+//   otherwise (exact-match)  → HashFullPath
+//
+// Out of scope here, deferred to follow-up PRs:
+//   - `:param` detection (the .rut DSL doesn't yet emit them)
+//   - Perfect-hash construction
+//   - Run-time recalibration based on observed traffic shape
+//
+// Selector branches are covered 1:1 by tests in
+// `tests/test_route_select.cc`.
+
+#include "rut/common/types.h"
+#include "rut/runtime/route_dispatch.h"
+#include "rut/runtime/route_hash_first_seg.h"  // for kBuckets / kPerBucket
+
+namespace rut {
+
+class RouteAnalysis {
+public:
+    // Cap mirrors RouteConfig::kMaxRoutes. Inputs past the cap return
+    // false from note_route — the picker will still produce a
+    // reasonable answer (it derives from accumulated state, not from
+    // the truncated tail), but the count-based threshold can no
+    // longer be relied on past kMaxPaths.
+    static constexpr u32 kMaxPaths = 128;
+
+    // Must mirror HashFirstSegmentTable's bucket count exactly so
+    // the picker's first-segment-bucket-fit check matches what
+    // hash_first_seg would actually do at insert time.
+    static constexpr u32 kFirstSegBuckets = HashFirstSegmentTable::kBuckets;
+
+    RouteAnalysis() {
+        for (u32 i = 0; i < kFirstSegBuckets; i++) bucket_counts_[i] = 0;
+    }
+
+    // Record a (path, method) the caller plans to register. Returns
+    // false if the analysis cap is exceeded — callers should still
+    // proceed (analysis stays correct for the first kMaxPaths routes
+    // and the picker's heuristics degrade gracefully).
+    //
+    // CONTRACT: `path` must outlive the RouteAnalysis instance — the
+    // builder stores non-owning Str views for the prefix-overlap
+    // check. Compile-to-config callers pass paths from RouteEntry-
+    // shaped buffers that live for the build's duration; that's safe.
+    bool note_route(Str path, u8 method);
+
+    // Snapshots accessible to the picker. The accessors are deliberate
+    // — pick_dispatch should never reach into the raw fields.
+
+    u32 count() const { return n_; }
+
+    // True iff any registered path is a strict prefix of another (in
+    // bytes). Hash variants (HashFullPath / HashFirstSegment exact
+    // mode) can't preserve linear-scan first-match-wins precedence
+    // across overlapping prefixes, so this flag steers the picker
+    // toward longest-prefix-capable impls (SegmentTrie, ByteRadix).
+    bool has_prefix_overlap() const { return has_prefix_overlap_; }
+
+    // True iff any path contains a `:param` segment marker. Currently
+    // always false — the .rut frontend doesn't emit them yet — but
+    // the picker hooks into it so the selector reads correctly when
+    // that work lands.
+    bool has_param_segments() const { return has_param_segments_; }
+
+    // Largest count of routes sharing a first-segment hash bucket
+    // (with kFirstSegBuckets buckets — same modulus hash_first_seg
+    // would use). HashFirstSegment is admissible only when this
+    // doesn't exceed its per-bucket cap.
+    u32 max_first_seg_bucket() const;
+
+    // Number of distinct first segments observed. Cheap proxy for
+    // "is the first-segment hash actually doing partitioning work" —
+    // when the count is tiny relative to the route count, hash_first_
+    // seg's buckets aren't really distributing and the cost of the
+    // hash isn't paid back.
+    u32 distinct_first_segments() const;
+
+private:
+    Str paths_[kMaxPaths];
+    u8 methods_[kMaxPaths];
+    u32 n_ = 0;
+    bool has_prefix_overlap_ = false;
+    bool has_param_segments_ = false;
+    u32 bucket_counts_[HashFirstSegmentTable::kBuckets];
+    // distinct first segments are reconstructed on demand from paths_
+    // — they're only consulted in pick_dispatch, not on every
+    // note_route, so we don't pay an extra hash table here.
+
+    static Str first_segment(Str p);
+    static u64 fnv_first_seg(Str seg);
+    static u32 first_seg_bucket(Str seg);
+};
+
+// Pick the canonical-singleton dispatch for the analyzed route set.
+// Always returns one of the kFooDispatch globals declared in
+// route_dispatch.h — never nullptr, never an unknown pointer (the
+// canonical-singleton whitelist in RouteConfig::set_dispatch checks
+// for this; the picker is the trusted source of those pointers).
+const RouteDispatch* pick_dispatch(const RouteAnalysis& analysis);
+
+}  // namespace rut

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -5,6 +5,7 @@
 #include "rut/common/types.h"
 #include "rut/jit/handler_abi.h"
 #include "rut/runtime/error.h"
+#include "rut/runtime/route_byte_radix.h"
 #include "rut/runtime/route_dispatch.h"
 #include "rut/runtime/route_hash_first_seg.h"
 #include "rut/runtime/route_hash_full.h"
@@ -143,7 +144,8 @@ struct RouteConfig {
     // and state-build gate).
     static bool is_canonical_dispatch(const RouteDispatch* d) {
         return d == &kLinearScanDispatch || d == &kSegmentTrieDispatch ||
-               d == &kHashFullPathDispatch || d == &kHashFirstSegmentDispatch;
+               d == &kHashFullPathDispatch || d == &kHashFirstSegmentDispatch ||
+               d == &kByteRadixDispatch;
     }
 
     // Segment-aware radix trie. Populated by add_* only when the
@@ -175,6 +177,13 @@ struct RouteConfig {
     // a first segment with another (otherwise plain linear scan is
     // just as fast and uses no per-impl memory).
     HashFirstSegmentTable hash_first_seg_state;
+
+    // Byte-level edge-compressed radix trie. ~18 KB inline (256
+    // nodes × ~70 B). Selected by the picker when the route set
+    // benefits from byte-level prefix sharing AND doesn't depend
+    // on segment-boundary precedence — see route_byte_radix.h for
+    // the contract distinction from SegmentTrie.
+    ByteRadixTrie byte_radix_state;
 
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
@@ -264,6 +273,9 @@ struct RouteConfig {
         }
         if (dispatch_ == &kHashFirstSegmentDispatch) {
             return hash_first_seg_state.insert(path_view, r.method, idx);
+        }
+        if (dispatch_ == &kByteRadixDispatch) {
+            return byte_radix_state.insert(path_view, r.method, idx);
         }
         if (dispatch_ == &kLinearScanDispatch) {
             // routes[] IS the data — nothing else to populate.

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -178,11 +178,13 @@ struct RouteConfig {
     // just as fast and uses no per-impl memory).
     HashFirstSegmentTable hash_first_seg_state;
 
-    // Byte-level edge-compressed radix trie. ~18 KB inline (256
-    // nodes × ~70 B). Selected by the picker when the route set
-    // benefits from byte-level prefix sharing AND doesn't depend
-    // on segment-boundary precedence — see route_byte_radix.h for
-    // the contract distinction from SegmentTrie.
+    // Byte-level edge-compressed radix trie. ~75 KB inline (256
+    // nodes × ~290 B; per-node cost dominated by the 260-B children
+    // FixedVec sized to kMaxRoutes after the #46-r3 fan-out bump).
+    // Selected by the picker when the route set benefits from byte-
+    // level prefix sharing AND doesn't depend on segment-boundary
+    // precedence — see route_byte_radix.h for the contract
+    // distinction from SegmentTrie.
     ByteRadixTrie byte_radix_state;
 
     UpstreamTarget upstreams[kMaxUpstreams];

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ add_library(rut_runtime STATIC
     runtime/route_dispatch.cc
     runtime/route_hash_first_seg.cc
     runtime/route_hash_full.cc
+    runtime/route_select.cc
     runtime/route_trie.cc
     ${SIMD_SOURCE}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,7 @@ add_library(rut_runtime STATIC
     runtime/chunked_parser.cc
     runtime/access_log.cc
     runtime/traffic_capture.cc
+    runtime/route_byte_radix.cc
     runtime/route_dispatch.cc
     runtime/route_hash_first_seg.cc
     runtime/route_hash_full.cc

--- a/src/runtime/route_byte_radix.cc
+++ b/src/runtime/route_byte_radix.cc
@@ -203,7 +203,16 @@ u16 ByteRadixTrie::match(Str path, u8 method_char) const {
 namespace {
 
 u16 byte_radix_match(const RouteConfig* cfg, Str path, u8 method) {
-    return cfg->byte_radix_state.match(path, method);
+    // Translate the impl's miss sentinel (TrieNode::kInvalidRoute,
+    // shared with SegmentTrie) into the dispatch interface's miss
+    // sentinel (kRouteIdxInvalid). Both are 0xffffu numerically today,
+    // but the names mean different things — the impl's is a route-
+    // table sentinel scoped to its own match() return; the
+    // interface's is a vtable contract. Codex on #46 caught the
+    // bare passthrough — segment_trie_match in route_dispatch.cc
+    // already does the same translation.
+    const u16 idx = cfg->byte_radix_state.match(path, method);
+    return idx == TrieNode::kInvalidRoute ? kRouteIdxInvalid : idx;
 }
 
 }  // namespace

--- a/src/runtime/route_byte_radix.cc
+++ b/src/runtime/route_byte_radix.cc
@@ -69,12 +69,19 @@ bool ByteRadixTrie::insert(Str path, u8 method_char, u16 route_idx) {
     // capacity failure rolls back to pre-insert state. Edge fields are
     // non-owning Str views (16 B each) and the FixedVec child arrays
     // are POD u16 buffers, so a memcpy-style snapshot is cheap. Worst
-    // case ~256 × ~70 B ≈ 18 KB copied, dwarfed by the trie's overall
-    // build cost on configs that even hit the pool cap.
+    // case after the #46-r3 fan-out bump (kMaxChildren=128): ~256 ×
+    // ~290 B ≈ 75 KB copied, plus the same on the stack as
+    // saved_nodes[]. The build cost is dominated by parser /
+    // RouteConfig::add_* setup at this scale, so the snapshot is
+    // still cheap; the stack draw fits easily under the default
+    // 8 MB pthread stack.
     //
     // Per-step pre-flight isn't sufficient on its own: a same-step
     // edge split allocates one node and would leave the parent's
     // edge truncated even if the subsequent leaf-allocation failed.
+    // A mutation-log rollback (reverse-apply each step on failure)
+    // would lower peak memory but adds bookkeeping; left for follow-up
+    // if profiles ever show this snapshot becoming a bottleneck.
     const u32 saved_len = nodes.len;
     ByteRadixNode saved_nodes[kMaxNodes];
     for (u32 i = 0; i < saved_len; i++) saved_nodes[i] = nodes[i];

--- a/src/runtime/route_byte_radix.cc
+++ b/src/runtime/route_byte_radix.cc
@@ -170,6 +170,15 @@ u16 ByteRadixTrie::match(Str path, u8 method_char) const {
     const u32 want_slot = method_slot(method_char);
     if (want_slot == kMethodSlotInvalid) return TrieNode::kInvalidRoute;
 
+    // Reject non-origin-form request targets BEFORE seeding `best`
+    // from the root terminal. Otherwise a configured "/" catchall
+    // would silently match HTTP/1.1 asterisk-form ("*"), authority-
+    // form ("host:port"), or empty targets — none of which are path-
+    // routable and the linear-scan dispatch never returns a route for
+    // them. RouteTrie::match applies the same guard (Codex P2 caught
+    // it there originally, P1 reapplied here on #46 round 1).
+    if (path.len == 0 || path.ptr[0] != '/') return TrieNode::kInvalidRoute;
+
     const Str p = canonicalize_request(path);
     u16 cur = 0;
     u16 best = pick_terminal(nodes[0], want_slot);

--- a/src/runtime/route_byte_radix.cc
+++ b/src/runtime/route_byte_radix.cc
@@ -1,0 +1,204 @@
+#include "rut/runtime/route_byte_radix.h"
+
+#include "rut/runtime/route_table.h"
+
+namespace rut {
+
+namespace {
+
+// Strip leading '/' and a trailing '/' run from `path`. insert() and
+// match() share this so a route registered as "/api" and a request for
+// "/api" tokenize to the same byte sequence ("api"); a trailing '/' on
+// either side is treated as no-trailing-'/' the same way SegmentTrie's
+// P2a normalization does.
+Str strip_slashes(Str path) {
+    u32 lo = 0;
+    if (lo < path.len && path.ptr[lo] == '/') lo++;
+    u32 hi = path.len;
+    while (hi > lo && path.ptr[hi - 1] == '/') hi--;
+    return Str{path.ptr + lo, hi - lo};
+}
+
+// Match-time-only: also stop at '?' / '#' so query / fragment bytes
+// don't participate in byte matching. Mirrors what SegmentTrie::match
+// does internally; insert() doesn't strip these because RouteConfig
+// already rejected paths containing them.
+Str canonicalize_request(Str path) {
+    u32 lo = 0;
+    if (lo < path.len && path.ptr[lo] == '/') lo++;
+    u32 hi = lo;
+    while (hi < path.len && path.ptr[hi] != '?' && path.ptr[hi] != '#') hi++;
+    while (hi > lo && path.ptr[hi - 1] == '/') hi--;
+    return Str{path.ptr + lo, hi - lo};
+}
+
+}  // namespace
+
+void ByteRadixTrie::clear() {
+    nodes.len = 0;
+    ByteRadixNode root{};
+    [[maybe_unused]] bool ok = nodes.push(root);
+    // push cannot fail on a fresh FixedVec; nodes starts empty.
+}
+
+u16 ByteRadixTrie::pick_terminal(const ByteRadixNode& n, u32 slot) {
+    if (slot != 0 && n.route_idx_by_method[slot] != TrieNode::kInvalidRoute) {
+        return n.route_idx_by_method[slot];
+    }
+    return n.route_idx_by_method[0];
+}
+
+u16 ByteRadixTrie::find_child_by_first_byte(u16 parent, u8 b) const {
+    const auto& p = nodes[parent];
+    for (u32 i = 0; i < p.children.len; i++) {
+        const u16 ci = p.children[i];
+        if (nodes[ci].edge.len > 0 && static_cast<u8>(nodes[ci].edge.ptr[0]) == b) {
+            return ci;
+        }
+    }
+    return TrieNode::kInvalidNodeIdx;
+}
+
+bool ByteRadixTrie::insert(Str path, u8 method_char, u16 route_idx) {
+    const u32 slot = method_slot(method_char);
+    if (slot == kMethodSlotInvalid) return false;
+
+    const Str p = strip_slashes(path);
+
+    // Atomic insert: snapshot the whole node pool so a mid-insert
+    // capacity failure rolls back to pre-insert state. Edge fields are
+    // non-owning Str views (16 B each) and the FixedVec child arrays
+    // are POD u16 buffers, so a memcpy-style snapshot is cheap. Worst
+    // case ~256 × ~70 B ≈ 18 KB copied, dwarfed by the trie's overall
+    // build cost on configs that even hit the pool cap.
+    //
+    // Per-step pre-flight isn't sufficient on its own: a same-step
+    // edge split allocates one node and would leave the parent's
+    // edge truncated even if the subsequent leaf-allocation failed.
+    const u32 saved_len = nodes.len;
+    ByteRadixNode saved_nodes[kMaxNodes];
+    for (u32 i = 0; i < saved_len; i++) saved_nodes[i] = nodes[i];
+
+    auto rollback = [&]() {
+        for (u32 i = 0; i < saved_len; i++) nodes[i] = saved_nodes[i];
+        nodes.len = saved_len;
+    };
+
+    u16 cur = 0;
+    u32 i = 0;
+    while (i < p.len) {
+        const u8 b = static_cast<u8>(p.ptr[i]);
+        const u16 child = find_child_by_first_byte(cur, b);
+        if (child == TrieNode::kInvalidNodeIdx) {
+            // No matching child — append a leaf with the rest of the
+            // path as its edge.
+            if (nodes.len >= kMaxNodes) {
+                rollback();
+                return false;
+            }
+            ByteRadixNode nn;
+            nn.edge = Str{p.ptr + i, p.len - i};
+            if (!nodes.push(nn)) {
+                rollback();
+                return false;
+            }
+            const u16 ni = static_cast<u16>(nodes.len - 1);
+            if (!nodes[cur].children.push(ni)) {
+                rollback();
+                return false;
+            }
+            cur = ni;
+            i = p.len;
+            break;
+        }
+        // Match as many bytes of the existing edge as possible.
+        const Str e = nodes[child].edge;
+        u32 k = 0;
+        while (k < e.len && i + k < p.len && e.ptr[k] == p.ptr[i + k]) k++;
+        if (k == e.len) {
+            // Full edge match — descend into child.
+            cur = child;
+            i += k;
+            continue;
+        }
+        // Partial match — split the edge at byte k. The original child
+        // now holds the shared prefix [0,k); a new node holds the old
+        // tail [k,e.len) with all of the original child's terminal
+        // slots and children moved to it.
+        if (nodes.len >= kMaxNodes) {
+            rollback();
+            return false;
+        }
+        ByteRadixNode tail;
+        tail.edge = Str{e.ptr + k, e.len - k};
+        for (u32 m = 0; m < kMethodSlots; m++) {
+            tail.route_idx_by_method[m] = nodes[child].route_idx_by_method[m];
+        }
+        tail.children = nodes[child].children;
+        if (!nodes.push(tail)) {
+            rollback();
+            return false;
+        }
+        const u16 tail_idx = static_cast<u16>(nodes.len - 1);
+        // Truncate child to shared prefix; clear its terminals/children
+        // (they moved to `tail`); install `tail` as its sole child.
+        nodes[child].edge = Str{e.ptr, k};
+        for (u32 m = 0; m < kMethodSlots; m++) {
+            nodes[child].route_idx_by_method[m] = TrieNode::kInvalidRoute;
+        }
+        nodes[child].children.len = 0;
+        if (!nodes[child].children.push(tail_idx)) {
+            rollback();
+            return false;
+        }
+        cur = child;
+        i += k;
+        // Loop continues — the new path either continues into a fresh
+        // sibling (next iteration's "no matching child" branch) or
+        // ends right at the split point (loop exits, terminal slot set
+        // on `cur`).
+    }
+
+    // First-insert-wins on duplicate (path, method).
+    if (nodes[cur].route_idx_by_method[slot] == TrieNode::kInvalidRoute) {
+        nodes[cur].route_idx_by_method[slot] = route_idx;
+    }
+    return true;
+}
+
+u16 ByteRadixTrie::match(Str path, u8 method_char) const {
+    const u32 want_slot = method_slot(method_char);
+    if (want_slot == kMethodSlotInvalid) return TrieNode::kInvalidRoute;
+
+    const Str p = canonicalize_request(path);
+    u16 cur = 0;
+    u16 best = pick_terminal(nodes[0], want_slot);
+    u32 i = 0;
+    while (i < p.len) {
+        const u8 b = static_cast<u8>(p.ptr[i]);
+        const u16 child = find_child_by_first_byte(cur, b);
+        if (child == TrieNode::kInvalidNodeIdx) break;
+        const Str e = nodes[child].edge;
+        if (i + e.len > p.len) break;  // request shorter than remaining edge
+        for (u32 k = 0; k < e.len; k++) {
+            if (e.ptr[k] != p.ptr[i + k]) return best;
+        }
+        cur = child;
+        i += e.len;
+        const u16 candidate = pick_terminal(nodes[cur], want_slot);
+        if (candidate != TrieNode::kInvalidRoute) best = candidate;
+    }
+    return best;
+}
+
+namespace {
+
+u16 byte_radix_match(const RouteConfig* cfg, Str path, u8 method) {
+    return cfg->byte_radix_state.match(path, method);
+}
+
+}  // namespace
+
+const RouteDispatch kByteRadixDispatch = {&byte_radix_match};
+
+}  // namespace rut

--- a/src/runtime/route_select.cc
+++ b/src/runtime/route_select.cc
@@ -2,7 +2,6 @@
 
 #include "rut/runtime/route_byte_radix.h"
 #include "rut/runtime/route_hash_first_seg.h"
-#include "rut/runtime/route_hash_full.h"
 
 namespace rut {
 
@@ -59,6 +58,30 @@ bool is_strict_byte_prefix(Str a, Str b) {
     return true;
 }
 
+// Given that `a` is a strict byte-prefix of `b`, returns true iff the
+// next byte in `b` (the byte immediately past the shared prefix) is
+// not '/'. That's the "segment-boundary-sensitive overlap" case —
+// /api vs /apix, where byte-prefix and segment-prefix dispatch would
+// give different answers for an intermediate request like /apij.
+// Caller must establish the strict-prefix relationship; we don't
+// reverify because the call sites already did.
+bool boundary_sensitive_after_prefix(Str shorter, Str longer) {
+    return longer.ptr[shorter.len] != '/';
+}
+
+// Largest route count that ByteRadix can absorb in the worst case
+// without tripping its node-pool cap. Each insert can split an edge
+// (1 new node) and add a leaf (1 more), so the strict upper bound is
+// 1 + 2N nodes. With ByteRadixTrie::kMaxNodes = 256, that admits
+// N ≤ 127. Realistic configs with prefix sharing fit far more, but
+// the picker is the trusted source of dispatch correctness — we keep
+// the conservative bound so a worst-case-shape config can never make
+// it past pick_dispatch and into a partial-build failure during
+// add_*. Codex P1 on #47 round 1 (the round-3 fan-out bump on #46
+// fixed the 16-children failure mode but the total-node ceiling
+// remains a separate constraint).
+constexpr u32 kByteRadixSafeMaxRoutes = (ByteRadixTrie::kMaxNodes - 1) / 2;
+
 }  // namespace
 
 Str RouteAnalysis::first_segment(Str p) {
@@ -82,18 +105,48 @@ u32 RouteAnalysis::first_seg_bucket(Str seg) {
 }
 
 bool RouteAnalysis::note_route(Str path, u8 method) {
+    // method is part of the (path, method) registration key callers
+    // already track; keeping the parameter in the API surface lets a
+    // future method-aware heuristic land without a signature churn.
+    // No current selector signal is method-dependent, so we don't
+    // store it. (Copilot on #47 round 1 flagged dead methods_ storage.)
+    (void)method;
     if (n_ >= kMaxPaths) return false;
 
-    // Update prefix-overlap flag against everything seen so far.
+    // Update prefix-overlap flags against everything seen so far.
     // O(N) per insert; bounded at kMaxPaths so total work is O(N²)
     // in the worst case, ~16K compares for the cap. Cheap relative
     // to the route-build cost the caller's already paying.
-    if (!has_prefix_overlap_) {
+    //
+    // Two flags piggyback on the same scan:
+    //   - has_prefix_overlap: any strict byte-prefix pair.
+    //   - has_segment_boundary_sensitive_overlap: a strict-prefix pair
+    //     whose continuation byte in the longer path is not '/'.
+    //     Boundary-sensitive overlaps disqualify ByteRadix because
+    //     its byte-prefix semantics would diverge from segment-aware
+    //     routing for in-between requests (e.g. /api + /apix → /apij
+    //     hits /api in byte mode, misses in segment mode).
+    if (!has_prefix_overlap_ || !has_segment_boundary_sensitive_overlap_) {
         for (u32 i = 0; i < n_; i++) {
-            if (is_strict_byte_prefix(path, paths_[i]) || is_strict_byte_prefix(paths_[i], path)) {
-                has_prefix_overlap_ = true;
-                break;
+            const Str& other = paths_[i];
+            Str shorter;
+            Str longer;
+            if (is_strict_byte_prefix(path, other)) {
+                shorter = path;
+                longer = other;
+            } else if (is_strict_byte_prefix(other, path)) {
+                shorter = other;
+                longer = path;
+            } else {
+                continue;
             }
+            has_prefix_overlap_ = true;
+            if (!has_segment_boundary_sensitive_overlap_ &&
+                boundary_sensitive_after_prefix(shorter, longer)) {
+                has_segment_boundary_sensitive_overlap_ = true;
+            }
+            // Both flags set → no further information to gather.
+            if (has_segment_boundary_sensitive_overlap_) break;
         }
     }
 
@@ -104,7 +157,6 @@ bool RouteAnalysis::note_route(Str path, u8 method) {
     bucket_counts_[first_seg_bucket(first_segment(path))]++;
 
     paths_[n_] = path;
-    methods_[n_] = method;
     n_++;
     return true;
 }
@@ -145,25 +197,47 @@ const RouteDispatch* pick_dispatch(const RouteAnalysis& a) {
     // indexed alternative.
     if (a.count() <= kLinearScanCutoff) return &kLinearScanDispatch;
 
-    // Routes that overlap as byte prefixes need longest-prefix
-    // matching; hash variants would lose precedence. ByteRadix beats
-    // SegmentTrie on the bench whenever we can use it (no params),
-    // so this branch picks ByteRadix for the prefix-overlap, no-param
-    // case. SegmentTrie is reserved for the param-capture path
-    // exclusively (above).
-    if (a.has_prefix_overlap()) return &kByteRadixDispatch;
+    // Boundary-sensitive overlap (e.g. /api + /apix registered
+    // together) disqualifies ByteRadix — its byte-prefix view would
+    // mis-route intermediate requests. SegmentTrie is the only impl
+    // that gives the segment-aware answer for these configs.
+    // (Copilot on #47 round 1.)
+    if (a.has_segment_boundary_sensitive_overlap()) return &kSegmentTrieDispatch;
 
-    // No prefix overlap, no params — exact-match hash variants are
-    // admissible. Choose HashFirstSegment when (a) the per-bucket
-    // cap holds and (b) first-segment hashing actually distributes
-    // (≥ kMinDistinctFirstSegmentsForFirstSeg). Otherwise
-    // HashFullPath, which is constant-time and unconditionally
-    // applicable.
+    // Pure segment-aligned prefix overlap: ByteRadix beats SegmentTrie
+    // on the bench (closed #41 data) and matches its semantics in this
+    // regime. We additionally gate on count: the trie's node pool
+    // (kMaxNodes = 256) has worst-case 1 + 2N capacity, so we route
+    // configs above the safe bound to SegmentTrie rather than risk an
+    // add_*-time build failure (Codex P1 on #47 round 1; the round-3
+    // fan-out bump on #46 already raised kMaxChildren to kMaxRoutes).
+    if (a.has_prefix_overlap()) {
+        if (a.count() <= kByteRadixSafeMaxRoutes) return &kByteRadixDispatch;
+        return &kSegmentTrieDispatch;
+    }
+
+    // No prefix overlap, no params. HashFirstSegment is the right
+    // pick when (a) the per-bucket cap holds and (b) first-segment
+    // hashing actually partitions the route set
+    // (≥ kMinDistinctFirstSegmentsForFirstSeg). Within a bucket
+    // HashFirstSegment still does a byte-prefix scan, so requests
+    // longer than the registered route (e.g., registered /api/users
+    // matching request /api/users/42) work correctly.
     if (a.max_first_seg_bucket() <= HashFirstSegmentTable::kPerBucket &&
         a.distinct_first_segments() >= kMinDistinctFirstSegmentsForFirstSeg) {
         return &kHashFirstSegmentDispatch;
     }
-    return &kHashFullPathDispatch;
+
+    // Fall through to SegmentTrie, NOT HashFullPath. HashFullPath is
+    // exact-match-only — it would silently turn a registered prefix
+    // (/api/users) into a miss when the request arrives longer
+    // (/api/users/42), breaking the linear-scan baseline contract
+    // even though the picker thought it was a safe choice. SegmentTrie
+    // is unconditionally correct (segment-prefix, longest-match wins)
+    // and stays available for any shape we couldn't route to a faster
+    // impl. Codex P1 on #47 round 1 caught the original
+    // HashFullPath fallback.
+    return &kSegmentTrieDispatch;
 }
 
 }  // namespace rut

--- a/src/runtime/route_select.cc
+++ b/src/runtime/route_select.cc
@@ -1,0 +1,169 @@
+#include "rut/runtime/route_select.h"
+
+#include "rut/runtime/route_byte_radix.h"
+#include "rut/runtime/route_hash_first_seg.h"
+#include "rut/runtime/route_hash_full.h"
+
+namespace rut {
+
+namespace {
+
+constexpr u64 kFnvBasis = 0xcbf29ce484222325ULL;
+constexpr u64 kFnvPrime = 0x100000001b3ULL;
+
+// Threshold below which LinearScan's early-exit + zero-indirection
+// dominates the indexed alternatives. Chosen at the bench data's
+// crossover point on realistic SaaS configs (closed #41 bench): at
+// N≤32 the trie/hash dispatchers are within 10% of linear or
+// behind it, and the extra build-time cost + storage isn't paid back.
+// We pick 16 to leave a margin — the bench is one machine's data
+// point, and the linear-scan code path is always faster to reason
+// about for tiny configs.
+constexpr u32 kLinearScanCutoff = 16;
+
+// Min distinct first segments to consider HashFirstSegment over
+// HashFullPath. With ≤4 distinct first segments and N>16, most routes
+// pile into a few buckets — the bucketing buys little over hashing
+// the full path, while HashFullPath's per-match cost is identical and
+// it sidesteps the per-bucket-cap selector check entirely.
+constexpr u32 kMinDistinctFirstSegmentsForFirstSeg = 4;
+
+// Detect `:param` style segments in a path. Format expected (when the
+// frontend grows the syntax): a segment that begins with ':' marks
+// that segment as a parameter capture. For now this scan never finds
+// one in real traffic — RouteConfig::is_routable_path doesn't accept
+// `:` differently from any other byte today, and the .rut DSL has no
+// `:foo` syntax yet — but pinning the contract early means the
+// picker's branch is in place when the syntax lands.
+bool path_has_param_segment(Str path) {
+    bool at_segment_start = true;
+    for (u32 i = 0; i < path.len; i++) {
+        const char c = path.ptr[i];
+        if (c == '/') {
+            at_segment_start = true;
+            continue;
+        }
+        if (at_segment_start && c == ':') return true;
+        at_segment_start = false;
+    }
+    return false;
+}
+
+// True iff `a` is a strict byte-prefix of `b` (a.len < b.len, and the
+// first a.len bytes are equal).
+bool is_strict_byte_prefix(Str a, Str b) {
+    if (a.len >= b.len) return false;
+    for (u32 i = 0; i < a.len; i++) {
+        if (a.ptr[i] != b.ptr[i]) return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+Str RouteAnalysis::first_segment(Str p) {
+    u32 start = (p.len > 0 && p.ptr[0] == '/') ? 1 : 0;
+    u32 end = start;
+    while (end < p.len && p.ptr[end] != '/' && p.ptr[end] != '?' && p.ptr[end] != '#') end++;
+    return Str{p.ptr + start, end - start};
+}
+
+u64 RouteAnalysis::fnv_first_seg(Str seg) {
+    u64 h = kFnvBasis;
+    for (u32 i = 0; i < seg.len; i++) {
+        h ^= static_cast<u8>(seg.ptr[i]);
+        h *= kFnvPrime;
+    }
+    return h;
+}
+
+u32 RouteAnalysis::first_seg_bucket(Str seg) {
+    return static_cast<u32>(fnv_first_seg(seg)) & (kFirstSegBuckets - 1);
+}
+
+bool RouteAnalysis::note_route(Str path, u8 method) {
+    if (n_ >= kMaxPaths) return false;
+
+    // Update prefix-overlap flag against everything seen so far.
+    // O(N) per insert; bounded at kMaxPaths so total work is O(N²)
+    // in the worst case, ~16K compares for the cap. Cheap relative
+    // to the route-build cost the caller's already paying.
+    if (!has_prefix_overlap_) {
+        for (u32 i = 0; i < n_; i++) {
+            if (is_strict_byte_prefix(path, paths_[i]) || is_strict_byte_prefix(paths_[i], path)) {
+                has_prefix_overlap_ = true;
+                break;
+            }
+        }
+    }
+
+    if (!has_param_segments_ && path_has_param_segment(path)) has_param_segments_ = true;
+
+    // Update first-segment bucket counts. Stays in sync with what
+    // HashFirstSegment would compute at insert time.
+    bucket_counts_[first_seg_bucket(first_segment(path))]++;
+
+    paths_[n_] = path;
+    methods_[n_] = method;
+    n_++;
+    return true;
+}
+
+u32 RouteAnalysis::max_first_seg_bucket() const {
+    u32 max = 0;
+    for (u32 i = 0; i < kFirstSegBuckets; i++) {
+        if (bucket_counts_[i] > max) max = bucket_counts_[i];
+    }
+    return max;
+}
+
+u32 RouteAnalysis::distinct_first_segments() const {
+    // O(N²) — for each path, check whether an earlier path has the
+    // same first segment. At kMaxPaths=128 the worst-case is ~8K
+    // compares, paid once at config-build time.
+    u32 distinct = 0;
+    for (u32 i = 0; i < n_; i++) {
+        const Str s = first_segment(paths_[i]);
+        bool seen = false;
+        for (u32 j = 0; j < i; j++) {
+            if (first_segment(paths_[j]).eq(s)) {
+                seen = true;
+                break;
+            }
+        }
+        if (!seen) distinct++;
+    }
+    return distinct;
+}
+
+const RouteDispatch* pick_dispatch(const RouteAnalysis& a) {
+    // Param segments require segment-bound parameter capture; only
+    // SegmentTrie supports that.
+    if (a.has_param_segments()) return &kSegmentTrieDispatch;
+
+    // Tiny configs: linear scan beats the bookkeeping cost of any
+    // indexed alternative.
+    if (a.count() <= kLinearScanCutoff) return &kLinearScanDispatch;
+
+    // Routes that overlap as byte prefixes need longest-prefix
+    // matching; hash variants would lose precedence. ByteRadix beats
+    // SegmentTrie on the bench whenever we can use it (no params),
+    // so this branch picks ByteRadix for the prefix-overlap, no-param
+    // case. SegmentTrie is reserved for the param-capture path
+    // exclusively (above).
+    if (a.has_prefix_overlap()) return &kByteRadixDispatch;
+
+    // No prefix overlap, no params — exact-match hash variants are
+    // admissible. Choose HashFirstSegment when (a) the per-bucket
+    // cap holds and (b) first-segment hashing actually distributes
+    // (≥ kMinDistinctFirstSegmentsForFirstSeg). Otherwise
+    // HashFullPath, which is constant-time and unconditionally
+    // applicable.
+    if (a.max_first_seg_bucket() <= HashFirstSegmentTable::kPerBucket &&
+        a.distinct_first_segments() >= kMinDistinctFirstSegmentsForFirstSeg) {
+        return &kHashFirstSegmentDispatch;
+    }
+    return &kHashFullPathDispatch;
+}
+
+}  // namespace rut

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -138,6 +138,15 @@ target_include_directories(test_route_hash_first_seg PRIVATE
 add_test(NAME test_route_hash_first_seg COMMAND test_route_hash_first_seg)
 set_tests_properties(test_route_hash_first_seg PROPERTIES LABELS "unit")
 
+add_executable(test_route_byte_radix test_route_byte_radix.cc)
+target_link_libraries(test_route_byte_radix rut_runtime)
+target_include_directories(test_route_byte_radix PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+)
+add_test(NAME test_route_byte_radix COMMAND test_route_byte_radix)
+set_tests_properties(test_route_byte_radix PROPERTIES LABELS "unit")
+
 add_executable(test_rir test_rir.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
 target_link_libraries(test_rir rut_compiler)
 target_include_directories(test_rir PRIVATE
@@ -275,6 +284,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_route_trie>
     COMMAND $<TARGET_FILE:test_route_hash_full>
     COMMAND $<TARGET_FILE:test_route_hash_first_seg>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_hash_full test_route_hash_first_seg
+    COMMAND $<TARGET_FILE:test_route_byte_radix>
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_hash_full test_route_hash_first_seg test_route_byte_radix
     COMMENT "Running all tests..."
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,15 @@ target_include_directories(test_route_byte_radix PRIVATE
 add_test(NAME test_route_byte_radix COMMAND test_route_byte_radix)
 set_tests_properties(test_route_byte_radix PROPERTIES LABELS "unit")
 
+add_executable(test_route_select test_route_select.cc)
+target_link_libraries(test_route_select rut_runtime)
+target_include_directories(test_route_select PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+)
+add_test(NAME test_route_select COMMAND test_route_select)
+set_tests_properties(test_route_select PROPERTIES LABELS "unit")
+
 add_executable(test_rir test_rir.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
 target_link_libraries(test_rir rut_compiler)
 target_include_directories(test_rir PRIVATE
@@ -285,6 +294,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_route_hash_full>
     COMMAND $<TARGET_FILE:test_route_hash_first_seg>
     COMMAND $<TARGET_FILE:test_route_byte_radix>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_hash_full test_route_hash_first_seg test_route_byte_radix
+    COMMAND $<TARGET_FILE:test_route_select>
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_hash_full test_route_hash_first_seg test_route_byte_radix test_route_select
     COMMENT "Running all tests..."
 )

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -2396,9 +2396,11 @@ TEST(route, set_dispatch_accepts_canonical_singletons) {
     CHECK(c.set_dispatch(&kHashFullPathDispatch));
     RouteConfig d;
     CHECK(d.set_dispatch(&kHashFirstSegmentDispatch));
-    // Null is still refused (no dispatch == no match).
     RouteConfig e;
-    CHECK(!e.set_dispatch(nullptr));
+    CHECK(e.set_dispatch(&kByteRadixDispatch));
+    // Null is still refused (no dispatch == no match).
+    RouteConfig f;
+    CHECK(!f.set_dispatch(nullptr));
 }
 
 TEST(route, set_dispatch_refuses_after_first_add) {

--- a/tests/test_route_byte_radix.cc
+++ b/tests/test_route_byte_radix.cc
@@ -185,44 +185,68 @@ TEST(route_byte_radix, rejects_unsupported_method_byte_at_match) {
 // ============================================================================
 
 TEST(route_byte_radix, atomic_insert_on_node_pool_exhaustion) {
-    // Fill the pool to within 1 of kMaxNodes with single-byte distinct
-    // routes (each takes ~1 node). The next insert that needs more
-    // than 1 node — a deeper distinct path — must fail and leave the
-    // pool unchanged.
+    // Drive the pool to exactly kMaxNodes - 1 with a deterministic
+    // sequence, then attempt an insert that demands 2 new nodes.
+    // With only 1 slot left the second allocation must fail and the
+    // rollback must restore the pre-insert pool exactly.
+    //
+    // The earlier shape used "if (!t.insert(...)) break;" plus a
+    // best-effort deep insert and accepted EITHER success or failure;
+    // Copilot on #46 round 3 flagged that the rollback path was
+    // never actually exercised. The new shape is fully deterministic.
     ByteRadixTrie t;
-    char paths[ByteRadixTrie::kMaxNodes][8];
-    u32 admitted = 0;
-    for (u32 i = 0; i + 2 < ByteRadixTrie::kMaxNodes; i++) {
-        paths[i][0] = '/';
-        paths[i][1] = static_cast<char>('a' + (i / 26 / 26) % 26);
-        paths[i][2] = static_cast<char>('a' + (i / 26) % 26);
-        paths[i][3] = static_cast<char>('a' + i % 26);
-        paths[i][4] = '\0';
-        if (!t.insert(Str{paths[i], 4}, 0, static_cast<u16>(i))) break;
-        admitted++;
+
+    // Phase 1 — fill root to kMaxChildren with 2-byte-edge leaves.
+    // Each insert: first byte unseen at root → add one leaf with a
+    // 2-byte edge. +1 node per insert. After kMaxChildren inserts:
+    // root + kMaxChildren leaves = 1 + kMaxChildren nodes.
+    //
+    // Each path needs its own backing buffer because the trie stores
+    // non-owning Str views into the path bytes; reusing one buffer
+    // across inserts would have every previously-inserted edge alias
+    // the latest write and collapse all leaves into one (subtle, and
+    // the in-place mutation of buffer contents would even change
+    // later find_child_by_first_byte lookups).
+    char p1_buf[ByteRadixNode::kMaxChildren][3];
+    for (u32 i = 0; i < ByteRadixNode::kMaxChildren; i++) {
+        p1_buf[i][0] = '/';
+        p1_buf[i][1] = static_cast<char>(0x40 + i);
+        p1_buf[i][2] = 'x';
+        REQUIRE(t.insert(Str{p1_buf[i], 3}, 0, static_cast<u16>(i)));
     }
-    REQUIRE(admitted > 4);
+    REQUIRE_EQ(t.node_count(), 1u + ByteRadixNode::kMaxChildren);
+
+    // Phase 2 — extend leaves with a 1-byte tail. Each descendant
+    // insert: full edge match on the 2-byte parent edge, then add
+    // one leaf for the trailing 'y'. +1 node per insert. Stop one
+    // short of kMaxNodes so phase 3 has exactly 1 free slot.
+    constexpr u32 phase2 =
+        ByteRadixTrie::kMaxNodes - 2u - ByteRadixNode::kMaxChildren;  // 126 with 256/128
+    static_assert(phase2 < ByteRadixNode::kMaxChildren,
+                  "phase2 must consume at most kMaxChildren leaves");
+    char p2_buf[phase2][4];
+    for (u32 i = 0; i < phase2; i++) {
+        p2_buf[i][0] = '/';
+        p2_buf[i][1] = static_cast<char>(0x40 + i);
+        p2_buf[i][2] = 'x';
+        p2_buf[i][3] = 'y';
+        REQUIRE(t.insert(Str{p2_buf[i], 4}, 0, static_cast<u16>(1000 + i)));
+    }
+    REQUIRE_EQ(t.node_count(), ByteRadixTrie::kMaxNodes - 1);
+
+    // Phase 3 — an insert that splits a 2-byte parent edge AND adds
+    // a sibling leaf. Needs 2 new nodes (split-tail + leaf); only 1
+    // slot remains, so rollback must fire. We split the edge of the
+    // 0th leaf ("/<0x40>x") with a fresh tail "z" via path "/<0x40>z".
+    const char split_path[3] = {'/', static_cast<char>(0x40), 'z'};
     const u32 nodes_before = t.node_count();
-    // Now insert a deep brand-new path that requires more nodes than
-    // are left. If the pre-flight allowed it to start, the rollback
-    // must restore the pool exactly.
-    char deep[64];
-    deep[0] = '/';
-    for (u32 i = 1; i < 60; i++) deep[i] = static_cast<char>('a' + i % 26);
-    deep[60] = '\0';
-    // The deep path may succeed or fail depending on remaining space;
-    // either way the post-state must be consistent — node_count is
-    // either unchanged (failure rolled back) or grew by exactly the
-    // number of new nodes the path actually allocated.
-    const bool ok = t.insert(Str{deep, 60}, 0, 9999);
-    if (!ok) {
-        CHECK_EQ(t.node_count(), nodes_before);  // rollback
-    } else {
-        CHECK(t.node_count() >= nodes_before);
-    }
-    // All previously-admitted routes still match correctly.
-    for (u32 i = 0; i < admitted; i++) {
-        CHECK_EQ(t.match(Str{paths[i], 4}, 0), static_cast<u16>(i));
+    CHECK(!t.insert(Str{split_path, 3}, 0, 9999));
+    CHECK_EQ(t.node_count(), nodes_before);  // rollback restored exactly
+
+    // All phase-1 routes still match correctly — rollback didn't
+    // corrupt their terminals or edges.
+    for (u32 i = 0; i < ByteRadixNode::kMaxChildren; i++) {
+        CHECK_EQ(t.match(Str{p1_buf[i], 3}, 0), static_cast<u16>(i));
     }
 }
 
@@ -269,24 +293,30 @@ TEST(route_byte_radix, accepts_kMaxRoutes_distinct_top_level_prefixes) {
     // fail at insert time even though kMaxRoutes is 128. Bumped to
     // 128 to cover the worst case.
     //
-    // Worst-case shape: 128 single-byte top-level paths, all sharing
-    // root as their parent. After this fix the trie accepts all of
-    // them.
+    // Worst-case shape: 128 paths whose first byte after the leading
+    // '/' is unique across the set, so they all become direct children
+    // of root and force the children FixedVec to its cap.
+    //
+    // Earlier r3 version used "/aa", "/ab", ... for 128 paths but
+    // collapsed all 128 to only 5 distinct first bytes — the root
+    // never actually grew past ~5 children, so the test passed even
+    // with the old kMaxChildren=16. Copilot on #46 round 3 caught
+    // it. We now use a contiguous run of 128 unique non-special
+    // bytes (0x40..0xbf, none of which are '/', '?', '#', or NUL).
     ByteRadixTrie t;
-    char paths[ByteRadixNode::kMaxChildren][4];
+    char paths[ByteRadixNode::kMaxChildren][2];
     for (u32 i = 0; i < ByteRadixNode::kMaxChildren; i++) {
-        // /<i>: encode i as 2 bytes (a-z + a-z) so each top-level
-        // path has a distinct first byte after the leading '/'.
         paths[i][0] = '/';
-        paths[i][1] = static_cast<char>('a' + i / 26);
-        paths[i][2] = static_cast<char>('a' + i % 26);
-        paths[i][3] = '\0';
-        REQUIRE(t.insert(Str{paths[i], 3}, 0, static_cast<u16>(i)));
+        paths[i][1] = static_cast<char>(0x40 + i);
+        REQUIRE(t.insert(Str{paths[i], 2}, 0, static_cast<u16>(i)));
     }
+    // Root must hold exactly kMaxChildren leaves now — verify via
+    // node_count (1 root + kMaxChildren leaves).
+    CHECK_EQ(t.node_count(), 1u + ByteRadixNode::kMaxChildren);
     // Spot-check a few — the first, the middle, and the last.
-    CHECK_EQ(t.match(Str{paths[0], 3}, 0), 0u);
-    CHECK_EQ(t.match(Str{paths[64], 3}, 0), 64u);
-    CHECK_EQ(t.match(Str{paths[ByteRadixNode::kMaxChildren - 1], 3}, 0),
+    CHECK_EQ(t.match(Str{paths[0], 2}, 0), 0u);
+    CHECK_EQ(t.match(Str{paths[64], 2}, 0), 64u);
+    CHECK_EQ(t.match(Str{paths[ByteRadixNode::kMaxChildren - 1], 2}, 0),
              static_cast<u16>(ByteRadixNode::kMaxChildren - 1));
 }
 

--- a/tests/test_route_byte_radix.cc
+++ b/tests/test_route_byte_radix.cc
@@ -1,0 +1,259 @@
+// Tests for runtime/route_byte_radix.h: byte-level edge-compressed
+// radix trie.
+//
+// Coverage:
+//   - basic exact match + miss
+//   - longest-prefix-match across edge splits
+//   - edge splitting on partial match (the canonical "shared prefix
+//     diverges later" pattern)
+//   - method-slot routing + first-insert-wins on duplicates
+//   - request-time '?' / '#' stripping
+//   - leading / trailing '/' canonicalization at insert and match
+//   - capacity rejection with atomic rollback
+//   - byte-aware (non-segment-aware) semantics — distinct from trie
+
+#include "rut/runtime/route_byte_radix.h"
+#include "test.h"
+
+using namespace rut;
+
+namespace {
+
+constexpr Str S(const char* s) {
+    u32 n = 0;
+    while (s[n]) n++;
+    return Str{s, n};
+}
+
+}  // namespace
+
+// ============================================================================
+// Basic match
+// ============================================================================
+
+TEST(route_byte_radix, exact_match_single_route) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/health"), 0, 7));
+    CHECK_EQ(t.match(S("/health"), 0), 7u);
+}
+
+TEST(route_byte_radix, no_match_when_no_routes) {
+    ByteRadixTrie t;
+    CHECK_EQ(t.match(S("/anything"), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_byte_radix, longest_prefix_match_wins) {
+    // Two registered routes: /api and /api/v1. A request for
+    // /api/v1/users hits /api/v1 (longer prefix) regardless of the
+    // insert order. Distinct from linear-scan first-match-wins —
+    // the selector picks byte_radix only for configs that don't
+    // depend on linear-scan precedence.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api"), 0, 0));
+    REQUIRE(t.insert(S("/api/v1"), 0, 1));
+    CHECK_EQ(t.match(S("/api"), 0), 0u);           // exact /api
+    CHECK_EQ(t.match(S("/api/v1"), 0), 1u);        // exact /api/v1
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), 1u);  // longer wins
+    CHECK_EQ(t.match(S("/api/other"), 0), 0u);     // /api wins (only /api fits)
+}
+
+TEST(route_byte_radix, longest_prefix_independent_of_insert_order) {
+    // Insert /api/v1 BEFORE /api — same outcome.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api/v1"), 0, 0));
+    REQUIRE(t.insert(S("/api"), 0, 1));
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), 0u);
+    CHECK_EQ(t.match(S("/api/other"), 0), 1u);
+}
+
+// ============================================================================
+// Edge splitting — the structurally interesting case
+// ============================================================================
+
+TEST(route_byte_radix, edge_split_on_partial_match) {
+    // Insert /api/v1 first (one edge "api/v1" from root). Then insert
+    // /api/v2 — the edge must split at "api/v" (5 bytes shared) into
+    //   root → "api/v" → {"1": old terminal, "2": new terminal}
+    // Both routes must remain matchable after the split.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api/v1"), 0, 0));
+    REQUIRE(t.insert(S("/api/v2"), 0, 1));
+    CHECK_EQ(t.match(S("/api/v1"), 0), 0u);
+    CHECK_EQ(t.match(S("/api/v2"), 0), 1u);
+    // Sibling that doesn't share the "api/v" stem must miss.
+    CHECK_EQ(t.match(S("/api/x"), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_byte_radix, multiple_splits_preserve_terminals) {
+    // /api/v1/users inserted first creates one long edge.
+    // /api/v1/orders splits at "api/v1/" → {users, orders}.
+    // /api/v2 splits at "api/v" → {"1/" → {users, orders}, "2"}.
+    // All four terminals (the three plus an /api shorter-prefix) must
+    // resolve to their original idx.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api/v1/users"), 0, 0));
+    REQUIRE(t.insert(S("/api/v1/orders"), 0, 1));
+    REQUIRE(t.insert(S("/api/v2"), 0, 2));
+    REQUIRE(t.insert(S("/api"), 0, 3));
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), 0u);
+    CHECK_EQ(t.match(S("/api/v1/orders"), 0), 1u);
+    CHECK_EQ(t.match(S("/api/v2"), 0), 2u);
+    CHECK_EQ(t.match(S("/api"), 0), 3u);
+    // Longest-prefix-match: /api/v1/anything hits /api (the only
+    // matching prefix of /api/v1/anything when v1's children diverge).
+    CHECK_EQ(t.match(S("/api/v1/x"), 0), 3u);
+    CHECK_EQ(t.match(S("/api/v3"), 0), 3u);
+}
+
+// ============================================================================
+// Byte-aware (NOT segment-aware) semantics
+// ============================================================================
+
+TEST(route_byte_radix, byte_match_crosses_segment_boundaries) {
+    // /api matches /apixyz because the trie is byte-aware. SegmentTrie
+    // would NOT match /apixyz against /api (segment boundary would
+    // have to align). This is the contract distinction the selector
+    // uses to choose between dispatches.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api"), 0, 0));
+    CHECK_EQ(t.match(S("/api"), 0), 0u);
+    CHECK_EQ(t.match(S("/apixyz"), 0), 0u);
+    CHECK_EQ(t.match(S("/apex"), 0), TrieNode::kInvalidRoute);  // diverges at 2nd byte
+}
+
+TEST(route_byte_radix, request_strips_query_and_fragment) {
+    // Request paths arrive raw from the parser; '?' / '#' must not
+    // participate in byte matching, otherwise /health?q=1 wouldn't hit
+    // a registered /health route.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/health"), 0, 0));
+    REQUIRE(t.insert(S("/api/users"), 0, 1));
+    CHECK_EQ(t.match(S("/health?check=1"), 0), 0u);
+    CHECK_EQ(t.match(S("/health?"), 0), 0u);
+    CHECK_EQ(t.match(S("/health#frag"), 0), 0u);
+    CHECK_EQ(t.match(S("/api/users?page=3"), 0), 1u);
+}
+
+TEST(route_byte_radix, trailing_slash_normalized) {
+    // P2a-style: a trailing '/' on the route at insert OR on the
+    // request at match is stripped to canonicalize to the same key.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/api"), 0, 0));
+    CHECK_EQ(t.match(S("/api"), 0), 0u);
+    CHECK_EQ(t.match(S("/api/"), 0), 0u);   // trailing slash on request
+    REQUIRE(t.insert(S("/admin/"), 0, 1));  // trailing slash on route
+    CHECK_EQ(t.match(S("/admin"), 0), 1u);
+    CHECK_EQ(t.match(S("/admin/"), 0), 1u);
+}
+
+// ============================================================================
+// Method dispatch
+// ============================================================================
+
+TEST(route_byte_radix, method_specific_beats_any_at_same_path) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/x"), 0, 0));    // any
+    REQUIRE(t.insert(S("/x"), 'G', 1));  // GET-specific
+    CHECK_EQ(t.match(S("/x"), 'G'), 1u);
+    CHECK_EQ(t.match(S("/x"), 'P'), 0u);  // POST falls back to any
+    CHECK_EQ(t.match(S("/x"), 0), 0u);
+}
+
+TEST(route_byte_radix, first_insert_wins_on_dup_method_slot) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/x"), 'G', 0));
+    REQUIRE(t.insert(S("/x"), 'G', 1));  // duplicate (path, method)
+    CHECK_EQ(t.match(S("/x"), 'G'), 0u);
+}
+
+TEST(route_byte_radix, rejects_unsupported_method_byte_at_insert) {
+    ByteRadixTrie t;
+    // 'g' (lowercase) is not a recognized method byte.
+    CHECK(!t.insert(S("/x"), 'g', 0));
+    CHECK(!t.insert(S("/x"), 'X', 0));
+}
+
+TEST(route_byte_radix, rejects_unsupported_method_byte_at_match) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/x"), 'G', 0));
+    CHECK_EQ(t.match(S("/x"), 'g'), TrieNode::kInvalidRoute);
+    CHECK_EQ(t.match(S("/x"), 'X'), TrieNode::kInvalidRoute);
+}
+
+// ============================================================================
+// Capacity / atomic rollback
+// ============================================================================
+
+TEST(route_byte_radix, atomic_insert_on_node_pool_exhaustion) {
+    // Fill the pool to within 1 of kMaxNodes with single-byte distinct
+    // routes (each takes ~1 node). The next insert that needs more
+    // than 1 node — a deeper distinct path — must fail and leave the
+    // pool unchanged.
+    ByteRadixTrie t;
+    char paths[ByteRadixTrie::kMaxNodes][8];
+    u32 admitted = 0;
+    for (u32 i = 0; i + 2 < ByteRadixTrie::kMaxNodes; i++) {
+        paths[i][0] = '/';
+        paths[i][1] = static_cast<char>('a' + (i / 26 / 26) % 26);
+        paths[i][2] = static_cast<char>('a' + (i / 26) % 26);
+        paths[i][3] = static_cast<char>('a' + i % 26);
+        paths[i][4] = '\0';
+        if (!t.insert(Str{paths[i], 4}, 0, static_cast<u16>(i))) break;
+        admitted++;
+    }
+    REQUIRE(admitted > 4);
+    const u32 nodes_before = t.node_count();
+    // Now insert a deep brand-new path that requires more nodes than
+    // are left. If the pre-flight allowed it to start, the rollback
+    // must restore the pool exactly.
+    char deep[64];
+    deep[0] = '/';
+    for (u32 i = 1; i < 60; i++) deep[i] = static_cast<char>('a' + i % 26);
+    deep[60] = '\0';
+    // The deep path may succeed or fail depending on remaining space;
+    // either way the post-state must be consistent — node_count is
+    // either unchanged (failure rolled back) or grew by exactly the
+    // number of new nodes the path actually allocated.
+    const bool ok = t.insert(Str{deep, 60}, 0, 9999);
+    if (!ok) {
+        CHECK_EQ(t.node_count(), nodes_before);  // rollback
+    } else {
+        CHECK(t.node_count() >= nodes_before);
+    }
+    // All previously-admitted routes still match correctly.
+    for (u32 i = 0; i < admitted; i++) {
+        CHECK_EQ(t.match(Str{paths[i], 4}, 0), static_cast<u16>(i));
+    }
+}
+
+TEST(route_byte_radix, clear_resets_state) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/a"), 0, 0));
+    REQUIRE(t.insert(S("/b"), 0, 1));
+    const u32 nodes_after_inserts = t.node_count();
+    CHECK(nodes_after_inserts > 1u);
+    t.clear();
+    CHECK_EQ(t.node_count(), 1u);  // root only
+    CHECK_EQ(t.match(S("/a"), 0), TrieNode::kInvalidRoute);
+    REQUIRE(t.insert(S("/c"), 0, 0));
+    CHECK_EQ(t.match(S("/c"), 0), 0u);
+    CHECK_EQ(t.match(S("/a"), 0), TrieNode::kInvalidRoute);
+}
+
+// ============================================================================
+// Empty / root path
+// ============================================================================
+
+TEST(route_byte_radix, root_path_matches_root_terminal) {
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/"), 0, 42));
+    CHECK_EQ(t.match(S("/"), 0), 42u);
+    // Root is a "shorter-than-anything" prefix — every request that
+    // starts with '/' inherits the root terminal as a fallback.
+    CHECK_EQ(t.match(S("/anything"), 0), 42u);
+    CHECK_EQ(t.match(S("/api/v1/users"), 0), 42u);
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}

--- a/tests/test_route_byte_radix.cc
+++ b/tests/test_route_byte_radix.cc
@@ -263,6 +263,33 @@ TEST(route_byte_radix, rejects_non_origin_form_request_targets) {
     CHECK_EQ(t.match(S(""), 0), TrieNode::kInvalidRoute);
 }
 
+TEST(route_byte_radix, accepts_kMaxRoutes_distinct_top_level_prefixes) {
+    // Codex P1 on #46 round 2: per-node fan-out was capped at 16,
+    // which made any config with 17+ distinct top-level prefixes
+    // fail at insert time even though kMaxRoutes is 128. Bumped to
+    // 128 to cover the worst case.
+    //
+    // Worst-case shape: 128 single-byte top-level paths, all sharing
+    // root as their parent. After this fix the trie accepts all of
+    // them.
+    ByteRadixTrie t;
+    char paths[ByteRadixNode::kMaxChildren][4];
+    for (u32 i = 0; i < ByteRadixNode::kMaxChildren; i++) {
+        // /<i>: encode i as 2 bytes (a-z + a-z) so each top-level
+        // path has a distinct first byte after the leading '/'.
+        paths[i][0] = '/';
+        paths[i][1] = static_cast<char>('a' + i / 26);
+        paths[i][2] = static_cast<char>('a' + i % 26);
+        paths[i][3] = '\0';
+        REQUIRE(t.insert(Str{paths[i], 3}, 0, static_cast<u16>(i)));
+    }
+    // Spot-check a few — the first, the middle, and the last.
+    CHECK_EQ(t.match(Str{paths[0], 3}, 0), 0u);
+    CHECK_EQ(t.match(Str{paths[64], 3}, 0), 64u);
+    CHECK_EQ(t.match(Str{paths[ByteRadixNode::kMaxChildren - 1], 3}, 0),
+             static_cast<u16>(ByteRadixNode::kMaxChildren - 1));
+}
+
 TEST(route_byte_radix, root_path_matches_root_terminal) {
     ByteRadixTrie t;
     REQUIRE(t.insert(S("/"), 0, 42));

--- a/tests/test_route_byte_radix.cc
+++ b/tests/test_route_byte_radix.cc
@@ -244,6 +244,25 @@ TEST(route_byte_radix, clear_resets_state) {
 // Empty / root path
 // ============================================================================
 
+TEST(route_byte_radix, rejects_non_origin_form_request_targets) {
+    // Codex P1 on #46: with a configured "/" catchall, match() seeded
+    // `best` from the root terminal regardless of whether the request
+    // was origin-form. Asterisk-form ("*"), authority-form ("host:port"),
+    // and empty targets must NOT match any route — the linear-scan
+    // dispatch never matches them either, and HTTP/1.1 doesn't define
+    // path routing for them.
+    ByteRadixTrie t;
+    REQUIRE(t.insert(S("/"), 0, 99));    // catchall
+    REQUIRE(t.insert(S("/api"), 0, 7));  // specific
+    // Origin-form still works.
+    CHECK_EQ(t.match(S("/api"), 0), 7u);
+    CHECK_EQ(t.match(S("/anything"), 0), 99u);
+    // Non-origin-form: NO match, even though "/" is registered.
+    CHECK_EQ(t.match(S("*"), 0), TrieNode::kInvalidRoute);
+    CHECK_EQ(t.match(S("example.com:443"), 0), TrieNode::kInvalidRoute);
+    CHECK_EQ(t.match(S(""), 0), TrieNode::kInvalidRoute);
+}
+
 TEST(route_byte_radix, root_path_matches_root_terminal) {
     ByteRadixTrie t;
     REQUIRE(t.insert(S("/"), 0, 42));

--- a/tests/test_route_select.cc
+++ b/tests/test_route_select.cc
@@ -134,19 +134,10 @@ TEST(route_select, picks_segment_trie_when_param_segments_present) {
 
 TEST(route_select, picks_linear_scan_for_tiny_configs) {
     // ≤16 routes, no params, irrespective of overlap shape.
+    // String-literal paths via S() have static storage duration, so
+    // the non-owning Str views stored by note_route remain valid for
+    // the whole RouteAnalysis lifetime here.
     RouteAnalysis a;
-    for (u32 i = 0; i < 8; i++) {
-        char buf[8];
-        buf[0] = '/';
-        buf[1] = static_cast<char>('a' + i);
-        const Str p{buf, 2};
-        // note_route stores a non-owning view; we must keep the
-        // backing storage alive across the analysis lifetime. For
-        // this test we don't outlive the loop scope, so use static
-        // strings instead.
-        (void)p;
-    }
-    // Static-storage paths so the views remain valid.
     REQUIRE(a.note_route(S("/a"), 0));
     REQUIRE(a.note_route(S("/b"), 0));
     REQUIRE(a.note_route(S("/c"), 0));
@@ -160,8 +151,8 @@ TEST(route_select, picks_linear_scan_for_tiny_configs) {
 
 TEST(route_select, picks_byte_radix_when_prefix_overlap_no_params) {
     // /api shadows /api/v1 — needs longest-prefix-match. ByteRadix
-    // is preferred over SegmentTrie when no params are present
-    // (ByteRadix wins on bench).
+    // is preferred over SegmentTrie when no params are present and
+    // overlaps are segment-aligned (ByteRadix wins on bench).
     RouteAnalysis a;
     REQUIRE(a.note_route(S("/api"), 0));
     REQUIRE(a.note_route(S("/api/v1"), 0));
@@ -169,19 +160,23 @@ TEST(route_select, picks_byte_radix_when_prefix_overlap_no_params) {
     REQUIRE(a.note_route(S("/api/v2"), 0));
     REQUIRE(a.note_route(S("/admin"), 0));
     REQUIRE(a.note_route(S("/admin/users"), 0));
-    // 17 routes total to clear the LinearScan cutoff.
-    REQUIRE(a.note_route(S("/r1"), 0));
-    REQUIRE(a.note_route(S("/r2"), 0));
-    REQUIRE(a.note_route(S("/r3"), 0));
-    REQUIRE(a.note_route(S("/r4"), 0));
-    REQUIRE(a.note_route(S("/r5"), 0));
-    REQUIRE(a.note_route(S("/r6"), 0));
-    REQUIRE(a.note_route(S("/r7"), 0));
-    REQUIRE(a.note_route(S("/r8"), 0));
-    REQUIRE(a.note_route(S("/r9"), 0));
-    REQUIRE(a.note_route(S("/r10"), 0));
-    REQUIRE(a.note_route(S("/r11"), 0));
+    // Pad past the LinearScan cutoff. Padding paths are chosen so no
+    // pair has a boundary-sensitive overlap (Copilot's signal would
+    // route us to SegmentTrie otherwise) — every path is two
+    // segments and pairwise non-prefix.
+    REQUIRE(a.note_route(S("/h/a"), 0));
+    REQUIRE(a.note_route(S("/h/b"), 0));
+    REQUIRE(a.note_route(S("/h/c"), 0));
+    REQUIRE(a.note_route(S("/h/d"), 0));
+    REQUIRE(a.note_route(S("/h/e"), 0));
+    REQUIRE(a.note_route(S("/h/f"), 0));
+    REQUIRE(a.note_route(S("/h/g"), 0));
+    REQUIRE(a.note_route(S("/h/h"), 0));
+    REQUIRE(a.note_route(S("/h/i"), 0));
+    REQUIRE(a.note_route(S("/h/j"), 0));
+    REQUIRE(a.note_route(S("/h/k"), 0));
     CHECK(a.has_prefix_overlap());
+    CHECK(!a.has_segment_boundary_sensitive_overlap());
     CHECK_EQ(pick_dispatch(a), &kByteRadixDispatch);
 }
 
@@ -211,10 +206,14 @@ TEST(route_select, picks_hash_first_segment_when_diverse_segments_no_overlap) {
     CHECK_EQ(pick_dispatch(a), &kHashFirstSegmentDispatch);
 }
 
-TEST(route_select, picks_hash_full_when_first_segments_concentrated) {
+TEST(route_select, picks_segment_trie_when_first_segments_concentrated) {
     // ≥17 routes, no prefix overlap, but first segments concentrated
     // — too few distinct first segments for HashFirstSegment to
-    // distribute. Picker falls back to HashFullPath.
+    // distribute. Picker falls back to SegmentTrie. NOT HashFullPath:
+    // HashFullPath is exact-match-only and would silently turn
+    // /api/v1/users matching request /api/v1/users/42 into a miss
+    // (Codex P1 on #47 round 1). SegmentTrie preserves prefix
+    // semantics generically.
     RouteAnalysis a;
     // All under /api/v1/<distinct_resource> — first segment is "api"
     // for every route, so distinct_first_segments == 1. Paths don't
@@ -243,10 +242,10 @@ TEST(route_select, picks_hash_full_when_first_segments_concentrated) {
     }
     REQUIRE(!a.has_prefix_overlap());
     REQUIRE_EQ(a.distinct_first_segments(), 1u);
-    CHECK_EQ(pick_dispatch(a), &kHashFullPathDispatch);
+    CHECK_EQ(pick_dispatch(a), &kSegmentTrieDispatch);
 }
 
-TEST(route_select, falls_back_to_hash_full_on_first_seg_bucket_overflow) {
+TEST(route_select, falls_back_to_segment_trie_on_first_seg_bucket_overflow) {
     // Synthetic case where first-segment hashing would overflow
     // HashFirstSegment's per-bucket cap. We force this by making
     // many routes share the same first segment with disjoint tails
@@ -265,9 +264,65 @@ TEST(route_select, falls_back_to_hash_full_on_first_seg_bucket_overflow) {
     }
     REQUIRE(!a.has_prefix_overlap());
     // 20 routes in one bucket > kPerBucket (16). Picker must reject
-    // HashFirstSegment.
+    // HashFirstSegment and fall through to SegmentTrie (NOT
+    // HashFullPath, which would silently break prefix routing).
     REQUIRE(a.max_first_seg_bucket() > HashFirstSegmentTable::kPerBucket);
-    CHECK_EQ(pick_dispatch(a), &kHashFullPathDispatch);
+    CHECK_EQ(pick_dispatch(a), &kSegmentTrieDispatch);
+}
+
+TEST(route_select, picks_segment_trie_for_boundary_sensitive_overlap) {
+    // /api and /apix registered together — /api is a strict byte
+    // prefix of /apix but the next byte ('x') is not '/'. ByteRadix's
+    // byte-prefix view would mis-route an intermediate request like
+    // /apij to /api; SegmentTrie treats /apij as a miss (segment
+    // "apij" matches neither registered segment). The picker steers
+    // boundary-sensitive configs to SegmentTrie. (Copilot on #47.)
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/api"), 0));
+    REQUIRE(a.note_route(S("/apix"), 0));
+    // Pad past the LinearScan cutoff so the boundary branch is the
+    // one being exercised, not the small-config branch.
+    REQUIRE(a.note_route(S("/r1"), 0));
+    REQUIRE(a.note_route(S("/r2"), 0));
+    REQUIRE(a.note_route(S("/r3"), 0));
+    REQUIRE(a.note_route(S("/r4"), 0));
+    REQUIRE(a.note_route(S("/r5"), 0));
+    REQUIRE(a.note_route(S("/r6"), 0));
+    REQUIRE(a.note_route(S("/r7"), 0));
+    REQUIRE(a.note_route(S("/r8"), 0));
+    REQUIRE(a.note_route(S("/r9"), 0));
+    REQUIRE(a.note_route(S("/r10"), 0));
+    REQUIRE(a.note_route(S("/r11"), 0));
+    REQUIRE(a.note_route(S("/r12"), 0));
+    REQUIRE(a.note_route(S("/r13"), 0));
+    REQUIRE(a.note_route(S("/r14"), 0));
+    REQUIRE(a.note_route(S("/r15"), 0));
+    REQUIRE(a.has_prefix_overlap());
+    REQUIRE(a.has_segment_boundary_sensitive_overlap());
+    CHECK_EQ(pick_dispatch(a), &kSegmentTrieDispatch);
+}
+
+TEST(route_select, segment_aligned_overlap_does_not_set_boundary_sensitive_flag) {
+    // /api and /api/v1 — /api is a strict prefix and the continuation
+    // byte in /api/v1 IS '/'. This is segment-aligned overlap; the
+    // boundary-sensitive flag must stay false (so the picker can still
+    // pick ByteRadix, which is faster than SegmentTrie when correct).
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/api"), 0));
+    REQUIRE(a.note_route(S("/api/v1"), 0));
+    CHECK(a.has_prefix_overlap());
+    CHECK(!a.has_segment_boundary_sensitive_overlap());
+}
+
+TEST(route_select, boundary_sensitive_flag_detected_either_insertion_order) {
+    // Reverse of picks_segment_trie_for_boundary_sensitive_overlap:
+    // insert /apix first, then /api. The longer path was already in
+    // paths_, so the scan sees the new (shorter) path strict-prefixes
+    // an existing path. Same flag must fire.
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/apix"), 0));
+    REQUIRE(a.note_route(S("/api"), 0));
+    CHECK(a.has_segment_boundary_sensitive_overlap());
 }
 
 // ============================================================================

--- a/tests/test_route_select.cc
+++ b/tests/test_route_select.cc
@@ -1,0 +1,286 @@
+// Tests for runtime/route_select.h: dispatch picker.
+//
+// Each branch of pick_dispatch() has a dedicated test that constructs
+// a RouteAnalysis matching that branch's preconditions and asserts
+// the picker returns the corresponding canonical singleton. Plus a
+// few RouteAnalysis-builder tests for the signal accumulators.
+
+#include "rut/runtime/route_select.h"
+#include "test.h"
+
+using namespace rut;
+
+namespace {
+
+constexpr Str S(const char* s) {
+    u32 n = 0;
+    while (s[n]) n++;
+    return Str{s, n};
+}
+
+}  // namespace
+
+// ============================================================================
+// RouteAnalysis builder
+// ============================================================================
+
+TEST(route_select, analysis_starts_empty) {
+    RouteAnalysis a;
+    CHECK_EQ(a.count(), 0u);
+    CHECK(!a.has_prefix_overlap());
+    CHECK(!a.has_param_segments());
+    CHECK_EQ(a.max_first_seg_bucket(), 0u);
+    CHECK_EQ(a.distinct_first_segments(), 0u);
+}
+
+TEST(route_select, note_route_increments_count) {
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/a"), 0));
+    REQUIRE(a.note_route(S("/b"), 0));
+    CHECK_EQ(a.count(), 2u);
+}
+
+TEST(route_select, prefix_overlap_detected_either_direction) {
+    // /api inserted first, /api/v1 second — a is prefix of b.
+    RouteAnalysis a1;
+    REQUIRE(a1.note_route(S("/api"), 0));
+    REQUIRE(a1.note_route(S("/api/v1"), 0));
+    CHECK(a1.has_prefix_overlap());
+
+    // Reverse insert order — same flag must fire (b's prefix is a).
+    RouteAnalysis a2;
+    REQUIRE(a2.note_route(S("/api/v1"), 0));
+    REQUIRE(a2.note_route(S("/api"), 0));
+    CHECK(a2.has_prefix_overlap());
+}
+
+TEST(route_select, no_prefix_overlap_for_disjoint_paths) {
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/api/users"), 0));
+    REQUIRE(a.note_route(S("/api/orders"), 0));  // siblings, no overlap
+    REQUIRE(a.note_route(S("/admin"), 0));       // different first segment
+    REQUIRE(a.note_route(S("/health"), 0));
+    CHECK(!a.has_prefix_overlap());
+}
+
+TEST(route_select, equal_length_distinct_paths_are_not_overlap) {
+    // Same length but different bytes — neither is a prefix of the
+    // other. Strict-prefix means a.len < b.len.
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/abc"), 0));
+    REQUIRE(a.note_route(S("/abd"), 0));
+    CHECK(!a.has_prefix_overlap());
+}
+
+TEST(route_select, identical_paths_are_not_strict_prefix_overlap) {
+    // Two registrations of the same path differ by method only.
+    // Neither is a STRICT prefix of the other (strict requires
+    // a.len < b.len), so the overlap flag stays false.
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/x"), 'G'));
+    REQUIRE(a.note_route(S("/x"), 'P'));
+    CHECK(!a.has_prefix_overlap());
+}
+
+TEST(route_select, param_segments_detected) {
+    // Forward-looking: the .rut DSL doesn't emit `:foo` yet, but the
+    // picker hooks into has_param_segments so the contract is in
+    // place when that lands.
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/api/:id"), 0));
+    CHECK(a.has_param_segments());
+}
+
+TEST(route_select, param_segments_only_at_segment_start) {
+    // ':' inside a segment (e.g., a literal byte that happens to be
+    // a colon) doesn't count as a param marker. Format: ':' must be
+    // the first byte of its segment.
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/api/foo:bar"), 0));  // colon mid-segment
+    CHECK(!a.has_param_segments());
+}
+
+TEST(route_select, distinct_first_segments_counted) {
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/api/v1"), 0));
+    REQUIRE(a.note_route(S("/api/v2"), 0));  // shares first seg "api"
+    REQUIRE(a.note_route(S("/admin/users"), 0));
+    REQUIRE(a.note_route(S("/health"), 0));
+    REQUIRE(a.note_route(S("/metrics"), 0));
+    CHECK_EQ(a.distinct_first_segments(), 4u);  // api, admin, health, metrics
+}
+
+TEST(route_select, max_first_seg_bucket_tracks_clustering) {
+    // 5 routes all under /api/* → all hash to the "api" bucket.
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/api/v1/users"), 0));
+    REQUIRE(a.note_route(S("/api/v1/orders"), 0));
+    REQUIRE(a.note_route(S("/api/v2/users"), 0));
+    REQUIRE(a.note_route(S("/api/v2/orders"), 0));
+    REQUIRE(a.note_route(S("/api/health"), 0));
+    CHECK_EQ(a.max_first_seg_bucket(), 5u);
+}
+
+// ============================================================================
+// pick_dispatch — one test per selector branch
+// ============================================================================
+
+TEST(route_select, picks_segment_trie_when_param_segments_present) {
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/api/:id"), 0));
+    REQUIRE(a.note_route(S("/users/:user_id/posts"), 0));
+    CHECK_EQ(pick_dispatch(a), &kSegmentTrieDispatch);
+}
+
+TEST(route_select, picks_linear_scan_for_tiny_configs) {
+    // ≤16 routes, no params, irrespective of overlap shape.
+    RouteAnalysis a;
+    for (u32 i = 0; i < 8; i++) {
+        char buf[8];
+        buf[0] = '/';
+        buf[1] = static_cast<char>('a' + i);
+        const Str p{buf, 2};
+        // note_route stores a non-owning view; we must keep the
+        // backing storage alive across the analysis lifetime. For
+        // this test we don't outlive the loop scope, so use static
+        // strings instead.
+        (void)p;
+    }
+    // Static-storage paths so the views remain valid.
+    REQUIRE(a.note_route(S("/a"), 0));
+    REQUIRE(a.note_route(S("/b"), 0));
+    REQUIRE(a.note_route(S("/c"), 0));
+    REQUIRE(a.note_route(S("/d"), 0));
+    REQUIRE(a.note_route(S("/e"), 0));
+    REQUIRE(a.note_route(S("/f"), 0));
+    REQUIRE(a.note_route(S("/g"), 0));
+    REQUIRE(a.note_route(S("/h"), 0));
+    CHECK_EQ(pick_dispatch(a), &kLinearScanDispatch);
+}
+
+TEST(route_select, picks_byte_radix_when_prefix_overlap_no_params) {
+    // /api shadows /api/v1 — needs longest-prefix-match. ByteRadix
+    // is preferred over SegmentTrie when no params are present
+    // (ByteRadix wins on bench).
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/api"), 0));
+    REQUIRE(a.note_route(S("/api/v1"), 0));
+    REQUIRE(a.note_route(S("/api/v1/users"), 0));
+    REQUIRE(a.note_route(S("/api/v2"), 0));
+    REQUIRE(a.note_route(S("/admin"), 0));
+    REQUIRE(a.note_route(S("/admin/users"), 0));
+    // 17 routes total to clear the LinearScan cutoff.
+    REQUIRE(a.note_route(S("/r1"), 0));
+    REQUIRE(a.note_route(S("/r2"), 0));
+    REQUIRE(a.note_route(S("/r3"), 0));
+    REQUIRE(a.note_route(S("/r4"), 0));
+    REQUIRE(a.note_route(S("/r5"), 0));
+    REQUIRE(a.note_route(S("/r6"), 0));
+    REQUIRE(a.note_route(S("/r7"), 0));
+    REQUIRE(a.note_route(S("/r8"), 0));
+    REQUIRE(a.note_route(S("/r9"), 0));
+    REQUIRE(a.note_route(S("/r10"), 0));
+    REQUIRE(a.note_route(S("/r11"), 0));
+    CHECK(a.has_prefix_overlap());
+    CHECK_EQ(pick_dispatch(a), &kByteRadixDispatch);
+}
+
+TEST(route_select, picks_hash_first_segment_when_diverse_segments_no_overlap) {
+    // ≥17 routes, no prefix overlap, ≥4 distinct first segments,
+    // bucket-fit holds. Should pick HashFirstSegment over HashFullPath.
+    RouteAnalysis a;
+    REQUIRE(a.note_route(S("/api/users"), 0));
+    REQUIRE(a.note_route(S("/api/orders"), 0));
+    REQUIRE(a.note_route(S("/api/products"), 0));
+    REQUIRE(a.note_route(S("/admin/users"), 0));
+    REQUIRE(a.note_route(S("/admin/audit"), 0));
+    REQUIRE(a.note_route(S("/admin/sessions"), 0));
+    REQUIRE(a.note_route(S("/oauth/token"), 0));
+    REQUIRE(a.note_route(S("/oauth/authorize"), 0));
+    REQUIRE(a.note_route(S("/webhooks/stripe"), 0));
+    REQUIRE(a.note_route(S("/webhooks/github"), 0));
+    REQUIRE(a.note_route(S("/health"), 0));
+    REQUIRE(a.note_route(S("/metrics"), 0));
+    REQUIRE(a.note_route(S("/_status"), 0));
+    REQUIRE(a.note_route(S("/_ready"), 0));
+    REQUIRE(a.note_route(S("/_live"), 0));
+    REQUIRE(a.note_route(S("/internal/debug"), 0));
+    REQUIRE(a.note_route(S("/internal/dump"), 0));
+    REQUIRE(!a.has_prefix_overlap());
+    REQUIRE(a.distinct_first_segments() >= 4u);
+    CHECK_EQ(pick_dispatch(a), &kHashFirstSegmentDispatch);
+}
+
+TEST(route_select, picks_hash_full_when_first_segments_concentrated) {
+    // ≥17 routes, no prefix overlap, but first segments concentrated
+    // — too few distinct first segments for HashFirstSegment to
+    // distribute. Picker falls back to HashFullPath.
+    RouteAnalysis a;
+    // All under /api/v1/<distinct_resource> — first segment is "api"
+    // for every route, so distinct_first_segments == 1. Paths don't
+    // overlap because each has a different last segment.
+    const char* paths[] = {
+        "/api/v1/users",
+        "/api/v1/orders",
+        "/api/v1/products",
+        "/api/v1/sessions",
+        "/api/v1/events",
+        "/api/v1/teams",
+        "/api/v1/projects",
+        "/api/v1/tasks",
+        "/api/v1/comments",
+        "/api/v1/tags",
+        "/api/v1/files",
+        "/api/v1/messages",
+        "/api/v1/channels",
+        "/api/v1/integrations",
+        "/api/v1/policies",
+        "/api/v1/notifications",
+        "/api/v1/customers",
+    };
+    for (u32 i = 0; i < sizeof(paths) / sizeof(paths[0]); i++) {
+        REQUIRE(a.note_route(S(paths[i]), 0));
+    }
+    REQUIRE(!a.has_prefix_overlap());
+    REQUIRE_EQ(a.distinct_first_segments(), 1u);
+    CHECK_EQ(pick_dispatch(a), &kHashFullPathDispatch);
+}
+
+TEST(route_select, falls_back_to_hash_full_on_first_seg_bucket_overflow) {
+    // Synthetic case where first-segment hashing would overflow
+    // HashFirstSegment's per-bucket cap. We force this by making
+    // many routes share the same first segment with disjoint tails
+    // — also engineered to NOT prefix-overlap each other (no
+    // shorter route is a prefix of a longer one).
+    RouteAnalysis a;
+    // 20 paths under a single "/api" first segment, distinct enough
+    // suffixes that no path is a strict prefix of another.
+    const char* paths[] = {
+        "/api/aa", "/api/ab", "/api/ac", "/api/ad", "/api/ae", "/api/af", "/api/ag",
+        "/api/ah", "/api/ai", "/api/aj", "/api/ak", "/api/al", "/api/am", "/api/an",
+        "/api/ao", "/api/ap", "/api/aq", "/api/ar", "/api/as", "/api/at",
+    };
+    for (u32 i = 0; i < sizeof(paths) / sizeof(paths[0]); i++) {
+        REQUIRE(a.note_route(S(paths[i]), 0));
+    }
+    REQUIRE(!a.has_prefix_overlap());
+    // 20 routes in one bucket > kPerBucket (16). Picker must reject
+    // HashFirstSegment.
+    REQUIRE(a.max_first_seg_bucket() > HashFirstSegmentTable::kPerBucket);
+    CHECK_EQ(pick_dispatch(a), &kHashFullPathDispatch);
+}
+
+// ============================================================================
+// Picker stability — never returns nullptr or an unknown pointer
+// ============================================================================
+
+TEST(route_select, picker_returns_canonical_singleton_for_empty_analysis) {
+    RouteAnalysis a;
+    const RouteDispatch* d = pick_dispatch(a);
+    // Empty analysis: count == 0 ≤ 16, so LinearScan.
+    CHECK_EQ(d, &kLinearScanDispatch);
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}


### PR DESCRIPTION
## Summary
- New: `RouteAnalysis` builder accumulates shape signals (count, prefix-overlap, `:param` presence, first-segment bucket distribution, distinct-first-segment count).
- New: `pick_dispatch(const RouteAnalysis&)` returns one of the canonical-singleton dispatches based on bench-justified heuristics.
- 17 new tests (136 checks).
- Coverage CI updated.

**Stacks on #46** (`feat/dispatch-byte-radix`).

## Why
The interface seam (#43) and 4 impl PRs (#44–#46) gave us a vtable + 5 specialized dispatches. None of them dominates across realistic configs — closed #41 bench data showed up to ~7× variance at N=128 and the winner depends on the route set's shape. This PR is the picker that closes the loop: caller analyzes → picker chooses → `set_dispatch` accepts (since the picker only ever returns canonical singletons).

## Selector heuristics
Each branch covered 1:1 by tests:

| Branch | Picks |
|--------|-------|
| `:param` segments present | `SegmentTrie` (only impl with parameter-capture support) |
| count ≤ 16 | `LinearScan` (early-exit + zero indirection wins at small N) |
| prefix-overlap, no params | `ByteRadix` (longest-prefix in bytes; bench winner among the longest-prefix-capable impls) |
| diverse first segments + bucket-fit, no overlap | `HashFirstSegment` |
| else | `HashFullPath` |

## Caller flow
```cpp
RouteAnalysis a;
for (each route) a.note_route(path, method);
RouteConfig cfg;
cfg.set_dispatch(pick_dispatch(a));
for (each route) cfg.add_*(path, method, ...);
```

Two passes over the route set are intentional — the picker needs the full set before deciding, and `set_dispatch` refuses after the first `add_*`. Fixed-cost per config-build, zero impact on the runtime hot path.

## Out of scope (deferred)
- **PR-F**: `compile_to_config.h` integration — wires the picker into the Rutlang DSL → CompiledConfig path.
- **PR-G**: tagged-union storage so per-impl state only costs what the active dispatch needs (currently `RouteConfig` embeds all 5 inline).
- Perfect-hash construction (`PR-H`?) — bench showed seed-search doesn't converge at N=128 with FNV-1a; needs CHD/BBHash.
- Run-time recalibration based on observed traffic shape.

## Test plan
- [x] All 1700+ existing tests pass
- [x] 17 new `route_select` tests pass (136 checks)
- [x] `clang-format` clean
- [x] Coverage CI updated to include `test_route_select`
- [ ] Reviewer eye on the heuristic thresholds — the bench data is one machine's measurement; the cutoffs (kLinearScanCutoff=16, kMinDistinctFirstSegmentsForFirstSeg=4) are starting points that PR-F integration will exercise on real route sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)