### PR TITLE
[codex] Add state invariant coverage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,8 @@ Outstanding work items, prioritized for the next implementation passes.
 - [x] Response parser rejects malformed status codes (`XYZ`, non-digit, `<100`, `>599`).
 - [x] Simulate engine rejects malformed captured request headers and counts malformed capture entries as failed.
 - [x] Proxy 502 paths assert `ConnState::Sending`; upstream connect failure now sets that state in production.
-- [x] State invariant tests cover representative static, proxy, body-streaming, idle, and 502 dispatch transitions.
+- [x] State invariant tests cover representative static, proxy, body-streaming, JIT-yield, idle, and 502 dispatch transitions.
+- [x] Testing notes document the callback-slot/state invariants and the streaming-body exception.
 
 ## P0: State Invariant Coverage
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,76 +1,118 @@
 # TODO
 
-Outstanding work items, tracked from code TODOs and Copilot review findings.
+Outstanding work items, prioritized for the next implementation passes.
 
-## Phase 1 (current)
+## Recently Completed
 
-### epoll backend
-- [x] **Partial send proactor semantics** — `add_send()` tracks offset/remaining in `SendState` per conn_id. `wait()` completes the send on EPOLLOUT via loop, emits real byte count. send_buf converted to Buffer.
-- [x] **recv into Connection buffer** — `wait()` now recv's into `Connection::recv_buf` (Buffer) via `write_ptr()`/`commit()`. Connection table passed to `wait()`. Callbacks use `recv_buf.data()`/`recv_buf.len()`.
-
-### io_uring backend
-- [x] **Timeout events** — timerfd created in `init()`, `IORING_OP_READ` submitted for 1-second ticks. `wait()` emits `Timeout` events and re-submits the read.
-- [x] **Provided buffer return** — `wait()` copies recv data from provided buffer into `Connection::recv_buf` via `write_ptr()`/`commit()`, then immediately calls `return_buffer(buf_id)`. Events reach dispatch with `has_buf=0`.
-
-## Phase 2 (shard integration)
-- [x] **Shard: per-core runtime** — Shard<Backend> wraps EventLoop (mmap'd), Arena (per-request scratch), listen_fd (SO_REUSEPORT), pthread with CPU affinity. Multi-shard main with signal-based graceful shutdown.
-- [x] **Shard: connection table** — EventLoop owns Connection[16384] with free-stack pool (inherited from Phase 1). SlabPool deferred to when Connection moves off fixed array.
-- [x] **Shard: timer wheel integration** — EventLoop owns TimerWheel, driven by timerfd. Shard lifecycle: shutdown drains via EventLoop::shutdown().
-- [x] **Shard: upstream connection pools** — UpstreamPool per shard (mmap'd, 4096 slots), alloc/free/find_idle/return_idle/shutdown. UpstreamConn tracks fd + upstream_id + idle state.
-- [x] **Shard: route table** — RouteConfig with RouteEntry[] (prefix match) + UpstreamTarget[] (addr:port). Supports Static/Proxy actions, method filter, first-match-wins. Shard holds const RouteConfig* (swappable for hot reload).
-- [x] **SlicePool** — 16KB slice allocator, mmap-backed, O(1) alloc/free via free-stack. Per-shard, for on-demand network I/O buffers (idle connections hold 0 slices).
-- [x] **SlabPool\<T, Cap\>** — generic fixed-size object pool, mmap-backed. alloc/free by pointer or index, index_of, capacity/available/in_use stats. Generalizes EventLoop's Connection free-stack.
-- [x] **Integration**: replace Connection inline storage with SlicePool slices (idle connections → zero buffer memory). Production loops allocate recv/send slices on accept, lazily allocate upstream recv for proxying, and release all slices when the connection returns idle.
-
-## Testing methodology gaps
-
-Recurring patterns found during code review that automated tests consistently miss. Each needs a systematic prevention mechanism.
-
-### 1. Fault injection for OS-level edge cases
-**Pattern**: EINTR non-retry, mmap failure silent degradation, clock boundary arithmetic overflow.
-**Why tests miss it**: Tests run on local loopback without signals, with abundant memory, and requests complete in < 1 second.
-
-**TODO**: Build fault injection shims for test builds:
-- **EINTR simulation**: Wrap `write()`/`read()`/`send()`/`recv()` to probabilistically return EINTR before the real call. Verifies all I/O loops retry correctly.
-- **mmap failure injection**: Force `mmap()` to return MAP_FAILED on demand. Verifies all allocation paths propagate failure.
-- **Boundary clock**: Provide a `clock_gettime()` shim that returns specific `timespec` values (e.g., `{tv_sec=1, tv_nsec=999999000}` → `{tv_sec=2, tv_nsec=1000}`) to exercise arithmetic edge cases.
-- [x] Capture file read/write tests inject one-shot EINTR and verify `capture_read_entry` / `capture_write_entry` retry.
-
-### 2. Untrusted/malicious input testing
-**Pattern**: Status code parsing assumes digits, response parsing assumes well-formed HTTP.
-**Why tests miss it**: Both client and server are our own code — always produce valid output.
-
-**TODO**: For every function that parses external input, add a "malicious input" test suite:
-- Garbage bytes, truncated data, oversized fields, non-ASCII characters.
-- For sim_one: test with a raw TCP server that returns malformed responses (e.g., `"HTTP/1.1 XYZ Bad\r\n"`, empty response, partial response).
-- For capture_read_entry: test with corrupted capture files (wrong magic, truncated entry, zeroed entry).
+- [x] epoll partial-send proactor semantics and recv-buffer integration.
+- [x] io_uring timerfd timeout events and provided-buffer return path.
+- [x] Shard runtime integration: per-core EventLoop, TimerWheel, route table, upstream pool, SlicePool, and SlabPool.
+- [x] Connection buffers moved from inline storage to SlicePool-backed slices; idle/free connections hold zero buffer slices.
+- [x] Traffic replay now covers static/default paths and explicitly skips proxy routes through `replay_one`.
+- [x] Capture persistence now covers raw-header tail zeroing, corrupted/truncated entries, zeroed entries, and EINTR retry for capture read/write.
 - [x] Response parser rejects malformed status codes (`XYZ`, non-digit, `<100`, `>599`).
-- [x] Capture file tests cover invalid header metadata plus truncated and zeroed entries.
 - [x] Simulate engine rejects malformed captured request headers and counts malformed capture entries as failed.
+- [x] Proxy 502 paths assert `ConnState::Sending`; upstream connect failure now sets that state in production.
 
-### 3. Unused data region hygiene
-**Pattern**: CaptureEntry raw_headers tail contains uninitialized stack data after memcpy of valid bytes.
-**Why tests miss it**: Tests only read `raw_headers[0..raw_header_len]`, never inspect the tail. But the full struct gets persisted to disk.
+## P0: State Invariant Coverage
 
-**TODO**: For any struct that is serialized/persisted:
-- Zero-initialize the entire struct, not just the used portion.
-- Or add a post-serialization check in debug builds that validates `memcmp(buf + used_len, zeros, total_len - used_len) == 0`.
-- [x] Add a test that writes an entry to file, reads it back, and verifies bytes beyond `raw_header_len` are zero.
+**Goal**: Catch debug/metrics state drift automatically after dispatch, not one assertion at a time.
 
-### 4. Internal state consistency testing
-**Pattern**: conn.state left as Proxying while sending a 502 static response.
-**Why tests miss it**: `conn.state` is only used for debugging/metrics, never checked in callback logic. Tests verify behavior (correct response), not internal state fields.
+**Why**: Reviews repeatedly found paths where behavior was correct but `conn.state` disagreed with callback slots. Those fields feed debugging and metrics, so regressions are easy to miss.
 
-**TODO**: For debug-only fields that track state machine position:
-- Add `CHECK_EQ(conn.state, ConnState::Sending)` assertions in tests that verify response paths.
-- Or add a debug-mode invariant checker that validates `state` matches the active callback slot configuration after each dispatch.
-- [x] Add `ConnState::Sending` assertions to proxy connect failure and malformed upstream 502 response paths.
+**Work**:
+- Add a test-only invariant helper for `Connection` slot/state consistency.
+- Run it after representative `SmallLoop::dispatch` / `inject_and_dispatch` transitions.
+- Cover at least:
+  - `ReadingHeader` implies `on_recv == on_header_received`.
+  - `Sending` implies `on_send != nullptr` and no upstream callback slots unless explicitly waiting on armed upstream recv.
+  - `Proxying` / streaming states agree with active upstream recv/send slots.
+  - closed or idle slots have all callback slots clear.
 
-### 5. Cross-path replay coverage
-**Pattern**: replay_one only tested with static routes. Proxy routes through replay_one produce send_len==0 and bogus results.
-**Why tests miss it**: Tests were written incrementally — static routes first, proxy routes tested separately via manual setup. Nobody ran a proxy route through the full `replay_one` → `replay_file` path.
+**Acceptance**:
+- Add focused tests that fail if a 502/500 path sends a response while leaving stale proxy/body-streaming state.
+- No behavior change unless an invariant failure exposes a real production-state bug.
 
-**TODO**: For any function that dispatches to multiple code paths (static vs proxy vs default):
-- Maintain an explicit coverage matrix: `[function × path × test]`.
-- Every time a new path is added to a function, require a test that drives it through ALL callers (not just direct unit tests).
-- [x] For replay: add a test that calls `replay_one` with a proxy route config and verifies `replayed == false` (the current correct behavior).
+## P0: Fault Injection Harness
+
+**Goal**: Make OS-level edge cases cheap to add and hard to skip.
+
+**Why**: EINTR, mmap failure, partial I/O, and clock-boundary issues rarely happen on local loopback. Small local shims caught real gaps, but they are currently duplicated per test file.
+
+**Work**:
+- Extract reusable test shims for:
+  - `read` / `write` / `send` / `recv` one-shot and repeated EINTR.
+  - `mmap` / `mprotect` failure injection.
+  - deterministic `clock_gettime` boundary values.
+- Start with runtime modules that already have retry/failure branches:
+  - `traffic_capture`
+  - `access_log`
+  - `epoll_backend`
+  - `io_uring_backend`
+  - `SlicePool` / `Arena`
+
+**Acceptance**:
+- At least one shared helper replaces ad hoc EINTR counters.
+- New tests verify retry or fail-closed behavior without depending on real network permissions.
+
+## P1: Malformed Upstream E2E
+
+**Goal**: Exercise parser-to-callback-to-wire behavior for malformed upstream responses through real sockets.
+
+**Why**: Parser unit tests reject malformed responses, and mock callback tests cover some 502 branches, but end-to-end proxy behavior should prove the production socket path also fails closed.
+
+**Work**:
+- Add integration tests with a raw TCP upstream returning:
+  - `HTTP/1.1 XYZ Bad\r\n\r\n`
+  - empty response / immediate EOF
+  - partial status line
+  - malformed CRLF in headers
+  - conflicting or invalid content framing
+- Verify client-visible result: 502 or close, depending on the current contract.
+- Verify metrics/debug state where available.
+
+**Acceptance**:
+- Tests drive full route config -> proxy connect -> upstream response -> client response path.
+- No dependency on external services; test server is local and deterministic.
+
+## P1: Replay Coverage Matrix
+
+**Goal**: Prevent caller/path coverage holes when routing behavior expands.
+
+**Why**: `replay_one` previously only covered static routes, so proxy route behavior regressed until review. Future route actions and callers need explicit matrix coverage.
+
+**Work**:
+- Document and enforce `[caller x route action x expected result]` cases for:
+  - `replay_one`
+  - `replay_file`
+  - `simulate_one`
+  - `simulate_file`
+- Include Static, Default, Proxy, JIT ReturnStatus, JIT Forward, malformed input, and unsupported action paths where relevant.
+
+**Acceptance**:
+- A table-driven test or comment block makes missing cells obvious.
+- Adding a route action requires adding or intentionally documenting replay/sim coverage.
+
+## P2: Coverage Tooling Hygiene
+
+**Goal**: Make coverage reports actionable instead of broad percentage noise.
+
+**Why**: The project has many generated, third-party, benchmark, and architecture-specific files. Raw coverage can hide runtime gaps or chase irrelevant files.
+
+**Work**:
+- Review `scripts/coverage_report.py` exclusions and CI coverage target.
+- Add per-area coverage summaries for runtime, parser, replay/sim, and compiler/JIT.
+- Track coverage deltas for changed files in PRs if practical.
+
+**Acceptance**:
+- CI coverage output identifies the lowest-covered first-party runtime files.
+- Third-party and benchmark files do not dominate coverage decisions.
+
+## P2: TODO Maintenance
+
+**Goal**: Keep this file as a live backlog, not a history log.
+
+**Rules**:
+- Move completed implementation milestones into `Recently Completed`.
+- Keep active work scoped, prioritized, and testable.
+- When review feedback creates a new recurring pattern, add it here with an acceptance criterion.

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@ Outstanding work items, prioritized for the next implementation passes.
 - [x] Response parser rejects malformed status codes (`XYZ`, non-digit, `<100`, `>599`).
 - [x] Simulate engine rejects malformed captured request headers and counts malformed capture entries as failed.
 - [x] Proxy 502 paths assert `ConnState::Sending`; upstream connect failure now sets that state in production.
+- [x] State invariant tests cover representative static, proxy, body-streaming, idle, and 502 dispatch transitions.
 
 ## P0: State Invariant Coverage
 

--- a/TODO.md
+++ b/TODO.md
@@ -16,24 +16,22 @@ Outstanding work items, prioritized for the next implementation passes.
 - [x] State invariant tests cover representative static, proxy, body-streaming, JIT-yield, idle, and 502 dispatch transitions.
 - [x] Testing notes document the callback-slot/state invariants and the streaming-body exception.
 
-## P0: State Invariant Coverage
+## P0: State Invariant Coverage Follow-ups
 
-**Goal**: Catch debug/metrics state drift automatically after dispatch, not one assertion at a time.
+**Goal**: Extend the newly added invariant checks to less-common transitions and keep the coverage aligned with future runtime changes.
 
-**Why**: Reviews repeatedly found paths where behavior was correct but `conn.state` disagreed with callback slots. Those fields feed debugging and metrics, so regressions are easy to miss.
+**Why**: Baseline slot/state invariant coverage is now in place for representative static, proxy, body-streaming, JIT-yield, idle, and 502 dispatch transitions. The remaining work is to widen that coverage so new paths do not drift from the same debug/metrics expectations.
 
 **Work**:
-- Add a test-only invariant helper for `Connection` slot/state consistency.
-- Run it after representative `SmallLoop::dispatch` / `inject_and_dispatch` transitions.
-- Cover at least:
-  - `ReadingHeader` implies `on_recv == on_header_received`.
-  - `Sending` implies `on_send != nullptr` and no upstream callback slots unless explicitly waiting on armed upstream recv.
-  - `Proxying` / streaming states agree with active upstream recv/send slots.
-  - closed or idle slots have all callback slots clear.
+- Add follow-up tests for less-common or newly introduced transitions not yet covered by the representative dispatch cases.
+- Reuse the existing invariant helper/check pattern when adding new dispatch paths or callback-slot combinations.
+- Audit future state-machine changes for:
+  - new `conn.state` values or transitions that need invariant assertions,
+  - upstream error/timeout paths that may bypass the representative 502/500 cases,
+  - teardown/reset flows where callback slots should be cleared before returning to idle/free states.
 
 **Acceptance**:
-- Add focused tests that fail if a 502/500 path sends a response while leaving stale proxy/body-streaming state.
-- No behavior change unless an invariant failure exposes a real production-state bug.
+- The backlog item is complete when remaining uncovered transitions have explicit invariant assertions or are documented as intentionally exempt.
 
 ## P0: Fault Injection Harness
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,35 @@
+# Testing Notes
+
+## Connection State Invariants
+
+`Connection::state` is debug and metrics state. Runtime dispatch is driven by
+the four callback slots:
+
+- `on_recv`
+- `on_send`
+- `on_upstream_recv`
+- `on_upstream_send`
+
+Tests should assert both the state and the slots after representative dispatch
+steps. A response can be correct on the wire while still leaving stale proxy or
+streaming state behind, so state-only or slot-only assertions are not enough.
+
+The main invariants are:
+
+- `Idle`: client and upstream fds are closed, and all callback slots are null.
+- `ReadingHeader`: client fd is live, `on_recv` is `on_header_received`, and all
+  send/upstream slots are null.
+- `Proxying`: upstream fd is live, and active slots describe the exact proxy
+  phase, such as upstream response wait, request body streaming, or early
+  response deferral.
+- `Sending`: client fd is live, `on_send` is active, and upstream slots are null.
+  The explicit exception is streaming response body wait after response headers
+  have been sent: state remains `Sending`, `on_send` is null, and
+  `on_upstream_recv` is `on_response_body_recvd`.
+- `ExecHandler`: a yielded JIT handler keeps all callback slots null while
+  `pending_handler_fn` and `handler_state` identify the resume target.
+
+When adding a callback path that sends a 500/502 response, include a focused
+state-invariant assertion. The expected shape is `ConnState::Sending` with only
+the client send slot active. This catches stale proxy/body-streaming callbacks
+that would otherwise be easy to miss in wire-level tests.

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8795,6 +8795,43 @@ static void check_proxying_body_stream_invariant(rut::test::TestCase* _tc,
     CHECK_EQ(c->on_upstream_send, upstream_send);
 }
 
+static void check_proxying_upstream_send_only_invariant(rut::test::TestCase* _tc,
+                                                        Connection* c,
+                                                        Connection::Callback upstream_send) {
+    CHECK_EQ(c->state, ConnState::Proxying);
+    CHECK(c->fd >= 0);
+    CHECK(c->upstream_fd >= 0);
+    CHECK_SLOTS(c, nullptr, nullptr, nullptr, upstream_send);
+}
+
+static void check_sending_waiting_upstream_body_invariant(rut::test::TestCase* _tc,
+                                                          Connection* c) {
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK(c->fd >= 0);
+    CHECK(c->upstream_fd >= 0);
+    CHECK_SLOTS(c, nullptr, nullptr, &on_response_body_recvd<SmallLoop>, nullptr);
+}
+
+static void check_exec_handler_yield_invariant(rut::test::TestCase* _tc,
+                                               Connection* c,
+                                               jit::HandlerFn fn,
+                                               u16 next_state) {
+    CHECK_EQ(c->state, ConnState::ExecHandler);
+    CHECK(c->fd >= 0);
+    CHECK_EQ(c->pending_handler_fn, fn);
+    CHECK_EQ(c->handler_state, next_state);
+    CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
+}
+
+static u64 state_invariant_wait_then_status(void*,
+                                            jit::HandlerCtx* ctx,
+                                            const u8*,
+                                            u32,
+                                            void*) {
+    if (ctx && ctx->state == 7) return jit::HandlerResult::make_status(204).pack();
+    return jit::HandlerResult::make_yield_payload(7, jit::YieldKind::Timer, 25).pack();
+}
+
 TEST(state_invariant, static_dispatch_keeps_slots_consistent) {
     SmallLoop loop;
     loop.setup();
@@ -8887,6 +8924,82 @@ TEST(state_invariant, connect_failure_drops_proxy_slots) {
 
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::UpstreamConnect, -111));
     CHECK_EQ(c->resp_status, kStatusBadGateway);
+    check_sending_response_invariant(_tc, c);
+}
+
+TEST(state_invariant, streaming_response_body_wait_is_explicit_sending_exception) {
+    SmallLoop loop;
+    loop.setup();
+    auto* c = setup_proxy_conn(loop);
+    REQUIRE(c != nullptr);
+    check_proxying_upstream_wait_invariant(_tc, c);
+
+    static const char kResp[] =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: 10000\r\n"
+        "\r\n";
+    const u32 rlen = sizeof(kResp) - 1;
+    c->upstream_recv_buf.reset();
+    u8* dst = c->upstream_recv_buf.write_ptr();
+    for (u32 j = 0; j < rlen; j++) dst[j] = static_cast<u8>(kResp[j]);
+    c->upstream_recv_buf.commit(rlen);
+    loop.dispatch(make_ev(c->id, IoEventType::UpstreamRecv, static_cast<i32>(rlen)));
+    CHECK_EQ(c->on_send, &on_response_header_sent<SmallLoop>);
+    check_sending_response_invariant(_tc, c);
+
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Send, static_cast<i32>(rlen)));
+    check_sending_waiting_upstream_body_invariant(_tc, c);
+
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::UpstreamRecv, 500));
+    CHECK_EQ(c->on_send, &on_response_body_sent<SmallLoop>);
+    check_sending_response_invariant(_tc, c);
+}
+
+TEST(state_invariant, early_response_during_body_send_has_one_upstream_slot) {
+    SmallLoop loop;
+    loop.setup();
+    auto* c = setup_body_streaming_proxy(loop, 200, 10);
+    REQUIRE(c != nullptr);
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 50));
+    check_proxying_body_stream_invariant(_tc,
+                                         c,
+                                         nullptr,
+                                         &on_early_upstream_recvd_send_inflight<SmallLoop>,
+                                         &on_request_body_sent<SmallLoop>);
+
+    static const char kResp413[] =
+        "HTTP/1.1 413 Request Entity Too Large\r\n"
+        "Content-Length: 0\r\n\r\n";
+    const u32 rlen = sizeof(kResp413) - 1;
+    c->upstream_recv_buf.reset();
+    u8* dst = c->upstream_recv_buf.write_ptr();
+    for (u32 j = 0; j < rlen; j++) dst[j] = static_cast<u8>(kResp413[j]);
+    c->upstream_recv_buf.commit(rlen);
+    loop.dispatch(make_ev(c->id, IoEventType::UpstreamRecv, static_cast<i32>(rlen)));
+
+    check_proxying_upstream_send_only_invariant(_tc,
+                                                c,
+                                                &on_body_send_with_early_response<SmallLoop>);
+}
+
+TEST(state_invariant, jit_timer_yield_keeps_exec_handler_slots_clear) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::TimerYield;
+    outcome.next_state = 7;
+    outcome.timer_ms = 25;
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_then_status, true);
+    check_exec_handler_yield_invariant(_tc, c, &state_invariant_wait_then_status, 7);
+
+    loop.dispatch(make_ev(c->id, IoEventType::Timeout, 0));
+    loop.dispatch(make_ev(c->id, IoEventType::Timeout, 0));
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, 204);
     check_sending_response_invariant(_tc, c);
 }
 

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8804,8 +8804,7 @@ static void check_proxying_upstream_send_only_invariant(rut::test::TestCase* _tc
     CHECK_SLOTS(c, nullptr, nullptr, nullptr, upstream_send);
 }
 
