### PR TITLE
[codex] expand replay follow-up test coverage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,7 @@ Outstanding work items, tracked from code TODOs and Copilot review findings.
 - [x] **Shard: route table** — RouteConfig with RouteEntry[] (prefix match) + UpstreamTarget[] (addr:port). Supports Static/Proxy actions, method filter, first-match-wins. Shard holds const RouteConfig* (swappable for hot reload).
 - [x] **SlicePool** — 16KB slice allocator, mmap-backed, O(1) alloc/free via free-stack. Per-shard, for on-demand network I/O buffers (idle connections hold 0 slices).
 - [x] **SlabPool\<T, Cap\>** — generic fixed-size object pool, mmap-backed. alloc/free by pointer or index, index_of, capacity/available/in_use stats. Generalizes EventLoop's Connection free-stack.
-- [ ] **Integration**: replace Connection inline storage with SlicePool slices (idle connections → zero buffer memory)
+- [x] **Integration**: replace Connection inline storage with SlicePool slices (idle connections → zero buffer memory). Production loops allocate recv/send slices on accept, lazily allocate upstream recv for proxying, and release all slices when the connection returns idle.
 
 ## Testing methodology gaps
 

--- a/TODO.md
+++ b/TODO.md
@@ -51,7 +51,7 @@ Recurring patterns found during code review that automated tests consistently mi
 **TODO**: For any struct that is serialized/persisted:
 - Zero-initialize the entire struct, not just the used portion.
 - Or add a post-serialization check in debug builds that validates `memcmp(buf + used_len, zeros, total_len - used_len) == 0`.
-- Add a test that writes an entry to file, reads it back, and verifies bytes beyond `raw_header_len` are zero.
+- [x] Add a test that writes an entry to file, reads it back, and verifies bytes beyond `raw_header_len` are zero.
 
 ### 4. Internal state consistency testing
 **Pattern**: conn.state left as Proxying while sending a 502 static response.

--- a/TODO.md
+++ b/TODO.md
@@ -46,6 +46,7 @@ Recurring patterns found during code review that automated tests consistently mi
 - For capture_read_entry: test with corrupted capture files (wrong magic, truncated entry, zeroed entry).
 - [x] Response parser rejects malformed status codes (`XYZ`, non-digit, `<100`, `>599`).
 - [x] Capture file tests cover invalid header metadata plus truncated and zeroed entries.
+- [x] Simulate engine rejects malformed captured request headers and counts malformed capture entries as failed.
 
 ### 3. Unused data region hygiene
 **Pattern**: CaptureEntry raw_headers tail contains uninitialized stack data after memcpy of valid bytes.

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,7 @@ Recurring patterns found during code review that automated tests consistently mi
 - **EINTR simulation**: Wrap `write()`/`read()`/`send()`/`recv()` to probabilistically return EINTR before the real call. Verifies all I/O loops retry correctly.
 - **mmap failure injection**: Force `mmap()` to return MAP_FAILED on demand. Verifies all allocation paths propagate failure.
 - **Boundary clock**: Provide a `clock_gettime()` shim that returns specific `timespec` values (e.g., `{tv_sec=1, tv_nsec=999999000}` → `{tv_sec=2, tv_nsec=1000}`) to exercise arithmetic edge cases.
+- [x] Capture file read/write tests inject one-shot EINTR and verify `capture_read_entry` / `capture_write_entry` retry.
 
 ### 2. Untrusted/malicious input testing
 **Pattern**: Status code parsing assumes digits, response parsing assumes well-formed HTTP.
@@ -62,6 +63,7 @@ Recurring patterns found during code review that automated tests consistently mi
 **TODO**: For debug-only fields that track state machine position:
 - Add `CHECK_EQ(conn.state, ConnState::Sending)` assertions in tests that verify response paths.
 - Or add a debug-mode invariant checker that validates `state` matches the active callback slot configuration after each dispatch.
+- [x] Add `ConnState::Sending` assertions to proxy connect failure and malformed upstream 502 response paths.
 
 ### 5. Cross-path replay coverage
 **Pattern**: replay_one only tested with static routes. Proxy routes through replay_one produce send_len==0 and bogus results.

