### PR TITLE
[codex] Add malformed upstream proxy e2e coverage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,7 @@ Outstanding work items, prioritized for the next implementation passes.
 - [x] Testing notes document the callback-slot/state invariants and the streaming-body exception.
 - [x] Runtime debug helpers can snapshot and format connection state, callback slots, armed operations, and buffer lengths.
 - [x] Test framework fault injection provides shared mmap/mprotect/socket/recv/poll/read/write/send/connect/epoll/timerfd/accept/open scopes for network/runtime tests.
+- [x] Malformed upstream E2E coverage drives real proxy sockets through malformed status, EOF, header, and framing failures.
 
 ## P0: State Invariant Coverage Follow-ups
 
@@ -56,26 +57,6 @@ Outstanding work items, prioritized for the next implementation passes.
 **Acceptance**:
 - At least one shared helper replaces ad hoc EINTR counters.
 - New tests verify retry or fail-closed behavior without depending on real network permissions.
-
-## P1: Malformed Upstream E2E
-
-**Goal**: Exercise parser-to-callback-to-wire behavior for malformed upstream responses through real sockets.
-
-**Why**: Parser unit tests reject malformed responses, and mock callback tests cover some 502 branches, but end-to-end proxy behavior should prove the production socket path also fails closed.
-
-**Work**:
-- Add integration tests with a raw TCP upstream returning:
-  - `HTTP/1.1 XYZ Bad\r\n\r\n`
-  - empty response / immediate EOF
-  - partial status line
-  - malformed CRLF in headers
-  - conflicting or invalid content framing
-- Verify client-visible result: 502 or close, depending on the current contract.
-- Verify metrics/debug state where available.
-
-**Acceptance**:
-- Tests drive full route config -> proxy connect -> upstream response -> client response path.
-- No dependency on external services; test server is local and deterministic.
 
 ## P1: Replay Coverage Matrix
 

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2966,7 +2966,8 @@ static void run_malformed_upstream_case(rut::test::TestCase* test_case,
         CHECK_MSG(buf_contains(buf, total, "502", 3), tc_cfg.name);
         CHECK_MSG(buf_contains(buf, total, "Connection: close", 17), tc_cfg.name);
     } else {
-        CHECK_MSG(total == 0 && n <= 0, tc_cfg.name);
+        const bool closed = n == 0 || n == -ECONNRESET || n == -ECONNABORTED || n == -EPIPE;
+        CHECK_MSG(total == 0 && closed, tc_cfg.name);
     }
 
     close(client);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2815,6 +2815,12 @@ struct ScriptedUpstreamServer {
 
     ~ScriptedUpstreamServer() { teardown(); }
 
+    static bool set_blocking(i32 fd) {
+        i32 flags = fcntl(fd, F_GETFL, 0);
+        if (flags < 0) return false;
+        return fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) == 0;
+    }
+
     static void* run(void* arg) {
         auto* server = static_cast<ScriptedUpstreamServer*>(arg);
         i32 client = -1;
@@ -2827,10 +2833,12 @@ struct ScriptedUpstreamServer {
             usleep(1000);
         }
         if (client >= 0) {
-            char req[1024];
-            (void)recv_timeout(client, req, sizeof(req), 1000);
-            if (server->response != nullptr && server->response_len > 0) {
-                (void)send_all(client, server->response, server->response_len);
+            if (set_blocking(client)) {
+                char req[1024];
+                (void)recv_timeout(client, req, sizeof(req), 1000);
+                if (server->response != nullptr && server->response_len > 0) {
+                    (void)send_all(client, server->response, server->response_len);
+                }
             }
             close(client);
         }

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2825,7 +2825,7 @@ struct ScriptedUpstreamServer {
         auto* server = static_cast<ScriptedUpstreamServer*>(arg);
         i32 client = -1;
         const i32 accept_fd = server->listen_fd;
-        for (u32 i = 0; i < 2000 && server->running.load(std::memory_order_acquire); i++) {
+        while (server->running.load(std::memory_order_acquire)) {
             client = accept(accept_fd, nullptr, nullptr);
             if (client >= 0) break;
             if (errno == EINTR) continue;

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2803,6 +2803,141 @@ TEST(route, jit_handler_custom_body_real_socket) {
     destroy_real_loop(loop);
 }
 
+struct ScriptedUpstreamServer {
+    i32 listen_fd = -1;
+    u16 port = 0;
+    const char* response = nullptr;
+    u32 response_len = 0;
+    bool running = false;
+    bool started = false;
+    pthread_t thread{};
+
+    ~ScriptedUpstreamServer() { teardown(); }
+
+    static void* run(void* arg) {
+        auto* server = static_cast<ScriptedUpstreamServer*>(arg);
+        i32 client = -1;
+        for (u32 i = 0; i < 2000 && server->running; i++) {
+            client = accept(server->listen_fd, nullptr, nullptr);
+            if (client >= 0) break;
+            if (errno != EAGAIN && errno != EWOULDBLOCK) break;
+            usleep(1000);
+        }
+        if (client >= 0) {
+            char req[1024];
+            (void)recv_timeout(client, req, sizeof(req), 1000);
+            if (server->response != nullptr && server->response_len > 0) {
+                (void)send_all(client, server->response, server->response_len);
+            }
+            close(client);
+        }
+        return nullptr;
+    }
+
+    bool setup(const char* bytes, u32 len) {
+        auto lfd_result = create_listen_socket(0);
+        if (!lfd_result.has_value()) return false;
+        listen_fd = lfd_result.value();
+        port = get_port(listen_fd);
+        response = bytes;
+        response_len = len;
+        running = true;
+        if (pthread_create(&thread, nullptr, run, this) != 0) {
+            running = false;
+            close(listen_fd);
+            listen_fd = -1;
+            return false;
+        }
+        started = true;
+        return true;
+    }
+
+    void teardown() {
+        running = false;
+        if (listen_fd >= 0) {
+            close(listen_fd);
+            listen_fd = -1;
+        }
+        if (started) {
+            pthread_join(thread, nullptr);
+            started = false;
+        }
+    }
+};
+
+struct MalformedUpstreamCase {
+    const char* name;
+    const char* response;
+    u32 response_len;
+    bool expect_502;
+};
+
+static void run_malformed_upstream_case(rut::test::TestCase* test_case,
+                                        const MalformedUpstreamCase& tc_cfg) {
+    auto* _tc = test_case;
+
+    ScriptedUpstreamServer upstream;
+    REQUIRE(upstream.setup(tc_cfg.response, tc_cfg.response_len));
+
+    RouteConfig cfg{};
+    auto upstream_id = cfg.add_upstream("malformed", 0x7F000001, upstream.port);
+    REQUIRE(upstream_id.has_value());
+    REQUIRE(cfg.add_proxy("/api", 0, upstream_id.value()));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 500};
+    lt.start();
+
+    i32 client = connect_to(port);
+    REQUIRE(client >= 0);
+    const char kReq[] = "GET /api HTTP/1.1\r\nHost: x\r\n\r\n";
+    REQUIRE(send_all(client, kReq, sizeof(kReq) - 1));
+
+    char buf[2048];
+    i32 n = recv_timeout(client, buf, sizeof(buf), 2000);
+    if (tc_cfg.expect_502) {
+        CHECK_GT(n, 0);
+        CHECK(buf_contains(buf, static_cast<u32>(n > 0 ? n : 0), "502", 3));
+        CHECK(buf_contains(buf, static_cast<u32>(n > 0 ? n : 0), "Connection: close", 17));
+    } else {
+        CHECK_LE(n, 0);
+    }
+
+    close(client);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    upstream.teardown();
+}
+
+TEST(proxy_e2e, malformed_upstream_responses_fail_closed) {
+    static const char kBadStatus[] = "HTTP/1.1 XYZ Bad\r\nContent-Length: 0\r\n\r\n";
+    static const char kPartialStatus[] = "HTTP/1.1 20";
+    static const char kBadHeaderCrlf[] = "HTTP/1.1 200 OK\r\nX-Test: bad\rX-Next: y\r\n\r\n";
+    static const char kBadContentLength[] = "HTTP/1.1 200 OK\r\nContent-Length: nope\r\n\r\n";
+
+    static const MalformedUpstreamCase kCases[] = {
+        {"bad status code", kBadStatus, sizeof(kBadStatus) - 1, true},
+        {"partial status then eof", kPartialStatus, sizeof(kPartialStatus) - 1, true},
+        {"malformed header crlf", kBadHeaderCrlf, sizeof(kBadHeaderCrlf) - 1, true},
+        {"invalid content length", kBadContentLength, sizeof(kBadContentLength) - 1, true},
+        {"empty eof", nullptr, 0, false},
+    };
+
+    for (const auto& tc_cfg : kCases) {
+        run_malformed_upstream_case(_tc, tc_cfg);
+    }
+}
+
 // Handler returns ReturnStatus with an out-of-range body_idx (e.g. no
 // body was registered). Runtime must fall back to the default status-
 // reason body rather than rendering garbage or hanging.

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2924,12 +2924,48 @@ TEST(proxy_e2e, malformed_upstream_responses_fail_closed) {
     static const char kPartialStatus[] = "HTTP/1.1 20";
     static const char kBadHeaderCrlf[] = "HTTP/1.1 200 OK\r\nX-Test: bad\rX-Next: y\r\n\r\n";
     static const char kBadContentLength[] = "HTTP/1.1 200 OK\r\nContent-Length: nope\r\n\r\n";
+    static const char kStatusTooLow[] = "HTTP/1.1 099 Low\r\nContent-Length: 0\r\n\r\n";
+    static const char kStatusTooHigh[] = "HTTP/1.1 600 High\r\nContent-Length: 0\r\n\r\n";
+    static const char kBadVersion[] = "HTTP/1.2 200 OK\r\nContent-Length: 0\r\n\r\n";
+    static const char kEmptyHeaderName[] = "HTTP/1.1 200 OK\r\n: bad\r\n\r\n";
+    static const char kConflictingContentLength[] =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: 1\r\n"
+        "Content-Length: 2\r\n"
+        "\r\n";
+    static const char kMalformedChunkedInitial[] =
+        "HTTP/1.1 200 OK\r\n"
+        "Transfer-Encoding: chunked\r\n"
+        "\r\n"
+        "XYZ\r\n";
+    static const char kChunkedBeatsContentLengthButStillValidatesChunks[] =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: 100\r\n"
+        "Transfer-Encoding: chunked\r\n"
+        "\r\n"
+        "ZZ\r\n";
 
     static const MalformedUpstreamCase kCases[] = {
         {"bad status code", kBadStatus, sizeof(kBadStatus) - 1, true},
         {"partial status then eof", kPartialStatus, sizeof(kPartialStatus) - 1, true},
         {"malformed header crlf", kBadHeaderCrlf, sizeof(kBadHeaderCrlf) - 1, true},
         {"invalid content length", kBadContentLength, sizeof(kBadContentLength) - 1, true},
+        {"status below range", kStatusTooLow, sizeof(kStatusTooLow) - 1, true},
+        {"status above range", kStatusTooHigh, sizeof(kStatusTooHigh) - 1, true},
+        {"unsupported http version", kBadVersion, sizeof(kBadVersion) - 1, true},
+        {"empty header name", kEmptyHeaderName, sizeof(kEmptyHeaderName) - 1, true},
+        {"conflicting content length",
+         kConflictingContentLength,
+         sizeof(kConflictingContentLength) - 1,
+         true},
+        {"malformed chunked initial body",
+         kMalformedChunkedInitial,
+         sizeof(kMalformedChunkedInitial) - 1,
+         true},
+        {"chunked wins over content length but malformed chunks fail",
+         kChunkedBeatsContentLengthButStillValidatesChunks,
+         sizeof(kChunkedBeatsContentLengthButStillValidatesChunks) - 1,
+         true},
         {"empty eof", nullptr, 0, false},
     };
 

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2881,10 +2881,16 @@ struct ScopedProxyLoop {
         loop = create_real_loop();
         if (loop == nullptr) return false;
         auto lfd_result = create_listen_socket(0);
-        if (!lfd_result.has_value()) return false;
+        if (!lfd_result.has_value()) {
+            teardown();
+            return false;
+        }
         listen_fd = lfd_result.value();
         port = get_port(listen_fd);
-        if (!loop->init(0, listen_fd).has_value()) return false;
+        if (!loop->init(0, listen_fd).has_value()) {
+            teardown();
+            return false;
+        }
         loop->config_ptr = active;
         lt = {loop, {}, iters};
         lt.start();
@@ -2904,6 +2910,7 @@ struct ScopedProxyLoop {
             close(listen_fd);
             listen_fd = -1;
         }
+        port = 0;
         if (loop != nullptr) {
             destroy_real_loop(loop);
             loop = nullptr;
@@ -2945,15 +2952,21 @@ static void run_malformed_upstream_case(rut::test::TestCase* test_case,
         return;
     }
 
-    char buf[2048];
-    i32 n = recv_timeout(client, buf, sizeof(buf), 2000);
+    char buf[4096];
+    u32 total = 0;
+    i32 n = 0;
+    while (total < sizeof(buf)) {
+        n = recv_timeout(client, buf + total, sizeof(buf) - total, 2000);
+        if (n <= 0) break;
+        total += static_cast<u32>(n);
+        if (buf_contains(buf, total, "\r\n\r\n", 4)) break;
+    }
     if (tc_cfg.expect_502) {
-        CHECK_MSG(n > 0, tc_cfg.name);
-        CHECK_MSG(buf_contains(buf, static_cast<u32>(n > 0 ? n : 0), "502", 3), tc_cfg.name);
-        CHECK_MSG(buf_contains(buf, static_cast<u32>(n > 0 ? n : 0), "Connection: close", 17),
-                  tc_cfg.name);
+        CHECK_MSG(total > 0, tc_cfg.name);
+        CHECK_MSG(buf_contains(buf, total, "502", 3), tc_cfg.name);
+        CHECK_MSG(buf_contains(buf, total, "Connection: close", 17), tc_cfg.name);
     } else {
-        CHECK_MSG(n <= 0, tc_cfg.name);
+        CHECK_MSG(total == 0 && n <= 0, tc_cfg.name);
     }
 
     close(client);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -14,6 +14,7 @@
 #include "rut/runtime/tls.h"
 #include "test.h"
 #include "test_helpers.h"
+#include <atomic>
 
 #include <openssl/ssl.h>
 #include <stdlib.h>
@@ -2808,7 +2809,7 @@ struct ScriptedUpstreamServer {
     u16 port = 0;
     const char* response = nullptr;
     u32 response_len = 0;
-    bool running = false;
+    std::atomic<bool> running{false};
     bool started = false;
     pthread_t thread{};
 
@@ -2817,9 +2818,11 @@ struct ScriptedUpstreamServer {
     static void* run(void* arg) {
         auto* server = static_cast<ScriptedUpstreamServer*>(arg);
         i32 client = -1;
-        for (u32 i = 0; i < 2000 && server->running; i++) {
-            client = accept(server->listen_fd, nullptr, nullptr);
+        const i32 accept_fd = server->listen_fd;
+        for (u32 i = 0; i < 2000 && server->running.load(std::memory_order_acquire); i++) {
+            client = accept(accept_fd, nullptr, nullptr);
             if (client >= 0) break;
+            if (errno == EINTR) continue;
             if (errno != EAGAIN && errno != EWOULDBLOCK) break;
             usleep(1000);
         }
@@ -2841,9 +2844,9 @@ struct ScriptedUpstreamServer {
         port = get_port(listen_fd);
         response = bytes;
         response_len = len;
-        running = true;
+        running.store(true, std::memory_order_release);
         if (pthread_create(&thread, nullptr, run, this) != 0) {
-            running = false;
+            running.store(false, std::memory_order_release);
             close(listen_fd);
             listen_fd = -1;
             return false;
@@ -2853,14 +2856,57 @@ struct ScriptedUpstreamServer {
     }
 
     void teardown() {
-        running = false;
+        running.store(false, std::memory_order_release);
+        if (started) {
+            pthread_join(thread, nullptr);
+            started = false;
+        }
         if (listen_fd >= 0) {
             close(listen_fd);
             listen_fd = -1;
         }
-        if (started) {
-            pthread_join(thread, nullptr);
-            started = false;
+    }
+};
+
+struct ScopedProxyLoop {
+    RealLoop* loop = nullptr;
+    i32 listen_fd = -1;
+    u16 port = 0;
+    LoopThread lt{};
+    bool loop_started = false;
+
+    ~ScopedProxyLoop() { teardown(); }
+
+    bool setup(const RouteConfig** active, i32 iters) {
+        loop = create_real_loop();
+        if (loop == nullptr) return false;
+        auto lfd_result = create_listen_socket(0);
+        if (!lfd_result.has_value()) return false;
+        listen_fd = lfd_result.value();
+        port = get_port(listen_fd);
+        if (!loop->init(0, listen_fd).has_value()) return false;
+        loop->config_ptr = active;
+        lt = {loop, {}, iters};
+        lt.start();
+        loop_started = true;
+        return true;
+    }
+
+    void teardown() {
+        if (loop_started) {
+            lt.stop();
+            loop_started = false;
+        }
+        if (loop != nullptr) {
+            loop->shutdown();
+        }
+        if (listen_fd >= 0) {
+            close(listen_fd);
+            listen_fd = -1;
+        }
+        if (loop != nullptr) {
+            destroy_real_loop(loop);
+            loop = nullptr;
         }
     }
 };
@@ -2885,38 +2931,32 @@ static void run_malformed_upstream_case(rut::test::TestCase* test_case,
     REQUIRE(cfg.add_proxy("/api", 0, upstream_id.value()));
     const RouteConfig* active = &cfg;
 
-    RealLoop* loop = create_real_loop();
-    REQUIRE(loop != nullptr);
-    auto lfd_result = create_listen_socket(0);
-    REQUIRE(lfd_result.has_value());
-    i32 lfd = lfd_result.value();
-    u16 port = get_port(lfd);
-    REQUIRE(loop->init(0, lfd).has_value());
-    loop->config_ptr = &active;
-    LoopThread lt = {loop, {}, 500};
-    lt.start();
+    ScopedProxyLoop proxy;
+    REQUIRE(proxy.setup(&active, 500));
 
-    i32 client = connect_to(port);
-    REQUIRE(client >= 0);
+    i32 client = connect_to(proxy.port);
+    CHECK_MSG(client >= 0, tc_cfg.name);
+    if (client < 0) return;
     const char kReq[] = "GET /api HTTP/1.1\r\nHost: x\r\n\r\n";
-    REQUIRE(send_all(client, kReq, sizeof(kReq) - 1));
+    bool sent = send_all(client, kReq, sizeof(kReq) - 1);
+    CHECK_MSG(sent, tc_cfg.name);
+    if (!sent) {
+        close(client);
+        return;
+    }
 
     char buf[2048];
     i32 n = recv_timeout(client, buf, sizeof(buf), 2000);
     if (tc_cfg.expect_502) {
-        CHECK_GT(n, 0);
-        CHECK(buf_contains(buf, static_cast<u32>(n > 0 ? n : 0), "502", 3));
-        CHECK(buf_contains(buf, static_cast<u32>(n > 0 ? n : 0), "Connection: close", 17));
+        CHECK_MSG(n > 0, tc_cfg.name);
+        CHECK_MSG(buf_contains(buf, static_cast<u32>(n > 0 ? n : 0), "502", 3), tc_cfg.name);
+        CHECK_MSG(buf_contains(buf, static_cast<u32>(n > 0 ? n : 0), "Connection: close", 17),
+                  tc_cfg.name);
     } else {
-        CHECK_LE(n, 0);
+        CHECK_MSG(n <= 0, tc_cfg.name);
     }
 
     close(client);
-    lt.stop();
-    loop->shutdown();
-    close(lfd);
-    destroy_real_loop(loop);
-    upstream.teardown();
 }
 
 TEST(proxy_e2e, malformed_upstream_responses_fail_closed) {


### PR DESCRIPTION
## Summary

Adds real-socket proxy E2E coverage for malformed upstream responses using a local scripted upstream server.

Covered upstream failure cases:
- malformed status code
- partial status line followed by EOF
- malformed header CRLF
- invalid Content-Length
- status codes outside the valid 100-599 range
- unsupported HTTP version digit
- empty header name
- conflicting Content-Length headers
- malformed chunked initial body
- malformed chunked body when both Transfer-Encoding and Content-Length are present
- empty upstream EOF

The malformed parser cases assert the client receives a 502 with `Connection: close`; the empty EOF case asserts fail-closed behavior. The TODO backlog is updated to mark the malformed upstream E2E item complete.

## Validation

- `cmake --build build --target test_integration`
- `build/tests/test_integration --filter=proxy_e2e.*`
- `build/tests/test_integration --filter=proxy_e2e.*,route.forward_jit_handler_enters_proxy_state,route.forward_jit_handler_rejects_unknown_upstream_id`
- `./dev.sh format`
- `git diff --check`
