### PR TITLE
[codex] Add replay simulate route matrix coverage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,7 @@ Outstanding work items, prioritized for the next implementation passes.
 - [x] Runtime debug helpers can snapshot and format connection state, callback slots, armed operations, and buffer lengths.
 - [x] Test framework fault injection provides shared mmap/mprotect/socket/recv/poll/read/write/send/connect/epoll/timerfd/accept/open scopes for network/runtime tests.
 - [x] Malformed upstream E2E coverage drives real proxy sockets through malformed status, EOF, header, and framing failures.
+- [x] Replay/simulate route-action matrix coverage documents Static, Default, Proxy/JIT Forward, JIT ReturnStatus, mismatch, and malformed capture behavior.
 
 ## P0: State Invariant Coverage Follow-ups
 
@@ -57,24 +58,6 @@ Outstanding work items, prioritized for the next implementation passes.
 **Acceptance**:
 - At least one shared helper replaces ad hoc EINTR counters.
 - New tests verify retry or fail-closed behavior without depending on real network permissions.
-
-## P1: Replay Coverage Matrix
-
-**Goal**: Prevent caller/path coverage holes when routing behavior expands.
-
-**Why**: `replay_one` previously only covered static routes, so proxy route behavior regressed until review. Future route actions and callers need explicit matrix coverage.
-
-**Work**:
-- Document and enforce `[caller x route action x expected result]` cases for:
-  - `replay_one`
-  - `replay_file`
-  - `simulate_one`
-  - `simulate_file`
-- Include Static, Default, Proxy, JIT ReturnStatus, JIT Forward, malformed input, and unsupported action paths where relevant.
-
-**Acceptance**:
-- A table-driven test or comment block makes missing cells obvious.
-- Adding a route action requires adding or intentionally documenting replay/sim coverage.
 
 ## P2: Coverage Tooling Hygiene
 

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -491,6 +491,134 @@ TEST(simulate_engine, default_200_when_no_route_matches) {
     ctx.destroy();
 }
 