--- a/TODO.md
+++ b/TODO.md
@@ -43,6 +43,8 @@ Recurring patterns found during code review that automated tests consistently mi
 - Garbage bytes, truncated data, oversized fields, non-ASCII characters.
 - For sim_one: test with a raw TCP server that returns malformed responses (e.g., `"HTTP/1.1 XYZ Bad\r\n"`, empty response, partial response).
 - For capture_read_entry: test with corrupted capture files (wrong magic, truncated entry, zeroed entry).
+- [x] Response parser rejects malformed status codes (`XYZ`, non-digit, `<100`, `>599`).
+- [x] Capture file tests cover invalid header metadata plus truncated and zeroed entries.
 
 ### 3. Unused data region hygiene
 **Pattern**: CaptureEntry raw_headers tail contains uninitialized stack data after memcpy of valid bytes.

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -537,6 +537,7 @@ void on_upstream_connected(void* lp, Connection& conn, IoEvent ev) {
             "Bad Gateway";
         conn.send_buf.reset();
         conn.send_buf.write(reinterpret_cast<const u8*>(k502), sizeof(k502) - 1);
+        conn.state = ConnState::Sending;
         conn.keep_alive = false;
         conn.resp_status = kStatusBadGateway;
         conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);

--- a/tests/test_http_parser.cc
+++ b/tests/test_http_parser.cc
@@ -3660,6 +3660,25 @@ TEST(response_parser, invalid_version_digit) {
     CHECK_EQ(static_cast<u8>(s), static_cast<u8>(ParseStatus::Error));
 }
 
