### PR TITLE
[codex] Complete route decorator wait support

### DIFF
--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -121,14 +121,18 @@ route {
 }
 ```
 
-Execution order for `/admin/upload` is:
+Guard order for `/admin/upload` is:
 
 1. `requestId`
 2. `auth`
 3. `maxBody`
 4. route handler
 
-The first decorator that returns a non-zero status stops the chain.
+Current implementation note: decorator expressions are materialized before the
+guard chain runs, so all decorators may be evaluated even when an earlier one
+returns a non-zero status. The guard chain still observes the order above: the
+first non-zero decorator result determines the returned status and prevents the
+route handler's terminal control from running.
 
 ## `wait(...)` Routes
 

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -149,12 +149,19 @@ The decorator runs before the timer yield is armed:
 - If `auth` returns `0`, the handler yields the timer and resumes to `return 200`.
 
 Current limitation: decorated `wait(...)` routes must use direct terminal
-control. These forms are rejected today:
+control and cannot contain user `let` bindings. These forms are rejected today:
 
 ```rut
 route {
     @auth "*"
     GET "/x" { wait(50) if true { return 200 } else { return 500 } }
+}
+```
+
+```rut
+route {
+    @auth "*"
+    GET "/x" { let code = 200 wait(50) return 200 }
 }
 ```
 

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -11,22 +11,23 @@ continue or reject it with an HTTP status code.
 Decorator functions use this convention:
 
 ```rut
-func auth(_ req: i32) -> i32 => 0
+func auth(_ ignored: i32) -> i32 => 0
 ```
 
 Rules:
 
 - The function must have at least one parameter.
-- The first parameter must use the omitted-label form: `_ req: ...`.
+- The first parameter must use the omitted-label form: `_ <name>: ...`.
 - The return type must be `i32`.
 - Returning `0` means pass through.
 - Returning any non-zero value short-circuits the route and returns that value
   as the HTTP status code.
 
 The first parameter is currently a placeholder. A real runtime `Request` type is
-not implemented yet. Decorators that need request data should use the existing
-request expression surface such as `req.header(...)`, `req.path`, and
-`req.method` inside the function body.
+not implemented yet. If a decorator needs the magic request expression surface
+such as `req.header(...)`, `req.path`, or `req.method`, do not name the
+placeholder parameter `req`; a user-bound parameter or local named `req` shadows
+the magic request object.
 
 ## Binding To Routes
 
@@ -37,7 +38,7 @@ Decorators can be bound inside a `route { ... }` block.
 `"*"` applies the decorator to every entry in the block:
 
 ```rut
