### PR TITLE
Cover proxy routes in traffic replay

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -68,4 +68,4 @@ Recurring patterns found during code review that automated tests consistently mi
 **TODO**: For any function that dispatches to multiple code paths (static vs proxy vs default):
 - Maintain an explicit coverage matrix: `[function × path × test]`.
 - Every time a new path is added to a function, require a test that drives it through ALL callers (not just direct unit tests).
-- For replay: add a test that calls `replay_one` with a proxy route config and verifies `replayed == false` (the current correct behavior).
+- [x] For replay: add a test that calls `replay_one` with a proxy route config and verifies `replayed == false` (the current correct behavior).

--- a/include/rut/runtime/traffic_replay.h
+++ b/include/rut/runtime/traffic_replay.h
@@ -16,7 +16,10 @@ struct ReplayResult {
     u16 expected_status;  // from capture file
     u16 actual_status;    // from replay
     bool status_match;    // expected == actual
-    bool replayed;        // false if injection failed (e.g., no free conn)
+    bool replayed;        // true if a static response was replayed; false
+                          // means either skipped or replay/injection failed
+    bool skipped;         // meaningful when replayed == false: true if
+                          // intentionally unsupported, false if failed
 };
 
 // Summary of a full replay session.
@@ -25,6 +28,7 @@ struct ReplaySummary {
     u32 replayed;    // successfully injected
     u32 matched;     // status matched
     u32 mismatched;  // status didn't match
+    u32 skipped;     // intentionally unsupported entries
     u32 failed;      // injection failures
 };
 
@@ -154,13 +158,28 @@ ReplayResult replay_one(Loop& loop, const CaptureEntry& entry, i32 fake_fd) {
     n = loop.backend.wait(events, 8);
     for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
 
-    // Step 4: Complete send (proxy routes don't populate send_buf — treat as not replayable)
+    // Step 4: Proxy/forward routes are not replayable here. The replay
+    // harness validates static response decisions only; proxy routes
+    // either submit an upstream connect or synthesize a local 502 if
+    // socket creation fails. In both cases upstream_name has been
+    // populated before the route leaves on_header_received.
+    if (conn->upstream_name[0] != '\0' || conn->state == ConnState::Proxying) {
+        const i32 saved_upstream_fd = conn->upstream_fd;
+        if (saved_upstream_fd >= 0) conn->upstream_fd = -1;
+        loop.close_conn(*conn);
+        if (saved_upstream_fd >= 0) ::close(saved_upstream_fd);
+        result.skipped = true;
+        return result;
+    }
+
+    // Step 5: Complete send (non-static routes that didn't generate a response are not replayable)
     u32 send_len = conn->send_buf.len();
     if (send_len == 0) {
-        // Proxy route initiated upstream connect instead of generating a response.
-        // Close and report as not replayed (replay only validates static routes).
-        IoEvent eof_ev = {conn->id, 0, 0, 0, IoEventType::Recv, 0};
-        loop.inject_and_dispatch(eof_ev);
+        const i32 saved_upstream_fd = conn->upstream_fd;
+        if (saved_upstream_fd >= 0) conn->upstream_fd = -1;
+        loop.close_conn(*conn);
+        if (saved_upstream_fd >= 0) ::close(saved_upstream_fd);
+        result.skipped = true;
         return result;
     }
     IoEvent send_ev = {conn->id, static_cast<i32>(send_len), 0, 0, IoEventType::Send, 0};
@@ -170,7 +189,7 @@ ReplayResult replay_one(Loop& loop, const CaptureEntry& entry, i32 fake_fd) {
     result.status_match = (result.expected_status == result.actual_status);
     result.replayed = true;
 
-    // Step 5: Close connection (inject EOF to free the slot)
+    // Step 6: Close connection (inject EOF to free the slot)
     IoEvent eof_ev = {conn->id, 0, 0, 0, IoEventType::Recv, 0};
     loop.inject_and_dispatch(eof_ev);
 
@@ -195,7 +214,10 @@ ReplaySummary replay_file(Loop& loop, ReplayReader& reader) {
             else
                 summary.mismatched++;
         } else {
-            summary.failed++;
+            if (result.skipped)
+                summary.skipped++;
+            else
+                summary.failed++;
         }
     }
     return summary;

--- a/tests/test_traffic_replay.cc
+++ b/tests/test_traffic_replay.cc
@@ -634,16 +634,15 @@ TEST(replay_gap, format_static_response_wire_format) {
     }
 }
 