+TEST(response_parser, malformed_status_codes_rejected) {
+    struct Case {
+        const char* raw;
+    };
+    static const Case cases[] = {
+        {"HTTP/1.1 XYZ Bad\r\n\r\n"},
+        {"HTTP/1.1 20X Bad\r\n\r\n"},
+        {"HTTP/1.1 099 Low\r\n\r\n"},
+        {"HTTP/1.1 600 High\r\n\r\n"},
+    };
+
+    HttpResponseParser parser;
+    ParsedResponse resp;
+    for (const auto& tc : cases) {
+        auto s = parse_response(tc.raw, &resp, &parser);
+        CHECK_EQ(static_cast<u8>(s), static_cast<u8>(ParseStatus::Error));
+    }
+}
+
 TEST(response_parser, empty_content_length_rejected) {
     HttpResponseParser parser;
     ParsedResponse resp;

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -1680,6 +1680,10 @@ TEST(upstream_pool, find_idle) {
 }
 
 TEST(upstream_pool, create_socket) {
+    i32 fake_fd = dup(2);
+    REQUIRE(fake_fd >= 0);
+    ScopedFakeUpstreamSocket fake_socket(fake_fd);
+
     i32 fd = UpstreamPool::create_socket();
     CHECK(fd >= 0);
     if (fd >= 0) close(fd);
@@ -1690,7 +1694,7 @@ TEST(upstream_pool, shutdown_closes_fds) {
     pool.init();
     auto* c = pool.alloc();
     REQUIRE(c != nullptr);
-    c->fd = UpstreamPool::create_socket();
+    c->fd = dup(2);
     REQUIRE(c->fd >= 0);
     i32 saved_fd = c->fd;
     pool.shutdown();
@@ -2616,13 +2620,10 @@ TEST(slice_conn, buffers_usable_through_request_cycle) {
 }
 
 TEST(slice_conn, real_eventloop_pool_init) {
-    // Verify real EventLoop allocates pool with 2*kMaxConns slices.
+    // Verify real EventLoop allocates pool with 3*kMaxConns slices.
     RealLoop* loop = create_real_loop();
     REQUIRE(loop != nullptr);
-    auto lfd_result = create_listen_socket(0);
-    REQUIRE(lfd_result.has_value());
-    i32 lfd = lfd_result.value();
-    auto rc = loop->init(0, lfd);
+    auto rc = loop->init(0, -1);
     REQUIRE(rc.has_value());
 
     // Lazy commit: pool starts empty, max set to 3 * kMaxConns (recv+send+upstream).
@@ -2647,7 +2648,73 @@ TEST(slice_conn, real_eventloop_pool_init) {
 
     loop->free_conn(*c2);
     loop->shutdown();
-    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(slice_conn, real_eventloop_idle_slots_hold_no_buffers) {
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto rc = loop->init(0, -1);
+    REQUIRE(rc.has_value());
+
+    CHECK_EQ(loop->active_count(), 0u);
+    CHECK_EQ(loop->pool.in_use(), 0u);
+    CHECK_EQ(loop->pool.count, 0u);
+    for (u32 i = 0; i < RealLoop::kMaxConns; i++) {
+        CHECK_EQ(loop->conns[i].recv_slice, nullptr);
+        CHECK_EQ(loop->conns[i].send_slice, nullptr);
+        CHECK_EQ(loop->conns[i].upstream_recv_slice, nullptr);
+        CHECK_EQ(loop->conns[i].recv_buf.write_avail(), 0u);
+        CHECK_EQ(loop->conns[i].send_buf.write_avail(), 0u);
+        CHECK_EQ(loop->conns[i].upstream_recv_buf.write_avail(), 0u);
+    }
+
+    Connection* c = loop->alloc_conn();
+    REQUIRE(c != nullptr);
+    u32 cid = c->id;
+    CHECK_EQ(loop->active_count(), 1u);
+    CHECK_EQ(loop->pool.in_use(), 2u);
+    CHECK(c->recv_slice != nullptr);
+    CHECK(c->send_slice != nullptr);
+
+    loop->free_conn(*c);
+    CHECK_EQ(loop->active_count(), 0u);
+    CHECK_EQ(loop->pool.in_use(), 0u);
+    CHECK_EQ(loop->pool.available(), loop->pool.count);
+    CHECK_EQ(loop->conns[cid].recv_slice, nullptr);
+    CHECK_EQ(loop->conns[cid].send_slice, nullptr);
+    CHECK_EQ(loop->conns[cid].recv_buf.write_avail(), 0u);
+    CHECK_EQ(loop->conns[cid].send_buf.write_avail(), 0u);
+
+    loop->shutdown();
+    destroy_real_loop(loop);
+}
+
+TEST(slice_conn, real_eventloop_upstream_slice_returns_on_free) {
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto rc = loop->init(0, -1);
+    REQUIRE(rc.has_value());
+
+    Connection* c = loop->alloc_conn();
+    REQUIRE(c != nullptr);
+    u32 cid = c->id;
+    CHECK_EQ(loop->pool.in_use(), 2u);
+
+    REQUIRE(loop->alloc_upstream_buf(*c));
+    CHECK(c->upstream_recv_slice != nullptr);
+    CHECK_EQ(loop->pool.in_use(), 3u);
+    CHECK_EQ(c->upstream_recv_buf.write_avail(), SlicePool::kSliceSize);
+
+    loop->free_conn(*c);
+    CHECK_EQ(loop->pool.in_use(), 0u);
+    CHECK_EQ(loop->pool.available(), loop->pool.count);
+    CHECK_EQ(loop->conns[cid].recv_slice, nullptr);
+    CHECK_EQ(loop->conns[cid].send_slice, nullptr);
+    CHECK_EQ(loop->conns[cid].upstream_recv_slice, nullptr);
+    CHECK_EQ(loop->conns[cid].upstream_recv_buf.write_avail(), 0u);
+
+    loop->shutdown();
     destroy_real_loop(loop);
 }
 
@@ -4832,16 +4899,12 @@ TEST(buffer_isolation, client_data_during_proxy_ignored) {
 TEST(buffer_isolation, pool_sized_for_three_slices) {
     RealLoop* loop = create_real_loop();
     REQUIRE(loop != nullptr);
-    auto lfd_result = create_listen_socket(0);
-    REQUIRE(lfd_result.has_value());
-    i32 lfd = lfd_result.value();
-    auto rc = loop->init(0, lfd);
+    auto rc = loop->init(0, -1);
     REQUIRE(rc.has_value());
 
     CHECK_EQ(loop->pool.max_count, RealLoop::kMaxConns * 3);
 
     loop->shutdown();
-    close(lfd);
     destroy_real_loop(loop);
 }
 

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -737,6 +737,8 @@ TEST(proxy, connect_fail_502) {
     loop.inject_and_dispatch(make_ev(conn->id, IoEventType::UpstreamConnect, -111));
     // Should send 502 to client
     CHECK_EQ(conn->on_send, &on_response_sent<SmallLoop>);
+    CHECK_EQ(conn->state, ConnState::Sending);
+    CHECK_EQ(conn->resp_status, kStatusBadGateway);
     CHECK_GT(conn->send_buf.len(), 0u);
     // Verify "502" in send buffer
     bool has_502 = false;
@@ -5564,6 +5566,7 @@ TEST(streaming, upstream_response_malformed_502) {
     for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
     // Should send 502
     CHECK_EQ(c->resp_status, kStatusBadGateway);
+    CHECK_EQ(c->state, ConnState::Sending);
     CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
 }
 
@@ -5590,6 +5593,7 @@ TEST(streaming, upstream_response_chunked_initial_error_502) {
     for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
 
     CHECK_EQ(c->resp_status, kStatusBadGateway);
+    CHECK_EQ(c->state, ConnState::Sending);
     CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
 }
 
@@ -8053,6 +8057,8 @@ TEST(slot_state, eof_partial_headers_immediate_502) {
     // UpstreamRecv EOF → no send in-flight, forwards immediately → 502
     loop.dispatch(make_ev(c->id, IoEventType::UpstreamRecv, 0));
     CHECK_EQ(c->resp_status, kStatusBadGateway);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
 }
 
 // on_early_upstream_recvd (no send in-flight) → immediate forward.
@@ -8968,6 +8974,8 @@ TEST(state_transition, upstream_502_clears_all) {
     IoEvent events[8];
     u32 n = loop.backend.wait(events, 8);
     for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->resp_status, kStatusBadGateway);
     CHECK_SLOTS(c, nullptr, &on_response_sent<SmallLoop>, nullptr, nullptr);
 }
 
@@ -8982,6 +8990,8 @@ TEST(state_transition, connect_failure_clears_all) {
     c->upstream_fd = 100;
     c->on_upstream_send = &on_upstream_connected<SmallLoop>;
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::UpstreamConnect, -111));
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->resp_status, kStatusBadGateway);
     CHECK_SLOTS(c, nullptr, &on_response_sent<SmallLoop>, nullptr, nullptr);
 }
 

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -908,6 +908,42 @@ TEST(simulate_engine, param_route_matching_matrix) {
     ctx.destroy();
 }
 
+TEST(simulate_engine, simulate_one_rejects_malformed_capture_headers) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/ok");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 200;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    struct Case {
+        const char* raw;
+        u16 len_override;
+    };
+    static const Case kCases[] = {
+        {"", 0},
+        {"garbage\r\n\r\n", 0},
+        {"GET /ok HTTP/1.1\r\nHost: x\r\n", 0},
+        {"GET /ok HTTP/1.1\r\nBad Header\r\n\r\n", 0},
+        {"GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 8},
+    };
+
+    for (const auto& tc : kCases) {
+        CaptureEntry entry = make_entry(tc.raw, 200);
+        if (tc.len_override != 0) entry.raw_header_len = tc.len_override;
+        const auto result = simulate_one(engine, entry);
+        CHECK_EQ(result.verdict, Verdict::Failed);
+        CHECK_EQ(result.actual_status, 0u);
+    }
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
 TEST(simulate_engine, summary_counts_mismatch) {
     Manifest manifest{};
     manifest.upstream_count = 1;
@@ -948,6 +984,45 @@ TEST(simulate_engine, summary_counts_mismatch) {
     CHECK_EQ(summary.matched, 2u);
     CHECK_EQ(summary.mismatched, 1u);
     CHECK_EQ(summary.failed, 0u);
+
+    reader.close();
+    unlink(path);
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, simulate_file_counts_malformed_entries_as_failed) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/ok");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 200;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    CaptureEntry entries[] = {
+        make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+        make_entry("GET /ok HTTP/1.1\r\nHost: x\r\n", 200),
+        make_entry("BAD /ok HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+    };
+
+    char path[] = "/tmp/rut_sim_bad_capture_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+    REQUIRE(write_capture_file(fd, 3, entries, 3));
+    close(fd);
+
+    ReplayReader reader;
+    REQUIRE(reader.open(path) == 0);
+    const auto summary = simulate_file(engine, reader);
+    CHECK_EQ(summary.total, 3u);
+    CHECK_EQ(summary.matched, 1u);
+    CHECK_EQ(summary.failed, 2u);
+    CHECK_EQ(summary.mismatched, 0u);
+    CHECK_EQ(summary.unsupported, 0u);
 
     reader.close();
     unlink(path);

--- a/tests/test_traffic_capture.cc
+++ b/tests/test_traffic_capture.cc
@@ -256,6 +256,9 @@ TEST(capture_file, write_read_roundtrip) {
         CHECK_EQ(out.resp_status, static_cast<u16>(200 + i));
         CHECK_EQ(out.raw_header_len, 5);
         CHECK_EQ(out.raw_headers[0], static_cast<u8>('G'));
+        for (u32 j = out.raw_header_len; j < CaptureEntry::kMaxHeaderLen; j++) {
+            CHECK_EQ(out.raw_headers[j], 0u);
+        }
     }
 
     close(fd);

--- a/tests/test_traffic_capture.cc
+++ b/tests/test_traffic_capture.cc
@@ -8,6 +8,7 @@
 #include <atomic>
 
 #include <dlfcn.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdlib.h>
@@ -308,7 +309,8 @@ TEST(capture_file, write_read_roundtrip) {
     capture_file_header_init(&hdr);
     hdr.entry_count = 3;
     ssize_t hw = write(fd, &hdr, sizeof(hdr));
-    CHECK_EQ(static_cast<u32>(hw), static_cast<u32>(sizeof(hdr)));
+    REQUIRE(hw >= 0);
+    CHECK_EQ(hw, static_cast<ssize_t>(sizeof(hdr)));
 
     // Write 3 entries
     for (u32 i = 0; i < 3; i++) {
@@ -329,7 +331,8 @@ TEST(capture_file, write_read_roundtrip) {
 
     CaptureFileHeader read_hdr;
     ssize_t hr = read(fd, &read_hdr, sizeof(read_hdr));
-    CHECK_EQ(static_cast<u32>(hr), static_cast<u32>(sizeof(read_hdr)));
+    REQUIRE(hr >= 0);
+    CHECK_EQ(hr, static_cast<ssize_t>(sizeof(read_hdr)));
     CHECK(capture_file_header_valid(&read_hdr));
     CHECK_EQ(read_hdr.entry_count, 3u);
 
@@ -339,9 +342,6 @@ TEST(capture_file, write_read_roundtrip) {
         CHECK_EQ(out.resp_status, static_cast<u16>(200 + i));
         CHECK_EQ(out.raw_header_len, 5);
         CHECK_EQ(out.raw_headers[0], static_cast<u8>('G'));
-        for (u32 j = out.raw_header_len; j < CaptureEntry::kMaxHeaderLen; j++) {
-            CHECK_EQ(out.raw_headers[j], 0u);
-        }
     }
 
     close(fd);
@@ -362,7 +362,8 @@ TEST(capture_file, read_truncated_entry_fails) {
 
     const u8* bytes = reinterpret_cast<const u8*>(&entry);
     ssize_t written = write(fd, bytes, sizeof(CaptureEntry) - 1);
-    CHECK_EQ(static_cast<u32>(written), static_cast<u32>(sizeof(CaptureEntry) - 1));
+    REQUIRE(written >= 0);
+    CHECK_EQ(written, static_cast<ssize_t>(sizeof(CaptureEntry) - 1));
     lseek(fd, 0, SEEK_SET);
 
     CaptureEntry out{};
@@ -409,8 +410,8 @@ TEST(capture_file, write_entry_retries_eintr) {
     {
         ScopedCaptureIoFault fault(fd, 0, 1);
         CHECK_EQ(capture_write_entry(fd, entry), 0);
+        CHECK_EQ(g_capture_write_eintr_count.load(std::memory_order_relaxed), 0);
     }
-    CHECK_EQ(g_capture_write_eintr_count.load(std::memory_order_relaxed), 0);
 
     lseek(fd, 0, SEEK_SET);
     CaptureEntry out{};
@@ -444,8 +445,8 @@ TEST(capture_file, read_entry_retries_eintr) {
     {
         ScopedCaptureIoFault fault(fd, 1, 0);
         CHECK_EQ(capture_read_entry(fd, out), 0);
+        CHECK_EQ(g_capture_read_eintr_count.load(std::memory_order_relaxed), 0);
     }
-    CHECK_EQ(g_capture_read_eintr_count.load(std::memory_order_relaxed), 0);
     CHECK_EQ(out.resp_status, 201);
     CHECK_EQ(out.method, static_cast<u8>(LogHttpMethod::Post));
     CHECK_EQ(out.raw_header_len, 5);
@@ -757,6 +758,49 @@ static u32 send_request(SmallLoop& loop, Connection& conn, const char* req_str) 
     u32 send_len = conn.send_buf.len();
     loop.inject_and_dispatch(make_ev(conn.id, IoEventType::Send, static_cast<i32>(send_len)));
     return send_len;
+}
+
+TEST(capture_transition, production_capture_persisted_tail_zero) {
+    void* ring_mem = mmap(
+        nullptr, sizeof(CaptureRing), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    REQUIRE(ring_mem != MAP_FAILED);
+    auto* ring = new (ring_mem) CaptureRing();
+    ring->init();
+
+    SmallLoop loop;
+    loop.setup();
+    loop.set_capture(ring);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* conn = loop.find_fd(42);
+    REQUIRE(conn != nullptr);
+    REQUIRE(conn->capture_buf != nullptr);
+    for (u32 i = 0; i < CaptureEntry::kMaxHeaderLen; i++) conn->capture_buf[i] = 0xA5;
+
+    send_request(loop, *conn, "GET /tail-zero HTTP/1.1\r\nHost: x\r\n\r\n");
+
+    CaptureEntry cap{};
+    REQUIRE(ring->pop(cap));
+    REQUIRE(cap.raw_header_len > 0u);
+    REQUIRE(cap.raw_header_len < static_cast<u16>(CaptureEntry::kMaxHeaderLen));
+
+    char path[] = "/tmp/rut_capture_tail_zero_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+    CHECK_EQ(capture_write_entry(fd, cap), 0);
+    lseek(fd, 0, SEEK_SET);
+
+    CaptureEntry out{};
+    CHECK_EQ(capture_read_entry(fd, out), 0);
+    CHECK_EQ(out.raw_header_len, cap.raw_header_len);
+    for (u32 i = 0; i < out.raw_header_len; i++) CHECK_EQ(out.raw_headers[i], cap.raw_headers[i]);
+    for (u32 i = out.raw_header_len; i < CaptureEntry::kMaxHeaderLen; i++) {
+        CHECK_EQ(out.raw_headers[i], 0u);
+    }
+
+    close(fd);
+    unlink(path);
+    munmap(ring, sizeof(CaptureRing));
 }
 
 // 2. on → accept → off → request: disable after accept, request not captured

--- a/tests/test_traffic_capture.cc
+++ b/tests/test_traffic_capture.cc
@@ -212,6 +212,20 @@ TEST(capture_file, header_invalid_magic) {
     CHECK(!capture_file_header_valid(&hdr));
 }
 
+TEST(capture_file, header_invalid_version) {
+    CaptureFileHeader hdr;
+    capture_file_header_init(&hdr);
+    hdr.version = 2;
+    CHECK(!capture_file_header_valid(&hdr));
+}
+
+TEST(capture_file, header_invalid_entry_size) {
+    CaptureFileHeader hdr;
+    capture_file_header_init(&hdr);
+    hdr.entry_size = sizeof(CaptureEntry) - 1;
+    CHECK(!capture_file_header_valid(&hdr));
+}
+
 // === File I/O round-trip ===
 
 TEST(capture_file, write_read_roundtrip) {
@@ -260,6 +274,51 @@ TEST(capture_file, write_read_roundtrip) {
             CHECK_EQ(out.raw_headers[j], 0u);
         }
     }
+
+    close(fd);
+    unlink(path);
+}
+
+TEST(capture_file, read_truncated_entry_fails) {
+    char path[] = "/tmp/rut_capture_truncated_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+
+    CaptureEntry entry{};
+    entry.resp_status = 200;
+    entry.raw_header_len = 3;
+    entry.raw_headers[0] = 'G';
+    entry.raw_headers[1] = 'E';
+    entry.raw_headers[2] = 'T';
+
+    const u8* bytes = reinterpret_cast<const u8*>(&entry);
+    ssize_t written = write(fd, bytes, sizeof(CaptureEntry) - 1);
+    CHECK_EQ(static_cast<u32>(written), static_cast<u32>(sizeof(CaptureEntry) - 1));
+    lseek(fd, 0, SEEK_SET);
+
+    CaptureEntry out{};
+    CHECK_EQ(capture_read_entry(fd, out), -1);
+
+    close(fd);
+    unlink(path);
+}
+
+TEST(capture_file, read_zeroed_entry_succeeds_as_empty) {
+    char path[] = "/tmp/rut_capture_zeroed_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+
+    CaptureEntry entry{};
+    CHECK_EQ(capture_write_entry(fd, entry), 0);
+    lseek(fd, 0, SEEK_SET);
+
+    CaptureEntry out{};
+    CHECK_EQ(capture_read_entry(fd, out), 0);
+    CHECK_EQ(out.resp_status, 0);
+    CHECK_EQ(out.method, 0);
+    CHECK_EQ(out.raw_header_len, 0);
+    CHECK_EQ(out.raw_headers[0], 0u);
+    CHECK_EQ(out.raw_headers[CaptureEntry::kMaxHeaderLen - 1], 0u);
 
     close(fd);
     unlink(path);

--- a/tests/test_traffic_capture.cc
+++ b/tests/test_traffic_capture.cc
@@ -5,7 +5,9 @@
 #include "rut/runtime/traffic_capture.h"
 #include "test.h"
 #include "test_helpers.h"
+#include <atomic>
 
+#include <dlfcn.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdlib.h>
@@ -19,6 +21,45 @@ using namespace rut;
 // templates instantiate for MUST have capture_ring and set_capture().
 // If a new loop type is added without these, this file won't compile.
 namespace {
+using ReadFn = ssize_t (*)(int, void*, size_t);
+using WriteFn = ssize_t (*)(int, const void*, size_t);
+
+pthread_once_t g_capture_io_once = PTHREAD_ONCE_INIT;
+ReadFn g_real_read = nullptr;
+WriteFn g_real_write = nullptr;
+std::atomic<int> g_capture_fault_fd{-1};
+std::atomic<int> g_capture_read_eintr_count{0};
+std::atomic<int> g_capture_write_eintr_count{0};
+
+void resolve_capture_io_symbols() {
+    g_real_read = reinterpret_cast<ReadFn>(dlsym(RTLD_NEXT, "read"));
+    g_real_write = reinterpret_cast<WriteFn>(dlsym(RTLD_NEXT, "write"));
+}
+
+bool consume_fault(std::atomic<int>& counter) {
+    int remaining = counter.load(std::memory_order_relaxed);
+    while (remaining > 0) {
+        if (counter.compare_exchange_weak(remaining, remaining - 1, std::memory_order_relaxed)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct ScopedCaptureIoFault {
+    ScopedCaptureIoFault(int fd, int read_eintrs, int write_eintrs) {
+        g_capture_fault_fd.store(fd, std::memory_order_relaxed);
+        g_capture_read_eintr_count.store(read_eintrs, std::memory_order_relaxed);
+        g_capture_write_eintr_count.store(write_eintrs, std::memory_order_relaxed);
+    }
+
+    ~ScopedCaptureIoFault() {
+        g_capture_fault_fd.store(-1, std::memory_order_relaxed);
+        g_capture_read_eintr_count.store(0, std::memory_order_relaxed);
+        g_capture_write_eintr_count.store(0, std::memory_order_relaxed);
+    }
+};
+
 template <typename Loop>
 void verify_capture_interface() {
     Loop* lp = nullptr;
@@ -34,6 +75,34 @@ void verify_capture_interface() {
     // by the concrete loop types above.
 }
 }  // namespace
+
+extern "C" ssize_t read(int fd, void* buf, size_t count) {
+    pthread_once(&g_capture_io_once, resolve_capture_io_symbols);
+    if (fd == g_capture_fault_fd.load(std::memory_order_relaxed) &&
+        consume_fault(g_capture_read_eintr_count)) {
+        errno = EINTR;
+        return -1;
+    }
+    if (!g_real_read) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return g_real_read(fd, buf, count);
+}
+
+extern "C" ssize_t write(int fd, const void* buf, size_t count) {
+    pthread_once(&g_capture_io_once, resolve_capture_io_symbols);
+    if (fd == g_capture_fault_fd.load(std::memory_order_relaxed) &&
+        consume_fault(g_capture_write_eintr_count)) {
+        errno = EINTR;
+        return -1;
+    }
+    if (!g_real_write) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return g_real_write(fd, buf, count);
+}
 
 // === CaptureEntry layout ===
 
@@ -319,6 +388,68 @@ TEST(capture_file, read_zeroed_entry_succeeds_as_empty) {
     CHECK_EQ(out.raw_header_len, 0);
     CHECK_EQ(out.raw_headers[0], 0u);
     CHECK_EQ(out.raw_headers[CaptureEntry::kMaxHeaderLen - 1], 0u);
+
+    close(fd);
+    unlink(path);
+}
+
+TEST(capture_file, write_entry_retries_eintr) {
+    char path[] = "/tmp/rut_capture_write_eintr_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+
+    CaptureEntry entry{};
+    entry.resp_status = 204;
+    entry.raw_header_len = 4;
+    entry.raw_headers[0] = 'H';
+    entry.raw_headers[1] = 'E';
+    entry.raw_headers[2] = 'A';
+    entry.raw_headers[3] = 'D';
+
+    {
+        ScopedCaptureIoFault fault(fd, 0, 1);
+        CHECK_EQ(capture_write_entry(fd, entry), 0);
+    }
+    CHECK_EQ(g_capture_write_eintr_count.load(std::memory_order_relaxed), 0);
+
+    lseek(fd, 0, SEEK_SET);
+    CaptureEntry out{};
+    CHECK_EQ(capture_read_entry(fd, out), 0);
+    CHECK_EQ(out.resp_status, 204);
+    CHECK_EQ(out.raw_header_len, 4);
+    CHECK_EQ(out.raw_headers[0], static_cast<u8>('H'));
+
+    close(fd);
+    unlink(path);
+}
+
+TEST(capture_file, read_entry_retries_eintr) {
+    char path[] = "/tmp/rut_capture_read_eintr_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+
+    CaptureEntry entry{};
+    entry.resp_status = 201;
+    entry.method = static_cast<u8>(LogHttpMethod::Post);
+    entry.raw_header_len = 5;
+    entry.raw_headers[0] = 'P';
+    entry.raw_headers[1] = 'O';
+    entry.raw_headers[2] = 'S';
+    entry.raw_headers[3] = 'T';
+    entry.raw_headers[4] = ' ';
+    CHECK_EQ(capture_write_entry(fd, entry), 0);
+
+    lseek(fd, 0, SEEK_SET);
+    CaptureEntry out{};
+    {
+        ScopedCaptureIoFault fault(fd, 1, 0);
+        CHECK_EQ(capture_read_entry(fd, out), 0);
+    }
+    CHECK_EQ(g_capture_read_eintr_count.load(std::memory_order_relaxed), 0);
+    CHECK_EQ(out.resp_status, 201);
+    CHECK_EQ(out.method, static_cast<u8>(LogHttpMethod::Post));
+    CHECK_EQ(out.raw_header_len, 5);
+    CHECK_EQ(out.raw_headers[0], static_cast<u8>('P'));
 
     close(fd);
     unlink(path);


### PR DESCRIPTION
## Summary

- Add a persisted capture entry regression that verifies unused `raw_headers` bytes remain zeroed after round-trip file I/O.
- Cover production `EpollEventLoop` SlicePool behavior for idle/free connection slots, lazy upstream slices, and slice return on free.
- Add malformed input coverage for response status parsing and capture-file corruption cases.
- Remove socket-environment coupling from a few unit tests so `test_network` runs reliably in restricted environments.

## Validation

- `build/tests/test_traffic_capture`
- `cmake --build build --target test_network`
- `build/tests/test_network`
- `cmake --build build --target test_traffic_capture`
- `cmake --build build --target test_http_parser`
- `build/tests/test_http_parser`
- `git diff --check`