+TEST(simulate_engine, simulate_one_route_action_matrix) {
+    Manifest manifest{};
+    manifest.upstream_count = 1;
+    manifest.upstreams[0].id = 7;
+    strcpy(manifest.upstreams[0].name, "api-v1");
+    manifest.route_count = 2;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/static");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 204;
+    manifest.routes[1].method = 'G';
+    strcpy(manifest.routes[1].pattern, "/api");
+    manifest.routes[1].action = ManifestAction::Forward;
+    manifest.routes[1].upstream_id = 7;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    struct MatrixCase {
+        const char* name;
+        CaptureEntry entry;
+        Verdict verdict;
+        jit::HandlerAction action;
+        u16 actual_status;
+        const char* actual_upstream;
+    };
+
+    const MatrixCase cases[] = {
+        {"static status",
+         make_entry("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 204),
+         Verdict::Match,
+         jit::HandlerAction::ReturnStatus,
+         204,
+         ""},
+        {"default status",
+         make_entry("GET /missing HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+         Verdict::Match,
+         jit::HandlerAction::ReturnStatus,
+         200,
+         ""},
+        {"static mismatch",
+         make_entry("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 201),
+         Verdict::Mismatch,
+         jit::HandlerAction::ReturnStatus,
+         204,
+         ""},
+        {"forward match",
+         make_entry("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 502, "api-v1"),
+         Verdict::Match,
+         jit::HandlerAction::Forward,
+         0,
+         "api-v1"},
+        {"forward mismatch",
+         make_entry("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 502, "wrong"),
+         Verdict::Mismatch,
+         jit::HandlerAction::Forward,
+         0,
+         "api-v1"},
+        {"malformed capture",
+         make_entry("GET /static HTTP/1.1\r\nHost: x\r\n", 204),
+         Verdict::Failed,
+         jit::HandlerAction::ReturnStatus,
+         0,
+         ""},
+    };
+
+    for (const auto& tc : cases) {
+        const auto result = simulate_one(engine, tc.entry);
+        CHECK_MSG(result.verdict == tc.verdict, tc.name);
+        CHECK_MSG(result.action == tc.action, tc.name);
+        CHECK_MSG(result.actual_status == tc.actual_status, tc.name);
+        CHECK_MSG(strcmp(result.actual_upstream, tc.actual_upstream) == 0, tc.name);
+    }
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, simulate_file_route_action_matrix_summary) {
+    Manifest manifest{};
+    manifest.upstream_count = 1;
+    manifest.upstreams[0].id = 7;
+    strcpy(manifest.upstreams[0].name, "api-v1");
+    manifest.route_count = 2;
+    manifest.routes[0].method = 'G';
+    strcpy(manifest.routes[0].pattern, "/static");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 204;
+    manifest.routes[1].method = 'G';
+    strcpy(manifest.routes[1].pattern, "/api");
+    manifest.routes[1].action = ManifestAction::Forward;
+    manifest.routes[1].upstream_id = 7;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    CaptureEntry entries[] = {
+        make_entry("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 204),
+        make_entry("GET /missing HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+        make_entry("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 201),
+        make_entry("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 502, "api-v1"),
+        make_entry("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 502, "wrong"),
+        make_entry("GET /static HTTP/1.1\r\nHost: x\r\n", 204),
+    };
+
+    char path[] = "/tmp/rut_sim_matrix_capture_XXXXXX";
+    i32 fd = mkstemp(path);
+    REQUIRE(fd >= 0);
+    REQUIRE(write_capture_file(fd, 6, entries, 6));
+    close(fd);
+
+    ReplayReader reader;
+    REQUIRE(reader.open(path) == 0);
+    const auto summary = simulate_file(engine, reader);
+    CHECK_EQ(summary.total, 6u);
+    CHECK_EQ(summary.matched, 3u);
+    CHECK_EQ(summary.mismatched, 2u);
+    CHECK_EQ(summary.failed, 1u);
+    CHECK_EQ(summary.unsupported, 0u);
+
+    reader.close();
+    unlink(path);
+    engine.shutdown();
+    ctx.destroy();
+}
+
 TEST(simulate_engine, param_prefix_route_matches) {
     Manifest manifest{};
     manifest.route_count = 1;

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -3,6 +3,7 @@
 #include "rut/compiler/lower_rir.h"
 #include "rut/compiler/mir_build.h"
 #include "rut/compiler/parser.h"
+#include "rut/runtime/route_method.h"
 #include "rut/sim/simulate_engine.h"
 #include "test.h"
 
@@ -334,7 +335,7 @@ TEST(simulate_engine, load_manifest_accepts_whitespace_comments_and_forward_refs
 TEST(simulate_engine, static_status_match) {
     Manifest manifest{};
     manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/health");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 204;
@@ -497,15 +498,15 @@ TEST(simulate_engine, simulate_one_route_action_matrix) {
     manifest.upstreams[0].id = 7;
     strcpy(manifest.upstreams[0].name, "api-v1");
     manifest.route_count = 3;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/static");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 204;
-    manifest.routes[1].method = 'P';
+    manifest.routes[1].method = kRouteMethodPost;
     strcpy(manifest.routes[1].pattern, "/post-only");
     manifest.routes[1].action = ManifestAction::ReturnStatus;
     manifest.routes[1].status_code = 202;
-    manifest.routes[2].method = 'G';
+    manifest.routes[2].method = kRouteMethodGet;
     strcpy(manifest.routes[2].pattern, "/api");
     manifest.routes[2].action = ManifestAction::Forward;
     manifest.routes[2].upstream_id = 7;
@@ -598,15 +599,15 @@ TEST(simulate_engine, simulate_file_route_action_matrix_summary) {
     manifest.upstreams[0].id = 7;
     strcpy(manifest.upstreams[0].name, "api-v1");
     manifest.route_count = 3;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/static");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 204;
-    manifest.routes[1].method = 'P';
+    manifest.routes[1].method = kRouteMethodPost;
     strcpy(manifest.routes[1].pattern, "/post-only");
     manifest.routes[1].action = ManifestAction::ReturnStatus;
     manifest.routes[1].status_code = 202;
-    manifest.routes[2].method = 'G';
+    manifest.routes[2].method = kRouteMethodGet;
     strcpy(manifest.routes[2].pattern, "/api");
     manifest.routes[2].action = ManifestAction::Forward;
     manifest.routes[2].upstream_id = 7;
@@ -651,7 +652,7 @@ TEST(simulate_engine, simulate_file_route_action_matrix_summary) {
 TEST(simulate_engine, param_prefix_route_matches) {
     Manifest manifest{};
     manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/users/:id");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 201;
@@ -671,7 +672,7 @@ TEST(simulate_engine, param_prefix_route_matches) {
 TEST(simulate_engine, param_route_rejects_empty_segment) {
     Manifest manifest{};
     manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/users/:id");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 201;
@@ -692,7 +693,7 @@ TEST(simulate_engine, param_route_rejects_empty_segment) {
 TEST(simulate_engine, colon_inside_segment_matches_literal_colon) {
     Manifest manifest{};
     manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/v1:beta");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 201;
@@ -913,7 +914,7 @@ TEST(simulate_engine, build_module_rejects_invalid_route_count_without_init) {
 TEST(simulate_engine, engine_init_accepts_codegen_truncated_handler_symbol_names) {
     Manifest manifest{};
     manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/long-name");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 204;
@@ -940,7 +941,7 @@ TEST(simulate_engine, engine_init_accepts_codegen_truncated_handler_symbol_names
 TEST(simulate_engine, engine_init_rejects_overlong_compiled_route_patterns) {
     Manifest manifest{};
     manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/ok");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 200;
@@ -967,14 +968,14 @@ TEST(simulate_engine, engine_init_rejects_overlong_compiled_route_patterns) {
 TEST(simulate_engine, engine_init_can_reinitialize_existing_engine) {
     Manifest manifest_a{};
     manifest_a.route_count = 1;
-    manifest_a.routes[0].method = 'G';
+    manifest_a.routes[0].method = kRouteMethodGet;
     strcpy(manifest_a.routes[0].pattern, "/first");
     manifest_a.routes[0].action = ManifestAction::ReturnStatus;
     manifest_a.routes[0].status_code = 201;
 
     Manifest manifest_b{};
     manifest_b.route_count = 1;
-    manifest_b.routes[0].method = 'G';
+    manifest_b.routes[0].method = kRouteMethodGet;
     strcpy(manifest_b.routes[0].pattern, "/second");
     manifest_b.routes[0].action = ManifestAction::ReturnStatus;
     manifest_b.routes[0].status_code = 202;
@@ -1006,7 +1007,7 @@ TEST(simulate_engine, engine_init_can_reinitialize_existing_engine) {
 TEST(simulate_engine, engine_init_clears_state_on_precondition_failure) {
     Manifest manifest{};
     manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/ok");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 200;
@@ -1033,11 +1034,11 @@ TEST(simulate_engine, param_route_matching_matrix) {
 
     Manifest manifest{};
     manifest.route_count = 2;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/users/:id");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 201;
-    manifest.routes[1].method = 'G';
+    manifest.routes[1].method = kRouteMethodGet;
     strcpy(manifest.routes[1].pattern, "/teams/:team/members/:member");
     manifest.routes[1].action = ManifestAction::ReturnStatus;
     manifest.routes[1].status_code = 202;
@@ -1068,7 +1069,7 @@ TEST(simulate_engine, param_route_matching_matrix) {
 TEST(simulate_engine, simulate_one_rejects_malformed_capture_headers) {
     Manifest manifest{};
     manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/ok");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 200;
@@ -1107,11 +1108,11 @@ TEST(simulate_engine, summary_counts_mismatch) {
     manifest.upstreams[0].id = 9;
     strcpy(manifest.upstreams[0].name, "edge");
     manifest.route_count = 2;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/ok");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 200;
-    manifest.routes[1].method = 'G';
+    manifest.routes[1].method = kRouteMethodGet;
     strcpy(manifest.routes[1].pattern, "/api");
     manifest.routes[1].action = ManifestAction::Forward;
     manifest.routes[1].upstream_id = 9;
@@ -1151,7 +1152,7 @@ TEST(simulate_engine, summary_counts_mismatch) {
 TEST(simulate_engine, simulate_file_counts_malformed_entries_as_failed) {
     Manifest manifest{};
     manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/ok");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 200;
@@ -1200,7 +1201,7 @@ TEST(simulate_engine, simulate_file_counts_truncated_capture_as_failed) {
 
     Manifest manifest{};
     manifest.route_count = 1;
-    manifest.routes[0].method = 'G';
+    manifest.routes[0].method = kRouteMethodGet;
     strcpy(manifest.routes[0].pattern, "/ok");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 200;
@@ -1249,7 +1250,7 @@ TEST(simulate_engine, simulate_file_counts_truncated_capture_as_failed) {
 TEST(simulate_engine, format_result_uses_mismatch_label) {
     SimulateResult result{};
     result.verdict = Verdict::Mismatch;
-    result.method = 'G';
+    result.method = static_cast<u8>(LogHttpMethod::Get);
     strcpy(result.path, "/api");
     result.action = jit::HandlerAction::ReturnStatus;
     result.expected_status = 200;
@@ -1265,7 +1266,7 @@ TEST(simulate_engine, format_result_uses_mismatch_label) {
 TEST(simulate_engine, format_result_failed_status_uses_placeholder) {
     SimulateResult result{};
     result.verdict = Verdict::Failed;
-    result.method = 'G';
+    result.method = static_cast<u8>(LogHttpMethod::Get);
     strcpy(result.path, "/bad");
     result.action = jit::HandlerAction::ReturnStatus;
     result.expected_status = 502;
@@ -1279,7 +1280,7 @@ TEST(simulate_engine, format_result_failed_status_uses_placeholder) {
 TEST(simulate_engine, format_result_yield_uses_placeholders) {
     SimulateResult result{};
     result.verdict = Verdict::Unsupported;
-    result.method = 'G';
+    result.method = static_cast<u8>(LogHttpMethod::Get);
     strcpy(result.path, "/yield");
     result.action = jit::HandlerAction::Yield;
     strcpy(result.expected_upstream, "edge");

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -496,15 +496,19 @@ TEST(simulate_engine, simulate_one_route_action_matrix) {
     manifest.upstream_count = 1;
     manifest.upstreams[0].id = 7;
     strcpy(manifest.upstreams[0].name, "api-v1");
-    manifest.route_count = 2;
+    manifest.route_count = 3;
     manifest.routes[0].method = 'G';
     strcpy(manifest.routes[0].pattern, "/static");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 204;
-    manifest.routes[1].method = 'G';
-    strcpy(manifest.routes[1].pattern, "/api");
-    manifest.routes[1].action = ManifestAction::Forward;
-    manifest.routes[1].upstream_id = 7;
+    manifest.routes[1].method = 'P';
+    strcpy(manifest.routes[1].pattern, "/post-only");
+    manifest.routes[1].action = ManifestAction::ReturnStatus;
+    manifest.routes[1].status_code = 202;
+    manifest.routes[2].method = 'G';
+    strcpy(manifest.routes[2].pattern, "/api");
+    manifest.routes[2].action = ManifestAction::Forward;
+    manifest.routes[2].upstream_id = 7;
 
     ModuleContext ctx;
     Engine engine;
@@ -531,6 +535,24 @@ TEST(simulate_engine, simulate_one_route_action_matrix) {
          Verdict::Match,
          jit::HandlerAction::ReturnStatus,
          200,
+         ""},
+        {"default upstream mismatch",
+         make_entry("GET /missing HTTP/1.1\r\nHost: x\r\n\r\n", 200, "api-v1"),
+         Verdict::Mismatch,
+         jit::HandlerAction::ReturnStatus,
+         200,
+         ""},
+        {"method default",
+         make_entry("GET /post-only HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+         Verdict::Match,
+         jit::HandlerAction::ReturnStatus,
+         200,
+         ""},
+        {"method match",
+         make_entry("POST /post-only HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n", 202),
+         Verdict::Match,
+         jit::HandlerAction::ReturnStatus,
+         202,
          ""},
         {"static mismatch",
          make_entry("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 201),
@@ -575,15 +597,19 @@ TEST(simulate_engine, simulate_file_route_action_matrix_summary) {
     manifest.upstream_count = 1;
     manifest.upstreams[0].id = 7;
     strcpy(manifest.upstreams[0].name, "api-v1");
-    manifest.route_count = 2;
+    manifest.route_count = 3;
     manifest.routes[0].method = 'G';
     strcpy(manifest.routes[0].pattern, "/static");
     manifest.routes[0].action = ManifestAction::ReturnStatus;
     manifest.routes[0].status_code = 204;
-    manifest.routes[1].method = 'G';
-    strcpy(manifest.routes[1].pattern, "/api");
-    manifest.routes[1].action = ManifestAction::Forward;
-    manifest.routes[1].upstream_id = 7;
+    manifest.routes[1].method = 'P';
+    strcpy(manifest.routes[1].pattern, "/post-only");
+    manifest.routes[1].action = ManifestAction::ReturnStatus;
+    manifest.routes[1].status_code = 202;
+    manifest.routes[2].method = 'G';
+    strcpy(manifest.routes[2].pattern, "/api");
+    manifest.routes[2].action = ManifestAction::Forward;
+    manifest.routes[2].upstream_id = 7;
 
     ModuleContext ctx;
     Engine engine;
@@ -592,6 +618,9 @@ TEST(simulate_engine, simulate_file_route_action_matrix_summary) {
     CaptureEntry entries[] = {
         make_entry("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 204),
         make_entry("GET /missing HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+        make_entry("GET /missing HTTP/1.1\r\nHost: x\r\n\r\n", 200, "api-v1"),
+        make_entry("GET /post-only HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+        make_entry("POST /post-only HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n", 202),
         make_entry("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 201),
         make_entry("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 502, "api-v1"),
         make_entry("GET /api/users HTTP/1.1\r\nHost: x\r\n\r\n", 502, "wrong"),
@@ -601,15 +630,15 @@ TEST(simulate_engine, simulate_file_route_action_matrix_summary) {
     char path[] = "/tmp/rut_sim_matrix_capture_XXXXXX";
     i32 fd = mkstemp(path);
     REQUIRE(fd >= 0);
-    REQUIRE(write_capture_file(fd, 6, entries, 6));
+    REQUIRE(write_capture_file(fd, 9, entries, 9));
     close(fd);
 
     ReplayReader reader;
     REQUIRE(reader.open(path) == 0);
     const auto summary = simulate_file(engine, reader);
-    CHECK_EQ(summary.total, 6u);
-    CHECK_EQ(summary.matched, 3u);
-    CHECK_EQ(summary.mismatched, 2u);
+    CHECK_EQ(summary.total, 9u);
+    CHECK_EQ(summary.matched, 5u);
+    CHECK_EQ(summary.mismatched, 3u);
     CHECK_EQ(summary.failed, 1u);
     CHECK_EQ(summary.unsupported, 0u);
 

--- a/tests/test_traffic_replay.cc
+++ b/tests/test_traffic_replay.cc
@@ -1,5 +1,6 @@
 // Tests for traffic replay: ReplayReader, replay_one, replay_file.
 #include "fault_injection.h"
+#include "rut/jit/handler_abi.h"
 #include "rut/runtime/traffic_replay.h"
 #include "test.h"
 #include "test_helpers.h"
@@ -74,6 +75,22 @@ static CaptureEntry make_captured_request(const char* req, u16 status) {
     entry.method = static_cast<u8>(LogHttpMethod::Get);
     entry.timestamp_us = realtime_us();
     return entry;
+}
+
+static u64 replay_matrix_status_207_handler(void* /*conn*/,
+                                            rut::jit::HandlerCtx* /*ctx*/,
+                                            const u8* /*req*/,
+                                            u32 /*len*/,
+                                            void* /*arena*/) {
+    return rut::jit::HandlerResult::make_status(207).pack();
+}
+
+static u64 replay_matrix_forward_0_handler(void* /*conn*/,
+                                           rut::jit::HandlerCtx* /*ctx*/,
+                                           const u8* /*req*/,
+                                           u32 /*len*/,
+                                           void* /*arena*/) {
+    return rut::jit::HandlerResult::make_forward(0).pack();
 }
 
 // === ReplayReader ===
@@ -500,6 +517,99 @@ TEST(route, replay_file_with_routing) {
     CHECK_EQ(summary.replayed, 4u);
     CHECK_EQ(summary.matched, 4u);
     CHECK_EQ(summary.mismatched, 0u);
+
+    reader.close();
+    tmp.cleanup();
+}
+
+TEST(route, replay_one_route_action_matrix) {
+    RouteConfig cfg;
+    auto up_result = cfg.add_upstream("backend", 0x7F000001, 9999);
+    REQUIRE(up_result.has_value());
+    REQUIRE(cfg.add_static("/static", 'G', 204));
+    REQUIRE(cfg.add_proxy("/proxy", 'G', static_cast<u16>(up_result.value())));
+    REQUIRE(cfg.add_jit_handler("/jit-status", 'G', &replay_matrix_status_207_handler));
+    REQUIRE(cfg.add_jit_handler("/jit-forward", 'G', &replay_matrix_forward_0_handler));
+
+    RoutedLoop rl;
+    rl.setup(&cfg);
+
+    struct MatrixCase {
+        const char* name;
+        const char* request;
+        u16 expected_status;
+        bool replayed;
+        bool skipped;
+        bool status_match;
+        u16 actual_status;
+    };
+
+    const MatrixCase cases[] = {
+        {"static status", "GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 204, true, false, true, 204},
+        {"default status", "GET /missing HTTP/1.1\r\nHost: x\r\n\r\n", 200, true, false, true, 200},
+        {"static mismatch",
+         "GET /static HTTP/1.1\r\nHost: x\r\n\r\n",
+         201,
+         true,
+         false,
+         false,
+         204},
+        {"proxy skipped", "GET /proxy/x HTTP/1.1\r\nHost: x\r\n\r\n", 502, false, true, false, 0},
+        {"jit status", "GET /jit-status HTTP/1.1\r\nHost: x\r\n\r\n", 207, true, false, true, 207},
+        {"jit forward skipped",
+         "GET /jit-forward HTTP/1.1\r\nHost: x\r\n\r\n",
+         502,
+         false,
+         true,
+         false,
+         0},
+    };
+
+    for (u32 i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        const auto& tc = cases[i];
+        CaptureEntry entry = make_captured_request(tc.request, tc.expected_status);
+        ReplayResult result = replay_one(rl.loop, entry, static_cast<i32>(4200 + i));
+        CHECK_MSG(result.replayed == tc.replayed, tc.name);
+        CHECK_MSG(result.skipped == tc.skipped, tc.name);
+        CHECK_MSG(result.status_match == tc.status_match, tc.name);
+        CHECK_MSG(result.actual_status == tc.actual_status, tc.name);
+    }
+}
+
+TEST(route, replay_file_route_action_matrix_summary) {
+    RouteConfig cfg;
+    auto up_result = cfg.add_upstream("backend", 0x7F000001, 9999);
+    REQUIRE(up_result.has_value());
+    REQUIRE(cfg.add_static("/static", 'G', 204));
+    REQUIRE(cfg.add_proxy("/proxy", 'G', static_cast<u16>(up_result.value())));
+    REQUIRE(cfg.add_jit_handler("/jit-status", 'G', &replay_matrix_status_207_handler));
+    REQUIRE(cfg.add_jit_handler("/jit-forward", 'G', &replay_matrix_forward_0_handler));
+
+    CaptureEntry entries[] = {
+        make_captured_request("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 204),
+        make_captured_request("GET /missing HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+        make_captured_request("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 201),
+        make_captured_request("GET /proxy/x HTTP/1.1\r\nHost: x\r\n\r\n", 502),
+        make_captured_request("GET /jit-status HTTP/1.1\r\nHost: x\r\n\r\n", 207),
+        make_captured_request("GET /jit-forward HTTP/1.1\r\nHost: x\r\n\r\n", 502),
+    };
+
+    TempCapture tmp;
+    REQUIRE(tmp.create(entries, sizeof(entries) / sizeof(entries[0])));
+
+    ReplayReader reader;
+    REQUIRE(reader.open(tmp.path) == 0);
+
+    RoutedLoop rl;
+    rl.setup(&cfg);
+
+    ReplaySummary summary = replay_file(rl.loop, reader);
+    CHECK_EQ(summary.total, 6u);
+    CHECK_EQ(summary.replayed, 4u);
+    CHECK_EQ(summary.matched, 3u);
+    CHECK_EQ(summary.mismatched, 1u);
+    CHECK_EQ(summary.skipped, 2u);
+    CHECK_EQ(summary.failed, 0u);
 
     reader.close();
     tmp.cleanup();

--- a/tests/test_traffic_replay.cc
+++ b/tests/test_traffic_replay.cc
@@ -527,6 +527,7 @@ TEST(route, replay_one_route_action_matrix) {
     auto up_result = cfg.add_upstream("backend", 0x7F000001, 9999);
     REQUIRE(up_result.has_value());
     REQUIRE(cfg.add_static("/static", 'G', 204));
+    REQUIRE(cfg.add_static("/post-only", 'P', 202));
     REQUIRE(cfg.add_proxy("/proxy", 'G', static_cast<u16>(up_result.value())));
     REQUIRE(cfg.add_jit_handler("/jit-status", 'G', &replay_matrix_status_207_handler));
     REQUIRE(cfg.add_jit_handler("/jit-forward", 'G', &replay_matrix_forward_0_handler));
@@ -547,6 +548,20 @@ TEST(route, replay_one_route_action_matrix) {
     const MatrixCase cases[] = {
         {"static status", "GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 204, true, false, true, 204},
         {"default status", "GET /missing HTTP/1.1\r\nHost: x\r\n\r\n", 200, true, false, true, 200},
+        {"method default",
+         "GET /post-only HTTP/1.1\r\nHost: x\r\n\r\n",
+         200,
+         true,
+         false,
+         true,
+         200},
+        {"method match",
+         "POST /post-only HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n",
+         202,
+         true,
+         false,
+         true,
+         202},
         {"static mismatch",
          "GET /static HTTP/1.1\r\nHost: x\r\n\r\n",
          201,
@@ -581,6 +596,7 @@ TEST(route, replay_file_route_action_matrix_summary) {
     auto up_result = cfg.add_upstream("backend", 0x7F000001, 9999);
     REQUIRE(up_result.has_value());
     REQUIRE(cfg.add_static("/static", 'G', 204));
+    REQUIRE(cfg.add_static("/post-only", 'P', 202));
     REQUIRE(cfg.add_proxy("/proxy", 'G', static_cast<u16>(up_result.value())));
     REQUIRE(cfg.add_jit_handler("/jit-status", 'G', &replay_matrix_status_207_handler));
     REQUIRE(cfg.add_jit_handler("/jit-forward", 'G', &replay_matrix_forward_0_handler));
@@ -588,6 +604,9 @@ TEST(route, replay_file_route_action_matrix_summary) {
     CaptureEntry entries[] = {
         make_captured_request("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 204),
         make_captured_request("GET /missing HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+        make_captured_request("GET /post-only HTTP/1.1\r\nHost: x\r\n\r\n", 200),
+        make_captured_request("POST /post-only HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n",
+                              202),
         make_captured_request("GET /static HTTP/1.1\r\nHost: x\r\n\r\n", 201),
         make_captured_request("GET /proxy/x HTTP/1.1\r\nHost: x\r\n\r\n", 502),
         make_captured_request("GET /jit-status HTTP/1.1\r\nHost: x\r\n\r\n", 207),
@@ -604,9 +623,9 @@ TEST(route, replay_file_route_action_matrix_summary) {
     rl.setup(&cfg);
 
     ReplaySummary summary = replay_file(rl.loop, reader);
-    CHECK_EQ(summary.total, 6u);
-    CHECK_EQ(summary.replayed, 4u);
-    CHECK_EQ(summary.matched, 3u);
+    CHECK_EQ(summary.total, 8u);
+    CHECK_EQ(summary.replayed, 6u);
+    CHECK_EQ(summary.matched, 5u);
     CHECK_EQ(summary.mismatched, 1u);
     CHECK_EQ(summary.skipped, 2u);
     CHECK_EQ(summary.failed, 0u);


### PR DESCRIPTION
## Summary

Adds explicit replay/simulate route-action matrix coverage so future routing changes have a clear caller x action expectation surface.

Covered replay cases:
- `replay_one` and `replay_file`
- static status routes
- default 200 fallback
- method-specific route match and method fallback
- static mismatch accounting
- proxy route skipped accounting
- JIT ReturnStatus replay
- JIT Forward skipped accounting

Covered simulate cases:
- `simulate_one` and `simulate_file`
- static status routes
- default 200 fallback
- default-with-expected-upstream mismatch
- method-specific route match and method fallback
- forward upstream match and mismatch
- malformed capture failure accounting

Also updates `TODO.md` to mark the Replay Coverage Matrix item complete.

## Validation

- `cmake --build build --target test_traffic_replay test_simulate_engine`
- `build/tests/test_traffic_replay`
- `build/tests/test_simulate_engine`
- `./dev.sh format`
- `git diff --check`