-// G4. Proxy route socket fail → 502 (via replay, not manual proxy setup)
-// Note: In SmallLoop, UpstreamPool::create_socket() calls real socket()
-// which typically succeeds. We can't easily force it to fail without
-// mocking. Instead, test the proxy route path works end-to-end by
-// verifying the connection enters Proxying state.
-TEST(replay_gap, proxy_route_enters_proxy_state) {
+// G4. Proxy route path is selected (manual setup). In SmallLoop,
+// UpstreamPool::create_socket() calls real socket(), which can fail in
+// sandboxed test environments. Either outcome is valid for this test:
+// success submits an upstream connect; failure generates a local 502.
+TEST(replay_gap, proxy_route_enters_proxy_path) {
     RouteConfig cfg;
     auto up_result = cfg.add_upstream("backend", 0x7F000001, 9999);
     REQUIRE(up_result.has_value());
-    cfg.add_proxy("/api", 0, static_cast<u16>(up_result.value()));
+    REQUIRE(cfg.add_proxy("/api", 0, static_cast<u16>(up_result.value())));
 
     RoutedLoop rl;
     rl.setup(&cfg);
@@ -663,18 +662,71 @@ TEST(replay_gap, proxy_route_enters_proxy_state) {
     u32 n = rl.loop.backend.wait(events, 8);
     for (u32 i = 0; i < n; i++) rl.loop.dispatch(events[i]);
 
-    // Should be in proxy state with upstream_fd set
-    CHECK_EQ(conn->state, ConnState::Proxying);
-    CHECK(conn->upstream_fd >= 0);
-
-    // upstream_name should be copied
+    // upstream_name is copied before either connect submission or
+    // socket-failure fallback, so it proves the proxy route matched.
     CHECK_EQ(conn->upstream_name[0], 'b');  // "backend"
 
-    // Clean up the real socket
-    close(conn->upstream_fd);
-    conn->upstream_fd = -1;
-    // Close connection
-    rl.loop.inject_and_dispatch(make_ev(conn->id, IoEventType::Recv, 0));
+    if (conn->state == ConnState::Proxying) {
+        auto* connect_op = rl.loop.backend.last_op(MockOp::Connect);
+        REQUIRE(connect_op != nullptr);
+        CHECK_EQ(connect_op->conn_id, conn->id);
+    } else {
+        CHECK_EQ(conn->state, ConnState::Sending);
+        CHECK_EQ(conn->resp_status, 502u);
+        CHECK_GT(conn->send_buf.len(), 0u);
+    }
+
+    if (conn->upstream_fd >= 0) {
+        close(conn->upstream_fd);
+        conn->upstream_fd = -1;
+    }
+    rl.loop.close_conn(*conn);
+}
+
+TEST(replay_gap, replay_one_proxy_route_not_replayed) {
+    RouteConfig cfg;
+    auto up_result = cfg.add_upstream("backend", 0x7F000001, 9999);
+    REQUIRE(up_result.has_value());
+    REQUIRE(cfg.add_proxy("/api", 0, static_cast<u16>(up_result.value())));
+
+    RoutedLoop rl;
+    rl.setup(&cfg);
+
+    CaptureEntry entry = make_captured_request("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 200);
+    ReplayResult result = replay_one(rl.loop, entry, 42);
+    CHECK(!result.replayed);
+    CHECK(result.skipped);
+    CHECK_EQ(result.expected_status, 200);
+    CHECK_EQ(result.actual_status, 0);
+    CHECK(!result.status_match);
+}
+
+TEST(replay_gap, replay_file_proxy_route_counted_as_skipped) {
+    RouteConfig cfg;
+    auto up_result = cfg.add_upstream("backend", 0x7F000001, 9999);
+    REQUIRE(up_result.has_value());
+    REQUIRE(cfg.add_proxy("/api", 0, static_cast<u16>(up_result.value())));
+    REQUIRE(cfg.add_static("/health", 0, 200));
+
+    RoutedLoop rl;
+    rl.setup(&cfg);
+
+    CaptureEntry entries[2];
+    entries[0] = make_captured_request("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 200);
+    entries[1] = make_captured_request("GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 200);
+    TempCapture tmp;
+    REQUIRE(tmp.create(entries, 2));
+
+    ReplayReader reader;
+    REQUIRE(reader.open(tmp.path) == 0);
+    ReplaySummary summary = replay_file(rl.loop, reader);
+    CHECK_EQ(summary.total, 2u);
+    CHECK_EQ(summary.replayed, 1u);
+    CHECK_EQ(summary.matched, 1u);
+    CHECK_EQ(summary.skipped, 1u);
+    CHECK_EQ(summary.failed, 0u);
+    reader.close();
+    tmp.cleanup();
 }
 
 // G5. Query string in path: /health?foo=bar should match /health prefix


### PR DESCRIPTION
## Summary

- Treat proxy/forward paths in `replay_one` as not replayable instead of counting local 502 fallback responses as successful replay results.
- Add a regression test for proxy-route replay returning `replayed=false`.
- Make the existing proxy-route test robust when test environments deny real socket creation.
- Mark the matching replay coverage TODO as complete.

## Validation

- `build/tests/test_traffic_replay`