### PR TITLE
[codex] Add runtime connection debug helpers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@ Outstanding work items, prioritized for the next implementation passes.
 - [x] Proxy 502 paths assert `ConnState::Sending`; upstream connect failure now sets that state in production.
 - [x] State invariant tests cover representative static, proxy, body-streaming, JIT-yield, idle, and 502 dispatch transitions.
 - [x] Testing notes document the callback-slot/state invariants and the streaming-body exception.
+- [x] Runtime debug helpers can snapshot and format connection state, callback slots, armed operations, and buffer lengths.
 
 ## P0: State Invariant Coverage Follow-ups
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,30 @@
+# Debugging Runtime Connections
+
+`rut/runtime/debug.h` provides lightweight helpers for inspecting a
+`Connection` without changing dispatch behavior.
+
+Use `make_conn_debug_snapshot(conn)` when a test or diagnostic path needs a
+stable value object. Use `format_conn_debug(conn, buf, len)` when a compact text
+line is more useful for logs or assertion failures.
+
+The formatted line includes:
+
+- connection id, client fd, and upstream fd
+- `ConnState` as a readable name
+- active callback slot mask (`recv`, `send`, `up_recv`, `up_send`)
+- armed backend operation mask (`recv`, `send`, `up_recv`, `up_send`, `yield`)
+- pending operation count
+- response status
+- yielded JIT handler state, when present
+- client recv, client send, and upstream recv buffer lengths
+
+Example:
+
+```text
+conn{id=7 state=Sending fd=42 upstream_fd=-1 slots=send armed=send|yield pending_ops=2 resp=204 handler=pending:3 bufs=10/20/30}
+```
+
+These helpers are intentionally header-only and allocation-free. They are safe
+to call from tests and debug logging paths, but they do not enforce invariants
+by themselves. Pair them with the state invariant tests when adding new
+callback-slot transitions.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -21,7 +21,7 @@ The formatted line includes:
 Example:
 
 ```text
-conn{id=7 state=Sending fd=42 upstream_fd=-1 slots=send armed=send|yield pending_ops=2 resp=204 handler=pending:3 bufs=10/20/30}
+conn{id=7 state=Sending fd=42 upstream_fd=-1 slots=send armed=send|yield pending_ops=2 resp=204 handler=pending:3 recv_buf=10 send_buf=20 upstream_recv_buf=30}
 ```
 
 These helpers are intentionally header-only and allocation-free. They are safe

--- a/include/rut/runtime/debug.h
+++ b/include/rut/runtime/debug.h
@@ -192,11 +192,11 @@ inline u32 format_conn_debug_snapshot(const ConnDebugSnapshot& s, char* out, u32
     } else {
         w.put_cstr("none");
     }
-    w.put_cstr(" bufs=");
+    w.put_cstr(" recv_buf=");
     w.put_u64(s.recv_len);
-    w.put_char('/');
+    w.put_cstr(" send_buf=");
     w.put_u64(s.send_len);
-    w.put_char('/');
+    w.put_cstr(" upstream_recv_buf=");
     w.put_u64(s.upstream_recv_len);
     w.put_char('}');
     return w.finish();