-func auth(_ req: i32) -> i32 => 0
+func auth(_ ignored: i32) -> i32 => 0
 
 route {
     @auth "*"
@@ -51,7 +52,7 @@ route {
 A string pattern other than `"*"` applies to route paths with that prefix:
 
 ```rut
-func adminOnly(_ req: i32) -> i32 => 0
+func adminOnly(_ ignored: i32) -> i32 => 0
 
 route {
     @adminOnly "/admin"
@@ -68,7 +69,7 @@ In this example, `adminOnly` applies to `/admin/users` but not to
 A decorator can be attached directly to a single route entry:
 
 ```rut
-func requestId(_ req: i32) -> i32 => 0
+func requestId(_ ignored: i32) -> i32 => 0
 
 route {
     @requestId
@@ -86,9 +87,9 @@ Block bindings and entry decorators are merged. Matching block bindings come
 first in declaration order, then entry decorators:
 
 ```rut
-func requestId(_ req: i32) -> i32 => 0
-func auth(_ req: i32) -> i32 => 0
-func maxBody(_ req: i32) -> i32 => 0
+func requestId(_ ignored: i32) -> i32 => 0
+func auth(_ ignored: i32) -> i32 => 0
+func maxBody(_ ignored: i32) -> i32 => 0
 
 route {
     @requestId "*"
@@ -113,7 +114,7 @@ The first decorator that returns a non-zero status stops the chain.
 Decorators can be used with direct terminal `wait(...)` routes:
 
 ```rut
-func auth(_ req: i32) -> i32 => 0
+func auth(_ ignored: i32) -> i32 => 0
 
 route {
     @auth "*"

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -5,8 +5,9 @@ route middleware subset, not a general language-level decorator system.
 
 ## Purpose
 
-A route decorator runs before the route handler. It can allow the request to
-continue or reject it with an HTTP status code.
+A route decorator can allow the request to continue or reject it with an HTTP
+status code before the route reaches terminal control such as `return`,
+`forward(...)`, or `wait(...)`.
 
 Decorator functions use this convention:
 
@@ -28,6 +29,26 @@ not implemented yet. If a decorator needs the magic request expression surface
 such as `req.header(...)`, `req.path`, or `req.method`, do not name the
 placeholder parameter `req`; a user-bound parameter or local named `req` shadows
 the magic request object.
+
+## Execution Order
+
+Decorators are currently lowered as synthetic locals and guards. User `let`
+initializers are materialized before those guards run, so a decorated route like
+this:
+
+```rut
+func auth(_ ignored: i32) -> i32 => 401
+
+route {
+    @auth "*"
+    GET "/x" { let code = 200 return code }
+}
+```
+
+still evaluates the `let code = 200` initializer before `auth` can reject.
+The decorator guard runs before the route's terminal control and before any
+`wait(...)` timer yield is armed, but it is not yet a strict "first instruction
+in the handler" hook.
 
 ## Binding To Routes
 

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -1,0 +1,161 @@
+# Route Decorators
+
+This document describes the decorator behavior implemented today. It is a
+route middleware subset, not a general language-level decorator system.
+
+## Purpose
+
+A route decorator runs before the route handler. It can allow the request to
+continue or reject it with an HTTP status code.
+
+Decorator functions use this convention:
+
+```rut
+func auth(_ req: i32) -> i32 => 0
+```
+
+Rules:
+
+- The function must have at least one parameter.
+- The first parameter must use the omitted-label form: `_ req: ...`.
+- The return type must be `i32`.
+- Returning `0` means pass through.
+- Returning any non-zero value short-circuits the route and returns that value
+  as the HTTP status code.
+
+The first parameter is currently a placeholder. A real runtime `Request` type is
+not implemented yet. Decorators that need request data should use the existing
+request expression surface such as `req.header(...)`, `req.path`, and
+`req.method` inside the function body.
+
+## Binding To Routes
+
+Decorators can be bound inside a `route { ... }` block.
+
+### Wildcard Binding
+
+`"*"` applies the decorator to every entry in the block:
+
+```rut
+func auth(_ req: i32) -> i32 => 0
+
+route {
+    @auth "*"
+    GET "/users" { return 200 }
+    POST "/orders" { return 201 }
+}
+```
+
+### Prefix Binding
+
+A string pattern other than `"*"` applies to route paths with that prefix:
+
+```rut
+func adminOnly(_ req: i32) -> i32 => 0
+
+route {
+    @adminOnly "/admin"
+    GET "/admin/users" { return 200 }
+    GET "/public/health" { return 200 }
+}
+```
+
+In this example, `adminOnly` applies to `/admin/users` but not to
+`/public/health`.
+
+### Entry Decorator
+
+A decorator can be attached directly to a single route entry:
+
+```rut
+func requestId(_ req: i32) -> i32 => 0
+
+route {
+    @requestId
+    GET "/users" { return 200 }
+
+    GET "/health" { return 200 }
+}
+```
+
+Here, `requestId` applies only to `GET "/users"`.
+
+### Merged Decorators
+
+Block bindings and entry decorators are merged. Matching block bindings come
+first in declaration order, then entry decorators:
+
+```rut
+func requestId(_ req: i32) -> i32 => 0
+func auth(_ req: i32) -> i32 => 0
+func maxBody(_ req: i32) -> i32 => 0
+
+route {
+    @requestId "*"
+    @auth "/admin"
+
+    @maxBody
+    POST "/admin/upload" { return 200 }
+}
+```
+
+Execution order for `/admin/upload` is:
+
+1. `requestId`
+2. `auth`
+3. `maxBody`
+4. route handler
+
+The first decorator that returns a non-zero status stops the chain.
+
+## `wait(...)` Routes
+
+Decorators can be used with direct terminal `wait(...)` routes:
+
+```rut
+func auth(_ req: i32) -> i32 => 0
+
+route {
+    @auth "*"
+    GET "/sleep" { wait(1000) return 200 }
+}
+```
+
+The decorator runs before the timer yield is armed:
+
+- If `auth` returns `401`, the handler immediately returns `401`.
+- If `auth` returns `0`, the handler yields the timer and resumes to `return 200`.
+
+Current limitation: decorated `wait(...)` routes must use direct terminal
+control. These forms are rejected today:
+
+```rut
+route {
+    @auth "*"
+    GET "/x" { wait(50) if true { return 200 } else { return 500 } }
+}
+```
+
+Decorated wait routes with user top-level guards or for-loops are also rejected.
+Those shapes need a fuller source-ordered state-machine lowering.
+
+## Unsupported Today
+
+The following are design goals or future work, not current behavior:
+
+- General-purpose decorators on arbitrary declarations.
+- Response middleware.
+- Decorator arguments such as `@auth(role: "admin")`.
+- Conditional decorators such as `@if(...)`.
+- A real `Request` parameter type for decorator signatures.
+- Post-handler response mutation.
+
+## Diagnostics
+
+The analyzer rejects:
+
+- Unknown decorator names.
+- Decorator functions with zero parameters.
+- Decorator functions whose first parameter is missing `_`.
+- Decorator functions whose return type is not `i32`.
+- Decorated wait routes outside the direct terminal subset described above.

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -759,6 +759,7 @@ struct HirRoute {
     FixedVec<HirLocal, kMaxLocals> locals;
     FixedVec<HirGuard, kMaxGuards> guards;
     FixedVec<DecoratorRef, kMaxDecorators> decorators;
+    u32 decorator_guard_count = 0;
     FixedVec<Wait, kMaxWaits> waits;
     FixedVec<HirForLoop, kMaxForLoops> for_loops;
     HirControl control{};
@@ -773,6 +774,7 @@ struct HirRoute {
           locals(other.locals),
           guards(other.guards),
           decorators(other.decorators),
+          decorator_guard_count(other.decorator_guard_count),
           waits(other.waits),
           for_loops(other.for_loops),
           control(other.control),
@@ -788,6 +790,7 @@ struct HirRoute {
         locals = other.locals;
         guards = other.guards;
         decorators = other.decorators;
+        decorator_guard_count = other.decorator_guard_count;
         waits = other.waits;
         for_loops = other.for_loops;
         control = other.control;
@@ -803,6 +806,7 @@ struct HirRoute {
           locals(other.locals),
           guards(other.guards),
           decorators(other.decorators),
+          decorator_guard_count(other.decorator_guard_count),
           waits(other.waits),
           for_loops(other.for_loops),
           control(other.control),
@@ -818,6 +822,7 @@ struct HirRoute {
         locals = other.locals;
         guards = other.guards;
         decorators = other.decorators;
+        decorator_guard_count = other.decorator_guard_count;
         waits = other.waits;
         for_loops = other.for_loops;
         control = other.control;

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -11,6 +11,7 @@ enum class MirTerminatorKind : u8 {
     Branch,
     ReturnStatus,
     ForwardUpstream,
+    YieldTimer,
 };
 
 enum class MirValueKind : u8 {
@@ -198,6 +199,8 @@ struct MirTerminator {
     MirValue rhs{};
     u32 then_block = 0;
     u32 else_block = 0;
+    u32 yield_ms = 0;
+    u16 yield_next_state = 0;
     // Optional response body literal — carried verbatim from HIR for
     // ReturnStatus terminators. lower_rir maps identical literals to a
     // shared body_idx that codegen packs into HandlerResult.upstream_id.
@@ -232,6 +235,8 @@ struct MirFunction {
     FixedVec<MirLocal, kMaxLocals> locals;
     FixedVec<MirBlock, kMaxBlocks> blocks;
     FixedVec<Wait, kMaxWaits> waits;
+    bool state_zero_enters_entry = false;
+    u32 resume_terminal_block = 0;
     u32 error_variant_index = 0xffffffffu;
 
     MirFunction() = default;
@@ -244,6 +249,8 @@ struct MirFunction {
           locals(other.locals),
           blocks(other.blocks),
           waits(other.waits),
+          state_zero_enters_entry(other.state_zero_enters_entry),
+          resume_terminal_block(other.resume_terminal_block),
           error_variant_index(other.error_variant_index) {
         rebase_from(other);
     }
@@ -257,6 +264,8 @@ struct MirFunction {
         locals = other.locals;
         blocks = other.blocks;
         waits = other.waits;
+        state_zero_enters_entry = other.state_zero_enters_entry;
+        resume_terminal_block = other.resume_terminal_block;
         error_variant_index = other.error_variant_index;
         rebase_from(other);
         return *this;
@@ -270,6 +279,8 @@ struct MirFunction {
           locals(other.locals),
           blocks(other.blocks),
           waits(other.waits),
+          state_zero_enters_entry(other.state_zero_enters_entry),
+          resume_terminal_block(other.resume_terminal_block),
           error_variant_index(other.error_variant_index) {
         rebase_from(other);
     }
@@ -283,6 +294,8 @@ struct MirFunction {
         locals = other.locals;
         blocks = other.blocks;
         waits = other.waits;
+        state_zero_enters_entry = other.state_zero_enters_entry;
+        resume_terminal_block = other.resume_terminal_block;
         error_variant_index = other.error_variant_index;
         rebase_from(other);
         return *this;

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -226,6 +226,7 @@ enum class Opcode : u8 {
     RetForward,  // ret.forward upstream [, options]
 
     // ── Yield (I/O suspend → state machine boundary) ──
+    YieldTimer,     // yield.timer ms, next_state
     YieldHttpGet,   // %r = yield.http_get url, headers
     YieldHttpPost,  // %r = yield.http_post url, headers, body
     YieldForward,   // %r = yield.forward upstream
@@ -288,6 +289,7 @@ struct Instruction {
             case Opcode::YieldHttpGet:
             case Opcode::YieldHttpPost:
             case Opcode::YieldForward:
+            case Opcode::YieldTimer:
                 return true;
             default:
                 return false;
@@ -353,6 +355,8 @@ struct Function {
 
     // Yield point count (determines state machine states).
     u32 yield_count;
+    bool state_zero_enters_entry;
+    u32 resume_terminal_block;
 
     // Per-yield payload. For a Timer yield, yield_payload[i] is the
     // duration in milliseconds (u32 ≈ 49 days). Arena-allocated, length

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -125,7 +125,9 @@ struct Builder {
     // Record the wait(ms) list for a function: arena-allocates a u32 array
     // sized to count and copies the ms values in order. After this call,
     // fn->yield_count reflects the number of state-machine yield points
-    // and codegen can consume fn->yield_payload[i].
+    // and codegen can consume fn->yield_payload[i]. Explicit YieldTimer
+    // terminators reuse this bookkeeping; emit_yield_timer validates that
+    // the payload table already covers its next state.
     VoidResult set_yield_payload(Function* fn, const u32* ms_list, u32 count) {
         if (count == 0) {
             fn->yield_count = 0;
@@ -867,6 +869,8 @@ struct Builder {
 
     VoidResult emit_yield_timer(u32 ms, u16 next_state, SourceLoc loc = {}) {
         if (!cur_func) return err(RirError::InvalidState);
+        if (cur_func->yield_count == 0 || next_state == 0 || next_state > cur_func->yield_count)
+            return err(RirError::InvalidState);
         auto r = TRY(emit(Opcode::YieldTimer, nullptr, loc));
         r.inst->imm.i64_val = (static_cast<i64>(next_state) << 32) | static_cast<i64>(ms);
         return {};

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -109,6 +109,8 @@ struct Builder {
         fn->route_pattern = route_pattern;
         fn->http_method = http_method;
         fn->yield_count = 0;
+        fn->state_zero_enters_entry = false;
+        fn->resume_terminal_block = 0;
         fn->yield_payload = nullptr;
         fn->blocks = blocks;
         fn->block_count = 0;
@@ -135,6 +137,13 @@ struct Builder {
         for (u32 i = 0; i < count; i++) buf[i] = ms_list[i];
         fn->yield_payload = buf;
         fn->yield_count = count;
+        return {};
+    }
+
+    VoidResult set_state_zero_entry_resume(Function* fn, BlockId terminal_block) {
+        if (!fn || terminal_block.id >= fn->block_count) return err(RirError::InvalidState);
+        fn->state_zero_enters_entry = true;
+        fn->resume_terminal_block = terminal_block.id;
         return {};
     }
 
@@ -854,6 +863,13 @@ struct Builder {
         }
         cur_func->yield_count++;
         return vid;
+    }
+
+    VoidResult emit_yield_timer(u32 ms, u16 next_state, SourceLoc loc = {}) {
+        if (!cur_func) return err(RirError::InvalidState);
+        auto r = TRY(emit(Opcode::YieldTimer, nullptr, loc));
+        r.inst->imm.i64_val = (static_cast<i64>(next_state) << 32) | static_cast<i64>(ms);
+        return {};
     }
 };
 

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9869,13 +9869,6 @@ static FrontendResult<HirModule*> analyze_file_internal(
         // awkwardly once impure inits land. Deferring until the
         // state-machine has real per-state code gen.
         //
-        // Decorators are routed through the entry block, so mixing
-        // waits with decorators would sleep before running the
-        // decorator — `@auth GET "/x" { wait(50) return 204 }` would
-        // let an unauthorized request sleep before rejecting. Reject
-        // that combination here until decorators gain pre-yield
-        // placement.
-        //
         // wait(0) is rejected: it has no meaning for a sleep primitive
         // and would stall 1s under the wheel fallback.
         bool seen_wait = false;
@@ -9886,8 +9879,6 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 if (seen_non_let_non_wait)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 if (stmt.status_code == 0)
-                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
-                if (!item.route.decorators.empty())
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 seen_wait = true;
                 // ms payload is the 32-bit Yield slot (status_code +
@@ -10450,11 +10441,17 @@ static FrontendResult<HirModule*> analyze_file_internal(
         // place doesn't invalidate any pointers.
         const u32 num_user_guards = first_decorator_guard_index;
         const u32 num_deco_guards = route.guards.len - first_decorator_guard_index;
+        route.decorator_guard_count = num_deco_guards;
         if (num_deco_guards > 0 && num_user_guards > 0) {
             HirGuard tmp[HirRoute::kMaxGuards];
             for (u32 i = 0; i < route.guards.len; i++) tmp[i] = route.guards[i];
             for (u32 i = 0; i < num_deco_guards; i++) route.guards[i] = tmp[num_user_guards + i];
             for (u32 i = 0; i < num_user_guards; i++) route.guards[num_deco_guards + i] = tmp[i];
+        }
+        if (route.waits.len != 0 && route.decorator_guard_count != 0 &&
+            (route.guards.len != route.decorator_guard_count ||
+             route.control.kind != HirControlKind::Direct || route.for_loops.len != 0)) {
+            return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
         }
 
         if (!mod.routes.push(route))

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -10353,6 +10353,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
         // local + guard pair. Pre-middleware short-circuit is achieved by guards:
         // each guard checks `local == 0`; on non-zero, fail_term returns the
         // local's runtime value (HirTerminatorSourceKind::LocalRef).
+        const u32 user_local_count_before_decorators = route.locals.len;
         const u32 first_decorator_guard_index = route.guards.len;
         for (u32 di = 0; di < item.route.decorators.len; di++) {
             const auto& ast_deco = item.route.decorators[di];
@@ -10448,10 +10449,16 @@ static FrontendResult<HirModule*> analyze_file_internal(
             for (u32 i = 0; i < num_deco_guards; i++) route.guards[i] = tmp[num_user_guards + i];
             for (u32 i = 0; i < num_user_guards; i++) route.guards[num_deco_guards + i] = tmp[i];
         }
-        if (route.waits.len != 0 && route.decorator_guard_count != 0 &&
-            (route.guards.len != route.decorator_guard_count ||
-             route.control.kind != HirControlKind::Direct || route.for_loops.len != 0)) {
-            return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
+        if (route.waits.len != 0 && route.decorator_guard_count != 0) {
+            for (u32 li = 0; li < user_local_count_before_decorators; li++) {
+                if (route.locals[li].name.len != 0) {
+                    return frontend_error(FrontendError::UnsupportedSyntax, route.locals[li].span);
+                }
+            }
+            if (route.guards.len != route.decorator_guard_count ||
+                route.control.kind != HirControlKind::Direct || route.for_loops.len != 0) {
+                return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
+            }
         }
 
         if (!mod.routes.push(route))

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2464,6 +2464,12 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
             return frontend_error(FrontendError::OutOfMemory, term.span);
         return {};
     }
+    if (term.kind == MirTerminatorKind::YieldTimer) {
+        if (!b.emit_yield_timer(
+                term.yield_ms, term.yield_next_state, {term.span.line, term.span.col}))
+            return frontend_error(FrontendError::OutOfMemory, term.span);
+        return {};
+    }
     return frontend_error(FrontendError::UnsupportedSyntax, term.span);
 }
 
@@ -3012,6 +3018,14 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
         if (mir.functions[i].blocks.len == 0) {
             out.destroy();
             return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
+        }
+        if (mir.functions[i].state_zero_enters_entry) {
+            if (mir.functions[i].resume_terminal_block >= mir.functions[i].blocks.len ||
+                !b.set_state_zero_entry_resume(fn.value(),
+                                               block_ids[mir.functions[i].resume_terminal_block])) {
+                out.destroy();
+                return frontend_error(FrontendError::UnsupportedSyntax, mir.functions[i].span);
+            }
         }
         b.set_insert_point(fn.value(), block_ids[0]);
 

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -1054,6 +1054,66 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             continue;
         }
 
+        if (fn.waits.len != 0 && module.routes[i].decorator_guard_count != 0) {
+            const u32 deco_count = module.routes[i].decorator_guard_count;
+            const bool scope = module.routes[i].control.kind == HirControlKind::Direct &&
+                               module.routes[i].guards.len == deco_count &&
+                               fn.waits.len <= MirFunction::kMaxWaits;
+            if (!scope) return frontend_error(FrontendError::UnsupportedSyntax, fn.span);
+
+            const u32 yield_index = deco_count;
+            const u32 terminal_index = yield_index + 1;
+            u32 guard_fail_index[HirRoute::kMaxGuards]{};
+            u32 fail_cursor = terminal_index + 1;
+            for (u32 gi = 0; gi < deco_count; gi++) {
+                guard_fail_index[gi] = fail_cursor;
+                fail_cursor += guard_fail_block_count(module.routes[i].guards[gi]);
+            }
+            if (fail_cursor > MirFunction::kMaxBlocks)
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+
+            for (u32 gi = 0; gi < deco_count; gi++) {
+                const auto& guard = module.routes[i].guards[gi];
+                MirBlock guard_block{};
+                guard_block.label = gi == 0 ? entry_label() : cont_label();
+                guard_block.term.kind = MirTerminatorKind::Branch;
+                guard_block.term.span = guard.span;
+                auto cond = mir_value(guard.cond, module, &fn);
+                if (!cond) return core::make_unexpected(cond.error());
+                guard_block.term.cond = cond.value();
+                guard_block.term.then_block = gi + 1 < deco_count ? gi + 1 : yield_index;
+                guard_block.term.else_block = guard_fail_index[gi];
+                if (!fn.blocks.push(guard_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+            }
+
+            MirBlock yield_block{};
+            yield_block.label = cont_label();
+            yield_block.term.kind = MirTerminatorKind::YieldTimer;
+            yield_block.term.span = fn.waits[0].span;
+            yield_block.term.yield_ms = fn.waits[0].ms;
+            yield_block.term.yield_next_state = 1;
+            if (!fn.blocks.push(yield_block))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+
+            MirBlock terminal_block{};
+            terminal_block.label = cont_label();
+            set_term_from_hir(&terminal_block.term, module.routes[i].control.direct_term);
+            if (!fn.blocks.push(terminal_block))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+
+            for (u32 gi = 0; gi < deco_count; gi++) {
+                auto emitted = emit_guard_fail(module.routes[i].guards[gi]);
+                if (!emitted) return core::make_unexpected(emitted.error());
+            }
+
+            fn.state_zero_enters_entry = true;
+            fn.resume_terminal_block = terminal_index;
+            if (!mir->functions.push(fn))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+            continue;
+        }
+
         MirBlock block{};
         block.label = entry_label();
         if (module.routes[i].guards.len != 0) {

--- a/src/compiler/rir_printer.cc
+++ b/src/compiler/rir_printer.cc
@@ -277,6 +277,9 @@ void print_opcode(PrintBuf& buf, Opcode op) {
         case Opcode::RetForward:
             buf.put_cstr("ret.forward");
             break;
+        case Opcode::YieldTimer:
+            buf.put_cstr("yield.timer");
+            break;
         case Opcode::YieldHttpGet:
             buf.put_cstr("yield.http_get");
             break;
@@ -631,6 +634,14 @@ void print_instruction(PrintBuf& buf, const Instruction& inst, const Function& f
             buf.put(' ');
             if (inst.operand_count > 0) print_value_ref(buf, inst.operands[0]);
             break;
+        case Opcode::YieldTimer: {
+            const u64 packed = static_cast<u64>(inst.imm.i64_val);
+            buf.put(' ');
+            buf.put_u32(static_cast<u32>(packed & 0xffffffffu));
+            buf.put_cstr(", state ");
+            buf.put_u32(static_cast<u32>((packed >> 32) & 0xffffu));
+            break;
+        }
 
         // Instrumentation
         case Opcode::TraceFuncEnter:

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -963,7 +963,9 @@ static bool emit_function(Ctx& c, const rir::Function& fn) {
 
     // State-machine prologue. When the RIR function has yield points, the
     // handler is called multiple times (once per state) and the first
-    // LLVM basic block dispatches on HandlerCtx::state:
+    // LLVM basic block dispatches on HandlerCtx::state. The default mapping
+    // uses state 0..N-1 for prologue yield blocks and any later state for
+    // terminal execution:
     //
     //   dispatch:
     //     switch state {
@@ -976,6 +978,11 @@ static bool emit_function(Ctx& c, const rir::Function& fn) {
     // running any of the original code; the terminal state runs the
     // original RIR blocks unchanged. Single-function model — no frame
     // needed for this slice (nothing lives across the yield).
+    //
+    // Decorated wait routes can set state_zero_enters_entry. In that mode,
+    // state 0 enters the original entry block so decorator guards run before
+    // the first timer yield, yield_0 is omitted from the prologue, and
+    // resumed states dispatch to the recorded terminal block by default.
     if (fn.yield_count > 0) {
         LLVMBasicBlockRef dispatch_bb = LLVMAppendBasicBlockInContext(c.llvm_ctx, func, "dispatch");
         // Move dispatch to be the first block; it will become the function's

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -895,6 +895,15 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             LLVMBuildRet(c.builder, result);
             break;
         }
+        case rir::Opcode::YieldTimer: {
+            const u64 packed = static_cast<u64>(inst.imm.i64_val);
+            const u32 payload = static_cast<u32>(packed & 0xffffffffu);
+            const u16 next_state = static_cast<u16>((packed >> 32) & 0xffffu);
+            LLVMBuildRet(
+                c.builder,
+                c.make_result_yield(next_state, static_cast<u8>(YieldKind::Timer), payload));
+            break;
+        }
 
         default:
             // Unhandled opcode in Phase 1 — emit unreachable as a placeholder.
@@ -978,13 +987,20 @@ static bool emit_function(Ctx& c, const rir::Function& fn) {
         // HandlerCtx layout: state (u16) @ offset 0.
         LLVMValueRef state = LLVMBuildLoad2(c.builder, c.i16_ty, c.param_ctx, "state");
 
-        LLVMBasicBlockRef terminal_bb = c.block_map[fn.blocks[0].id.id];
-        LLVMValueRef sw = LLVMBuildSwitch(c.builder, state, terminal_bb, fn.yield_count);
+        const u32 terminal_block_id =
+            fn.state_zero_enters_entry ? fn.resume_terminal_block : fn.blocks[0].id.id;
+        LLVMBasicBlockRef terminal_bb = c.block_map[terminal_block_id];
+        LLVMValueRef sw = LLVMBuildSwitch(
+            c.builder, state, terminal_bb, fn.yield_count + (fn.state_zero_enters_entry ? 1 : 0));
+        if (fn.state_zero_enters_entry) {
+            LLVMAddCase(sw, LLVMConstInt(c.i16_ty, 0, 0), c.block_map[fn.blocks[0].id.id]);
+        }
 
         // Use function-specific yield kind. v1: all yields are Timer; later
         // layers will branch on per-yield metadata.
         constexpr u8 kYieldKindTimer = static_cast<u8>(YieldKind::Timer);
-        for (u32 si = 0; si < fn.yield_count; si++) {
+        const u32 first_prologue_yield = fn.state_zero_enters_entry ? 1 : 0;
+        for (u32 si = first_prologue_yield; si < fn.yield_count; si++) {
             char ylabel[24];
             u32 lpos = 0;
             const char* prefix = "yield_";

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1500,7 +1500,7 @@ route {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    CHECK(!hir);
+    REQUIRE(!hir);
     CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
@@ -1517,7 +1517,7 @@ route {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    CHECK(!hir);
+    REQUIRE(!hir);
     CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1504,6 +1504,23 @@ route {
     CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
+TEST(frontend, analyze_rejects_decorated_wait_with_user_local) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/x" { let code = 200 wait(50) return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
 TEST(frontend, rir_function_carries_yield_payload_for_waits) {
     const char* src = "route GET \"/x\" { wait(500) wait(1000) return 200 }\n";
     auto lexed = lex(lit(src));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1466,12 +1466,9 @@ TEST(frontend, analyze_rejects_wait_after_let_guard) {
     CHECK(!hir);
 }
 
-TEST(frontend, analyze_rejects_wait_in_decorated_route) {
-    // The codegen state-machine prologue routes states 0..yield_count-1
-    // to yield blocks before the entry block. Once decorators are wired
-    // from HIR to codegen, they'd run AFTER all waits — unauthorized
-    // requests would sleep before rejecting. Reject the combination
-    // until decorators land with a proper pre-yield placement.
+TEST(frontend, analyze_accepts_wait_in_decorated_route) {
+    // Decorators are lowered as pre-yield guards for wait routes, so
+    // middleware can reject before a timer is armed.
     const char* src = R"rut(
 func auth(_ req: i32) -> i32 => 0
 route {
@@ -1484,7 +1481,27 @@ route {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].decorators.len, 1u);
+    REQUIRE_EQ(hir->routes[0].decorator_guard_count, 1u);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+}
+
+TEST(frontend, analyze_rejects_decorated_wait_with_terminal_control) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/x" { wait(50) if true { return 204 } else { return 500 } }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
     CHECK(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
 TEST(frontend, rir_function_carries_yield_payload_for_waits) {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -14199,6 +14199,61 @@ route {
     rir.destroy();
 }
 
+TEST(jit, frontend_route_decorator_passes_then_multiple_waits) {
+    const auto src = R"rut(
+func passing(_ req: i32) -> i32 => 0
+route {
+    @passing "*"
+    GET "/sleep" { wait(100) wait(200) return 202 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    HandlerCtx ctx{};
+    ctx.state = 0;
+    const u32 expected_ms[] = {100u, 200u};
+    for (u16 state = 0; state < 2; state++) {
+        auto r = HandlerResult::unpack(handler(nullptr,
+                                               &ctx,
+                                               reinterpret_cast<const u8*>(kGetRootRequest),
+                                               sizeof(kGetRootRequest) - 1,
+                                               nullptr));
+        CHECK_EQ(static_cast<u8>(r.action), static_cast<u8>(HandlerAction::Yield));
+        CHECK_EQ(r.next_state, static_cast<u16>(state + 1));
+        CHECK_EQ(static_cast<u8>(r.yield_kind), static_cast<u8>(YieldKind::Timer));
+        CHECK_EQ(r.yield_payload_u32(), expected_ms[state]);
+        ctx.state = r.next_state;
+    }
+
+    auto done = HandlerResult::unpack(handler(nullptr,
+                                              &ctx,
+                                              reinterpret_cast<const u8*>(kGetRootRequest),
+                                              sizeof(kGetRootRequest) - 1,
+                                              nullptr));
+    CHECK_EQ(static_cast<u8>(done.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(done.status_code, 202);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_route_wait_emits_yield_then_terminal_status) {
     // Source: one wait(1000) followed by return 200.
     // Expected: first handler call returns Yield(next_state=1, kind=Timer, payload=1000);

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -14106,6 +14106,99 @@ route {
     rir.destroy();
 }
 
+TEST(jit, frontend_route_decorator_rejects_before_wait_yield) {
+    const auto src = R"rut(
+func rejecting(_ req: i32) -> i32 => 401
+route {
+    @rejecting "*"
+    GET "/sleep" { wait(1000) return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    HandlerCtx ctx{};
+    ctx.state = 0;
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           &ctx,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK_EQ(static_cast<u8>(r.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r.status_code, 401);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_decorator_passes_then_waits) {
+    const auto src = R"rut(
+func passing(_ req: i32) -> i32 => 0
+route {
+    @passing "*"
+    GET "/sleep" { wait(1000) return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    HandlerCtx ctx{};
+    ctx.state = 0;
+    auto r0 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r0.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(r0.next_state, 1);
+    CHECK_EQ(static_cast<u8>(r0.yield_kind), static_cast<u8>(YieldKind::Timer));
+    CHECK_EQ(r0.yield_payload_u32(), 1000u);
+
+    ctx.state = r0.next_state;
+    auto r1 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r1.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r1.status_code, 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_route_wait_emits_yield_then_terminal_status) {
     // Source: one wait(1000) followed by return 200.
     // Expected: first handler call returns Yield(next_state=1, kind=Timer, payload=1000);


### PR DESCRIPTION
## Summary

- Allow route decorators to run before timer waits for direct terminal routes.
- Add a timer yield terminator through MIR/RIR and teach JIT dispatch to enter decorator guards at state 0, then resume into the terminal route body.
- Keep unsupported decorated wait shapes explicit by rejecting non-direct terminal control during analysis.

## Validation

- `clang-format --dry-run --Werror include/rut/compiler/hir.h include/rut/compiler/mir.h include/rut/compiler/rir.h include/rut/compiler/rir_builder.h src/compiler/analyze.cc src/compiler/mir_build.cc src/compiler/lower_rir.cc src/compiler/rir_printer.cc src/jit/codegen.cc tests/test_frontend.cc tests/test_jit.cc`
- `git diff --check`
- `cmake --build /tmp/rut-build --target test_frontend test_jit`
- `/tmp/rut-build/tests/test_frontend`
- `/tmp/rut-build/tests/test_jit`
- `cmake --build /tmp/rut-build --target test_simulate_engine`
- `/tmp/rut-build/tests/test_simulate_engine`