-static void check_sending_waiting_upstream_body_invariant(rut::test::TestCase* _tc,
-                                                          Connection* c) {
+static void check_sending_waiting_upstream_body_invariant(rut::test::TestCase* _tc, Connection* c) {
     CHECK_EQ(c->state, ConnState::Sending);
     CHECK(c->fd >= 0);
     CHECK(c->upstream_fd >= 0);
@@ -8823,11 +8822,7 @@ static void check_exec_handler_yield_invariant(rut::test::TestCase* _tc,
     CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
 }
 
-static u64 state_invariant_wait_then_status(void*,
-                                            jit::HandlerCtx* ctx,
-                                            const u8*,
-                                            u32,
-                                            void*) {
+static u64 state_invariant_wait_then_status(void*, jit::HandlerCtx* ctx, const u8*, u32, void*) {
     if (ctx && ctx->state == 7) return jit::HandlerResult::make_status(204).pack();
     return jit::HandlerResult::make_yield_payload(7, jit::YieldKind::Timer, 25).pack();
 }
@@ -8871,11 +8866,8 @@ TEST(state_invariant, body_streaming_slots_match_proxying_state) {
     loop.setup();
     auto* c = setup_body_streaming_proxy(loop, 200, 10);
     REQUIRE(c != nullptr);
-    check_proxying_body_stream_invariant(_tc,
-                                         c,
-                                         &on_request_body_recvd<SmallLoop>,
-                                         &on_early_upstream_recvd<SmallLoop>,
-                                         nullptr);
+    check_proxying_body_stream_invariant(
+        _tc, c, &on_request_body_recvd<SmallLoop>, &on_early_upstream_recvd<SmallLoop>, nullptr);
 
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 50));
     check_proxying_body_stream_invariant(_tc,
@@ -8885,11 +8877,8 @@ TEST(state_invariant, body_streaming_slots_match_proxying_state) {
                                          &on_request_body_sent<SmallLoop>);
 
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::UpstreamSend, 50));
-    check_proxying_body_stream_invariant(_tc,
-                                         c,
-                                         &on_request_body_recvd<SmallLoop>,
-                                         &on_early_upstream_recvd<SmallLoop>,
-                                         nullptr);
+    check_proxying_body_stream_invariant(
+        _tc, c, &on_request_body_recvd<SmallLoop>, &on_early_upstream_recvd<SmallLoop>, nullptr);
 }
 
 TEST(state_invariant, error_responses_drop_proxy_slots) {
@@ -8977,9 +8966,8 @@ TEST(state_invariant, early_response_during_body_send_has_one_upstream_slot) {
     c->upstream_recv_buf.commit(rlen);
     loop.dispatch(make_ev(c->id, IoEventType::UpstreamRecv, static_cast<i32>(rlen)));
 
-    check_proxying_upstream_send_only_invariant(_tc,
-                                                c,
-                                                &on_body_send_with_early_response<SmallLoop>);
+    check_proxying_upstream_send_only_invariant(
+        _tc, c, &on_body_send_with_early_response<SmallLoop>);
 }
 
 TEST(state_invariant, jit_timer_yield_keeps_exec_handler_slots_clear) {

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8746,6 +8746,150 @@ TEST(dispatch_isolation, upstream_send_reaches_upstream_send_slot) {
         CHECK_EQ((c)->on_upstream_send, (us)); \
     } while (0)
 
+static void check_idle_invariant(rut::test::TestCase* _tc, Connection* c) {
+    CHECK_EQ(c->state, ConnState::Idle);
+    CHECK_EQ(c->fd, -1);
+    CHECK_EQ(c->upstream_fd, -1);
+    CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
+}
+
+static void check_reading_header_invariant(rut::test::TestCase* _tc, Connection* c) {
+    CHECK_EQ(c->state, ConnState::ReadingHeader);
+    CHECK(c->fd >= 0);
+    CHECK_EQ(c->on_recv, &on_header_received<SmallLoop>);
+    CHECK_EQ(c->on_send, nullptr);
+    CHECK_EQ(c->on_upstream_recv, nullptr);
+    CHECK_EQ(c->on_upstream_send, nullptr);
+}
+
+static void check_sending_response_invariant(rut::test::TestCase* _tc, Connection* c) {
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK(c->fd >= 0);
+    CHECK(c->on_send != nullptr);
+    CHECK_EQ(c->on_recv, nullptr);
+    CHECK_EQ(c->on_upstream_recv, nullptr);
+    CHECK_EQ(c->on_upstream_send, nullptr);
+}
+
+static void check_proxying_upstream_wait_invariant(rut::test::TestCase* _tc, Connection* c) {
+    CHECK_EQ(c->state, ConnState::Proxying);
+    CHECK(c->fd >= 0);
+    CHECK(c->upstream_fd >= 0);
+    CHECK_EQ(c->on_recv, nullptr);
+    CHECK_EQ(c->on_send, nullptr);
+    CHECK_EQ(c->on_upstream_recv, &on_upstream_response<SmallLoop>);
+    CHECK_EQ(c->on_upstream_send, nullptr);
+}
+
+static void check_proxying_body_stream_invariant(rut::test::TestCase* _tc,
+                                                 Connection* c,
+                                                 Connection::Callback recv,
+                                                 Connection::Callback upstream_recv,
+                                                 Connection::Callback upstream_send) {
+    CHECK_EQ(c->state, ConnState::Proxying);
+    CHECK(c->fd >= 0);
+    CHECK(c->upstream_fd >= 0);
+    CHECK_EQ(c->on_recv, recv);
+    CHECK_EQ(c->on_send, nullptr);
+    CHECK_EQ(c->on_upstream_recv, upstream_recv);
+    CHECK_EQ(c->on_upstream_send, upstream_send);
+}
+
+TEST(state_invariant, static_dispatch_keeps_slots_consistent) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    check_reading_header_invariant(_tc, c);
+
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 100));
+    check_sending_response_invariant(_tc, c);
+
+    const u32 slen = c->send_buf.len();
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Send, static_cast<i32>(slen)));
+    check_reading_header_invariant(_tc, c);
+
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 0));
+    check_idle_invariant(_tc, c);
+}
+
+TEST(state_invariant, proxy_dispatch_keeps_slots_consistent) {
+    SmallLoop loop;
+    loop.setup();
+    auto* c = setup_proxy_conn(loop);
+    REQUIRE(c != nullptr);
+    check_proxying_upstream_wait_invariant(_tc, c);
+
+    inject_upstream_response(loop, *c);
+    check_sending_response_invariant(_tc, c);
+
+    loop.inject_and_dispatch(
+        make_ev(c->id, IoEventType::Send, static_cast<i32>(kMockHttpResponseLen)));
+    check_reading_header_invariant(_tc, c);
+}
+
+TEST(state_invariant, body_streaming_slots_match_proxying_state) {
+    SmallLoop loop;
+    loop.setup();
+    auto* c = setup_body_streaming_proxy(loop, 200, 10);
+    REQUIRE(c != nullptr);
+    check_proxying_body_stream_invariant(_tc,
+                                         c,
+                                         &on_request_body_recvd<SmallLoop>,
+                                         &on_early_upstream_recvd<SmallLoop>,
+                                         nullptr);
+
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 50));
+    check_proxying_body_stream_invariant(_tc,
+                                         c,
+                                         nullptr,
+                                         &on_early_upstream_recvd_send_inflight<SmallLoop>,
+                                         &on_request_body_sent<SmallLoop>);
+
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::UpstreamSend, 50));
+    check_proxying_body_stream_invariant(_tc,
+                                         c,
+                                         &on_request_body_recvd<SmallLoop>,
+                                         &on_early_upstream_recvd<SmallLoop>,
+                                         nullptr);
+}
+
+TEST(state_invariant, error_responses_drop_proxy_slots) {
+    SmallLoop loop;
+    loop.setup();
+    auto* c = setup_proxy_conn(loop);
+    REQUIRE(c != nullptr);
+    check_proxying_upstream_wait_invariant(_tc, c);
+
+    static const char kBad[] = "XHTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+    const u32 blen = sizeof(kBad) - 1;
+    c->upstream_recv_buf.reset();
+    u8* dst = c->upstream_recv_buf.write_ptr();
+    for (u32 j = 0; j < blen; j++) dst[j] = static_cast<u8>(kBad[j]);
+    c->upstream_recv_buf.commit(blen);
+    loop.dispatch(make_ev(c->id, IoEventType::UpstreamRecv, static_cast<i32>(blen)));
+
+    CHECK_EQ(c->resp_status, kStatusBadGateway);
+    check_sending_response_invariant(_tc, c);
+}
+
+TEST(state_invariant, connect_failure_drops_proxy_slots) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 100));
+    c->upstream_fd = 100;
+    c->on_upstream_send = &on_upstream_connected<SmallLoop>;
+    c->state = ConnState::Proxying;
+
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::UpstreamConnect, -111));
+    CHECK_EQ(c->resp_status, kStatusBadGateway);
+    check_sending_response_invariant(_tc, c);
+}
+
 // State 1: Accept → ReadingHeader {on_recv=header, rest=null}
 TEST(state_transition, accept_to_reading_header) {
     SmallLoop loop;

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8983,6 +8983,7 @@ TEST(state_invariant, jit_timer_yield_keeps_exec_handler_slots_clear) {
     outcome.timer_ms = 25;
     handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_then_status, true);
     check_exec_handler_yield_invariant(_tc, c, &state_invariant_wait_then_status, 7);
+    CHECK_EQ(loop.last_yield_ms, outcome.timer_ms);
 
     loop.dispatch(make_ev(c->id, IoEventType::Timeout, 0));
     loop.dispatch(make_ev(c->id, IoEventType::Timeout, 0));


### PR DESCRIPTION
## Summary

- Reorganized `TODO.md` into a prioritized testing backlog.
- Added state invariant tests for connection state and callback-slot consistency across static, proxy, body-streaming, error, early-response, and JIT-yield paths.
- Added `docs/testing.md` with maintenance notes for `ConnState` and callback slot invariants.

## Validation

- `build/tests/test_network --filter=state_invariant`
- `build/tests/test_network`
- `git diff --check`