--- a/include/rut/runtime/debug.h
+++ b/include/rut/runtime/debug.h
@@ -1,0 +1,209 @@
+#pragma once
+
+#include "rut/runtime/connection.h"
+
+namespace rut {
+
+enum ConnSlotMask : u8 {
+    kConnSlotRecv = 1u << 0,
+    kConnSlotSend = 1u << 1,
+    kConnSlotUpstreamRecv = 1u << 2,
+    kConnSlotUpstreamSend = 1u << 3,
+};
+
+enum ConnArmedMask : u8 {
+    kConnArmedRecv = 1u << 0,
+    kConnArmedSend = 1u << 1,
+    kConnArmedUpstreamRecv = 1u << 2,
+    kConnArmedUpstreamSend = 1u << 3,
+    kConnArmedYield = 1u << 4,
+};
+
+struct ConnDebugSnapshot {
+    u32 id = 0;
+    i32 fd = -1;
+    i32 upstream_fd = -1;
+    ConnState state = ConnState::Idle;
+    u8 slot_mask = 0;
+    u8 armed_mask = 0;
+    u32 pending_ops = 0;
+    u16 resp_status = 0;
+    u16 handler_state = 0;
+    bool pending_handler = false;
+    u32 recv_len = 0;
+    u32 send_len = 0;
+    u32 upstream_recv_len = 0;
+};
+
+inline const char* conn_state_name(ConnState state) {
+    switch (state) {
+        case ConnState::Idle:
+            return "Idle";
+        case ConnState::ReadingHeader:
+            return "ReadingHeader";
+        case ConnState::ReadingBody:
+            return "ReadingBody";
+        case ConnState::ExecHandler:
+            return "ExecHandler";
+        case ConnState::Proxying:
+            return "Proxying";
+        case ConnState::Sending:
+            return "Sending";
+    }
+    return "Unknown";
+}
+
+inline u8 conn_slot_mask(const Connection& c) {
+    u8 mask = 0;
+    if (c.on_recv) mask |= kConnSlotRecv;
+    if (c.on_send) mask |= kConnSlotSend;
+    if (c.on_upstream_recv) mask |= kConnSlotUpstreamRecv;
+    if (c.on_upstream_send) mask |= kConnSlotUpstreamSend;
+    return mask;
+}
+
+inline u8 conn_armed_mask(const Connection& c) {
+    u8 mask = 0;
+    if (c.recv_armed) mask |= kConnArmedRecv;
+    if (c.send_armed) mask |= kConnArmedSend;
+    if (c.upstream_recv_armed) mask |= kConnArmedUpstreamRecv;
+    if (c.upstream_send_armed) mask |= kConnArmedUpstreamSend;
+    if (c.yield_armed) mask |= kConnArmedYield;
+    return mask;
+}
+
+inline ConnDebugSnapshot make_conn_debug_snapshot(const Connection& c) {
+    ConnDebugSnapshot s{};
+    s.id = c.id;
+    s.fd = c.fd;
+    s.upstream_fd = c.upstream_fd;
+    s.state = c.state;
+    s.slot_mask = conn_slot_mask(c);
+    s.armed_mask = conn_armed_mask(c);
+    s.pending_ops = c.pending_ops;
+    s.resp_status = c.resp_status;
+    s.handler_state = c.handler_state;
+    s.pending_handler = c.pending_handler_fn != nullptr;
+    s.recv_len = c.recv_buf.len();
+    s.send_len = c.send_buf.len();
+    s.upstream_recv_len = c.upstream_recv_buf.len();
+    return s;
+}
+
+struct DebugBufferWriter {
+    char* out;
+    u32 cap;
+    u32 len;
+
+    void put_char(char c) {
+        if (cap > 0 && len + 1 < cap) out[len] = c;
+        len++;
+    }
+
+    void put_cstr(const char* s) {
+        for (u32 i = 0; s[i] != '\0'; i++) put_char(s[i]);
+    }
+
+    void put_u64(u64 v) {
+        char tmp[20];
+        u32 n = 0;
+        do {
+            tmp[n++] = static_cast<char>('0' + (v % 10));
+            v /= 10;
+        } while (v != 0);
+        while (n > 0) put_char(tmp[--n]);
+    }
+
+    void put_i32(i32 v) {
+        if (v < 0) {
+            put_char('-');
+            put_u64(static_cast<u64>(-(v + 1)) + 1u);
+        } else {
+            put_u64(static_cast<u64>(v));
+        }
+    }
+
+    u32 finish() {
+        if (cap > 0) {
+            const u32 pos = len < cap ? len : cap - 1;
+            out[pos] = '\0';
+        }
+        return len;
+    }
+};
+
+inline void format_conn_slot_mask(DebugBufferWriter& w, u8 mask) {
+    if (mask == 0) {
+        w.put_cstr("none");
+        return;
+    }
+    bool first = true;
+    auto put = [&](const char* name) {
+        if (!first) w.put_char('|');
+        w.put_cstr(name);
+        first = false;
+    };
+    if (mask & kConnSlotRecv) put("recv");
+    if (mask & kConnSlotSend) put("send");
+    if (mask & kConnSlotUpstreamRecv) put("up_recv");
+    if (mask & kConnSlotUpstreamSend) put("up_send");
+}
+
+inline void format_conn_armed_mask(DebugBufferWriter& w, u8 mask) {
+    if (mask == 0) {
+        w.put_cstr("none");
+        return;
+    }
+    bool first = true;
+    auto put = [&](const char* name) {
+        if (!first) w.put_char('|');
+        w.put_cstr(name);
+        first = false;
+    };
+    if (mask & kConnArmedRecv) put("recv");
+    if (mask & kConnArmedSend) put("send");
+    if (mask & kConnArmedUpstreamRecv) put("up_recv");
+    if (mask & kConnArmedUpstreamSend) put("up_send");
+    if (mask & kConnArmedYield) put("yield");
+}
+
+inline u32 format_conn_debug_snapshot(const ConnDebugSnapshot& s, char* out, u32 out_size) {
+    DebugBufferWriter w{out, out_size, 0};
+    w.put_cstr("conn{id=");
+    w.put_u64(s.id);
+    w.put_cstr(" state=");
+    w.put_cstr(conn_state_name(s.state));
+    w.put_cstr(" fd=");
+    w.put_i32(s.fd);
+    w.put_cstr(" upstream_fd=");
+    w.put_i32(s.upstream_fd);
+    w.put_cstr(" slots=");
+    format_conn_slot_mask(w, s.slot_mask);
+    w.put_cstr(" armed=");
+    format_conn_armed_mask(w, s.armed_mask);
+    w.put_cstr(" pending_ops=");
+    w.put_u64(s.pending_ops);
+    w.put_cstr(" resp=");
+    w.put_u64(s.resp_status);
+    w.put_cstr(" handler=");
+    if (s.pending_handler) {
+        w.put_cstr("pending:");
+        w.put_u64(s.handler_state);
+    } else {
+        w.put_cstr("none");
+    }
+    w.put_cstr(" bufs=");
+    w.put_u64(s.recv_len);
+    w.put_char('/');
+    w.put_u64(s.send_len);
+    w.put_char('/');
+    w.put_u64(s.upstream_recv_len);
+    w.put_char('}');
+    return w.finish();
+}
+
+inline u32 format_conn_debug(const Connection& c, char* out, u32 out_size) {
+    return format_conn_debug_snapshot(make_conn_debug_snapshot(c), out, out_size);
+}
+
+}  // namespace rut

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -186,6 +186,16 @@ target_include_directories(test_metrics PRIVATE
 add_test(NAME test_metrics COMMAND test_metrics)
 set_tests_properties(test_metrics PROPERTIES LABELS "unit")
 
+add_executable(test_debug test_debug.cc)
+target_link_libraries(test_debug rut_runtime)
+target_include_directories(test_debug PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/testing
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+add_test(NAME test_debug COMMAND test_debug)
+set_tests_properties(test_debug PROPERTIES LABELS "unit")
+
 add_executable(test_shard_control test_shard_control.cc)
 target_link_libraries(test_shard_control rut_runtime Threads::Threads)
 target_include_directories(test_shard_control PRIVATE
@@ -265,6 +275,7 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_drain>
     COMMAND $<TARGET_FILE:test_access_log>
     COMMAND $<TARGET_FILE:test_metrics>
+    COMMAND $<TARGET_FILE:test_debug>
     COMMAND $<TARGET_FILE:test_chunked_parser>
     COMMAND $<TARGET_FILE:test_shard_control>
     COMMAND $<TARGET_FILE:test_jit>
@@ -275,6 +286,6 @@ add_custom_target(check
     COMMAND $<TARGET_FILE:test_route_trie>
     COMMAND $<TARGET_FILE:test_route_art>
     COMMAND $<TARGET_FILE:test_route_select>
-    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_art test_route_select
+    DEPENDS test_network test_integration test_arena test_expected test_http_parser test_chunked_parser test_buffer test_types test_rir test_frontend test_drain test_access_log test_metrics test_debug test_shard_control test_jit test_traffic_capture test_traffic_replay test_sim rut-simulate test_simulate_engine test_route_trie test_route_art test_route_select
     COMMENT "Running all tests..."
 )

--- a/tests/test_debug.cc
+++ b/tests/test_debug.cc
@@ -1,0 +1,120 @@
+#include "rut/runtime/debug.h"
+#include "test.h"
+
+using namespace rut;
+
+static void dummy_callback(void*, ConnectionBase&, IoEvent) {}
+
+static u64 dummy_handler(void*, jit::HandlerCtx*, const u8*, u32, void*) {
+    return 0;
+}
+
+TEST(debug, conn_state_name_all_values) {
+    CHECK_STREQ(conn_state_name(ConnState::Idle), "Idle");
+    CHECK_STREQ(conn_state_name(ConnState::ReadingHeader), "ReadingHeader");
+    CHECK_STREQ(conn_state_name(ConnState::ReadingBody), "ReadingBody");
+    CHECK_STREQ(conn_state_name(ConnState::ExecHandler), "ExecHandler");
+    CHECK_STREQ(conn_state_name(ConnState::Proxying), "Proxying");
+    CHECK_STREQ(conn_state_name(ConnState::Sending), "Sending");
+}
+
+TEST(debug, slot_and_armed_masks_reflect_connection_bits) {
+    Connection c{};
+    c.reset();
+    CHECK_EQ(conn_slot_mask(c), 0u);
+    CHECK_EQ(conn_armed_mask(c), 0u);
+
+    c.on_recv = &dummy_callback;
+    c.on_upstream_send = &dummy_callback;
+    c.recv_armed = true;
+    c.upstream_recv_armed = true;
+    c.yield_armed = true;
+
+    CHECK_EQ(conn_slot_mask(c), static_cast<u8>(kConnSlotRecv | kConnSlotUpstreamSend));
+    CHECK_EQ(conn_armed_mask(c),
+             static_cast<u8>(kConnArmedRecv | kConnArmedUpstreamRecv | kConnArmedYield));
+}
+
+TEST(debug, snapshot_captures_connection_debug_fields) {
+    u8 recv_storage[64];
+    u8 send_storage[64];
+    u8 upstream_storage[64];
+    Connection c{};
+    c.reset();
+    c.id = 17;
+    c.fd = 42;
+    c.upstream_fd = 100;
+    c.state = ConnState::Proxying;
+    c.on_recv = &dummy_callback;
+    c.on_send = &dummy_callback;
+    c.send_armed = true;
+    c.pending_ops = 3;
+    c.resp_status = 502;
+    c.handler_state = 9;
+    c.pending_handler_fn = &dummy_handler;
+    c.recv_buf.bind(recv_storage, sizeof(recv_storage));
+    c.send_buf.bind(send_storage, sizeof(send_storage));
+    c.upstream_recv_buf.bind(upstream_storage, sizeof(upstream_storage));
+    c.recv_buf.commit(5);
+    c.send_buf.commit(7);
+    c.upstream_recv_buf.commit(11);
+
+    const auto s = make_conn_debug_snapshot(c);
+    CHECK_EQ(s.id, 17u);
+    CHECK_EQ(s.fd, 42);
+    CHECK_EQ(s.upstream_fd, 100);
+    CHECK_EQ(s.state, ConnState::Proxying);
+    CHECK_EQ(s.slot_mask, static_cast<u8>(kConnSlotRecv | kConnSlotSend));
+    CHECK_EQ(s.armed_mask, static_cast<u8>(kConnArmedSend));
+    CHECK_EQ(s.pending_ops, 3u);
+    CHECK_EQ(s.resp_status, 502u);
+    CHECK_EQ(s.pending_handler, true);
+    CHECK_EQ(s.handler_state, 9u);
+    CHECK_EQ(s.recv_len, 5u);
+    CHECK_EQ(s.send_len, 7u);
+    CHECK_EQ(s.upstream_recv_len, 11u);
+}
+
+TEST(debug, format_conn_debug_snapshot_is_stable) {
+    ConnDebugSnapshot s{};
+    s.id = 7;
+    s.fd = 42;
+    s.upstream_fd = -1;
+    s.state = ConnState::Sending;
+    s.slot_mask = kConnSlotSend;
+    s.armed_mask = static_cast<u8>(kConnArmedSend | kConnArmedYield);
+    s.pending_ops = 2;
+    s.resp_status = 204;
+    s.pending_handler = true;
+    s.handler_state = 3;
+    s.recv_len = 10;
+    s.send_len = 20;
+    s.upstream_recv_len = 30;
+
+    char buf[256];
+    u32 n = format_conn_debug_snapshot(s, buf, sizeof(buf));
+    CHECK_EQ(n, static_cast<u32>(__builtin_strlen(buf)));
+    CHECK_STREQ(buf,
+                "conn{id=7 state=Sending fd=42 upstream_fd=-1 slots=send "
+                "armed=send|yield pending_ops=2 resp=204 handler=pending:3 "
+                "bufs=10/20/30}");
+}
+
+TEST(debug, format_conn_debug_truncates_and_reports_full_length) {
+    ConnDebugSnapshot s{};
+    s.id = 123;
+    s.state = ConnState::ReadingHeader;
+
+    char full[256];
+    char small[12];
+    u32 full_len = format_conn_debug_snapshot(s, full, sizeof(full));
+    u32 small_len = format_conn_debug_snapshot(s, small, sizeof(small));
+
+    CHECK_EQ(small_len, full_len);
+    CHECK_EQ(small[sizeof(small) - 1], '\0');
+    CHECK_STREQ(small, "conn{id=123");
+}
+
+int main(int argc, char** argv) {
+    return rut::test::run_all(argc, argv);
+}

--- a/tests/test_debug.cc
+++ b/tests/test_debug.cc
@@ -97,7 +97,7 @@ TEST(debug, format_conn_debug_snapshot_is_stable) {
     CHECK_STREQ(buf,
                 "conn{id=7 state=Sending fd=42 upstream_fd=-1 slots=send "
                 "armed=send|yield pending_ops=2 resp=204 handler=pending:3 "
-                "bufs=10/20/30}");
+                "recv_buf=10 send_buf=20 upstream_recv_buf=30}");
 }
 
 TEST(debug, format_conn_debug_truncates_and_reports_full_length) {


### PR DESCRIPTION
## Summary

- Add `rut/runtime/debug.h` with connection state names, slot/armed masks, debug snapshots, and compact connection formatting.
- Add `test_debug` coverage for snapshot fields, formatting, masks, and truncation behavior.
- Document the debug helper output in `docs/debugging.md` and include the new test in the CMake `check` target.

## Validation

- `./dev.sh format`
- `cmake --build build --target test_debug`
- `build/tests/test_debug`
- `git diff --check origin/main...HEAD`