### PR TITLE
[codex] Complete wait operation semantics

### DIFF
--- a/docs/wait.md
+++ b/docs/wait.md
@@ -1,12 +1,139 @@
 # `wait(...)` Routes
 
-`wait(...)` pauses a JIT route handler for a timer duration, then resumes the
-same handler state machine.
+`wait(...)` pauses a JIT route handler and resumes the same handler state
+machine when the requested timer or IO completion event occurs.
 
-## Syntax
+## Event Model
+
+The handler can suspend for three classes of events:
+
+- Any currently supported `wait(any(...))` arm: downstream recv or a timer.
+- A specific IO completion such as downstream recv/send or upstream
+  connect/send/recv.
+- A timer deadline.
+
+Timer waits, statement-form event waits, and bound result-valued event waits are
+currently wired through the frontend, JIT ABI, and runtime resume path.
+
+The statement forms available today are:
 
 ```rut
-route GET "/sleep" { wait(1000) return 204 }
+wait()
+wait(downstream.recv())
+wait(upstream(api).connect())
+wait(upstream(api).recv())
+wait(upstream(api).send(req.body))
+wait(any(downstream.recv(), timer(250)))
+wait(250)
+```
+
+`wait()` resumes when downstream recv completes.
+The forms are either operation-start waits or completion waits:
+
+- `wait(downstream.recv())` arms downstream recv and waits for its completion.
+- `wait(upstream(api).connect())` opens an upstream socket, starts connecting
+  to `api`, and waits for the connect completion.
+- `wait(upstream(api).recv())` arms upstream recv on the current upstream
+  socket and waits for the recv completion.
+- `wait(upstream(api).send(req.body))` sends the current request buffer
+  upstream and waits for the send completion.
+
+`wait(any(...))` resumes on any declared supported arm. Today that means
+`downstream.recv()` plus an optional `timer(N)` timeout arm; `N` is
+milliseconds.
+
+## Result Values
+
+`wait(...)` may be bound to a local. The result currently exposes these fields:
+
+- `kind`: numeric `YieldKind` value for the event that resumed the handler.
+  Current resume values are `3 = Timer`, `5 = Recv`, `6 = Send`,
+  `7 = UpstreamConnect`, `8 = UpstreamRecv`, and `9 = UpstreamSend`.
+  `4 = Any` is only a requested wait kind; resumes report the actual event arm.
+- `result`: raw `IoEvent::result`.
+- `ok`: true when `result >= 0`.
+- `eof`: true only for recv-like events (`downstream.recv` and
+  `upstream.recv`) when `result == 0`; false for timer/connect/send events.
+
+Wait for downstream activity on the current connection:
+
+```rut
+route GET "/stream" {
+    let ev = wait()
+    guard ev.ok else { return 500 }
+    if ev.eof { return 499 } else { return 200 }
+}
+```
+
+Wait for request body data:
+
+```rut
+route POST "/upload" {
+    let ev = wait(downstream.recv())
+    guard ev.ok else { return 400 }
+    if ev.eof { return 400 } else { return 204 }
+}
+```
+
+Wait for an upstream connection:
+
+```rut
+upstream api at "127.0.0.1:9000"
+
+route GET "/proxy" {
+    let conn = wait(upstream(api).connect())
+    guard conn.ok else { return 502 }
+    return 200
+}
+```
+
+Wait for upstream request send and response recv:
+
+```rut
+upstream api at "127.0.0.1:9000"
+
+route POST "/proxy" {
+    let up = wait(upstream(api).connect())
+    guard up.ok else { return 502 }
+
+    let sent = wait(upstream(api).send(req.body))
+    guard sent.ok else { return 502 }
+
+    let response = wait(upstream(api).recv())
+    guard response.ok else { return 502 }
+    return 204
+}
+```
+
+The bound result is backed by the event that most recently resumed the handler.
+Do not rely on an older wait result after a later `wait(...)` until frame-slot
+storage is added.
+
+Wait routes support direct `return`, `if`, and `match` terminal control after
+the ordered wait/guard sequence.
+
+## Race Waits
+
+`wait(any(...))` returns the same result surface as other event waits:
+
+```rut
+route POST "/upload" {
+    let ev = wait(any(downstream.recv(), timer(2000)))
+    if ev.kind == 3 { return 408 }
+    guard ev.ok else { return 400 }
+    return 200
+}
+```
+
+## Timer Waits
+
+Timer waits suspend for a deadline and then resume the same handler:
+
+```rut
+route GET "/sleep" {
+    wait(250)
+    return 204
+}
 ```
 
 The bare integer form is milliseconds. Duration suffixes are also supported:
@@ -21,28 +148,71 @@ route GET "/d" { wait(1h) return 204 }
 The duration is stored as an unsigned 32-bit millisecond payload. `wait(0)` is
 rejected.
 
+## Event Waits
+
+Event waits suspend until the requested event kind completes:
+
+```rut
+route POST "/upload" {
+    wait(downstream.recv())
+    return 204
+}
+```
+
+The event kind is encoded in the JIT yield result:
+
+- `wait()` -> `YieldKind::Any`
+- `wait(downstream.recv())` -> `YieldKind::Recv`
+- `wait(upstream(api).connect())` -> `YieldKind::UpstreamConnect`
+- `wait(upstream(api).recv())` -> `YieldKind::UpstreamRecv`
+- `wait(upstream(api).send(req.body))` -> `YieldKind::UpstreamSend`
+
+The runtime stores the pending yield kind and only resumes the handler when a
+matching event arrives. In this slice, downstream recv is auto-armed when
+entering `wait()` or `wait(downstream.recv())`; upstream connect, upstream
+recv, and upstream send with `req.body` start the corresponding operation
+before waiting. Starting a downstream response send inside
+`wait(downstream.send(...))` is not supported yet.
+
+For this slice, "completion wait" is the important boundary:
+
+- `wait(downstream.recv())` can arm downstream recv and wait for its completion.
+- `wait(upstream(api).connect())` starts the upstream connect and waits for
+  its completion.
+- `wait(upstream(api).recv())` arms upstream recv on the current upstream
+  socket and waits for its completion.
+- `wait(upstream(api).send(req.body))` sends the current request buffer
+  upstream and waits for its completion.
+- Upstream recv/send waits preserve the named upstream target and fail closed
+  if the current upstream socket was opened for a different target.
+- `wait(any(downstream.recv(), timer(250)))` waits for downstream recv and also
+  resumes with `kind = 3` when the timeout fires. Upstream arms inside
+  `any(...)` are rejected until the arm list is carried through lowering.
+
 ## Supported Route Shape
 
-Current wait lowering supports this top-level route body shape:
+Current wait lowering supports source-ordered top-level guards and waits:
 
 ```rut
 route GET "/x" {
     let code = 201
+    guard req.path == "/x" else { return 404 }
     wait(100)
-    wait(200)
-    if code == 201 { return 201 } else { return 500 }
+    guard code == 201 else { return 500 }
+    return 201
 }
 ```
 
 In other words:
 
 ```text
-let* ; wait* ; guard* ; terminal_control
+let* ; (guard | wait)* ; terminal_control
 ```
 
-`let` bindings may appear before the first `wait`. Additional `wait(...)`
-statements must be contiguous. `let` after a `wait`, or a `wait` after a
-top-level `guard` / `if` / `match` / `return` / `forward`, is rejected today.
+`let` bindings may appear before the first `wait`. Top-level guards may appear
+before, between, or after waits, and a failing guard returns immediately without
+arming later waits. A `let` after a `wait`, or a `wait` after terminal control
+(`if` / `match` / `return` / `forward`), is rejected today.
 
 The current codegen re-materializes pure pre-wait local initializers when the
 handler reaches the terminal state. Dedicated `HandlerCtx` slot storage for
@@ -51,14 +221,14 @@ state-machine lowering pass.
 
 ## Runtime Behavior
 
-Each `wait(...)` compiles to a timer yield:
+Timer `wait(...)` compiles to a timer yield:
 
-1. Initial call with `state = 0` returns `Yield(Timer, ms, next_state = 1)`.
+1. Initial call with `state = 0` enters the first route state. It may return,
+   forward, branch through guards, or return `Yield(Timer, ms, next_state = 1)`.
 2. The event loop schedules a timer for the raw millisecond payload.
 3. When the timer fires, the loop resumes the same handler with `state =
    next_state`.
-4. After the final wait, the handler runs the terminal control and returns or
-   forwards.
+4. The resumed state continues after the corresponding `wait(...)`.
 
 Both production loops have millisecond-resolution timer paths:
 
@@ -68,6 +238,17 @@ Both production loops have millisecond-resolution timer paths:
 If a precise timer path is unavailable under pressure, the loops may use the
 1-second wheel only when the requested wait can still be represented safely.
 Otherwise the request fails instead of resuming early.
+
+Event `wait(...)` compiles to an event yield:
+
+1. Initial call reaches `wait()` or `wait(downstream.*)` / `wait(upstream(...).*)` and returns
+   `Yield(event_kind, next_state)`.
+2. The runtime clears handler callback slots, records the pending handler,
+   state, and event kind, and returns to the event loop.
+3. When a matching completion event arrives, the loop records the completion
+   kind/result in `HandlerCtx` and resumes the handler with `state =
+   next_state`.
+4. Non-matching events do not resume the pending handler.
 
 ## Decorators
 
@@ -90,9 +271,15 @@ and non-direct terminal control such as `if` / `match`.
 
 The following are future work rather than current behavior:
 
-- Full source-ordered state-machine lowering for arbitrary route control around
-  waits.
-- `HandlerCtx` frame slots for impure local initializers or values that must be
-  stored instead of re-materialized across a yield.
+- Rich result payloads beyond `kind`, `result`, `ok`, and `eof`.
+- Response starts inside `wait(downstream.send(response(...)))`; use terminal
+  `return response(...)` for downstream responses until route completion can
+  model "send and finish" without a second terminal response.
+- Exact event subsets inside `wait(any(...))`; today it uses current-connection
+  `Any` once the listed forms validate.
+- Parameterized IO starts inside `wait(any(...))`; start the operation before a
+  later race wait until that payload has a richer representation.
+- `HandlerCtx` frame slots for older wait results that must survive a later
+  wait.
+- Non-wait `let` bindings after a `wait(...)`.
 - Waits inside nested blocks, loops, branches, or decorator bodies.
-- Non-timer yield kinds such as upstream async operations.

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -43,6 +43,16 @@ enum class AstStmtKind : u8 {
     For,
 };
 
+enum class WaitEventKind : u8 {
+    Timer,
+    Any,
+    Recv,
+    Send,
+    UpstreamConnect,
+    UpstreamRecv,
+    UpstreamSend,
+};
+
 // Single response header key/value pair, used by `response(N, headers: {...})`.
 // Both fields are non-owning views into the lexer's source buffer.
 struct AstHeaderKV {
@@ -84,6 +94,7 @@ enum class AstExprKind : u8 {
     Gt,
     Or,
     Pipe,
+    Wait,
 };
 
 struct AstTypeRef {
@@ -127,6 +138,8 @@ struct AstExpr {
     FixedVec<FieldInit, kMaxFieldInits> field_inits;
     FixedVec<AstTypeRef, kMaxTypeArgs> type_args;
     FixedVec<AstExpr*, kMaxArgs> args;
+    WaitEventKind wait_event_kind = WaitEventKind::Timer;
+    u32 wait_ms = 0;
 };
 
 struct AstStatement {
@@ -142,6 +155,8 @@ struct AstStatement {
     // `wait(N)`. u32 fits both the HTTP range and the full u32 yield
     // payload range (~49 days); semantic validation is in analyze.
     u32 status_code = 0;
+    WaitEventKind wait_event_kind = WaitEventKind::Timer;
+    bool has_wait_expr = false;
     // Response body literal, populated when `return` uses the
     // `response(N, body: "...")` form. `has_response_body` distinguishes
     // an omitted kwarg from an explicit empty string — the latter must

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rut/common/types.h"
+#include "rut/compiler/ast.h"
 #include "rut/compiler/diagnostic.h"
 #include <deque>
 #include <string>
@@ -86,6 +87,8 @@ enum class HirExprKind : u8 {
     MissingOf,
     MatchPayload,
     ProtocolCall,
+    WaitResult,
+    WaitField,
 };
 
 enum class HirTypeKind : u8 {
@@ -325,6 +328,10 @@ struct HirExpr {
     u32 array_len = 0;
     HirExpr* lhs = nullptr;
     HirExpr* rhs = nullptr;
+    bool is_wait_result = false;
+    WaitEventKind wait_event_kind = WaitEventKind::Timer;
+    u32 wait_payload = 0;
+    u32 wait_index = 0xffffffffu;
     static constexpr u32 kMaxFieldInits = 8;
     // HIR-level cap stays at 8 even though AstExpr::kMaxArgs = 32: HirRoute
     // sits at ~300 KB on stack and is copied on each recursive
@@ -560,6 +567,10 @@ struct HirLocal {
     u32 shape_index = 0xffffffffu;
     u32 error_struct_index = 0xffffffffu;
     u32 error_variant_index = 0xffffffffu;
+    bool is_wait_result = false;
+    WaitEventKind wait_event_kind = WaitEventKind::Timer;
+    u32 wait_payload = 0;
+    u32 wait_index = 0xffffffffu;
     HirExpr init{};
 };
 
@@ -737,6 +748,7 @@ struct HirRoute {
     };
     struct Wait {
         Span span{};
+        WaitEventKind event_kind = WaitEventKind::Timer;
         u32 ms = 0;  // duration in milliseconds; packed into the u32 yield
                      // payload (status_code + upstream_id) at codegen time.
                      // Parser caps at UINT32_MAX (~49 days).

--- a/include/rut/compiler/lexer.h
+++ b/include/rut/compiler/lexer.h
@@ -38,6 +38,7 @@ enum class TokenType : u8 {
     KwIn,
     KwReturn,
     KwUpstream,
+    KwDownstream,
     KwListen,
     KwTls,
     KwDefaults,

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rut/common/types.h"
+#include "rut/compiler/ast.h"
 #include "rut/compiler/diagnostic.h"
 
 namespace rut {
@@ -43,6 +44,8 @@ enum class MirValueKind : u8 {
     ValueOf,
     MissingOf,
     MatchPayload,
+    WaitResult,
+    WaitField,
 };
 
 enum class MirTypeKind : u8 {
@@ -151,6 +154,9 @@ struct MirValue {
     u32 error_case_index = 0xffffffffu;
     MirValue* lhs = nullptr;
     MirValue* rhs = nullptr;
+    bool is_wait_result = false;
+    WaitEventKind wait_event_kind = WaitEventKind::Timer;
+    u32 wait_payload = 0;
     static constexpr u32 kMaxFieldInits = 8;
     static constexpr u32 kMaxArgs = 8;
     FixedVec<FieldInit, kMaxFieldInits> field_inits;
@@ -173,6 +179,9 @@ struct MirLocal {
     u32 tuple_struct_indices[kMaxMirTupleSlots]{};
     u32 error_struct_index = 0xffffffffu;
     u32 error_variant_index = 0xffffffffu;
+    bool is_wait_result = false;
+    WaitEventKind wait_event_kind = WaitEventKind::Timer;
+    u32 wait_payload = 0;
     MirValue init{};
 };
 
@@ -199,6 +208,7 @@ struct MirTerminator {
     MirValue rhs{};
     u32 then_block = 0;
     u32 else_block = 0;
+    WaitEventKind yield_event_kind = WaitEventKind::Timer;
     u32 yield_ms = 0;
     u16 yield_next_state = 0;
     // Optional response body literal — carried verbatim from HIR for
@@ -220,6 +230,7 @@ struct MirBlock {
 struct MirFunction {
     struct Wait {
         Span span{};
+        WaitEventKind event_kind = WaitEventKind::Timer;
         u32 ms = 0;
     };
 
@@ -237,6 +248,8 @@ struct MirFunction {
     FixedVec<Wait, kMaxWaits> waits;
     bool state_zero_enters_entry = false;
     u32 resume_terminal_block = 0;
+    bool has_explicit_resume_blocks = false;
+    u32 resume_blocks[kMaxWaits + 1]{};
     u32 error_variant_index = 0xffffffffu;
 
     MirFunction() = default;
@@ -251,7 +264,9 @@ struct MirFunction {
           waits(other.waits),
           state_zero_enters_entry(other.state_zero_enters_entry),
           resume_terminal_block(other.resume_terminal_block),
+          has_explicit_resume_blocks(other.has_explicit_resume_blocks),
           error_variant_index(other.error_variant_index) {
+        for (u32 i = 0; i < kMaxWaits + 1; i++) resume_blocks[i] = other.resume_blocks[i];
         rebase_from(other);
     }
     MirFunction& operator=(const MirFunction& other) {
@@ -266,6 +281,8 @@ struct MirFunction {
         waits = other.waits;
         state_zero_enters_entry = other.state_zero_enters_entry;
         resume_terminal_block = other.resume_terminal_block;
+        has_explicit_resume_blocks = other.has_explicit_resume_blocks;
+        for (u32 i = 0; i < kMaxWaits + 1; i++) resume_blocks[i] = other.resume_blocks[i];
         error_variant_index = other.error_variant_index;
         rebase_from(other);
         return *this;
@@ -281,7 +298,9 @@ struct MirFunction {
           waits(other.waits),
           state_zero_enters_entry(other.state_zero_enters_entry),
           resume_terminal_block(other.resume_terminal_block),
+          has_explicit_resume_blocks(other.has_explicit_resume_blocks),
           error_variant_index(other.error_variant_index) {
+        for (u32 i = 0; i < kMaxWaits + 1; i++) resume_blocks[i] = other.resume_blocks[i];
         rebase_from(other);
     }
     MirFunction& operator=(MirFunction&& other) noexcept {
@@ -296,6 +315,8 @@ struct MirFunction {
         waits = other.waits;
         state_zero_enters_entry = other.state_zero_enters_entry;
         resume_terminal_block = other.resume_terminal_block;
+        has_explicit_resume_blocks = other.has_explicit_resume_blocks;
+        for (u32 i = 0; i < kMaxWaits + 1; i++) resume_blocks[i] = other.resume_blocks[i];
         error_variant_index = other.error_variant_index;
         rebase_from(other);
         return *this;

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -143,13 +143,15 @@ enum class Opcode : u8 {
     ConstStatus,    // %r = const.status <code>       (printed as raw i32)
 
     // ── Request access ──
-    ReqHeader,         // %r = req.header "Name"        → Optional(str)
-    ReqParam,          // %r = req.param "id"           → str
-    ReqMethod,         // %r = req.method               → Method
-    ReqPath,           // %r = req.path                 → str
-    ReqRemoteAddr,     // %r = req.remote_addr          → IP
-    ReqContentLength,  // %r = req.content_length       → ByteSize
-    ReqCookie,         // %r = req.cookie "name"        → Optional(str)
+    ReqHeader,          // %r = req.header "Name"        → Optional(str)
+    ReqParam,           // %r = req.param "id"           → str
+    ReqMethod,          // %r = req.method               → Method
+    ReqPath,            // %r = req.path                 → str
+    ResumeEventKind,    // %r = ctx.resume_event_kind    → i32
+    ResumeEventResult,  // %r = ctx.resume_event_result  → i32
+    ReqRemoteAddr,      // %r = req.remote_addr          → IP
+    ReqContentLength,   // %r = req.content_length       → ByteSize
+    ReqCookie,          // %r = req.cookie "name"        → Optional(str)
 
     // ── Request mutation ──
     ReqSetHeader,  // req.set_header "Name", %val
@@ -357,12 +359,15 @@ struct Function {
     u32 yield_count;
     bool state_zero_enters_entry;
     u32 resume_terminal_block;
+    bool has_explicit_resume_blocks;
+    static constexpr u32 kMaxResumeBlocks = 8;
+    u32 resume_blocks[kMaxResumeBlocks];
 
-    // Per-yield payload. For a Timer yield, yield_payload[i] is the
-    // duration in milliseconds (u32 ≈ 49 days). Arena-allocated, length
-    // = yield_count. Other yield kinds will extend this or use a richer
-    // structure; for v1 timer-only it stays a flat u32 array.
+    // Per-yield ABI metadata. yield_payload[i] is the u32 payload carried
+    // by state i+1, and yield_kinds[i] is the jit::YieldKind ABI byte.
+    // Both arrays are arena-allocated with length = yield_count.
     u32* yield_payload;
+    u8* yield_kinds;
 
     Block* entry() { return block_count > 0 ? &blocks[0] : nullptr; }
     const Block* entry() const { return block_count > 0 ? &blocks[0] : nullptr; }

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rut/compiler/rir.h"
+#include "rut/jit/handler_abi.h"
 
 namespace rut {
 namespace rir {
@@ -28,6 +29,8 @@ inline auto err(RirError e) {
 }
 
 struct Builder {
+    static constexpr u8 kDefaultYieldKind = static_cast<u8>(jit::YieldKind::Timer);
+
     Module* mod;
 
     // Current insert point — stored as index to survive grow_blocks().
@@ -111,7 +114,10 @@ struct Builder {
         fn->yield_count = 0;
         fn->state_zero_enters_entry = false;
         fn->resume_terminal_block = 0;
+        fn->has_explicit_resume_blocks = false;
+        for (u32 i = 0; i < Function::kMaxResumeBlocks; i++) fn->resume_blocks[i] = 0;
         fn->yield_payload = nullptr;
+        fn->yield_kinds = nullptr;
         fn->blocks = blocks;
         fn->block_count = 0;
         fn->block_cap = kInitBlocks;
@@ -122,22 +128,30 @@ struct Builder {
         return fn;
     }
 
-    // Record the wait(ms) list for a function: arena-allocates a u32 array
-    // sized to count and copies the ms values in order. After this call,
-    // fn->yield_count reflects the number of state-machine yield points
-    // and codegen can consume fn->yield_payload[i]. Explicit YieldTimer
-    // terminators reuse this bookkeeping; emit_yield_timer validates that
-    // the payload table already covers its next state.
-    VoidResult set_yield_payload(Function* fn, const u32* ms_list, u32 count) {
+    // Record the wait list for a function. After this call, fn->yield_count
+    // reflects the number of state-machine yield points, and codegen can
+    // consume fn->yield_payload[i] and fn->yield_kinds[i]. Explicit
+    // YieldTimer terminators reuse this bookkeeping; emit_yield_timer
+    // validates that the metadata table already covers its next state.
+    VoidResult set_yield_payload(Function* fn,
+                                 const u32* ms_list,
+                                 u32 count,
+                                 const u8* kind_list = nullptr) {
         if (count == 0) {
             fn->yield_count = 0;
             fn->yield_payload = nullptr;
+            fn->yield_kinds = nullptr;
             return {};
         }
         auto* buf = mod->arena->alloc_array<u32>(count);
-        if (!buf) return err(RirError::OutOfMemory);
-        for (u32 i = 0; i < count; i++) buf[i] = ms_list[i];
+        auto* kinds = mod->arena->alloc_array<u8>(count);
+        if (!buf || !kinds) return err(RirError::OutOfMemory);
+        for (u32 i = 0; i < count; i++) {
+            buf[i] = ms_list[i];
+            kinds[i] = kind_list ? kind_list[i] : kDefaultYieldKind;
+        }
         fn->yield_payload = buf;
+        fn->yield_kinds = kinds;
         fn->yield_count = count;
         return {};
     }
@@ -146,6 +160,19 @@ struct Builder {
         if (!fn || terminal_block.id >= fn->block_count) return err(RirError::InvalidState);
         fn->state_zero_enters_entry = true;
         fn->resume_terminal_block = terminal_block.id;
+        return {};
+    }
+
+    VoidResult set_explicit_resume_blocks(Function* fn, const BlockId* blocks, u32 count) {
+        if (!fn || count > Function::kMaxResumeBlocks) return err(RirError::InvalidState);
+        for (u32 i = 0; i < count; i++) {
+            if (blocks[i].id >= fn->block_count) return err(RirError::InvalidState);
+            fn->resume_blocks[i] = blocks[i].id;
+        }
+        for (u32 i = count; i < Function::kMaxResumeBlocks; i++) fn->resume_blocks[i] = 0;
+        fn->has_explicit_resume_blocks = true;
+        fn->state_zero_enters_entry = true;
+        fn->resume_terminal_block = count != 0 ? blocks[count - 1].id : 0;
         return {};
     }
 
@@ -414,6 +441,16 @@ struct Builder {
     Result<ValueId> emit_req_path(SourceLoc loc = {}) {
         auto* ty = TRY(make_type(TypeKind::Str));
         return TRY(emit(Opcode::ReqPath, ty, loc)).vid;
+    }
+
+    Result<ValueId> emit_resume_event_kind(SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::I32));
+        return TRY(emit(Opcode::ResumeEventKind, ty, loc)).vid;
+    }
+
+    Result<ValueId> emit_resume_event_result(SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::I32));
+        return TRY(emit(Opcode::ResumeEventResult, ty, loc)).vid;
     }
 
     Result<ValueId> emit_req_remote_addr(SourceLoc loc = {}) {
@@ -868,11 +905,16 @@ struct Builder {
     }
 
     VoidResult emit_yield_timer(u32 ms, u16 next_state, SourceLoc loc = {}) {
+        return emit_yield_event(kDefaultYieldKind, ms, next_state, loc);
+    }
+
+    VoidResult emit_yield_event(u8 kind, u32 payload, u16 next_state, SourceLoc loc = {}) {
         if (!cur_func) return err(RirError::InvalidState);
         if (cur_func->yield_count == 0 || next_state == 0 || next_state > cur_func->yield_count)
             return err(RirError::InvalidState);
         auto r = TRY(emit(Opcode::YieldTimer, nullptr, loc));
-        r.inst->imm.i64_val = (static_cast<i64>(next_state) << 32) | static_cast<i64>(ms);
+        r.inst->imm.i64_val = (static_cast<i64>(kind) << 48) |
+                              (static_cast<i64>(next_state) << 32) | static_cast<i64>(payload);
         return {};
     }
 };

--- a/include/rut/jit/handler_abi.h
+++ b/include/rut/jit/handler_abi.h
@@ -24,6 +24,12 @@ enum class YieldKind : u8 {
     Timer = 3,  // sleep for N ms; payload packed across status_code +
                 // upstream_id as a u32 (~49 days). See make_yield_payload /
                 // yield_payload_u32.
+    Any = 4,
+    Recv = 5,
+    Send = 6,
+    UpstreamConnect = 7,
+    UpstreamRecv = 8,
+    UpstreamSend = 9,
 };
 
 // ── Handler Result ─────────────────────────────────────────────────
@@ -118,9 +124,11 @@ struct HandlerResult {
 // determined at compile time by the state-splitting pass.
 
 struct HandlerCtx {
-    u16 state;        // current state machine state
-    u16 handler_idx;  // index into CompiledHandlers::handlers[]
-    u32 slot_count;   // number of 8-byte slots following this header
+    u16 state;                // current state machine state
+    u16 handler_idx;          // index into CompiledHandlers::handlers[]
+    u32 slot_count;           // number of 8-byte slots following this header
+    u32 resume_event_kind;    // YieldKind value that resumed this handler
+    i32 resume_event_result;  // IoEvent::result for event waits
 
     // Access slot storage (8-byte aligned, immediately after header).
     u8* slots() { return reinterpret_cast<u8*>(this + 1); }
@@ -146,7 +154,7 @@ struct HandlerCtx {
     }
 };
 
-static_assert(sizeof(HandlerCtx) == 8, "HandlerCtx header must be 8 bytes");
+static_assert(sizeof(HandlerCtx) == 16, "HandlerCtx header must be 16 bytes");
 
 // ── Handler Function Pointer ───────────────────────────────────────
 // JIT-compiled handlers return u64 (not a struct) to guarantee

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -260,9 +260,22 @@ void on_header_received(void* lp, Connection& conn, IoEvent ev) {
             return;
         }
         conn.upstream_fd = kUpstreamFd;
+        conn.upstream_idx = route->upstream_id;
         conn.upstream_start_us = monotonic_us();
         conn.set_slots(nullptr, nullptr, nullptr, &on_upstream_connected<Loop>);
-        loop->submit_connect(conn, &target.addr, sizeof(target.addr));
+        if (!loop->submit_connect(conn, &target.addr, sizeof(target.addr))) {
+            ::close(conn.upstream_fd);
+            conn.upstream_fd = -1;
+            conn.upstream_idx = 0;
+            loop->clear_upstream_fd(conn.id);
+            conn.state = ConnState::Sending;
+            conn.resp_status = kStatusBadGateway;
+            format_static_response(conn, 502, false);
+            conn.keep_alive = false;
+            conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);
+            loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
+            return;
+        }
     } else if (route && route->action == RouteAction::Static) {
         conn.state = ConnState::Sending;
         conn.resp_status = route->status_code;
@@ -274,6 +287,8 @@ void on_header_received(void* lp, Connection& conn, IoEvent ev) {
         conn.handler_state = 0;  // entry state
         jit::HandlerCtx ctx{};
         ctx.state = 0;
+        ctx.resume_event_kind = static_cast<u32>(jit::YieldKind::Timer);
+        ctx.resume_event_result = 0;
         auto outcome = invoke_jit_handler(route->fn,
                                           static_cast<void*>(&conn),
                                           ctx,
@@ -315,6 +330,15 @@ void on_response_sent(void* lp, Connection& conn, IoEvent ev) {
 
     on_request_complete(loop, conn, conn.resp_status, conn.send_buf.len());
     loop->epoch_leave();
+
+    if (conn.upstream_fd >= 0) {
+        ::close(conn.upstream_fd);
+        conn.upstream_fd = -1;
+    }
+    conn.upstream_idx = 0;
+    loop->clear_upstream_fd(conn.id);
+    conn.upstream_recv_armed = false;
+    conn.upstream_send_armed = false;
 
     if (!conn.keep_alive) {
         loop->close_conn(conn);
@@ -423,6 +447,7 @@ void handle_jit_outcome(Loop* loop,
             // on epoll).
             conn.pending_handler_fn = fn;
             conn.handler_state = outcome.next_state;
+            conn.pending_yield_kind = jit::YieldKind::Timer;
             conn.state = ConnState::ExecHandler;
             conn.set_slots(nullptr, nullptr, nullptr, nullptr);
             if (loop->schedule_yield_timer(conn, outcome.timer_ms)) return;
@@ -443,6 +468,147 @@ void handle_jit_outcome(Loop* loop,
             // cover it, but only if the Send CQE arrives.
             loop->timer.add(&conn, loop->keepalive_timeout);
             loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
+            return;
+        }
+        case JitDispatchOutcome::Kind::EventYield: {
+            conn.pending_handler_fn = fn;
+            conn.handler_state = outcome.next_state;
+            conn.pending_yield_kind = outcome.yield_kind;
+            conn.state = ConnState::ExecHandler;
+            conn.set_slots(nullptr, nullptr, nullptr, nullptr);
+            auto send_bad_gateway = [&]() {
+                conn.pending_handler_fn = nullptr;
+                conn.state = ConnState::Sending;
+                conn.resp_status = kStatusBadGateway;
+                format_static_response(conn, 502, /*keep_alive=*/false);
+                conn.keep_alive = false;
+                conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);
+                loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
+            };
+            auto send_internal_error = [&]() {
+                conn.pending_handler_fn = nullptr;
+                conn.state = ConnState::Sending;
+                conn.resp_status = 500;
+                format_static_response(conn, 500, /*keep_alive=*/false);
+                conn.keep_alive = false;
+                conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);
+                loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
+            };
+            auto upstream_target_matches = [&]() {
+                if (conn.upstream_fd < 0) return false;
+                if (outcome.timer_ms == 0) return true;
+                return conn.upstream_idx == static_cast<u16>(outcome.timer_ms - 1);
+            };
+            if constexpr (requires { Loop::kSupportsEventYieldResume; }) {
+                if (!Loop::kSupportsEventYieldResume) {
+                    send_internal_error();
+                    return;
+                }
+            }
+            if (outcome.yield_kind == jit::YieldKind::Send) {
+                send_internal_error();
+                return;
+            } else if (outcome.yield_kind == jit::YieldKind::UpstreamConnect &&
+                       outcome.timer_ms != 0) {
+                const RouteConfig* config = conn.request_config;
+                const u32 upstream_id = outcome.timer_ms - 1;
+                if (!config || upstream_id >= config->upstream_count) {
+                    conn.pending_handler_fn = nullptr;
+                    conn.state = ConnState::Sending;
+                    conn.resp_status = kStatusBadGateway;
+                    format_static_response(conn, 502, /*keep_alive=*/false);
+                    conn.keep_alive = false;
+                    conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);
+                    loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
+                    return;
+                }
+                auto& target = config->upstreams[upstream_id];
+                const i32 kUpstreamFd = UpstreamPool::create_socket();
+                if (kUpstreamFd < 0) {
+                    conn.pending_handler_fn = nullptr;
+                    conn.state = ConnState::Sending;
+                    conn.resp_status = kStatusBadGateway;
+                    format_static_response(conn, 502, /*keep_alive=*/false);
+                    conn.keep_alive = false;
+                    conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);
+                    loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
+                    return;
+                }
+                if (conn.upstream_fd >= 0) {
+                    ::close(conn.upstream_fd);
+                    conn.upstream_fd = -1;
+                    conn.upstream_idx = 0;
+                    loop->clear_upstream_fd(conn.id);
+                    conn.upstream_recv_armed = false;
+                    conn.upstream_send_armed = false;
+                }
+                conn.upstream_fd = kUpstreamFd;
+                conn.upstream_idx = static_cast<u16>(upstream_id);
+                conn.upstream_start_us = monotonic_us();
+                if (!loop->submit_connect(conn, &target.addr, sizeof(target.addr))) {
+                    ::close(conn.upstream_fd);
+                    conn.upstream_fd = -1;
+                    conn.upstream_idx = 0;
+                    loop->clear_upstream_fd(conn.id);
+                    send_bad_gateway();
+                    return;
+                }
+            } else if (outcome.yield_kind == jit::YieldKind::UpstreamSend) {
+                if (upstream_target_matches()) {
+                    if (!loop->submit_send_upstream(
+                            conn, conn.recv_buf.data(), conn.recv_buf.len())) {
+                        send_bad_gateway();
+                        return;
+                    }
+                } else {
+                    send_bad_gateway();
+                    return;
+                }
+            } else if (outcome.yield_kind == jit::YieldKind::UpstreamRecv) {
+                if (upstream_target_matches()) {
+                    if (!loop->submit_recv_upstream(conn)) {
+                        send_bad_gateway();
+                        return;
+                    }
+                } else {
+                    send_bad_gateway();
+                    return;
+                }
+            }
+            const bool waits_downstream_recv = outcome.yield_kind == jit::YieldKind::Any ||
+                                               outcome.yield_kind == jit::YieldKind::Recv;
+            if (!waits_downstream_recv) {
+                if constexpr (requires(Loop* lp, u32 conn_id) {
+                                  lp->backend.pause_recv(conn_id);
+                              }) {
+                    loop->backend.pause_recv(conn.id);
+                }
+            }
+            if (outcome.yield_kind == jit::YieldKind::Any && outcome.timer_ms != 0 &&
+                !loop->schedule_yield_timer(conn, outcome.timer_ms)) {
+                send_internal_error();
+                loop->timer.refresh(&conn, loop->keepalive_timeout);
+                return;
+            }
+            auto disarm_yield_timer = [&]() {
+                if constexpr (requires(Loop* lp, Connection& c) { lp->disarm_yield_timer(c); }) {
+                    loop->disarm_yield_timer(conn);
+                } else {
+                    conn.yield_armed = false;
+                }
+            };
+            if ((outcome.yield_kind == jit::YieldKind::Any ||
+                 outcome.yield_kind == jit::YieldKind::Recv) &&
+                conn.fd >= 0 && !conn.recv_armed) {
+                if (!loop->submit_recv(conn)) {
+                    if (conn.yield_armed) {
+                        disarm_yield_timer();
+                        loop->timer.refresh(&conn, loop->keepalive_timeout);
+                    }
+                    send_internal_error();
+                    return;
+                }
+            }
             return;
         }
         case JitDispatchOutcome::Kind::Forward: {
@@ -472,6 +638,14 @@ void handle_jit_outcome(Loop* loop,
                 conn.upstream_name[target.name_len] = '\0';
             else
                 conn.upstream_name[sizeof(conn.upstream_name) - 1] = '\0';
+            if (conn.upstream_fd >= 0) {
+                ::close(conn.upstream_fd);
+                conn.upstream_fd = -1;
+                conn.upstream_idx = 0;
+                loop->clear_upstream_fd(conn.id);
+                conn.upstream_recv_armed = false;
+                conn.upstream_send_armed = false;
+            }
             const i32 kUpstreamFd = UpstreamPool::create_socket();
             if (kUpstreamFd < 0) {
                 conn.state = ConnState::Sending;
@@ -505,16 +679,15 @@ void handle_jit_outcome(Loop* loop,
 
 template <typename Loop>
 void resume_jit_handler(Loop* loop, Connection& conn) {
-    // schedule_yield_timer took the conn off the keepalive wheel while
-    // the precise timer owned its wakeup. Restore it before running the
-    // handler: non-TimerYield outcomes submit I/O whose completion will
-    // call timer.refresh via dispatch_event, but until that happens a
-    // silent peer has no backstop. A chained wait removes again via
-    // schedule_yield_timer, so this is harmless when yielding again.
-    loop->timer.add(&conn, loop->keepalive_timeout);
+    // A yielded handler can resume while still on the keepalive wheel
+    // (pure event waits) or after schedule_yield_timer removed it.
+    // refresh handles both without double-inserting the intrusive node.
+    loop->timer.refresh(&conn, loop->keepalive_timeout);
     auto* fn = conn.pending_handler_fn;
     jit::HandlerCtx ctx{};
     ctx.state = conn.handler_state;
+    ctx.resume_event_kind = static_cast<u32>(conn.resume_event_kind);
+    ctx.resume_event_result = conn.resume_event_result;
     auto outcome = invoke_jit_handler(fn,
                                       static_cast<void*>(&conn),
                                       ctx,

--- a/include/rut/runtime/connection_base.h
+++ b/include/rut/runtime/connection_base.h
@@ -84,6 +84,9 @@ struct ConnectionBase {
     //     to distinguish "resume JIT handler" from "keepalive expired,
     //     close connection". Reset to null on terminal outcome.
     u16 handler_state;
+    jit::YieldKind pending_yield_kind;
+    jit::YieldKind resume_event_kind;
+    i32 resume_event_result;
     void* handler_ctx;
     jit::HandlerFn pending_handler_fn;
 
@@ -111,6 +114,7 @@ struct ConnectionBase {
     // stable lifetime. Unused by the epoll backend (which uses a shared
     // yield_timer_fd + min-heap).
     __kernel_timespec yield_timespec;
+    u32 yield_timer_gen = 0;
 
     bool keep_alive;
     bool tls_active;
@@ -224,6 +228,9 @@ struct ConnectionBase {
         upstream_fd = -1;
         upstream_idx = 0;
         handler_state = 0;
+        pending_yield_kind = jit::YieldKind::Timer;
+        resume_event_kind = jit::YieldKind::Timer;
+        resume_event_result = 0;
         handler_ctx = nullptr;
         // Deliberately NOT reset here: handler_gen persists across
         // reset() so a stale YieldHeap entry whose target slot was
@@ -233,6 +240,7 @@ struct ConnectionBase {
         pending_handler_fn = nullptr;
         yield_timespec.tv_sec = 0;
         yield_timespec.tv_nsec = 0;
+        yield_timer_gen = 0;
         keep_alive = false;
         tls_active = false;
         tls_handshake_complete = false;

--- a/include/rut/runtime/epoll_event_loop.h
+++ b/include/rut/runtime/epoll_event_loop.h
@@ -371,7 +371,7 @@ public:
         free_stack[free_top++] = cid;
     }
 
-    void submit_recv_impl(Connection& c) { backend.add_recv(c.fd, c.id); }
+    bool submit_recv_impl(Connection& c) { return backend.add_recv(c.fd, c.id); }
 
     void submit_send_impl(Connection& c, const u8* buf, u32 len) {
         if (c.tls_active) {
@@ -381,16 +381,16 @@ public:
         backend.add_send(c.fd, c.id, buf, len);
     }
 
-    void submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
-        backend.add_connect(c.upstream_fd, c.id, addr, addr_len);
+    bool submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
+        return backend.add_connect(c.upstream_fd, c.id, addr, addr_len);
     }
 
-    void submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
-        backend.add_send_upstream(c.upstream_fd, c.id, buf, len);
+    bool submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
+        return backend.add_send_upstream(c.upstream_fd, c.id, buf, len);
     }
 
-    void submit_recv_upstream_impl(Connection& c) {
-        backend.add_recv_upstream(c.upstream_fd, c.id);
+    bool submit_recv_upstream_impl(Connection& c) {
+        return backend.add_recv_upstream(c.upstream_fd, c.id);
     }
 
     void close_conn_impl(Connection& c) {
@@ -455,6 +455,7 @@ public:
         u64 now = epoll_yield::monotonic_ns();
         u64 deadline = now + static_cast<u64>(ms) * 1'000'000ull;
         if (yield_heap.push(deadline, conn.handler_gen, conn.id)) {
+            conn.yield_armed = true;
             rearm_yield_timerfd();
             return true;
         }
@@ -469,6 +470,7 @@ public:
         // the entry would then sit idle until the wheel wraps (~64s).
         // analyze rejects wait(0) upstream, so this is defence-in-depth.
         if (secs == 0) secs = 1;
+        conn.yield_armed = true;
         timer.add(&conn, secs);
         return true;
     }
@@ -490,6 +492,14 @@ public:
         yield_timer_armed_ns = top;
     }
 
+    void disarm_yield_timer(Connection& conn) {
+        if (!conn.yield_armed) return;
+        conn.yield_armed = false;
+        conn.yield_timer_gen++;
+        timer.remove(&conn);
+        if (yield_heap.remove_by_conn(conn.id) > 0) rearm_yield_timerfd();
+    }
+
     // Drain all heap entries whose deadline has passed. Resume each
     // connection's pending JIT handler (skipping stale entries whose
     // handler_gen no longer matches — indicating the slot was closed
@@ -502,7 +512,13 @@ public:
             if (entry.conn_id >= kMaxConns) continue;
             auto& c = conns[entry.conn_id];
             if (!c.pending_handler_fn) continue;
+            if (c.pending_yield_kind != jit::YieldKind::Timer &&
+                !yield_kind_matches_event(c.pending_yield_kind, IoEventType::HandlerTimer))
+                continue;
             if (c.handler_gen != entry.handler_gen) continue;  // stale
+            c.yield_armed = false;
+            c.resume_event_kind = jit::YieldKind::Timer;
+            c.resume_event_result = 0;
             resume_jit_handler<EpollEventLoop>(this, c);
         }
         rearm_yield_timerfd();
@@ -529,10 +545,15 @@ public:
                 timer.tick([this](Connection* c) {
                     // A timer can now expire for two reasons:
                     //   (1) keepalive — close the connection (existing).
-                    //   (2) a JIT handler yielded with wait(ms) and asked to
-                    //       be resumed; pending_handler_fn is the handler to
-                    //       re-enter with ctx.state = c->handler_state.
-                    if (c->pending_handler_fn) {
+                    //   (2) a JIT handler yielded with wait(ms), or wait-any
+                    //       chose timeout as its completion event.
+                    if (c->pending_handler_fn &&
+                        (c->pending_yield_kind == jit::YieldKind::Timer ||
+                         (c->yield_armed &&
+                          yield_kind_matches_event(c->pending_yield_kind, IoEventType::Timeout)))) {
+                        c->yield_armed = false;
+                        c->resume_event_kind = jit::YieldKind::Timer;
+                        c->resume_event_result = 0;
                         resume_jit_handler<EpollEventLoop>(this, *c);
                     } else {
                         this->close_conn(*c);
@@ -558,6 +579,13 @@ public:
                 timer.refresh(&conn, keepalive_timeout);
                 this->dispatch_event(conn, ev);
             } else if (conn.pending_handler_fn) {
+                if (yield_kind_matches_event(conn.pending_yield_kind, ev.type)) {
+                    disarm_yield_timer(conn);
+                    conn.resume_event_kind = yield_kind_from_event(ev.type);
+                    conn.resume_event_result = ev.result;
+                    resume_jit_handler<EpollEventLoop>(this, conn);
+                    return;
+                }
                 // Mid-yield (all callback slots null while the yield timer
                 // owns the wakeup). Close on terminal recv (peer FIN / RST /
                 // hang-up) so a client disconnect during wait(ms) can't

--- a/include/rut/runtime/event_loop.h
+++ b/include/rut/runtime/event_loop.h
@@ -27,9 +27,11 @@ namespace rut {
 // No virtual functions, no vtable, no RTTI. The compiler inlines everything.
 //
 // Derived must implement:
-//   void submit_recv_impl(Connection& c)
+//   bool submit_recv_impl(Connection& c)
 //   void submit_send_impl(Connection& c, const u8* buf, u32 len)
-//   void submit_connect_impl(Connection& c, const void* addr, u32 addr_len)
+//   bool submit_connect_impl(Connection& c, const void* addr, u32 addr_len)
+//   bool submit_send_upstream_impl(Connection& c, const u8* buf, u32 len)
+//   bool submit_recv_upstream_impl(Connection& c)
 //   void close_conn_impl(Connection& c)
 //   Connection* alloc_conn_impl()
 //   void free_conn_impl(Connection& c)
@@ -42,22 +44,22 @@ class EventLoopCRTP {
     Derived& self() { return static_cast<Derived&>(*this); }
 
 public:
-    void submit_recv(Connection& c) { self().submit_recv_impl(c); }
+    bool submit_recv(Connection& c) { return self().submit_recv_impl(c); }
     void submit_send(Connection& c, const u8* buf, u32 len) {
         self().submit_send_impl(c, buf, len);
     }
-    void submit_connect(Connection& c, const void* addr, u32 addr_len) {
-        self().submit_connect_impl(c, addr, addr_len);
+    bool submit_connect(Connection& c, const void* addr, u32 addr_len) {
+        return self().submit_connect_impl(c, addr, addr_len);
     }
     void close_conn(Connection& c) { self().close_conn_impl(c); }
     Connection* alloc_conn() { return self().alloc_conn_impl(); }
     void free_conn(Connection& c) { self().free_conn_impl(c); }
 
     // Upstream I/O: send/recv on upstream_fd instead of fd.
-    void submit_send_upstream(Connection& c, const u8* buf, u32 len) {
-        self().submit_send_upstream_impl(c, buf, len);
+    bool submit_send_upstream(Connection& c, const u8* buf, u32 len) {
+        return self().submit_send_upstream_impl(c, buf, len);
     }
-    void submit_recv_upstream(Connection& c) { self().submit_recv_upstream_impl(c); }
+    bool submit_recv_upstream(Connection& c) { return self().submit_recv_upstream_impl(c); }
 
     // Per-event-type dispatch: route to typed slot.
     // Called from each concrete EventLoop's dispatch() after timer refresh.
@@ -77,8 +79,11 @@ public:
             case IoEventType::UpstreamRecv:
                 if (conn.on_upstream_recv) {
                     conn.on_upstream_recv(&self(), conn, ev);
-                } else if (ev.result < 0) {
+                } else if (ev.result < 0 && conn.state != ConnState::ReadingHeader) {
                     // -ENOBUFS: upstream_recv_buf full, close to prevent hot-loop.
+                    // Once keep-alive has returned to ReadingHeader, negative
+                    // UpstreamRecv CQEs can be stale completions from a just-
+                    // closed upstream fd and must not kill the client.
                     self().close_conn(conn);
                 }
                 // null + result >= 0: data in upstream_recv_buf, safely ignored.
@@ -133,6 +138,7 @@ private:
 public:
     static constexpr u32 kMaxConns = 16384;
     static constexpr u32 kDefaultKeepaliveTimeout = 60;
+    static constexpr bool kSupportsEventYieldResume = false;
     SlicePool
         pool;  // per-shard buffer pool (3 slices max per connection: recv + send + upstream_recv)
     Connection conns[kMaxConns];
@@ -483,18 +489,20 @@ public:
         }
     }
 
-    void submit_recv_impl(Connection& c) {
+    bool submit_recv_impl(Connection& c) {
         if constexpr (Backend::kAsyncIo) {
             // Multishot recv stays armed across keep-alive cycles.
             // Skip re-submit to avoid inflating pending_ops.
-            if (c.recv_armed) return;
+            if (c.recv_armed) return true;
         }
         if (backend.add_recv(c.fd, c.id)) {
             if constexpr (Backend::kAsyncIo) {
                 c.pending_ops++;
                 c.recv_armed = true;
             }
+            return true;
         }
+        return false;
     }
     void submit_send_impl(Connection& c, const u8* buf, u32 len) {
         if constexpr (requires(Backend& be, Connection& conn, const u8* ptr, u32 n) {
@@ -511,29 +519,35 @@ public:
             }
         }
     }
-    void submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
+    bool submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
         if (backend.add_connect(c.upstream_fd, c.id, addr, addr_len)) {
             if constexpr (Backend::kAsyncIo) c.pending_ops++;
+            return true;
         }
+        return false;
     }
-    void submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
+    bool submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
         if (backend.add_send_upstream(c.upstream_fd, c.id, buf, len)) {
             if constexpr (Backend::kAsyncIo) {
                 c.pending_ops++;
                 c.upstream_send_armed = true;
             }
+            return true;
         }
+        return false;
     }
-    void submit_recv_upstream_impl(Connection& c) {
+    bool submit_recv_upstream_impl(Connection& c) {
         if constexpr (Backend::kAsyncIo) {
-            if (c.upstream_recv_armed) return;
+            if (c.upstream_recv_armed) return true;
         }
         if (backend.add_recv_upstream(c.upstream_fd, c.id)) {
             if constexpr (Backend::kAsyncIo) {
                 c.pending_ops++;
                 c.upstream_recv_armed = true;
             }
+            return true;
         }
+        return false;
     }
 
     void close_conn_impl(Connection& c) {

--- a/include/rut/runtime/io_uring_backend.h
+++ b/include/rut/runtime/io_uring_backend.h
@@ -118,7 +118,8 @@ struct IoUringBackend {
     // the timespec storage lives on the Connection because the kernel
     // reads it asynchronously. CQE completes with res == -ETIME under
     // normal expiry; the wait() path emits IoEvent{HandlerTimer, conn_id}
-    // regardless of res so the dispatcher can resume the handler.
+    // with IoEvent::result set to the connection's yield_timer_gen so
+    // the dispatcher can reject stale timeout CQEs.
     bool add_yield_timeout(u32 conn_id, Connection& conn, u32 ms);
 
     // Cancel outstanding operations for a connection (by user_data match).
@@ -131,7 +132,10 @@ struct IoUringBackend {
                bool upstream_recv_armed,
                bool upstream_send_armed,
                bool has_upstream,
-               bool yield_armed = false);
+               bool yield_armed = false,
+               u32 yield_timer_gen = 0);
+
+    bool cancel_yield_timeout(u32 conn_id, u32 yield_timer_gen);
 
     // Cancel the multishot accept request. Must be called before closing
     // listen_fd during drain to stop io_uring from accepting new connections.
@@ -149,20 +153,27 @@ struct IoUringBackend {
     // Return a provided buffer back to the ring after processing.
     void return_buffer(u16 buf_id);
 
+#ifdef RUT_TESTING
+public:
+#else
+private:
+#endif
+    // Encode/decode SQE user_data. Production callers should continue using the
+    // typed submit/cancel helpers.
+    static u64 encode_user_data(u32 conn_id, IoEventType type);
+    static u64 encode_user_data(u32 conn_id, IoEventType type, u32 aux);
+    static void decode_user_data(u64 data, u32& conn_id, IoEventType& type);
+    static void decode_user_data(u64 data, u32& conn_id, IoEventType& type, u32& aux);
+
 private:
     // Submit a cancel SQE matching a specific user_data value.
-    // conn_id is encoded in the cancel CQE's user_data so dispatch()
-    // can decrement pending_ops when the cancel completes.
-    bool cancel_by_user_data(u64 target, u32 conn_id, IoEventType type);
+    // conn_id/type/aux are encoded in the cancel CQE's user_data. Pass the real
+    // conn_id for tracked close-path cancels, or kCancelConnId for fire-and-
+    // forget cancels that should be consumed silently.
+    bool cancel_by_user_data(u64 target, u32 conn_id, IoEventType type, u32 aux = 0);
 
     // Get next available SQE. Returns nullptr if SQ is full.
     io_uring_sqe* get_sqe();
-
-    // Encode conn_id + event type into SQE user_data.
-    static u64 encode_user_data(u32 conn_id, IoEventType type);
-
-    // Decode user_data back into conn_id + event type.
-    static void decode_user_data(u64 data, u32& conn_id, IoEventType& type);
 
     // Setup provided buffer ring via io_uring_register.
     core::Expected<void, Error> setup_buf_ring();

--- a/include/rut/runtime/iouring_event_loop.h
+++ b/include/rut/runtime/iouring_event_loop.h
@@ -324,12 +324,14 @@ public:
         pending_free[pending_free_count++] = cid;
     }
 
-    void submit_recv_impl(Connection& c) {
-        if (c.recv_armed) return;
+    bool submit_recv_impl(Connection& c) {
+        if (c.recv_armed) return true;
         if (backend.add_recv(c.fd, c.id)) {
             c.pending_ops++;
             c.recv_armed = true;
+            return true;
         }
+        return false;
     }
 
     void submit_send_impl(Connection& c, const u8* buf, u32 len) {
@@ -339,25 +341,31 @@ public:
         }
     }
 
-    void submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
+    bool submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
         if (backend.add_connect(c.upstream_fd, c.id, addr, addr_len)) {
             c.pending_ops++;
+            return true;
         }
+        return false;
     }
 
-    void submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
+    bool submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
         if (backend.add_send_upstream(c.upstream_fd, c.id, buf, len)) {
             c.pending_ops++;
             c.upstream_send_armed = true;
+            return true;
         }
+        return false;
     }
 
-    void submit_recv_upstream_impl(Connection& c) {
-        if (c.upstream_recv_armed) return;
+    bool submit_recv_upstream_impl(Connection& c) {
+        if (c.upstream_recv_armed) return true;
         if (backend.add_recv_upstream(c.upstream_fd, c.id)) {
             c.pending_ops++;
             c.upstream_recv_armed = true;
+            return true;
         }
+        return false;
     }
 
     void close_conn_impl(Connection& c) {
@@ -371,7 +379,8 @@ public:
                                             c.upstream_recv_armed,
                                             c.upstream_send_armed,
                                             c.upstream_fd >= 0,
-                                            c.yield_armed);
+                                            c.yield_armed,
+                                            c.yield_timer_gen);
         }
         if (c.fd >= 0) {
             ::close(c.fd);
@@ -454,8 +463,18 @@ public:
         // the entry would then sit idle until the wheel wraps (~64s).
         // analyze rejects wait(0) upstream, so this is defence-in-depth.
         if (secs == 0) secs = 1;
+        conn.yield_armed = true;
         timer.add(&conn, secs);
         return true;
+    }
+
+    void disarm_yield_timer(Connection& conn) {
+        if (!conn.yield_armed) return;
+        const u32 old_gen = conn.yield_timer_gen;
+        conn.yield_armed = false;
+        conn.yield_timer_gen++;
+        timer.remove(&conn);
+        (void)backend.cancel_yield_timeout(conn.id, old_gen);
     }
 
     void dispatch(const IoEvent& ev) {
@@ -476,10 +495,17 @@ public:
             if (ev.conn_id < kMaxConns) {
                 auto& c = conns[ev.conn_id];
                 if (c.pending_ops > 0) c.pending_ops--;
-                c.yield_armed = false;
-                if (c.pending_handler_fn) {
+                const bool matching_generation = ev.result == static_cast<i32>(c.yield_timer_gen);
+                const bool was_yield_armed = c.yield_armed;
+                if (matching_generation) c.yield_armed = false;
+                if (c.pending_handler_fn && matching_generation &&
+                    (c.pending_yield_kind == jit::YieldKind::Timer ||
+                     (was_yield_armed &&
+                      yield_kind_matches_event(c.pending_yield_kind, IoEventType::HandlerTimer)))) {
+                    c.resume_event_kind = jit::YieldKind::Timer;
+                    c.resume_event_result = 0;
                     resume_jit_handler<IoUringEventLoop>(this, c);
-                } else if (c.pending_ops == 0) {
+                } else if (c.pending_ops == 0 && !c.pending_handler_fn && c.fd < 0) {
                     // Stale CQE for an already-closed slot; safe to
                     // reclaim now that the last in-flight op has drained.
                     reclaim_slot(ev.conn_id);
@@ -493,9 +519,15 @@ public:
             if (ticks > max_ticks) ticks = max_ticks;
             for (i32 t = 0; t < ticks; t++) {
                 timer.tick([this](Connection* c) {
-                    // See epoll_event_loop.h: timer fires for keepalive OR
-                    // for a JIT handler resume (pending_handler_fn set).
-                    if (c->pending_handler_fn) {
+                    // See epoll_event_loop.h: timer fires for keepalive,
+                    // wait(ms), or wait-any timeout completion.
+                    if (c->pending_handler_fn &&
+                        (c->pending_yield_kind == jit::YieldKind::Timer ||
+                         (c->yield_armed &&
+                          yield_kind_matches_event(c->pending_yield_kind, IoEventType::Timeout)))) {
+                        c->yield_armed = false;
+                        c->resume_event_kind = jit::YieldKind::Timer;
+                        c->resume_event_result = 0;
                         resume_jit_handler<IoUringEventLoop>(this, *c);
                     } else {
                         this->close_conn(*c);
@@ -529,6 +561,13 @@ public:
                 timer.refresh(&conn, keepalive_timeout);
                 this->dispatch_event(conn, ev);
             } else if (conn.pending_handler_fn) {
+                if (yield_kind_matches_event(conn.pending_yield_kind, ev.type)) {
+                    disarm_yield_timer(conn);
+                    conn.resume_event_kind = yield_kind_from_event(ev.type);
+                    conn.resume_event_result = ev.result;
+                    resume_jit_handler<IoUringEventLoop>(this, conn);
+                    return;
+                }
                 // Stray CQE for a conn that's mid-yield (all slots null
                 // while the timer owns the wakeup). Provided-buffer
                 // lifetime is already handled inside

--- a/include/rut/runtime/jit_dispatch.h
+++ b/include/rut/runtime/jit_dispatch.h
@@ -2,6 +2,7 @@
 
 #include "rut/common/types.h"
 #include "rut/jit/handler_abi.h"
+#include "rut/runtime/io_event.h"
 
 namespace rut {
 
@@ -29,6 +30,7 @@ struct JitDispatchOutcome {
         ReturnStatus,
         Forward,
         TimerYield,
+        EventYield,
         Error,
     };
 
@@ -36,6 +38,7 @@ struct JitDispatchOutcome {
     u16 status_code = 0;
     u16 upstream_id = 0;
     u16 next_state = 0;
+    jit::YieldKind yield_kind = jit::YieldKind::Timer;
     u32 timer_ms = 0;  // raw ms payload; callers pick their own precision
     // 1-based index into RouteConfig::response_bodies for
     // Kind::ReturnStatus; 0 = no custom body. Decoded from the
@@ -73,11 +76,33 @@ inline u32 timer_seconds_from_ms(u32 ms) {
     return secs > 0xFFFFFFFFu ? 0xFFFFFFFFu : static_cast<u32>(secs);
 }
 
+inline bool yield_kind_matches_event(jit::YieldKind kind, IoEventType type) {
+    if (kind == jit::YieldKind::Any) {
+        return type == IoEventType::Recv || type == IoEventType::Timeout ||
+               type == IoEventType::HandlerTimer;
+    }
+    if (kind == jit::YieldKind::Recv) return type == IoEventType::Recv;
+    if (kind == jit::YieldKind::Send) return type == IoEventType::Send;
+    if (kind == jit::YieldKind::UpstreamConnect) return type == IoEventType::UpstreamConnect;
+    if (kind == jit::YieldKind::UpstreamRecv) return type == IoEventType::UpstreamRecv;
+    if (kind == jit::YieldKind::UpstreamSend) return type == IoEventType::UpstreamSend;
+    return false;
+}
+
+inline jit::YieldKind yield_kind_from_event(IoEventType type) {
+    if (type == IoEventType::Recv) return jit::YieldKind::Recv;
+    if (type == IoEventType::Send) return jit::YieldKind::Send;
+    if (type == IoEventType::UpstreamConnect) return jit::YieldKind::UpstreamConnect;
+    if (type == IoEventType::UpstreamRecv) return jit::YieldKind::UpstreamRecv;
+    if (type == IoEventType::UpstreamSend) return jit::YieldKind::UpstreamSend;
+    return jit::YieldKind::Timer;
+}
+
 // Invoke a JIT-compiled handler once and translate the packed result
-// into an event-loop-facing outcome. Does NOT loop — each Yield returns
-// a TimerYield outcome, and the caller is expected to resume by setting
+// into an event-loop-facing outcome. Does NOT loop: a Yield returns either
+// TimerYield or EventYield, and the caller is expected to resume by setting
 // `ctx.state = out.next_state` and calling this function again after the
-// timer fires.
+// requested timer or event fires.
 //
 // Caller owns storage for `ctx`. For Layer 0 (no live-across-yield
 // locals) `ctx.slot_count == 0` and the same `ctx` is reused across
@@ -112,9 +137,19 @@ inline JitDispatchOutcome invoke_jit_handler(jit::HandlerFn fn,
             out.upstream_id = r.upstream_id;
             return out;
         case jit::HandlerAction::Yield:
+            out.next_state = r.next_state;
+            out.yield_kind = r.yield_kind;
             if (r.yield_kind == jit::YieldKind::Timer) {
                 out.kind = JitDispatchOutcome::Kind::TimerYield;
-                out.next_state = r.next_state;
+                out.timer_ms = r.yield_payload_u32();
+                return out;
+            }
+            if (r.yield_kind == jit::YieldKind::Any || r.yield_kind == jit::YieldKind::Recv ||
+                r.yield_kind == jit::YieldKind::Send ||
+                r.yield_kind == jit::YieldKind::UpstreamConnect ||
+                r.yield_kind == jit::YieldKind::UpstreamRecv ||
+                r.yield_kind == jit::YieldKind::UpstreamSend) {
+                out.kind = JitDispatchOutcome::Kind::EventYield;
                 out.timer_ms = r.yield_payload_u32();
                 return out;
             }

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3962,6 +3962,156 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
 }
 
+struct WaitSpec {
+    WaitEventKind kind = WaitEventKind::Timer;
+    u32 payload = 0;
+};
+
+static FrontendResult<u32> find_wait_upstream_index(const HirModule& mod, const AstExpr& arg) {
+    if (arg.kind != AstExprKind::Ident)
+        return frontend_error(FrontendError::UnsupportedSyntax, arg.span);
+    for (u32 i = 0; i < mod.upstreams.len; i++) {
+        if (mod.upstreams[i].name.eq(arg.name)) return i;
+    }
+    return frontend_error(FrontendError::UnknownUpstream, arg.span, arg.name);
+}
+
+static bool wait_req_body_arg(const AstExpr& arg) {
+    return arg.kind == AstExprKind::Field && arg.lhs != nullptr &&
+           arg.lhs->kind == AstExprKind::Ident && arg.lhs->name.eq({"req", 3}) &&
+           arg.name.eq({"body", 4});
+}
+
+static FrontendResult<WaitSpec> analyze_wait_io_op_spec(const AstExpr& op, const HirModule& mod) {
+    if (op.kind != AstExprKind::MethodCall || op.lhs == nullptr) {
+        return frontend_error(FrontendError::UnsupportedSyntax, op.span);
+    }
+    WaitSpec spec{};
+    const bool is_downstream =
+        op.lhs->kind == AstExprKind::Ident && op.lhs->name.eq({"downstream", 10});
+    const bool is_upstream = op.lhs->kind == AstExprKind::Call &&
+                             op.lhs->name.eq({"upstream", 8}) && op.lhs->args.len == 1 &&
+                             op.lhs->args[0] != nullptr;
+    if (!is_downstream && !is_upstream)
+        return frontend_error(FrontendError::UnsupportedSyntax, op.span);
+
+    if (is_downstream && op.name.eq({"recv", 4})) {
+        if (op.args.len != 0) return frontend_error(FrontendError::UnsupportedSyntax, op.span);
+        spec.kind = WaitEventKind::Recv;
+        return spec;
+    }
+    if (is_downstream && op.name.eq({"send", 4})) {
+        return frontend_error(FrontendError::UnsupportedSyntax, op.span);
+    }
+    if (is_upstream && op.name.eq({"connect", 7})) {
+        if (op.args.len != 0) return frontend_error(FrontendError::UnsupportedSyntax, op.span);
+        spec.kind = WaitEventKind::UpstreamConnect;
+        auto upstream = find_wait_upstream_index(mod, *op.lhs->args[0]);
+        if (!upstream) return core::make_unexpected(upstream.error());
+        spec.payload = upstream.value() + 1;
+        return spec;
+    }
+    if (is_upstream && op.name.eq({"recv", 4})) {
+        if (op.args.len != 0) return frontend_error(FrontendError::UnsupportedSyntax, op.span);
+        auto upstream = find_wait_upstream_index(mod, *op.lhs->args[0]);
+        if (!upstream) return core::make_unexpected(upstream.error());
+        spec.kind = WaitEventKind::UpstreamRecv;
+        spec.payload = upstream.value() + 1;
+        return spec;
+    }
+    if (is_upstream && op.name.eq({"send", 4})) {
+        if (op.args.len != 1) return frontend_error(FrontendError::UnsupportedSyntax, op.span);
+        if (!wait_req_body_arg(*op.args[0]))
+            return frontend_error(FrontendError::UnsupportedSyntax, op.args[0]->span);
+        auto upstream = find_wait_upstream_index(mod, *op.lhs->args[0]);
+        if (!upstream) return core::make_unexpected(upstream.error());
+        spec.kind = WaitEventKind::UpstreamSend;
+        spec.payload = upstream.value() + 1;
+        return spec;
+    }
+    return frontend_error(FrontendError::UnsupportedSyntax, op.span, op.name);
+}
+
+static bool wait_timer_call_ms(const AstExpr& op, u32& ms) {
+    if (op.kind != AstExprKind::Call || !op.name.eq({"timer", 5}) || op.args.len != 1 ||
+        op.args[0] == nullptr || op.args[0]->kind != AstExprKind::IntLit ||
+        op.args[0]->int_value <= 0) {
+        return false;
+    }
+    ms = static_cast<u32>(op.args[0]->int_value);
+    return true;
+}
+
+static FrontendResult<WaitSpec> analyze_wait_any_call(const AstExpr& call,
+                                                      const HirModule& mod,
+                                                      u32& ms) {
+    if (call.kind != AstExprKind::Call || !call.name.eq({"any", 3}) || call.args.len == 0)
+        return frontend_error(FrontendError::UnsupportedSyntax, call.span);
+    bool saw_event = false;
+    bool saw_timer = false;
+    for (u32 ai = 0; ai < call.args.len; ai++) {
+        const AstExpr* arg = call.args[ai];
+        if (arg == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, call.span);
+        u32 timer_ms = 0;
+        if (wait_timer_call_ms(*arg, timer_ms)) {
+            if (saw_timer) return frontend_error(FrontendError::UnsupportedSyntax, arg->span);
+            saw_timer = true;
+            ms = timer_ms;
+            continue;
+        }
+        if (arg->kind == AstExprKind::MethodCall && arg->args.len != 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, arg->span);
+        auto event_spec = analyze_wait_io_op_spec(*arg, mod);
+        if (!event_spec) return core::make_unexpected(event_spec.error());
+        if (event_spec->payload != 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, arg->span);
+        if (event_spec->kind != WaitEventKind::Recv)
+            return frontend_error(FrontendError::UnsupportedSyntax, arg->span);
+        saw_event = true;
+    }
+    if (!saw_event) return frontend_error(FrontendError::UnsupportedSyntax, call.span);
+    WaitSpec spec{};
+    spec.kind = WaitEventKind::Any;
+    spec.payload = ms;
+    return spec;
+}
+
+static FrontendResult<WaitSpec> analyze_wait_value_spec(const AstExpr& expr,
+                                                        const HirModule& mod,
+                                                        u32& ms) {
+    if (expr.kind != AstExprKind::Wait)
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+    ms = expr.wait_ms;
+    if (expr.lhs == nullptr && (expr.wait_event_kind == WaitEventKind::Timer ||
+                                expr.wait_event_kind == WaitEventKind::Any)) {
+        WaitSpec spec{};
+        spec.kind = expr.wait_event_kind;
+        spec.payload = ms;
+        return spec;
+    }
+
+    const AstExpr& op = *expr.lhs;
+    if (op.kind == AstExprKind::Call && op.name.eq({"any", 3}))
+        return analyze_wait_any_call(op, mod, ms);
+    return analyze_wait_io_op_spec(op, mod);
+}
+
+static FrontendResult<HirExpr> analyze_wait_result_expr(const AstExpr& expr, const HirModule& mod) {
+    HirExpr out{};
+    out.span = expr.span;
+    u32 wait_ms = 0;
+    auto wait_spec = analyze_wait_value_spec(expr, mod, wait_ms);
+    if (!wait_spec) return core::make_unexpected(wait_spec.error());
+    if (wait_spec->kind == WaitEventKind::Timer && wait_spec->payload == 0)
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+    out.kind = HirExprKind::WaitResult;
+    out.type = HirTypeKind::Unknown;
+    out.is_wait_result = true;
+    out.wait_event_kind = wait_spec->kind;
+    out.wait_payload = wait_spec->payload;
+    return out;
+}
+
 static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                                                  HirRoute* route,
                                                  const HirModule& mod,
@@ -3971,6 +4121,9 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                                                  bool allow_array_lit) {
     HirExpr out{};
     out.span = expr.span;
+    if (expr.kind == AstExprKind::Wait) {
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+    }
     if (expr.kind == AstExprKind::Placeholder)
         return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
     if (expr.kind == AstExprKind::BoolLit) {
@@ -4264,6 +4417,27 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         }
         auto base = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
         if (!base) return core::make_unexpected(base.error());
+        if (base->is_wait_result) {
+            if (base->kind != HirExprKind::LocalRef)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            if (base->wait_index + 1 != route->waits.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            out.kind = HirExprKind::WaitField;
+            out.span = expr.span;
+            out.str_value = expr.name;
+            out.is_wait_result = false;
+            if (expr.name.eq({"kind", 4}) || expr.name.eq({"result", 6})) {
+                out.type = HirTypeKind::I32;
+            } else if (expr.name.eq({"ok", 2}) || expr.name.eq({"eof", 3})) {
+                out.type = HirTypeKind::Bool;
+            } else {
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+            }
+            if (!route->exprs.push(base.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.lhs = &route->exprs[route->exprs.len - 1];
+            return out;
+        }
         const auto known_state = known_value_state(base.value(), locals, local_count, 0);
         if (known_state == KnownValueState::Error && !expr.name.eq({"file", 4}) &&
             !expr.name.eq({"func", 4}))
@@ -4877,6 +5051,10 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             }
             out.kind = HirExprKind::LocalRef;
             out.type = locals[i].type;
+            out.is_wait_result = locals[i].is_wait_result;
+            out.wait_event_kind = locals[i].wait_event_kind;
+            out.wait_payload = locals[i].wait_payload;
+            out.wait_index = locals[i].wait_index;
             out.generic_index = locals[i].generic_index;
             out.generic_has_error_constraint = locals[i].generic_has_error_constraint;
             out.generic_has_eq_constraint = locals[i].generic_has_eq_constraint;
@@ -7368,6 +7546,23 @@ static FrontendResult<void> load_imported_modules(
             return frontend_error(FrontendError::TooManyItems, item.import_decl.span);
     }
     return {};
+}
+
+static FrontendResult<WaitSpec> analyze_wait_stmt_spec(const AstStatement& stmt,
+                                                       const HirModule& mod) {
+    if (!stmt.has_wait_expr) {
+        WaitSpec spec{};
+        spec.kind = stmt.wait_event_kind;
+        spec.payload = stmt.status_code;
+        return spec;
+    }
+
+    const AstExpr& expr = stmt.expr;
+    if (expr.kind == AstExprKind::Call && expr.name.eq({"any", 3})) {
+        u32 ms = 0;
+        return analyze_wait_any_call(expr, mod, ms);
+    }
+    return analyze_wait_io_op_spec(expr, mod);
 }
 
 static FrontendResult<HirModule*> analyze_file_internal(
@@ -9872,13 +10067,14 @@ static FrontendResult<HirModule*> analyze_file_internal(
         // wait(0) is rejected: it has no meaning for a sleep primitive
         // and would stall 1s under the wheel fallback.
         bool seen_wait = false;
-        bool seen_non_let_non_wait = false;
+        bool seen_for = false;
         for (u32 si = 0; si < item.route.statements.len; si++) {
             const auto& stmt = item.route.statements[si];
             if (stmt.kind == AstStmtKind::Wait) {
-                if (seen_non_let_non_wait)
-                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
-                if (stmt.status_code == 0)
+                if (seen_for) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                auto wait_spec = analyze_wait_stmt_spec(stmt, mod);
+                if (!wait_spec) return core::make_unexpected(wait_spec.error());
+                if (wait_spec->kind == WaitEventKind::Timer && wait_spec->payload == 0)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 seen_wait = true;
                 // ms payload is the 32-bit Yield slot (status_code +
@@ -9887,17 +10083,18 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 // `1m`, `1h`) to a UINT32_MAX-capped millisecond value.
                 HirRoute::Wait w{};
                 w.span = stmt.span;
-                w.ms = stmt.status_code;
+                w.event_kind = wait_spec->kind;
+                w.ms = wait_spec->payload;
                 if (!route.waits.push(w))
                     return frontend_error(FrontendError::TooManyItems, stmt.span);
                 continue;
             }
-            // Pre-wait lets are allowed; post-wait lets are not. Any
-            // other statement (guard/if/match/return/forward/...) counts
-            // as the terminal region and gates further waits.
-            if (stmt.kind != AstStmtKind::Let) {
-                seen_non_let_non_wait = true;
-            } else if (seen_wait) {
+            // Post-wait locals need frame slots or per-state rematerialization
+            // to preserve source order across resume. Keep that scoped out
+            // while guards/control are now source-ordered around waits.
+            const bool let_wait_result =
+                stmt.kind == AstStmtKind::Let && stmt.expr.kind == AstExprKind::Wait;
+            if (stmt.kind == AstStmtKind::Let && seen_wait && !let_wait_result) {
                 return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
             }
             if (stmt.kind == AstStmtKind::Let) {
@@ -9905,8 +10102,11 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 local.span = stmt.span;
                 local.name = stmt.name;
                 local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
-                auto init = analyze_expr(
-                    stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
+                auto init =
+                    stmt.expr.kind == AstExprKind::Wait
+                        ? analyze_wait_result_expr(stmt.expr, mod)
+                        : analyze_expr(
+                              stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!init) return core::make_unexpected(init.error());
                 // ArrayLit at let RHS fails at MIR because MIR has no
                 // ArrayLit → MirValue lowering. Reject at analyze so users
@@ -9918,9 +10118,25 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 // pass before they can be supported.
                 if (init->kind == HirExprKind::ArrayLit)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                if (init->kind == HirExprKind::WaitResult) {
+                    if (seen_for)
+                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                    HirRoute::Wait w{};
+                    w.span = stmt.expr.span;
+                    w.event_kind = init->wait_event_kind;
+                    w.ms = init->wait_payload;
+                    init->wait_index = route.waits.len;
+                    if (!route.waits.push(w))
+                        return frontend_error(FrontendError::TooManyItems, stmt.span);
+                    seen_wait = true;
+                }
                 auto typed = apply_declared_type_to_expr(&init.value(), mod, stmt);
                 if (!typed) return core::make_unexpected(typed.error());
                 local.type = init->type;
+                local.is_wait_result = init->is_wait_result;
+                local.wait_event_kind = init->wait_event_kind;
+                local.wait_payload = init->wait_payload;
+                local.wait_index = init->wait_index;
                 local.generic_index = init->generic_index;
                 local.generic_has_error_constraint = init->generic_has_error_constraint;
                 local.generic_has_eq_constraint = init->generic_has_eq_constraint;
@@ -10044,6 +10260,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 continue;
             }
             if (stmt.kind == AstStmtKind::For) {
+                seen_for = true;
                 // Phase 3b: analyze `for <var> in <iter> { <body> }` into a
                 // HirForLoop node. Body is restricted to `guard*` + optional
                 // terminator (return/forward) per Phase 3b MVP. The loop

--- a/src/compiler/lexer.cc
+++ b/src/compiler/lexer.cc
@@ -43,6 +43,7 @@ static TokenType keyword_type(Str text) {
     if (text.eq({"or", 2})) return TokenType::KwOr;
     if (text.eq({"nil", 3})) return TokenType::KwNil;
     if (text.eq({"upstream", 8})) return TokenType::KwUpstream;
+    if (text.eq({"downstream", 10})) return TokenType::KwDownstream;
     // `at` is deliberately NOT reserved globally — only
     // `parse_upstream` treats the identifier specially, matching the
     // `response()` / `forward()` builder pattern. This keeps `at`

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -1,10 +1,31 @@
 #include "rut/compiler/lower_rir.h"
 
 #include "rut/compiler/rir_builder.h"
+#include "rut/jit/handler_abi.h"
 
 namespace rut {
 
 namespace {
+
+static u8 yield_kind_abi(WaitEventKind kind) {
+    switch (kind) {
+        case WaitEventKind::Timer:
+            return static_cast<u8>(jit::YieldKind::Timer);
+        case WaitEventKind::Any:
+            return static_cast<u8>(jit::YieldKind::Any);
+        case WaitEventKind::Recv:
+            return static_cast<u8>(jit::YieldKind::Recv);
+        case WaitEventKind::Send:
+            return static_cast<u8>(jit::YieldKind::Send);
+        case WaitEventKind::UpstreamConnect:
+            return static_cast<u8>(jit::YieldKind::UpstreamConnect);
+        case WaitEventKind::UpstreamRecv:
+            return static_cast<u8>(jit::YieldKind::UpstreamRecv);
+        case WaitEventKind::UpstreamSend:
+            return static_cast<u8>(jit::YieldKind::UpstreamSend);
+    }
+    return static_cast<u8>(jit::YieldKind::Timer);
+}
 
 struct VariantLoweringInfo {
     const rir::Type* struct_type = nullptr;
@@ -1397,6 +1418,62 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
         if (!v) return frontend_error(FrontendError::OutOfMemory, span);
         return v.value();
     }
+    if (value.kind == MirValueKind::WaitResult) {
+        return frontend_error(FrontendError::UnsupportedSyntax, span);
+    }
+    if (value.kind == MirValueKind::WaitField) {
+        if (value.str_value.eq({"kind", 4})) {
+            auto v = b.emit_resume_event_kind({span.line, span.col});
+            if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+            return v.value();
+        }
+        auto result = b.emit_resume_event_result({span.line, span.col});
+        if (!result) return frontend_error(FrontendError::OutOfMemory, span);
+        if (value.str_value.eq({"result", 6})) return result.value();
+        auto zero = b.emit_const_i32(0, {span.line, span.col});
+        if (!zero) return frontend_error(FrontendError::OutOfMemory, span);
+        if (value.str_value.eq({"ok", 2})) {
+            auto cmp =
+                b.emit_cmp(rir::Opcode::CmpGe, result.value(), zero.value(), {span.line, span.col});
+            if (!cmp) return frontend_error(FrontendError::OutOfMemory, span);
+            return cmp.value();
+        }
+        if (value.str_value.eq({"eof", 3})) {
+            auto event_kind = b.emit_resume_event_kind({span.line, span.col});
+            if (!event_kind) return frontend_error(FrontendError::OutOfMemory, span);
+            auto recv_kind =
+                b.emit_const_i32(static_cast<i32>(jit::YieldKind::Recv), {span.line, span.col});
+            if (!recv_kind) return frontend_error(FrontendError::OutOfMemory, span);
+            auto upstream_recv_kind = b.emit_const_i32(
+                static_cast<i32>(jit::YieldKind::UpstreamRecv), {span.line, span.col});
+            if (!upstream_recv_kind) return frontend_error(FrontendError::OutOfMemory, span);
+            auto recv_like = b.emit_cmp(
+                rir::Opcode::CmpEq, event_kind.value(), recv_kind.value(), {span.line, span.col});
+            if (!recv_like) return frontend_error(FrontendError::OutOfMemory, span);
+            auto upstream_recv_like = b.emit_cmp(rir::Opcode::CmpEq,
+                                                 event_kind.value(),
+                                                 upstream_recv_kind.value(),
+                                                 {span.line, span.col});
+            if (!upstream_recv_like) return frontend_error(FrontendError::OutOfMemory, span);
+            auto result_is_zero =
+                b.emit_cmp(rir::Opcode::CmpEq, result.value(), zero.value(), {span.line, span.col});
+            if (!result_is_zero) return frontend_error(FrontendError::OutOfMemory, span);
+            auto false_v = b.emit_const_bool(false, {span.line, span.col});
+            if (!false_v) return frontend_error(FrontendError::OutOfMemory, span);
+            auto upstream_eof = b.emit_select(upstream_recv_like.value(),
+                                              result_is_zero.value(),
+                                              false_v.value(),
+                                              {span.line, span.col});
+            if (!upstream_eof) return frontend_error(FrontendError::OutOfMemory, span);
+            auto eof = b.emit_select(recv_like.value(),
+                                     result_is_zero.value(),
+                                     upstream_eof.value(),
+                                     {span.line, span.col});
+            if (!eof) return frontend_error(FrontendError::OutOfMemory, span);
+            return eof.value();
+        }
+        return frontend_error(FrontendError::UnsupportedSyntax, span, value.str_value);
+    }
     if (value.kind == MirValueKind::Nil) {
         auto v = b.emit_const_i32(0, {span.line, span.col});
         if (!v) return frontend_error(FrontendError::OutOfMemory, span);
@@ -2465,8 +2542,10 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
         return {};
     }
     if (term.kind == MirTerminatorKind::YieldTimer) {
-        if (!b.emit_yield_timer(
-                term.yield_ms, term.yield_next_state, {term.span.line, term.span.col}))
+        if (!b.emit_yield_event(yield_kind_abi(term.yield_event_kind),
+                                term.yield_ms,
+                                term.yield_next_state,
+                                {term.span.line, term.span.col}))
             return frontend_error(FrontendError::OutOfMemory, term.span);
         return {};
     }
@@ -2999,9 +3078,12 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
         }
         if (mir.functions[i].waits.len > 0) {
             u32 ms_list[MirFunction::kMaxWaits]{};
-            for (u32 wi = 0; wi < mir.functions[i].waits.len; wi++)
+            u8 kind_list[MirFunction::kMaxWaits]{};
+            for (u32 wi = 0; wi < mir.functions[i].waits.len; wi++) {
                 ms_list[wi] = mir.functions[i].waits[wi].ms;
-            if (!b.set_yield_payload(fn.value(), ms_list, mir.functions[i].waits.len)) {
+                kind_list[wi] = yield_kind_abi(mir.functions[i].waits[wi].event_kind);
+            }
+            if (!b.set_yield_payload(fn.value(), ms_list, mir.functions[i].waits.len, kind_list)) {
                 out.destroy();
                 return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
             }
@@ -3019,7 +3101,25 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
             out.destroy();
             return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
         }
-        if (mir.functions[i].state_zero_enters_entry) {
+        if (mir.functions[i].has_explicit_resume_blocks) {
+            if (mir.functions[i].waits.len + 1 > rir::Function::kMaxResumeBlocks) {
+                out.destroy();
+                return frontend_error(FrontendError::TooManyItems, mir.functions[i].span);
+            }
+            rir::BlockId resume_blocks[rir::Function::kMaxResumeBlocks]{};
+            for (u32 ri = 0; ri <= mir.functions[i].waits.len; ri++) {
+                if (mir.functions[i].resume_blocks[ri] >= mir.functions[i].blocks.len) {
+                    out.destroy();
+                    return frontend_error(FrontendError::UnsupportedSyntax, mir.functions[i].span);
+                }
+                resume_blocks[ri] = block_ids[mir.functions[i].resume_blocks[ri]];
+            }
+            if (!b.set_explicit_resume_blocks(
+                    fn.value(), resume_blocks, mir.functions[i].waits.len + 1)) {
+                out.destroy();
+                return frontend_error(FrontendError::UnsupportedSyntax, mir.functions[i].span);
+            }
+        } else if (mir.functions[i].state_zero_enters_entry) {
             if (mir.functions[i].resume_terminal_block >= mir.functions[i].blocks.len ||
                 !b.set_state_zero_entry_resume(fn.value(),
                                                block_ids[mir.functions[i].resume_terminal_block])) {

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -571,12 +571,34 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         }
         v.kind = MirValueKind::LocalRef;
         v.type = mir_type_kind(expr.type);
+        v.is_wait_result = expr.is_wait_result;
+        v.wait_event_kind = expr.wait_event_kind;
+        v.wait_payload = expr.wait_payload;
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.local_index = expr.local_index;
         v.error_struct_index = expr.error_struct_index;
         v.error_variant_index = expr.error_variant_index;
         apply_expr_shape_if_available(module, expr, &v);
+        return v;
+    }
+    if (expr.kind == HirExprKind::WaitResult) {
+        v.kind = MirValueKind::WaitResult;
+        v.type = MirTypeKind::Unknown;
+        v.is_wait_result = true;
+        v.wait_event_kind = expr.wait_event_kind;
+        v.wait_payload = expr.wait_payload;
+        return v;
+    }
+    if (expr.kind == HirExprKind::WaitField) {
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        v.kind = MirValueKind::WaitField;
+        v.type = mir_type_kind(expr.type);
+        v.str_value = expr.str_value;
+        v.lhs = &fn->values[fn->values.len - 1];
         return v;
     }
     return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
@@ -746,6 +768,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         for (u32 wi = 0; wi < module.routes[i].waits.len; wi++) {
             MirFunction::Wait w{};
             w.span = module.routes[i].waits[wi].span;
+            w.event_kind = module.routes[i].waits[wi].event_kind;
             w.ms = module.routes[i].waits[wi].ms;
             if (!fn.waits.push(w)) return frontend_error(FrontendError::TooManyItems, w.span);
         }
@@ -764,6 +787,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             // the slot is still being initialized, turning any future
             // substitution regression into a silent miscompile.
             if (module.routes[i].locals[li].name.len == 0) continue;
+            if (module.routes[i].locals[li].is_wait_result) continue;
             MirLocal local{};
             local.span = module.routes[i].locals[li].span;
             local.name = module.routes[i].locals[li].name;
@@ -784,6 +808,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             }
             local.error_struct_index = module.routes[i].locals[li].error_struct_index;
             local.error_variant_index = module.routes[i].locals[li].error_variant_index;
+            local.is_wait_result = module.routes[i].locals[li].is_wait_result;
+            local.wait_event_kind = module.routes[i].locals[li].wait_event_kind;
+            local.wait_payload = module.routes[i].locals[li].wait_payload;
             auto init = mir_value(module.routes[i].locals[li].init, module, &fn);
             if (!init) return core::make_unexpected(init.error());
             local.init = init.value();
@@ -928,6 +955,343 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             }
             return {};
         };
+
+        if (fn.waits.len != 0 && module.routes[i].for_loops.len == 0) {
+            if (module.routes[i].control.kind != HirControlKind::Direct &&
+                module.routes[i].control.kind != HirControlKind::If &&
+                module.routes[i].control.kind != HirControlKind::Match) {
+                return frontend_error(FrontendError::UnsupportedSyntax, fn.span);
+            }
+
+            struct RouteStep {
+                enum class Kind : u8 { Guard, Wait };
+                Kind kind;
+                u32 index;
+                Span span;
+            };
+            RouteStep steps[HirRoute::kMaxGuards + HirRoute::kMaxWaits]{};
+            u32 step_count = 0;
+            for (u32 gi = 0; gi < module.routes[i].guards.len; gi++) {
+                steps[step_count++] = {
+                    RouteStep::Kind::Guard, gi, module.routes[i].guards[gi].span};
+            }
+            for (u32 wi = 0; wi < fn.waits.len; wi++) {
+                steps[step_count++] = {RouteStep::Kind::Wait, wi, fn.waits[wi].span};
+            }
+            for (u32 si = 1; si < step_count; si++) {
+                RouteStep cur = steps[si];
+                u32 pos = si;
+                while (pos > 0 && cur.span.start < steps[pos - 1].span.start) {
+                    steps[pos] = steps[pos - 1];
+                    pos--;
+                }
+                steps[pos] = cur;
+            }
+
+            const u32 terminal_index = step_count;
+            const u32 then_index =
+                module.routes[i].control.kind == HirControlKind::If ? terminal_index + 1 : 0;
+            const u32 else_index =
+                module.routes[i].control.kind == HirControlKind::If ? terminal_index + 2 : 0;
+            u32 match_arm_block_index[HirControl::kMaxMatchArms]{};
+            u32 match_arm_body_index[HirControl::kMaxMatchArms]{};
+            u32 match_arm_then_index[HirControl::kMaxMatchArms]{};
+            u32 match_arm_else_index[HirControl::kMaxMatchArms]{};
+            u32 match_arm_guard_index[HirControl::kMaxMatchArms][HirMatchArm::kMaxPreludeGuards]{};
+            u32 match_arm_guard_fail_index[HirControl::kMaxMatchArms]
+                                          [HirMatchArm::kMaxPreludeGuards]{};
+            u32 match_arm_count = 0;
+            u32 match_test_count = 0;
+            u32 match_end_index = 0;
+            if (module.routes[i].control.kind == HirControlKind::Match) {
+                match_arm_count = module.routes[i].control.match_arms.len;
+                match_test_count = match_arm_count - 1;
+                u32 next_index = terminal_index + match_test_count;
+                for (u32 ai = 0; ai < match_arm_count; ai++) {
+                    const auto& arm = module.routes[i].control.match_arms[ai];
+                    match_arm_block_index[ai] = next_index++;
+                    if (arm.guards.len != 0) {
+                        for (u32 gi = 1; gi < arm.guards.len; gi++)
+                            match_arm_guard_index[ai][gi] = next_index++;
+                        match_arm_body_index[ai] = next_index++;
+                        for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                            match_arm_guard_fail_index[ai][gi] = next_index;
+                            next_index += guard_fail_block_count(arm.guards[gi]);
+                        }
+                    } else {
+                        match_arm_body_index[ai] = match_arm_block_index[ai];
+                    }
+                    if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                        match_arm_then_index[ai] = next_index++;
+                        match_arm_else_index[ai] = next_index++;
+                    }
+                }
+                match_end_index = next_index;
+            }
+            u32 fail_cursor = terminal_index + 1;
+            if (module.routes[i].control.kind == HirControlKind::If)
+                fail_cursor = terminal_index + 3;
+            if (module.routes[i].control.kind == HirControlKind::Match)
+                fail_cursor = match_end_index;
+            u32 guard_fail_index[HirRoute::kMaxGuards]{};
+            for (u32 si = 0; si < step_count; si++) {
+                if (steps[si].kind != RouteStep::Kind::Guard) continue;
+                const u32 gi = steps[si].index;
+                guard_fail_index[gi] = fail_cursor;
+                fail_cursor += guard_fail_block_count(module.routes[i].guards[gi]);
+            }
+            if (fail_cursor > MirFunction::kMaxBlocks)
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+
+            u32 wait_ordinal = 0;
+            fn.has_explicit_resume_blocks = true;
+            fn.state_zero_enters_entry = true;
+            fn.resume_blocks[0] = 0;
+            for (u32 si = 0; si < step_count; si++) {
+                MirBlock step_block{};
+                step_block.label = si == 0 ? entry_label() : cont_label();
+                const u32 next_index = si + 1 < step_count ? si + 1 : terminal_index;
+                if (steps[si].kind == RouteStep::Kind::Guard) {
+                    const auto& guard = module.routes[i].guards[steps[si].index];
+                    step_block.term.kind = MirTerminatorKind::Branch;
+                    step_block.term.span = guard.span;
+                    auto cond = mir_value(guard.cond, module, &fn);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    step_block.term.cond = cond.value();
+                    step_block.term.then_block = next_index;
+                    step_block.term.else_block = guard_fail_index[steps[si].index];
+                } else {
+                    const auto& wait = fn.waits[steps[si].index];
+                    wait_ordinal++;
+                    step_block.term.kind = MirTerminatorKind::YieldTimer;
+                    step_block.term.span = wait.span;
+                    step_block.term.yield_event_kind = wait.event_kind;
+                    step_block.term.yield_ms = wait.ms;
+                    step_block.term.yield_next_state = static_cast<u16>(wait_ordinal);
+                    fn.resume_blocks[wait_ordinal] = next_index;
+                }
+                if (!fn.blocks.push(step_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+            }
+            if (wait_ordinal != fn.waits.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, fn.span);
+
+            MirBlock terminal_block{};
+            terminal_block.label = cont_label();
+            if (module.routes[i].control.kind == HirControlKind::Direct) {
+                set_term_from_hir(&terminal_block.term, module.routes[i].control.direct_term);
+                if (!fn.blocks.push(terminal_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+            } else if (module.routes[i].control.kind == HirControlKind::If) {
+                terminal_block.term.kind = MirTerminatorKind::Branch;
+                terminal_block.term.span = module.routes[i].control.cond.span;
+                auto cond = mir_value(module.routes[i].control.cond, module, &fn);
+                if (!cond) return core::make_unexpected(cond.error());
+                terminal_block.term.cond = cond.value();
+                terminal_block.term.then_block = then_index;
+                terminal_block.term.else_block = else_index;
+                if (!fn.blocks.push(terminal_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                MirBlock then_block{};
+                then_block.label = then_label();
+                set_term_from_hir(&then_block.term, module.routes[i].control.then_term);
+                if (!fn.blocks.push(then_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                MirBlock else_block{};
+                else_block.label = else_label();
+                set_term_from_hir(&else_block.term, module.routes[i].control.else_term);
+                if (!fn.blocks.push(else_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+            } else if (module.routes[i].control.kind == HirControlKind::Match) {
+                auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
+                if (!subject) return core::make_unexpected(subject.error());
+                if (match_test_count == 0) {
+                    MirBlock case_block{};
+                    const auto& arm = module.routes[i].control.match_arms[0];
+                    case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
+                    if (arm.guards.len != 0) {
+                        auto cond = mir_value(arm.guards[0].cond, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        case_block.term.kind = MirTerminatorKind::Branch;
+                        case_block.term.span = arm.guards[0].span;
+                        case_block.term.cond = cond.value();
+                        case_block.term.then_block = arm.guards.len > 1
+                                                         ? match_arm_guard_index[0][1]
+                                                         : match_arm_body_index[0];
+                        case_block.term.else_block = match_arm_guard_fail_index[0][0];
+                    } else if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                        case_block.term.kind = MirTerminatorKind::Branch;
+                        case_block.term.span = arm.cond.span;
+                        auto cond = mir_value(arm.cond, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        case_block.term.cond = cond.value();
+                        case_block.term.then_block = match_arm_then_index[0];
+                        case_block.term.else_block = match_arm_else_index[0];
+                    } else {
+                        set_term_from_hir(&case_block.term, arm.direct_term);
+                    }
+                    if (!fn.blocks.push(case_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                    for (u32 gi = 1; gi < arm.guards.len; gi++) {
+                        MirBlock guard_block{};
+                        guard_block.label = cont_label();
+                        auto cond = mir_value(arm.guards[gi].cond, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        guard_block.term.kind = MirTerminatorKind::Branch;
+                        guard_block.term.span = arm.guards[gi].span;
+                        guard_block.term.cond = cond.value();
+                        guard_block.term.then_block = gi + 1 < arm.guards.len
+                                                          ? match_arm_guard_index[0][gi + 1]
+                                                          : match_arm_body_index[0];
+                        guard_block.term.else_block = match_arm_guard_fail_index[0][gi];
+                        if (!fn.blocks.push(guard_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                    }
+                    if (arm.guards.len != 0) {
+                        MirBlock body_block{};
+                        body_block.label = cont_label();
+                        if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                            body_block.term.kind = MirTerminatorKind::Branch;
+                            body_block.term.span = arm.cond.span;
+                            auto cond = mir_value(arm.cond, module, &fn);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            body_block.term.cond = cond.value();
+                            body_block.term.then_block = match_arm_then_index[0];
+                            body_block.term.else_block = match_arm_else_index[0];
+                        } else {
+                            set_term_from_hir(&body_block.term, arm.direct_term);
+                        }
+                        if (!fn.blocks.push(body_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                        for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                            auto emitted = emit_guard_fail(arm.guards[gi]);
+                            if (!emitted) return core::make_unexpected(emitted.error());
+                        }
+                    }
+                    if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                        MirBlock then_block{};
+                        then_block.label = then_label();
+                        set_term_from_hir(&then_block.term, arm.then_term);
+                        if (!fn.blocks.push(then_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                        MirBlock else_block{};
+                        else_block.label = else_label();
+                        set_term_from_hir(&else_block.term, arm.else_term);
+                        if (!fn.blocks.push(else_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                    }
+                } else {
+                    for (u32 ai = 0; ai < match_test_count; ai++) {
+                        MirBlock test_block{};
+                        test_block.label = ai == 0 ? cont_label() : match_test_label();
+                        const auto& arm = module.routes[i].control.match_arms[ai];
+                        auto arm_pattern = mir_value(arm.pattern, module, &fn);
+                        if (!arm_pattern) return core::make_unexpected(arm_pattern.error());
+                        test_block.term.kind = MirTerminatorKind::Branch;
+                        test_block.term.use_cmp = true;
+                        test_block.term.span = arm.span;
+                        test_block.term.lhs = subject.value();
+                        test_block.term.rhs = arm_pattern.value();
+                        test_block.term.then_block = match_arm_block_index[ai];
+                        test_block.term.else_block = ai + 1 < match_test_count
+                                                         ? terminal_index + ai + 1
+                                                         : match_arm_block_index[match_test_count];
+                        if (!fn.blocks.push(test_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                    }
+
+                    for (u32 ai = 0; ai < match_arm_count; ai++) {
+                        MirBlock case_block{};
+                        const auto& arm = module.routes[i].control.match_arms[ai];
+                        case_block.label =
+                            arm.is_wildcard ? match_default_label() : match_case_label();
+                        if (arm.guards.len != 0) {
+                            auto cond = mir_value(arm.guards[0].cond, module, &fn);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            case_block.term.kind = MirTerminatorKind::Branch;
+                            case_block.term.span = arm.guards[0].span;
+                            case_block.term.cond = cond.value();
+                            case_block.term.then_block = arm.guards.len > 1
+                                                             ? match_arm_guard_index[ai][1]
+                                                             : match_arm_body_index[ai];
+                            case_block.term.else_block = match_arm_guard_fail_index[ai][0];
+                        } else if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                            case_block.term.kind = MirTerminatorKind::Branch;
+                            case_block.term.span = arm.cond.span;
+                            auto cond = mir_value(arm.cond, module, &fn);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            case_block.term.cond = cond.value();
+                            case_block.term.then_block = match_arm_then_index[ai];
+                            case_block.term.else_block = match_arm_else_index[ai];
+                        } else {
+                            set_term_from_hir(&case_block.term, arm.direct_term);
+                        }
+                        if (!fn.blocks.push(case_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                        for (u32 gi = 1; gi < arm.guards.len; gi++) {
+                            MirBlock guard_block{};
+                            guard_block.label = cont_label();
+                            auto cond = mir_value(arm.guards[gi].cond, module, &fn);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            guard_block.term.kind = MirTerminatorKind::Branch;
+                            guard_block.term.span = arm.guards[gi].span;
+                            guard_block.term.cond = cond.value();
+                            guard_block.term.then_block = gi + 1 < arm.guards.len
+                                                              ? match_arm_guard_index[ai][gi + 1]
+                                                              : match_arm_body_index[ai];
+                            guard_block.term.else_block = match_arm_guard_fail_index[ai][gi];
+                            if (!fn.blocks.push(guard_block))
+                                return frontend_error(FrontendError::TooManyItems, fn.span);
+                        }
+                        if (arm.guards.len != 0) {
+                            MirBlock body_block{};
+                            body_block.label = cont_label();
+                            if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                                body_block.term.kind = MirTerminatorKind::Branch;
+                                body_block.term.span = arm.cond.span;
+                                auto cond = mir_value(arm.cond, module, &fn);
+                                if (!cond) return core::make_unexpected(cond.error());
+                                body_block.term.cond = cond.value();
+                                body_block.term.then_block = match_arm_then_index[ai];
+                                body_block.term.else_block = match_arm_else_index[ai];
+                            } else {
+                                set_term_from_hir(&body_block.term, arm.direct_term);
+                            }
+                            if (!fn.blocks.push(body_block))
+                                return frontend_error(FrontendError::TooManyItems, fn.span);
+                            for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                                auto emitted = emit_guard_fail(arm.guards[gi]);
+                                if (!emitted) return core::make_unexpected(emitted.error());
+                            }
+                        }
+                        if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                            MirBlock then_block{};
+                            then_block.label = then_label();
+                            set_term_from_hir(&then_block.term, arm.then_term);
+                            if (!fn.blocks.push(then_block))
+                                return frontend_error(FrontendError::TooManyItems, fn.span);
+                            MirBlock else_block{};
+                            else_block.label = else_label();
+                            set_term_from_hir(&else_block.term, arm.else_term);
+                            if (!fn.blocks.push(else_block))
+                                return frontend_error(FrontendError::TooManyItems, fn.span);
+                        }
+                    }
+                }
+            }
+
+            for (u32 si = 0; si < step_count; si++) {
+                if (steps[si].kind != RouteStep::Kind::Guard) continue;
+                auto emitted = emit_guard_fail(module.routes[i].guards[steps[si].index]);
+                if (!emitted) return core::make_unexpected(emitted.error());
+            }
+
+            if (!mir->functions.push(fn))
+                return frontend_error(FrontendError::TooManyItems, fn.span);
+            continue;
+        }
 
         // Phase 4b Scope A for-loop unroll. A for-loop compiles to a flat
         // chain of N × M virtual guards (N = iter_expr.args.len, M =
@@ -1091,6 +1455,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             yield_block.label = cont_label();
             yield_block.term.kind = MirTerminatorKind::YieldTimer;
             yield_block.term.span = fn.waits[0].span;
+            yield_block.term.yield_event_kind = fn.waits[0].event_kind;
             yield_block.term.yield_ms = fn.waits[0].ms;
             yield_block.term.yield_next_state = 1;
             if (!fn.blocks.push(yield_block))

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -237,6 +237,70 @@ struct Parser {
             expr.span = Span{start.start, rparen.value()->end, start.line, start.col};
             return expr;
         }
+        if (take(TokenType::KwWait)) {
+            auto lparen = expect(TokenType::LParen);
+            if (!lparen) return core::make_unexpected(lparen.error());
+            expr.kind = AstExprKind::Wait;
+            if (const Token* rparen = take(TokenType::RParen)) {
+                expr.wait_event_kind = WaitEventKind::Any;
+                expr.span = Span{start.start, rparen->end, start.line, start.col};
+                return expr;
+            }
+            const Token* arg = nullptr;
+            if (const Token* t = take(TokenType::IntLit)) {
+                arg = t;
+            } else if (const Token* t = take(TokenType::DurLit)) {
+                arg = t;
+            } else {
+                auto op = parse_expr();
+                if (!op) return core::make_unexpected(op.error());
+                auto op_ptr = alloc_expr(op.value());
+                if (!op_ptr) return core::make_unexpected(op_ptr.error());
+                auto rparen = expect(TokenType::RParen);
+                if (!rparen) return core::make_unexpected(rparen.error());
+                expr.lhs = op_ptr.value();
+                expr.wait_event_kind = WaitEventKind::Any;
+                expr.span = Span{start.start, rparen.value()->end, start.line, start.col};
+                return expr;
+            }
+            u32 digit_len = arg->text.len;
+            u64 multiplier_ms = 1;
+            if (arg->type == TokenType::DurLit) {
+                if (digit_len >= 2 && arg->text.ptr[digit_len - 2] == 'm' &&
+                    arg->text.ptr[digit_len - 1] == 's') {
+                    digit_len -= 2;
+                } else if (digit_len >= 1) {
+                    const char unit = arg->text.ptr[digit_len - 1];
+                    digit_len -= 1;
+                    if (unit == 's')
+                        multiplier_ms = 1000;
+                    else if (unit == 'm')
+                        multiplier_ms = 60ull * 1000;
+                    else if (unit == 'h')
+                        multiplier_ms = 3600ull * 1000;
+                    else
+                        return frontend_error(
+                            FrontendError::InvalidInteger, span_from(*arg), arg->text);
+                }
+            }
+            u64 value = 0;
+            for (u32 i = 0; i < digit_len; i++) {
+                const u32 digit = static_cast<u32>(arg->text.ptr[i] - '0');
+                if (value > (static_cast<u64>(0xffffffffu) - static_cast<u64>(digit)) / 10)
+                    return frontend_error(
+                        FrontendError::InvalidInteger, span_from(*arg), arg->text);
+                value = value * 10 + static_cast<u64>(digit);
+            }
+            const u64 ms = value * multiplier_ms;
+            if (ms > 0xffffffffull)
+                return frontend_error(FrontendError::InvalidInteger, span_from(*arg), arg->text);
+            auto rparen = expect(TokenType::RParen);
+            if (!rparen) return core::make_unexpected(rparen.error());
+            expr.wait_event_kind = WaitEventKind::Timer;
+            expr.wait_ms = static_cast<u32>(ms);
+            expr.span = Span{start.start, rparen.value()->end, start.line, start.col};
+            return expr;
+        }
         if (take(TokenType::KwTrue)) {
             expr.kind = AstExprKind::BoolLit;
             expr.bool_value = true;
@@ -383,6 +447,14 @@ struct Parser {
                 default:
                     return frontend_error(FrontendError::UnsupportedSyntax, span_from(tok));
             }
+            expr.span = span_from(tok);
+            return expr;
+        }
+        if (cur().type == TokenType::KwUpstream || cur().type == TokenType::KwDownstream) {
+            const Token tok = cur();
+            pos++;
+            expr.kind = AstExprKind::Ident;
+            expr.name = tok.text;
             expr.span = span_from(tok);
             return expr;
         }
@@ -950,19 +1022,35 @@ struct Parser {
             return stmt;
         }
         if (take(TokenType::KwWait)) {
+            auto lparen = expect(TokenType::LParen);
+            if (!lparen) return core::make_unexpected(lparen.error());
+            AstStatement stmt{};
+            stmt.kind = AstStmtKind::Wait;
+            if (const Token* rparen = take(TokenType::RParen)) {
+                stmt.wait_event_kind = WaitEventKind::Any;
+                stmt.span = Span{start.start, rparen->end, start.line, start.col};
+                return stmt;
+            }
+
             // Accepts either a bare IntLit (milliseconds, legacy form) or
             // a DurLit (digits + ms/s/m/h suffix). u64 accumulator +
             // UINT32_MAX cap — the yield payload is 32 bits wide, so
             // waits up to ~49 days are expressible.
-            auto lparen = expect(TokenType::LParen);
-            if (!lparen) return core::make_unexpected(lparen.error());
             const Token* arg = nullptr;
             if (const Token* t = take(TokenType::IntLit)) {
                 arg = t;
             } else if (const Token* t = take(TokenType::DurLit)) {
                 arg = t;
             } else {
-                return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
+                auto op = parse_expr();
+                if (!op) return core::make_unexpected(op.error());
+                auto rparen = expect(TokenType::RParen);
+                if (!rparen) return core::make_unexpected(rparen.error());
+                stmt.expr = op.value();
+                stmt.wait_event_kind = WaitEventKind::Any;
+                stmt.has_wait_expr = true;
+                stmt.span = Span{start.start, rparen.value()->end, start.line, start.col};
+                return stmt;
             }
             // Peel the unit suffix (if any) off the end of the text:
             // DurLit ends in ms/s/m/h; IntLit has no suffix.
@@ -1001,8 +1089,7 @@ struct Parser {
                 return frontend_error(FrontendError::InvalidInteger, span_from(*arg), arg->text);
             auto rparen = expect(TokenType::RParen);
             if (!rparen) return core::make_unexpected(rparen.error());
-            AstStatement stmt{};
-            stmt.kind = AstStmtKind::Wait;
+            stmt.wait_event_kind = WaitEventKind::Timer;
             stmt.status_code = static_cast<u32>(ms);  // reused field: ms to sleep
             stmt.span = Span{start.start, rparen.value()->end, start.line, start.col};
             return stmt;

--- a/src/compiler/rir_printer.cc
+++ b/src/compiler/rir_printer.cc
@@ -151,6 +151,12 @@ void print_opcode(PrintBuf& buf, Opcode op) {
         case Opcode::ReqPath:
             buf.put_cstr("req.path");
             break;
+        case Opcode::ResumeEventKind:
+            buf.put_cstr("resume.event_kind");
+            break;
+        case Opcode::ResumeEventResult:
+            buf.put_cstr("resume.event_result");
+            break;
         case Opcode::ReqRemoteAddr:
             buf.put_cstr("req.remote_addr");
             break;
@@ -470,6 +476,8 @@ void print_instruction(PrintBuf& buf, const Instruction& inst, const Function& f
             break;
         case Opcode::ReqMethod:
         case Opcode::ReqPath:
+        case Opcode::ResumeEventKind:
+        case Opcode::ResumeEventResult:
         case Opcode::ReqRemoteAddr:
         case Opcode::ReqContentLength:
         case Opcode::TimeNow:

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -3,6 +3,7 @@
 #include "rut/compiler/rir.h"
 #include "rut/jit/handler_abi.h"
 #include <atomic>
+#include <cstddef>
 
 #include <llvm-c/Core.h>
 #include <stdio.h>
@@ -511,6 +512,24 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             c.set_value(inst.result, v);
             break;
         }
+        case rir::Opcode::ResumeEventKind: {
+            LLVMValueRef off = LLVMConstInt(
+                c.i32_ty, static_cast<u32>(offsetof(HandlerCtx, resume_event_kind)), 0);
+            LLVMValueRef ptr =
+                LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &off, 1, "ev.kind.ptr");
+            LLVMValueRef v = LLVMBuildLoad2(c.builder, c.i32_ty, ptr, "ev.kind");
+            c.set_value(inst.result, v);
+            break;
+        }
+        case rir::Opcode::ResumeEventResult: {
+            LLVMValueRef off = LLVMConstInt(
+                c.i32_ty, static_cast<u32>(offsetof(HandlerCtx, resume_event_result)), 0);
+            LLVMValueRef ptr =
+                LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &off, 1, "ev.result.ptr");
+            LLVMValueRef v = LLVMBuildLoad2(c.builder, c.i32_ty, ptr, "ev.result");
+            c.set_value(inst.result, v);
+            break;
+        }
         case rir::Opcode::ReqHeader: {
             Str name = inst.imm.str_val;
             LLVMValueRef name_ptr = c.make_global_str(name, "hdr.name");
@@ -899,9 +918,9 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             const u64 packed = static_cast<u64>(inst.imm.i64_val);
             const u32 payload = static_cast<u32>(packed & 0xffffffffu);
             const u16 next_state = static_cast<u16>((packed >> 32) & 0xffffu);
-            LLVMBuildRet(
-                c.builder,
-                c.make_result_yield(next_state, static_cast<u8>(YieldKind::Timer), payload));
+            u8 yield_kind = static_cast<u8>((packed >> 48) & 0xffu);
+            if (yield_kind == 0) yield_kind = static_cast<u8>(YieldKind::Timer);
+            LLVMBuildRet(c.builder, c.make_result_yield(next_state, yield_kind, payload));
             break;
         }
 
@@ -995,19 +1014,28 @@ static bool emit_function(Ctx& c, const rir::Function& fn) {
         LLVMValueRef state = LLVMBuildLoad2(c.builder, c.i16_ty, c.param_ctx, "state");
 
         const u32 terminal_block_id =
-            fn.state_zero_enters_entry ? fn.resume_terminal_block : fn.blocks[0].id.id;
+            fn.has_explicit_resume_blocks
+                ? fn.resume_blocks[0]
+                : (fn.state_zero_enters_entry ? fn.resume_terminal_block : fn.blocks[0].id.id);
         LLVMBasicBlockRef terminal_bb = c.block_map[terminal_block_id];
         LLVMValueRef sw = LLVMBuildSwitch(
-            c.builder, state, terminal_bb, fn.yield_count + (fn.state_zero_enters_entry ? 1 : 0));
-        if (fn.state_zero_enters_entry) {
+            c.builder,
+            state,
+            terminal_bb,
+            fn.yield_count +
+                ((fn.state_zero_enters_entry || fn.has_explicit_resume_blocks) ? 1 : 0));
+        if (fn.has_explicit_resume_blocks) {
+            for (u32 si = 0; si <= fn.yield_count && si < rir::Function::kMaxResumeBlocks; si++) {
+                LLVMAddCase(sw, LLVMConstInt(c.i16_ty, si, 0), c.block_map[fn.resume_blocks[si]]);
+            }
+        } else if (fn.state_zero_enters_entry) {
             LLVMAddCase(sw, LLVMConstInt(c.i16_ty, 0, 0), c.block_map[fn.blocks[0].id.id]);
         }
 
-        // Use function-specific yield kind. v1: all yields are Timer; later
-        // layers will branch on per-yield metadata.
-        constexpr u8 kYieldKindTimer = static_cast<u8>(YieldKind::Timer);
         const u32 first_prologue_yield = fn.state_zero_enters_entry ? 1 : 0;
-        for (u32 si = first_prologue_yield; si < fn.yield_count; si++) {
+        for (u32 si = fn.has_explicit_resume_blocks ? fn.yield_count : first_prologue_yield;
+             si < fn.yield_count;
+             si++) {
             char ylabel[24];
             u32 lpos = 0;
             const char* prefix = "yield_";
@@ -1022,9 +1050,11 @@ static bool emit_function(Ctx& c, const rir::Function& fn) {
             LLVMBasicBlockRef yield_bb = LLVMAppendBasicBlockInContext(c.llvm_ctx, func, ylabel);
             LLVMMoveBasicBlockBefore(yield_bb, terminal_bb);
             const u32 payload = fn.yield_payload ? fn.yield_payload[si] : 0;
+            u8 yield_kind = fn.yield_kinds ? fn.yield_kinds[si] : static_cast<u8>(YieldKind::Timer);
+            if (yield_kind == 0) yield_kind = static_cast<u8>(YieldKind::Timer);
             LLVMPositionBuilderAtEnd(c.builder, yield_bb);
             LLVMValueRef result =
-                c.make_result_yield(static_cast<u16>(si + 1), kYieldKindTimer, payload);
+                c.make_result_yield(static_cast<u16>(si + 1), yield_kind, payload);
             LLVMBuildRet(c.builder, result);
             LLVMAddCase(sw, LLVMConstInt(c.i16_ty, si, 0), yield_bb);
         }

--- a/src/runtime/io_uring_backend.cc
+++ b/src/runtime/io_uring_backend.cc
@@ -49,16 +49,29 @@ static i32 io_uring_register(i32 fd, u32 opcode, const void* arg, u32 nr_args) {
 }
 
 // --- user_data encoding ---
-// Layout: [63:8] = conn_id (up to 56 bits used, stored in u32 on decode), [7:0] = IoEventType
-// Enough for 16M connections per shard.
+// Layout: [63:32] = auxiliary generation, [31:8] = 24-bit conn_id/sentinel,
+// [7:0] = IoEventType. conn_id is still decoded as u32; 24 bits covers every
+// live connection id and the io_uring sentinel ids while preserving the full
+// u32 HandlerTimer generation used to reject stale timeout CQEs.
 
 u64 IoUringBackend::encode_user_data(u32 conn_id, IoEventType type) {
-    return (static_cast<u64>(conn_id) << 8) | static_cast<u64>(type);
+    return encode_user_data(conn_id, type, 0);
+}
+
+u64 IoUringBackend::encode_user_data(u32 conn_id, IoEventType type, u32 aux) {
+    return (static_cast<u64>(aux) << 32) | ((static_cast<u64>(conn_id) & 0xFFFFFFu) << 8) |
+           static_cast<u64>(type);
 }
 
 void IoUringBackend::decode_user_data(u64 data, u32& conn_id, IoEventType& type) {
+    u32 aux = 0;
+    decode_user_data(data, conn_id, type, aux);
+}
+
+void IoUringBackend::decode_user_data(u64 data, u32& conn_id, IoEventType& type, u32& aux) {
     type = static_cast<IoEventType>(data & 0xFF);
-    conn_id = static_cast<u32>(data >> 8);
+    conn_id = static_cast<u32>((data >> 8) & 0xFFFFFFu);
+    aux = static_cast<u32>(data >> 32);
 }
 
 // --- SQE helpers ---
@@ -415,7 +428,8 @@ bool IoUringBackend::add_yield_timeout(u32 conn_id, Connection& conn, u32 ms) {
     sqe->addr = reinterpret_cast<u64>(&conn.yield_timespec);
     sqe->len = 1;  // one timespec
     sqe->off = 0;  // count=0 → plain relative timeout (no "wait for N events" semantics)
-    sqe->user_data = encode_user_data(conn_id, IoEventType::HandlerTimer);
+    conn.yield_timer_gen++;
+    sqe->user_data = encode_user_data(conn_id, IoEventType::HandlerTimer, conn.yield_timer_gen);
 
     sqe_advance_tail(sq_tail);
     pending++;
@@ -448,7 +462,7 @@ void IoUringBackend::cancel_accept() {
 
 // Submit a cancel SQE matching a specific user_data value.
 // Returns true if the SQE was queued, false if SQ is full.
-bool IoUringBackend::cancel_by_user_data(u64 target, u32 conn_id, IoEventType type) {
+bool IoUringBackend::cancel_by_user_data(u64 target, u32 conn_id, IoEventType type, u32 aux) {
     io_uring_sqe* sqe = get_sqe();
     if (!sqe) {
         // SQ ring full — flush pending SQEs to make room, then retry.
@@ -465,14 +479,22 @@ bool IoUringBackend::cancel_by_user_data(u64 target, u32 conn_id, IoEventType ty
     // Cancel by user_data match (not fd) — safe across fd reuse after close().
     sqe->addr = target;
     sqe->cancel_flags = IORING_ASYNC_CANCEL_ALL;
-    // Encode the real conn_id in the cancel CQE's user_data so dispatch()
-    // can decrement pending_ops when the cancel completes. This prevents
-    // slot reuse before all cancel CQEs have been processed.
-    sqe->user_data = encode_user_data(conn_id, type);
+    // Encode the caller-provided conn_id/type/aux in the cancel CQE. Close-path
+    // cancels use the real conn_id so dispatch can account pending_ops; mid-wait
+    // timeout disarms use kCancelConnId so the cancel CQE is consumed silently.
+    sqe->user_data = encode_user_data(conn_id, type, aux);
 
     sqe_advance_tail(sq_tail);
     pending++;
     return true;
+}
+
+bool IoUringBackend::cancel_yield_timeout(u32 conn_id, u32 yield_timer_gen) {
+    return cancel_by_user_data(
+        encode_user_data(conn_id, IoEventType::HandlerTimer, yield_timer_gen),
+        kCancelConnId,
+        IoEventType::HandlerTimer,
+        yield_timer_gen);
 }
 
 u32 IoUringBackend::cancel(i32 /*fd*/,
@@ -482,7 +504,8 @@ u32 IoUringBackend::cancel(i32 /*fd*/,
                            bool upstream_recv_armed,
                            bool upstream_send_armed,
                            bool has_upstream,
-                           bool yield_armed) {
+                           bool yield_armed,
+                           u32 yield_timer_gen) {
     // Only cancel op types that are actually in flight to avoid wasting
     // SQ/CQ capacity with no-op cancels that produce -ENOENT completions.
     u32 submitted = 0;
@@ -520,9 +543,11 @@ u32 IoUringBackend::cancel(i32 /*fd*/,
     // until the target CQE arrives, preventing stale HandlerTimer events
     // from resuming a handler on a reused slot.
     if (yield_armed) {
-        if (cancel_by_user_data(encode_user_data(conn_id, IoEventType::HandlerTimer),
-                                conn_id,
-                                IoEventType::HandlerTimer))
+        if (cancel_by_user_data(
+                encode_user_data(conn_id, IoEventType::HandlerTimer, yield_timer_gen),
+                conn_id,
+                IoEventType::HandlerTimer,
+                yield_timer_gen))
             submitted++;
     }
 
@@ -572,7 +597,8 @@ u32 IoUringBackend::wait(IoEvent* events, u32 max_events, Connection* conns, u32
 
         u32 conn_id;
         IoEventType type;
-        decode_user_data(cqe->user_data, conn_id, type);
+        u32 aux = 0;
+        decode_user_data(cqe->user_data, conn_id, type, aux);
 
         // Cancel CQEs — silently consume, don't emit event
         if (conn_id == kCancelConnId) {
@@ -696,7 +722,7 @@ u32 IoUringBackend::wait(IoEvent* events, u32 max_events, Connection* conns, u32
         // --- Default: non-buffer events (Accept, Connect, error Send/Recv) ---
         events[count].conn_id = conn_id;
         events[count].type = type;
-        events[count].result = cqe->res;
+        events[count].result = type == IoEventType::HandlerTimer ? static_cast<i32>(aux) : cqe->res;
         events[count].buf_id = 0;
         events[count].has_buf = 0;
         events[count].more = (cqe->flags & IORING_CQE_F_MORE) ? 1 : 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(test_network PRIVATE
     ${PROJECT_SOURCE_DIR}/testing
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+target_compile_definitions(test_network PRIVATE RUT_TESTING=1)
 add_test(NAME test_network COMMAND test_network)
 set_tests_properties(test_network PROPERTIES LABELS "unit;network")
 

--- a/tests/mock_backend.h
+++ b/tests/mock_backend.h
@@ -15,7 +15,7 @@ using Connection = ConnectionBase;  // alias (matches connection.h)
 // No real sockets, no syscalls, fully deterministic.
 
 struct MockOp {
-    enum Type : u8 { Accept, Recv, Send, Connect, Cancel };
+    enum Type : u8 { Accept, Recv, Send, Connect, Cancel, PauseRecv };
     Type type;
     i32 fd;
     u32 conn_id;
@@ -31,6 +31,9 @@ struct MockBackend {
     static constexpr u32 kMaxOps = 256;
     MockOp ops[kMaxOps];
     u32 op_count = 0;
+    bool fail_connect = false;
+    bool fail_upstream_recv = false;
+    bool fail_upstream_send = false;
 
     // Injected completions (fed back to event loop)
     static constexpr u32 kMaxEvents = 256;
@@ -40,6 +43,9 @@ struct MockBackend {
     core::Expected<void, Error> init(u32 /*shard_id*/, i32 /*listen_fd*/) {
         op_count = 0;
         pending_count = 0;
+        fail_connect = false;
+        fail_upstream_recv = false;
+        fail_upstream_send = false;
         return {};
     }
 
@@ -56,9 +62,13 @@ struct MockBackend {
         return true;
     }
 
-    bool add_recv_upstream(i32 fd, u32 conn_id) { return add_recv(fd, conn_id); }
+    bool add_recv_upstream(i32 fd, u32 conn_id) {
+        if (fail_upstream_recv) return false;
+        return add_recv(fd, conn_id);
+    }
 
     bool add_send_upstream(i32 fd, u32 conn_id, const u8* buf, u32 len) {
+        if (fail_upstream_send) return false;
         return add_send(fd, conn_id, buf, len);
     }
 
@@ -70,10 +80,17 @@ struct MockBackend {
     }
 
     bool add_connect(i32 fd, u32 conn_id, const void* /*addr*/, u32 /*len*/) {
+        if (fail_connect) return false;
         if (op_count < kMaxOps) {
             ops[op_count++] = {MockOp::Connect, fd, conn_id, nullptr, 0};
         }
         return true;
+    }
+
+    void pause_recv(u32 conn_id) {
+        if (op_count < kMaxOps) {
+            ops[op_count++] = {MockOp::PauseRecv, -1, conn_id, nullptr, 0};
+        }
     }
 
     u32 cancel(i32 fd,

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -137,6 +137,14 @@ TEST(frontend, lex_recognizes_wait_keyword) {
     CHECK_EQ(static_cast<u8>(lexed->tokens[0].type), static_cast<u8>(TokenType::KwWait));
 }
 
+TEST(frontend, lex_recognizes_downstream_keyword) {
+    const char* src = "downstream";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    REQUIRE_EQ(lexed->tokens.len, 2u);  // downstream, EOF
+    CHECK_EQ(static_cast<u8>(lexed->tokens[0].type), static_cast<u8>(TokenType::KwDownstream));
+}
+
 TEST(frontend, lex_recognizes_regex_literal) {
     const char* src = "re\"^/v[0-9]+$\"";
     auto lexed = lex(lit(src));
@@ -1232,18 +1240,21 @@ TEST(frontend, lex_duration_suffix_boundary) {
 }
 
 TEST(frontend, parse_route_accepts_wait_statement) {
-    const char* src = "route GET \"/sleep\" { wait(1000) return 200 }\n";
+    const char* src = "route GET \"/sleep\" { wait(1000) wait(downstream.recv()) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     REQUIRE_EQ(ast->items.len, 1u);
     const auto& route = ast->items[0].route;
-    REQUIRE_EQ(route.statements.len, 2u);
+    REQUIRE_EQ(route.statements.len, 3u);
     CHECK_EQ(static_cast<u8>(route.statements[0].kind), static_cast<u8>(AstStmtKind::Wait));
     CHECK_EQ(route.statements[0].status_code, 1000);  // ms stored in status_code field
-    CHECK_EQ(static_cast<u8>(route.statements[1].kind), static_cast<u8>(AstStmtKind::ReturnStatus));
-    CHECK_EQ(route.statements[1].status_code, 200);
+    CHECK(!route.statements[0].has_wait_expr);
+    CHECK_EQ(static_cast<u8>(route.statements[1].kind), static_cast<u8>(AstStmtKind::Wait));
+    CHECK(route.statements[1].has_wait_expr);
+    CHECK_EQ(static_cast<u8>(route.statements[2].kind), static_cast<u8>(AstStmtKind::ReturnStatus));
+    CHECK_EQ(route.statements[2].status_code, 200);
 }
 
 TEST(frontend, analyze_records_wait_in_hir_route) {
@@ -1313,6 +1324,26 @@ TEST(frontend, analyze_accepts_wait_at_u32_max) {
     CHECK_EQ(hir->routes[0].waits[0].ms, 4294967295u);
 }
 
+TEST(frontend, bound_wait_preserves_u32_timer_payload) {
+    const char* src = "route GET \"/x\" { let ev = wait(4294967295) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(hir->routes[0].waits[0].ms, 4294967295u);
+    CHECK_EQ(hir->routes[0].locals[0].init.wait_payload, 4294967295u);
+    CHECK_EQ(hir->routes[0].locals[0].wait_payload, 4294967295u);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].waits.len, 1u);
+    CHECK_EQ(mir->functions[0].waits[0].ms, 4294967295u);
+}
+
 TEST(frontend, parser_rejects_wait_above_u32_max) {
     // 2^32 overflows the u32 cap even with the u64 accumulator.
     const char* src = "route GET \"/x\" { wait(4294967296) return 200 }\n";
@@ -1322,17 +1353,17 @@ TEST(frontend, parser_rejects_wait_above_u32_max) {
     CHECK(!ast);
 }
 
-TEST(frontend, analyze_rejects_wait_after_non_wait_statement) {
-    // Slice 0 codegen dispatches yields before the entry block, so waits
-    // must be a contiguous prefix. `guard ...; wait(50); return 204`
-    // would otherwise run the wait before the guard check.
+TEST(frontend, analyze_accepts_guard_before_wait) {
+    // Source-ordered wait lowering must run the guard before arming the wait.
     const char* src = "route GET \"/x\" { guard true else { return 500 } wait(50) return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    CHECK(!hir);
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].guards.len, 1u);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
 }
 
 TEST(frontend, analyze_accepts_wait_as_prefix_with_return) {
@@ -1464,10 +1495,8 @@ TEST(frontend, parse_wait_rejects_unknown_suffix) {
     CHECK(!ast);
 }
 
-TEST(frontend, analyze_rejects_wait_after_let_guard) {
-    // Non-let non-wait statements still gate subsequent waits. A guard
-    // between a let and a wait introduces a terminal-ish control path
-    // the state machine can't yet thread through.
+TEST(frontend, analyze_accepts_let_guard_wait_source_order) {
+    // Guards and waits are threaded in source order after pre-wait locals.
     const char* src =
         "route GET \"/x\" { let k = 42 guard k else { return 401 } wait(50) return 204 }\n";
     auto lexed = lex(lit(src));
@@ -1475,7 +1504,10 @@ TEST(frontend, analyze_rejects_wait_after_let_guard) {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    CHECK(!hir);
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    REQUIRE_EQ(hir->routes[0].guards.len, 1u);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
 }
 
 TEST(frontend, analyze_accepts_wait_in_decorated_route) {
@@ -1559,6 +1591,279 @@ TEST(frontend, rir_function_carries_yield_payload_for_waits) {
     rir.destroy();
 }
 
+TEST(frontend, analyze_wait_event_statement_kinds) {
+    struct Case {
+        const char* src;
+        WaitEventKind kind;
+    };
+    const Case cases[] = {
+        {"route GET \"/x\" { wait() return 204 }\n", WaitEventKind::Any},
+        {"route GET \"/x\" { wait(downstream.recv()) return 204 }\n", WaitEventKind::Recv},
+        {"upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { wait(upstream(api).connect()) "
+         "return 204 }\n",
+         WaitEventKind::UpstreamConnect},
+        {"upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { wait(upstream(api).recv()) return "
+         "204 }\n",
+         WaitEventKind::UpstreamRecv},
+        {"upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { "
+         "wait(upstream(api).send(req.body)) return 204 }\n",
+         WaitEventKind::UpstreamSend},
+    };
+
+    for (const auto& c : cases) {
+        auto lexed = lex(lit(c.src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(hir);
+        REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+        CHECK_EQ(static_cast<u8>(hir->routes[0].waits[0].event_kind), static_cast<u8>(c.kind));
+        auto mir = build_mir_heap(hir.value());
+        REQUIRE(mir);
+        REQUIRE_EQ(mir->functions[0].waits.len, 1u);
+        CHECK_EQ(static_cast<u8>(mir->functions[0].waits[0].event_kind), static_cast<u8>(c.kind));
+    }
+}
+
+TEST(frontend, analyze_wait_result_fields) {
+    const char* src =
+        "route GET \"/x\" { let ev = wait(downstream.recv()) guard ev.ok else { return 500 } "
+        "guard ev.kind == 5 else { return 501 } guard ev.result > 0 else { return 502 } "
+        "if ev.eof { return 499 } else { return 204 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].waits[0].event_kind),
+             static_cast<u8>(WaitEventKind::Recv));
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].is_wait_result);
+    REQUIRE_EQ(hir->routes[0].guards.len, 3u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].cond.kind),
+             static_cast<u8>(HirExprKind::WaitField));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[1].cond.kind), static_cast<u8>(HirExprKind::Eq));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[2].cond.kind), static_cast<u8>(HirExprKind::Gt));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.cond.kind),
+             static_cast<u8>(HirExprKind::WaitField));
+}
+
+TEST(frontend, analyze_rejects_unbound_wait_result_field) {
+    const char* src =
+        "route GET \"/x\" { guard wait(downstream.recv()).ok else { return 500 } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_wait_expression_outside_let_initializer) {
+    const char* sources[] = {
+        "route GET \"/x\" { guard wait(50) else { return 500 } return 204 }\n",
+        "route GET \"/x\" { guard wait(downstream.recv()) == 1 else { return 500 } return 204 }\n",
+    };
+    for (const char* src : sources) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(!hir);
+    }
+}
+
+TEST(frontend, analyze_rejects_stale_wait_result_field_after_later_wait) {
+    const char* src =
+        "upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { let first = "
+        "wait(downstream.recv()) let second = "
+        "wait(upstream(api).connect()) guard first.ok else { return 500 } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, lower_wait_result_then_guard_let_preserves_local_refs) {
+    const char* src =
+        "route GET \"/x\" { let ev = wait(downstream.recv()) guard let code = 204 else { return "
+        "500 } guard code == 204 else { return 501 } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, lower_wait_result_then_match_terminal) {
+    const char* src =
+        "route GET \"/x\" { let ev = wait(downstream.recv()) match ev.kind { case 5: return 204 "
+        "case _: return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_wait_io_arguments_start_operations) {
+    const char* sources[] = {
+        "route GET \"/x\" { wait(downstream.recv()) return 204 }\n",
+        "upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { let ev = "
+        "wait(upstream(api).connect()) "
+        "return 204 }\n",
+        "upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { let ev = "
+        "wait(upstream(api).send(req.body)) "
+        "return 204 }\n",
+        "upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { let ev = "
+        "wait(upstream(api).recv()) "
+        "return 204 }\n",
+    };
+    for (const char* src : sources) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(hir);
+        REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+    }
+}
+
+TEST(frontend, analyze_wait_upstream_recv_send_preserve_target_payload) {
+    const char* src =
+        "upstream api at \"127.0.0.1:9000\"\n"
+        "upstream other at \"127.0.0.1:9001\"\n"
+        "route GET \"/x\" { wait(upstream(other).recv()) wait(upstream(other).send(req.body)) "
+        "return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 2u);
+    CHECK_EQ(hir->routes[0].waits[0].event_kind, WaitEventKind::UpstreamRecv);
+    CHECK_EQ(hir->routes[0].waits[0].ms, 2u);
+    CHECK_EQ(hir->routes[0].waits[1].event_kind, WaitEventKind::UpstreamSend);
+    CHECK_EQ(hir->routes[0].waits[1].ms, 2u);
+}
+
+TEST(frontend, analyze_wait_io_rejects_ignored_arguments) {
+    const char* sources[] = {
+        "route GET \"/x\" { wait(downstream.recv(req.body)) return 204 }\n",
+        "route GET \"/x\" { wait(downstream.send()) return 204 }\n",
+        "route GET \"/x\" { wait(downstream.send(response(200))) return 204 }\n",
+        "route GET \"/x\" { wait(any(downstream.send(), timer(250))) return 204 }\n",
+        "upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { "
+        "wait(upstream(api).send(123)) return 204 }\n",
+        "upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { "
+        "wait(upstream(api).send()) return 204 }\n",
+    };
+    for (const char* src : sources) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(!hir);
+    }
+}
+
+TEST(frontend, analyze_wait_connect_argument_records_upstream_payload) {
+    const char* src =
+        "upstream api at \"127.0.0.1:9000\"\n"
+        "route GET \"/x\" { let ev = wait(upstream(api).connect()) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+    CHECK_EQ(hir->routes[0].waits[0].event_kind, WaitEventKind::UpstreamConnect);
+    CHECK_EQ(hir->routes[0].waits[0].ms, 1u);
+}
+
+TEST(frontend, analyze_wait_any_records_event_payload) {
+    const char* src =
+        "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(250))) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+    CHECK_EQ(hir->routes[0].waits[0].event_kind, WaitEventKind::Any);
+    CHECK_EQ(hir->routes[0].waits[0].ms, 250u);
+}
+
+TEST(frontend, analyze_rejects_timer_only_wait_any) {
+    const char* src = "route GET \"/x\" { let ev = wait(any(timer(250))) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_parameterized_wait_any_arms_until_rich_payloads) {
+    const char* sources[] = {
+        "upstream api at \"127.0.0.1:9000\"\n"
+        "route GET \"/x\" { let ev = wait(any(upstream(api).connect(), timer(250))) return 204 "
+        "}\n",
+        "upstream api at \"127.0.0.1:9000\"\n"
+        "route GET \"/x\" { let ev = wait(any(upstream(api).recv(), timer(250))) return 204 }\n",
+    };
+    for (const char* src : sources) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(!hir);
+    }
+}
+
+TEST(frontend, analyze_rejects_wait_after_for_loop) {
+    const char* sources[] = {
+        "route GET \"/x\" { for item in [1] { guard item > 0 else { return 400 } } "
+        "wait(50) return 204 }\n",
+        "route GET \"/x\" { for item in [1] { guard item > 0 else { return 400 } } "
+        "let ev = wait(downstream.recv()) return 204 }\n",
+    };
+    for (const char* src : sources) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(!hir);
+    }
+}
+
 TEST(frontend, parse_route_rejects_wait_without_parens) {
     const char* src = "route GET \"/sleep\" { wait 1000 return 200 }\n";
     auto lexed = lex(lit(src));
@@ -1567,12 +1872,14 @@ TEST(frontend, parse_route_rejects_wait_without_parens) {
     REQUIRE(!ast);
 }
 
-TEST(frontend, parse_route_rejects_wait_non_integer_arg) {
+TEST(frontend, analyze_route_rejects_unsupported_wait_expr) {
     const char* src = "route GET \"/sleep\" { wait(\"1s\") return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
-    REQUIRE(!ast);
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
 }
 
 TEST(frontend, parse_route_block_single_entry_no_decorators) {

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -147,18 +147,18 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
         c.reset();
         free_stack[free_top++] = cid;
     }
-    void submit_recv_impl(Connection& c) { backend.add_recv(c.fd, c.id); }
+    bool submit_recv_impl(Connection& c) { return backend.add_recv(c.fd, c.id); }
     void submit_send_impl(Connection& c, const u8* buf, u32 len) {
         backend.add_send(c.fd, c.id, buf, len);
     }
-    void submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
-        backend.add_send_upstream(c.upstream_fd, c.id, buf, len);
+    bool submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
+        return backend.add_send_upstream(c.upstream_fd, c.id, buf, len);
     }
-    void submit_recv_upstream_impl(Connection& c) {
-        backend.add_recv_upstream(c.upstream_fd, c.id);
+    bool submit_recv_upstream_impl(Connection& c) {
+        return backend.add_recv_upstream(c.upstream_fd, c.id);
     }
-    void submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
-        backend.add_connect(c.upstream_fd, c.id, addr, addr_len);
+    bool submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
+        return backend.add_connect(c.upstream_fd, c.id, addr, addr_len);
     }
     // Test shim: record the ms for assertions, fall back to 1s wheel so
     // pending_handler_fn is still re-entered when the test ticks.
@@ -177,6 +177,7 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
         // intrusive list. Production loops remove first; mirror that
         // so keepalive-armed conns can yield safely.
         timer.remove(&c);
+        c.yield_armed = true;
         timer.add(&c, secs);
         return true;
     }
@@ -249,7 +250,13 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
                 // yield fallback (resume). schedule_yield_timer on
                 // this mock uses the wheel, so tests exercising
                 // wait(...) reach this branch.
-                if (c->pending_handler_fn) {
+                if (c->pending_handler_fn &&
+                    (c->pending_yield_kind == jit::YieldKind::Timer ||
+                     (c->yield_armed &&
+                      yield_kind_matches_event(c->pending_yield_kind, IoEventType::Timeout)))) {
+                    c->yield_armed = false;
+                    c->resume_event_kind = jit::YieldKind::Timer;
+                    c->resume_event_result = 0;
                     resume_jit_handler<SmallLoop>(this, *c);
                 } else {
                     this->close_conn(*c);
@@ -262,6 +269,15 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
             if (conn.on_recv || conn.on_send || conn.on_upstream_recv || conn.on_upstream_send) {
                 timer.refresh(&conn, keepalive_timeout);
                 this->dispatch_event(conn, ev);
+            } else if (conn.pending_handler_fn &&
+                       yield_kind_matches_event(conn.pending_yield_kind, ev.type)) {
+                if (conn.yield_armed) {
+                    conn.yield_armed = false;
+                    timer.remove(&conn);
+                }
+                conn.resume_event_kind = yield_kind_from_event(ev.type);
+                conn.resume_event_result = ev.result;
+                resume_jit_handler<SmallLoop>(this, conn);
             }
         }
     }
@@ -290,6 +306,9 @@ struct AsyncMockBackend {
     static constexpr u32 kMaxOps = 256;
     MockOp ops[kMaxOps];
     u32 op_count = 0;
+    bool fail_connect = false;
+    bool fail_upstream_recv = false;
+    bool fail_upstream_send = false;
 
     static constexpr u32 kMaxEvents = 256;
     IoEvent pending[kMaxEvents];
@@ -298,6 +317,9 @@ struct AsyncMockBackend {
     core::Expected<void, Error> init(u32 /*shard_id*/, i32 /*listen_fd*/) {
         op_count = 0;
         pending_count = 0;
+        fail_connect = false;
+        fail_upstream_recv = false;
+        fail_upstream_send = false;
         return {};
     }
 
@@ -314,7 +336,10 @@ struct AsyncMockBackend {
         return true;
     }
 
-    bool add_recv_upstream(i32 fd, u32 conn_id) { return add_recv(fd, conn_id); }
+    bool add_recv_upstream(i32 fd, u32 conn_id) {
+        if (fail_upstream_recv) return false;
+        return add_recv(fd, conn_id);
+    }
 
     bool add_send(i32 fd, u32 conn_id, const u8* buf, u32 len) {
         if (op_count < kMaxOps) {
@@ -324,10 +349,12 @@ struct AsyncMockBackend {
     }
 
     bool add_send_upstream(i32 fd, u32 conn_id, const u8* buf, u32 len) {
+        if (fail_upstream_send) return false;
         return add_send(fd, conn_id, buf, len);
     }
 
     bool add_connect(i32 fd, u32 conn_id, const void* /*addr*/, u32 /*len*/) {
+        if (fail_connect) return false;
         if (op_count < kMaxOps) {
             ops[op_count++] = {MockOp::Connect, fd, conn_id, nullptr, 0};
         }
@@ -504,12 +531,14 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
         }
     }
 
-    void submit_recv_impl(Connection& c) {
-        if (c.recv_armed) return;
+    bool submit_recv_impl(Connection& c) {
+        if (c.recv_armed) return true;
         if (backend.add_recv(c.fd, c.id)) {
             c.pending_ops++;
             c.recv_armed = true;
+            return true;
         }
+        return false;
     }
     void submit_send_impl(Connection& c, const u8* buf, u32 len) {
         if (backend.add_send(c.fd, c.id, buf, len)) {
@@ -517,23 +546,29 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
             c.send_armed = true;
         }
     }
-    void submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
+    bool submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
         if (backend.add_send_upstream(c.upstream_fd, c.id, buf, len)) {
             c.pending_ops++;
             c.upstream_send_armed = true;
+            return true;
         }
+        return false;
     }
-    void submit_recv_upstream_impl(Connection& c) {
-        if (c.upstream_recv_armed) return;
-        if (backend.add_recv(c.upstream_fd, c.id)) {
+    bool submit_recv_upstream_impl(Connection& c) {
+        if (c.upstream_recv_armed) return true;
+        if (backend.add_recv_upstream(c.upstream_fd, c.id)) {
             c.pending_ops++;
             c.upstream_recv_armed = true;
+            return true;
         }
+        return false;
     }
-    void submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
+    bool submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
         if (backend.add_connect(c.upstream_fd, c.id, addr, addr_len)) {
             c.pending_ops++;
+            return true;
         }
+        return false;
     }
 
     // Test shim matching SmallLoop's: drive the legacy wheel so existing
@@ -553,6 +588,7 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
         // intrusive list. Production loops remove first; mirror that
         // so keepalive-armed conns can yield safely.
         timer.remove(&c);
+        c.yield_armed = true;
         timer.add(&c, secs);
         return true;
     }
@@ -615,11 +651,41 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
             this->submit_recv(*c);
             return;
         }
+        if (ev.type == IoEventType::HandlerTimer) {
+            if (ev.conn_id < kMaxConns) {
+                auto& conn = conns[ev.conn_id];
+                if (conn.pending_ops > 0) conn.pending_ops--;
+                const bool matching_generation =
+                    ev.result == static_cast<i32>(conn.yield_timer_gen);
+                const bool was_yield_armed = conn.yield_armed;
+                if (matching_generation) {
+                    conn.yield_armed = false;
+                    timer.remove(&conn);
+                }
+                if (conn.pending_handler_fn && matching_generation &&
+                    (conn.pending_yield_kind == jit::YieldKind::Timer ||
+                     (was_yield_armed && yield_kind_matches_event(conn.pending_yield_kind,
+                                                                  IoEventType::HandlerTimer)))) {
+                    conn.resume_event_kind = jit::YieldKind::Timer;
+                    conn.resume_event_result = 0;
+                    resume_jit_handler<AsyncSmallLoop>(this, conn);
+                } else if (conn.pending_ops == 0 && !conn.pending_handler_fn && conn.fd < 0) {
+                    reclaim_slot(ev.conn_id);
+                }
+            }
+            return;
+        }
         if (ev.type == IoEventType::Timeout) {
             timer.tick([this](Connection* c) {
                 // See SmallLoop: a tick resumes yielded JIT handlers and
                 // otherwise closes on keepalive expiry.
-                if (c->pending_handler_fn) {
+                if (c->pending_handler_fn &&
+                    (c->pending_yield_kind == jit::YieldKind::Timer ||
+                     (c->yield_armed &&
+                      yield_kind_matches_event(c->pending_yield_kind, IoEventType::Timeout)))) {
+                    c->yield_armed = false;
+                    c->resume_event_kind = jit::YieldKind::Timer;
+                    c->resume_event_result = 0;
                     resume_jit_handler<AsyncSmallLoop>(this, *c);
                 } else {
                     this->close_conn(*c);
@@ -640,6 +706,15 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
             if (conn.on_recv || conn.on_send || conn.on_upstream_recv || conn.on_upstream_send) {
                 timer.refresh(&conn, keepalive_timeout);
                 this->dispatch_event(conn, ev);
+            } else if (conn.pending_handler_fn &&
+                       yield_kind_matches_event(conn.pending_yield_kind, ev.type)) {
+                if (conn.yield_armed) {
+                    conn.yield_armed = false;
+                    timer.remove(&conn);
+                }
+                conn.resume_event_kind = yield_kind_from_event(ev.type);
+                conn.resume_event_result = ev.result;
+                resume_jit_handler<AsyncSmallLoop>(this, conn);
             } else {
                 // Stale CQE: if all ops complete, reclaim immediately.
                 if (conn.pending_ops == 0) {
@@ -707,6 +782,7 @@ struct FailRecvAsyncSmallLoop : EventLoopCRTP<FailRecvAsyncSmallLoop> {
     bool is_draining() const { return draining; }
 
     // Per-shard control plane pointers (mirrors EventLoop for testing).
+    const RouteConfig** config_ptr = nullptr;
     ShardEpoch* epoch = nullptr;
 
     // Epoch helpers — functional when epoch pointer is wired.
@@ -737,6 +813,7 @@ struct FailRecvAsyncSmallLoop : EventLoopCRTP<FailRecvAsyncSmallLoop> {
         draining = false;
         access_log = nullptr;
         metrics = nullptr;
+        config_ptr = nullptr;
         epoch = nullptr;
         keepalive_timeout = 60;
         free_top = kMaxConns;
@@ -768,28 +845,40 @@ struct FailRecvAsyncSmallLoop : EventLoopCRTP<FailRecvAsyncSmallLoop> {
         free_stack[free_top++] = cid;
     }
 
-    void submit_recv_impl(Connection& c) {
-        if (c.recv_armed) return;
+    bool submit_recv_impl(Connection& c) {
+        if (c.recv_armed) return true;
         if (backend.add_recv(c.fd, c.id)) {
             c.pending_ops++;
             c.recv_armed = true;
+            return true;
         }
+        return false;
     }
     void submit_send_impl(Connection& c, const u8* buf, u32 len) {
         if (backend.add_send(c.fd, c.id, buf, len)) c.pending_ops++;
     }
-    void submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
-        if (backend.add_send(c.upstream_fd, c.id, buf, len)) c.pending_ops++;
+    bool submit_send_upstream_impl(Connection& c, const u8* buf, u32 len) {
+        if (backend.add_send_upstream(c.upstream_fd, c.id, buf, len)) {
+            c.pending_ops++;
+            return true;
+        }
+        return false;
     }
-    void submit_recv_upstream_impl(Connection& c) {
-        if (c.upstream_recv_armed) return;
-        if (backend.add_recv(c.upstream_fd, c.id)) {
+    bool submit_recv_upstream_impl(Connection& c) {
+        if (c.upstream_recv_armed) return true;
+        if (backend.add_recv_upstream(c.upstream_fd, c.id)) {
             c.pending_ops++;
             c.upstream_recv_armed = true;
+            return true;
         }
+        return false;
     }
-    void submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
-        if (backend.add_connect(c.upstream_fd, c.id, addr, addr_len)) c.pending_ops++;
+    bool submit_connect_impl(Connection& c, const void* addr, u32 addr_len) {
+        if (backend.add_connect(c.upstream_fd, c.id, addr, addr_len)) {
+            c.pending_ops++;
+            return true;
+        }
+        return false;
     }
     u32 last_yield_ms = 0;
     [[nodiscard]] bool schedule_yield_timer(Connection& c, u32 ms) {
@@ -806,6 +895,7 @@ struct FailRecvAsyncSmallLoop : EventLoopCRTP<FailRecvAsyncSmallLoop> {
         // intrusive list. Production loops remove first; mirror that
         // so keepalive-armed conns can yield safely.
         timer.remove(&c);
+        c.yield_armed = true;
         timer.add(&c, secs);
         return true;
     }

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -14310,6 +14310,267 @@ route GET "/sleep" { wait(1000) return 200 }
     rir.destroy();
 }
 
+TEST(jit, frontend_route_event_waits_emit_event_yield_kinds) {
+    struct Case {
+        const char* wait_src;
+        YieldKind kind;
+        u32 payload;
+    };
+    const Case cases[] = {
+        {"wait()", YieldKind::Any, 0},
+        {"wait(any(downstream.recv(), timer(250)))", YieldKind::Any, 250},
+        {"wait(downstream.recv())", YieldKind::Recv, 0},
+        {"wait(upstream(api).connect())", YieldKind::UpstreamConnect, 1},
+        {"wait(upstream(api).recv())", YieldKind::UpstreamRecv, 1},
+        {"wait(upstream(api).send(req.body))", YieldKind::UpstreamSend, 1},
+    };
+
+    for (const auto& c : cases) {
+        char src[240];
+        int n = snprintf(src,
+                         sizeof(src),
+                         "upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { %s return 204 }\n",
+                         c.wait_src);
+        REQUIRE(n > 0);
+        REQUIRE(static_cast<size_t>(n) < sizeof(src));
+
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(hir);
+        auto mir = build_mir_heap(hir.value());
+        REQUIRE(mir);
+        FrontendRirModule rir{};
+        auto lowered = lower_to_rir(mir.value(), rir);
+        REQUIRE(lowered);
+        auto cg = codegen(rir.module);
+        REQUIRE(cg.ok);
+        JitEngine engine;
+        REQUIRE(engine.init());
+        REQUIRE(engine.compile(cg.mod, cg.ctx));
+        auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+        REQUIRE(handler != nullptr);
+
+        HandlerCtx ctx{};
+        ctx.state = 0;
+        auto r0 = HandlerResult::unpack(handler(nullptr,
+                                                &ctx,
+                                                reinterpret_cast<const u8*>(kGetRootRequest),
+                                                sizeof(kGetRootRequest) - 1,
+                                                nullptr));
+        CHECK_EQ(static_cast<u8>(r0.action), static_cast<u8>(HandlerAction::Yield));
+        CHECK_EQ(r0.next_state, 1);
+        CHECK_EQ(static_cast<u8>(r0.yield_kind), static_cast<u8>(c.kind));
+        CHECK_EQ(r0.yield_payload_u32(), c.payload);
+
+        ctx.state = r0.next_state;
+        auto r1 = HandlerResult::unpack(handler(nullptr,
+                                                &ctx,
+                                                reinterpret_cast<const u8*>(kGetRootRequest),
+                                                sizeof(kGetRootRequest) - 1,
+                                                nullptr));
+        CHECK_EQ(static_cast<u8>(r1.action), static_cast<u8>(HandlerAction::ReturnStatus));
+        CHECK_EQ(r1.status_code, 204);
+
+        engine.shutdown();
+        rir.destroy();
+    }
+}
+
+TEST(jit, decorated_route_prologue_yields_preserve_event_kind) {
+    const auto src = R"rut(
+func auth(_ req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/x" { wait(5) wait(downstream.recv()) return 204 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    HandlerCtx ctx{};
+    auto first = HandlerResult::unpack(handler(nullptr,
+                                               &ctx,
+                                               reinterpret_cast<const u8*>(kGetRootRequest),
+                                               sizeof(kGetRootRequest) - 1,
+                                               nullptr));
+    CHECK_EQ(static_cast<u8>(first.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(first.next_state, 1);
+    CHECK_EQ(static_cast<u8>(first.yield_kind), static_cast<u8>(YieldKind::Timer));
+    CHECK_EQ(first.yield_payload_u32(), 5u);
+
+    ctx.state = first.next_state;
+    auto second = HandlerResult::unpack(handler(nullptr,
+                                                &ctx,
+                                                reinterpret_cast<const u8*>(kGetRootRequest),
+                                                sizeof(kGetRootRequest) - 1,
+                                                nullptr));
+    CHECK_EQ(static_cast<u8>(second.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(second.next_state, 2);
+    CHECK_EQ(static_cast<u8>(second.yield_kind), static_cast<u8>(YieldKind::Recv));
+    CHECK_EQ(second.yield_payload_u32(), 0u);
+
+    ctx.state = second.next_state;
+    auto done = HandlerResult::unpack(handler(nullptr,
+                                              &ctx,
+                                              reinterpret_cast<const u8*>(kGetRootRequest),
+                                              sizeof(kGetRootRequest) - 1,
+                                              nullptr));
+    CHECK_EQ(static_cast<u8>(done.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(done.status_code, 204);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_wait_result_fields_drive_control_flow) {
+    const auto src = R"rut(
+route GET "/x" {
+    let ev = wait(downstream.recv())
+    guard ev.ok else { return 500 }
+    if ev.eof { return 499 } else { return 204 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    HandlerCtx ctx{};
+    ctx.state = 0;
+    auto r0 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r0.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(r0.next_state, 1);
+    CHECK_EQ(static_cast<u8>(r0.yield_kind), static_cast<u8>(YieldKind::Recv));
+
+    ctx.state = r0.next_state;
+    ctx.resume_event_kind = static_cast<u32>(YieldKind::Recv);
+    ctx.resume_event_result = 12;
+    auto r_data = HandlerResult::unpack(handler(nullptr,
+                                                &ctx,
+                                                reinterpret_cast<const u8*>(kGetRootRequest),
+                                                sizeof(kGetRootRequest) - 1,
+                                                nullptr));
+    CHECK_EQ(static_cast<u8>(r_data.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r_data.status_code, 204);
+
+    ctx.resume_event_result = 0;
+    auto r_eof = HandlerResult::unpack(handler(nullptr,
+                                               &ctx,
+                                               reinterpret_cast<const u8*>(kGetRootRequest),
+                                               sizeof(kGetRootRequest) - 1,
+                                               nullptr));
+    CHECK_EQ(static_cast<u8>(r_eof.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r_eof.status_code, 499);
+
+    ctx.resume_event_kind = static_cast<u32>(YieldKind::UpstreamConnect);
+    ctx.resume_event_result = 0;
+    auto r_connect_ok = HandlerResult::unpack(handler(nullptr,
+                                                      &ctx,
+                                                      reinterpret_cast<const u8*>(kGetRootRequest),
+                                                      sizeof(kGetRootRequest) - 1,
+                                                      nullptr));
+    CHECK_EQ(static_cast<u8>(r_connect_ok.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r_connect_ok.status_code, 204);
+
+    ctx.resume_event_kind = static_cast<u32>(YieldKind::Recv);
+    ctx.resume_event_result = -104;
+    auto r_err = HandlerResult::unpack(handler(nullptr,
+                                               &ctx,
+                                               reinterpret_cast<const u8*>(kGetRootRequest),
+                                               sizeof(kGetRootRequest) - 1,
+                                               nullptr));
+    CHECK_EQ(static_cast<u8>(r_err.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r_err.status_code, 500);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_parameterized_event_waits_emit_payloads) {
+    struct Case {
+        const char* src;
+        YieldKind kind;
+        u32 payload;
+    };
+    const Case cases[] = {
+        {"upstream api at \"127.0.0.1:9000\"\n"
+         "route GET \"/x\" { wait(upstream(api).connect()) return 204 }\n",
+         YieldKind::UpstreamConnect,
+         1},
+    };
+    for (const auto& c : cases) {
+        auto lexed = lex(lit(c.src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(hir);
+        auto mir = build_mir_heap(hir.value());
+        REQUIRE(mir);
+        FrontendRirModule rir{};
+        auto lowered = lower_to_rir(mir.value(), rir);
+        REQUIRE(lowered);
+        auto cg = codegen(rir.module);
+        REQUIRE(cg.ok);
+        JitEngine engine;
+        REQUIRE(engine.init());
+        REQUIRE(engine.compile(cg.mod, cg.ctx));
+        auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+        REQUIRE(handler != nullptr);
+
+        HandlerCtx ctx{};
+        ctx.state = 0;
+        auto r0 = HandlerResult::unpack(handler(nullptr,
+                                                &ctx,
+                                                reinterpret_cast<const u8*>(kGetRootRequest),
+                                                sizeof(kGetRootRequest) - 1,
+                                                nullptr));
+        CHECK_EQ(static_cast<u8>(r0.action), static_cast<u8>(HandlerAction::Yield));
+        CHECK_EQ(static_cast<u8>(r0.yield_kind), static_cast<u8>(c.kind));
+        CHECK_EQ(r0.yield_payload_u32(), c.payload);
+
+        engine.shutdown();
+        rir.destroy();
+    }
+}
+
 TEST(jit, frontend_route_multiple_waits_chain_through_states) {
     // Two waits: state 0 yields 500ms, state 1 yields 1000ms, state 2 returns 201.
     const auto src = R"rut(
@@ -14358,6 +14619,78 @@ route GET "/sleep" { wait(500) wait(1000) return 201 }
                                             nullptr));
     CHECK_EQ(static_cast<u8>(rf.action), static_cast<u8>(HandlerAction::ReturnStatus));
     CHECK_EQ(rf.status_code, 201);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_source_ordered_guard_waits) {
+    const auto src = R"rut(
+route GET "/" {
+    guard req.path == "/" else { return 404 }
+    wait(50)
+    guard req.method == GET else { return 405 }
+    wait(downstream.recv())
+    return 204
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    HandlerCtx ctx{};
+    ctx.state = 0;
+    auto r0 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r0.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(r0.next_state, 1);
+    CHECK_EQ(static_cast<u8>(r0.yield_kind), static_cast<u8>(YieldKind::Timer));
+    CHECK_EQ(r0.yield_payload_u32(), 50u);
+
+    ctx.state = r0.next_state;
+    auto r1 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r1.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(r1.next_state, 2);
+    CHECK_EQ(static_cast<u8>(r1.yield_kind), static_cast<u8>(YieldKind::Recv));
+
+    ctx.state = r1.next_state;
+    ctx.resume_event_kind = static_cast<u32>(YieldKind::Recv);
+    ctx.resume_event_result = 3;
+    auto r2 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r2.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r2.status_code, 204);
+
+    ctx.state = 0;
+    auto r_fail = HandlerResult::unpack(handler(
+        nullptr, &ctx, reinterpret_cast<const u8*>("GET /bad HTTP/1.1\r\n\r\n"), 21, nullptr));
+    CHECK_EQ(static_cast<u8>(r_fail.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r_fail.status_code, 404);
 
     engine.shutdown();
     rir.destroy();

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -2,6 +2,7 @@
 #include "fault_injection.h"
 #include "rut/runtime/arena.h"
 #include "rut/runtime/error.h"
+#include "rut/runtime/io_uring_backend.h"
 #include "rut/runtime/route_table.h"
 #include "rut/runtime/slab_pool.h"
 #include "rut/runtime/slice_pool.h"
@@ -5590,6 +5591,36 @@ TEST(log_method, all_methods) {
     CHECK_EQ(map_log_method(HttpMethod::Unknown), static_cast<u8>(LogHttpMethod::Other));
 }
 
+TEST(route_method, key_helpers_cover_all_runtime_methods) {
+    CHECK_EQ(route_method_key(HttpMethod::GET), kRouteMethodGet);
+    CHECK_EQ(route_method_key(HttpMethod::POST), kRouteMethodPost);
+    CHECK_EQ(route_method_key(HttpMethod::PUT), kRouteMethodPut);
+    CHECK_EQ(route_method_key(HttpMethod::DELETE), kRouteMethodDelete);
+    CHECK_EQ(route_method_key(HttpMethod::PATCH), kRouteMethodPatch);
+    CHECK_EQ(route_method_key(HttpMethod::HEAD), kRouteMethodHead);
+    CHECK_EQ(route_method_key(HttpMethod::OPTIONS), kRouteMethodOptions);
+    CHECK_EQ(route_method_key(HttpMethod::CONNECT), kRouteMethodConnect);
+    CHECK_EQ(route_method_key(HttpMethod::TRACE), kRouteMethodTrace);
+    CHECK_EQ(route_method_key(HttpMethod::Unknown), kRouteMethodInvalid);
+
+    CHECK_EQ(route_method_key(LogHttpMethod::Get), kRouteMethodGet);
+    CHECK_EQ(route_method_key(LogHttpMethod::Post), kRouteMethodPost);
+    CHECK_EQ(route_method_key(LogHttpMethod::Put), kRouteMethodPut);
+    CHECK_EQ(route_method_key(LogHttpMethod::Delete), kRouteMethodDelete);
+    CHECK_EQ(route_method_key(LogHttpMethod::Patch), kRouteMethodPatch);
+    CHECK_EQ(route_method_key(LogHttpMethod::Head), kRouteMethodHead);
+    CHECK_EQ(route_method_key(LogHttpMethod::Options), kRouteMethodOptions);
+    CHECK_EQ(route_method_key(LogHttpMethod::Connect), kRouteMethodConnect);
+    CHECK_EQ(route_method_key(LogHttpMethod::Trace), kRouteMethodTrace);
+    CHECK_EQ(route_method_key(LogHttpMethod::Other), kRouteMethodAny);
+
+    CHECK_EQ(route_method_slot('H'), kRouteMethodHead);
+    CHECK_EQ(route_method_slot('O'), kRouteMethodOptions);
+    CHECK_EQ(route_method_slot('C'), kRouteMethodConnect);
+    CHECK_EQ(route_method_slot('T'), kRouteMethodTrace);
+    CHECK_EQ(route_method_slot('?'), kRouteMethodSlotInvalid);
+}
+
 // === Coverage: parse_log_method_fallback ===
 
 TEST(log_method, fallback_all) {
@@ -7864,15 +7895,126 @@ TEST(upstream_pool, free_closes_fd) {
 
 // === Coverage: legacy EventLoop<Backend> alloc_upstream_buf ===
 
+static u64 state_invariant_wait_recv_then_status(
+    void*, jit::HandlerCtx* ctx, const u8*, u32, void*);
+
 TEST(legacy_loop, alloc_upstream_buf) {
-    // Minimal test of legacy EventLoop<Backend> alloc_upstream_buf
-    ConnectionBase c;
-    c.reset();
-    c.upstream_recv_slice = nullptr;
-    // Simulate: if upstream_recv_slice is set, alloc_upstream_buf returns true
-    u8 fake_slice[16];
-    c.upstream_recv_slice = fake_slice;
-    CHECK(c.upstream_recv_slice != nullptr);
+    EventLoop<MockBackend> loop;
+    auto initialized = loop.init(0, -1);
+    REQUIRE(initialized);
+    auto* c = loop.alloc_conn();
+    REQUIRE(c != nullptr);
+
+    CHECK(loop.alloc_upstream_buf(*c));
+    CHECK(c->upstream_recv_slice != nullptr);
+    CHECK(loop.alloc_upstream_buf(*c));
+
+    loop.free_conn(*c);
+    loop.shutdown();
+}
+
+TEST(legacy_loop, sync_submit_and_close_paths) {
+    EventLoop<MockBackend> loop;
+    auto initialized = loop.init(0, -1);
+    REQUIRE(initialized);
+    ShardMetrics metrics;
+    metrics.init();
+    metrics.connections_active = 1;
+    metrics.requests_active = 1;
+    loop.metrics = &metrics;
+    ShardEpoch epoch;
+    epoch.epoch.store(0, std::memory_order_relaxed);
+    loop.epoch = &epoch;
+
+    auto* c = loop.alloc_conn();
+    REQUIRE(c != nullptr);
+    c->fd = dup(2);
+    REQUIRE(c->fd >= 0);
+    c->upstream_fd = dup(2);
+    REQUIRE(c->upstream_fd >= 0);
+    c->req_start_us = 1;
+    CHECK(loop.alloc_upstream_buf(*c));
+
+    static const u8 kBody[] = {'o', 'k'};
+    sockaddr_in addr{};
+    CHECK(loop.submit_recv(*c));
+    loop.submit_send(*c, kBody, sizeof(kBody));
+    CHECK(loop.submit_connect(*c, &addr, sizeof(addr)));
+    CHECK(loop.submit_send_upstream(*c, kBody, sizeof(kBody)));
+    CHECK(loop.submit_recv_upstream(*c));
+
+    loop.backend.fail_connect = true;
+    CHECK(!loop.submit_connect(*c, &addr, sizeof(addr)));
+    loop.backend.fail_upstream_send = true;
+    CHECK(!loop.submit_send_upstream(*c, kBody, sizeof(kBody)));
+    loop.backend.fail_upstream_recv = true;
+    CHECK(!loop.submit_recv_upstream(*c));
+
+    loop.close_conn(*c);
+    CHECK_EQ(metrics.connections_closed, 1u);
+    CHECK_EQ(metrics.connections_active, 0u);
+    CHECK_EQ(metrics.requests_active, 0u);
+    CHECK_EQ(epoch.epoch.load(std::memory_order_relaxed), 1u);
+    loop.shutdown();
+}
+
+TEST(legacy_loop, async_submit_and_close_paths) {
+    EventLoop<AsyncMockBackend> loop;
+    auto initialized = loop.init(0, -1);
+    REQUIRE(initialized);
+    auto* c = loop.alloc_conn();
+    REQUIRE(c != nullptr);
+    c->fd = dup(2);
+    REQUIRE(c->fd >= 0);
+    c->upstream_fd = dup(2);
+    REQUIRE(c->upstream_fd >= 0);
+
+    static const u8 kBody[] = {'o', 'k'};
+    sockaddr_in addr{};
+    CHECK(loop.submit_recv(*c));
+    CHECK(loop.submit_recv(*c));
+    loop.submit_send(*c, kBody, sizeof(kBody));
+    CHECK(loop.submit_connect(*c, &addr, sizeof(addr)));
+    CHECK(loop.submit_send_upstream(*c, kBody, sizeof(kBody)));
+    CHECK(loop.submit_recv_upstream(*c));
+    CHECK(loop.submit_recv_upstream(*c));
+    CHECK(c->pending_ops > 0);
+    CHECK(c->recv_armed);
+    CHECK(c->send_armed);
+    CHECK(c->upstream_recv_armed);
+    CHECK(c->upstream_send_armed);
+
+    loop.close_conn(*c);
+    CHECK_EQ(loop.pending_free_count, 1u);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Cancel), 1u);
+    loop.shutdown();
+}
+
+TEST(legacy_loop, event_yield_fails_fast) {
+    EventLoop<MockBackend> loop;
+    auto initialized = loop.init(0, -1);
+    REQUIRE(initialized);
+    auto* c = loop.alloc_conn();
+    REQUIRE(c != nullptr);
+    c->fd = 42;
+    loop.timer.add(c, loop.keepalive_timeout);
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 7;
+    outcome.yield_kind = jit::YieldKind::Recv;
+    loop.backend.clear_ops();
+    handle_jit_outcome<EventLoop<MockBackend>>(
+        &loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->resp_status, 500);
+    CHECK_EQ(c->on_send, &on_response_sent<EventLoop<MockBackend>>);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+
+    loop.free_conn(*c);
+    loop.shutdown();
 }
 
 // === Slot state machine tests: on_body_send_with_early_response ===
@@ -8271,6 +8413,25 @@ TEST(dispatch, null_upstream_recv_enobufs_closes) {
     // -ENOBUFS on null upstream_recv → close (prevent hot-loop)
     loop.dispatch(make_ev(cid, IoEventType::UpstreamRecv, -105));
     CHECK_EQ(loop.conns[cid].fd, -1);
+}
+
+TEST(dispatch, stale_upstream_recv_error_after_keepalive_completion_ignored) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 100));
+    c->state = ConnState::ReadingHeader;
+    c->on_recv = &on_header_received<SmallLoop>;
+    c->on_upstream_recv = nullptr;
+    c->upstream_fd = -1;
+
+    loop.dispatch(make_ev(c->id, IoEventType::UpstreamRecv, -ECANCELED));
+
+    CHECK(c->fd >= 0);
+    CHECK_EQ(c->state, ConnState::ReadingHeader);
+    CHECK_EQ(c->on_recv, &on_header_received<SmallLoop>);
 }
 
 TEST(dispatch, null_upstream_recv_eof_ignored) {
@@ -8691,6 +8852,22 @@ static u64 state_invariant_wait_then_status(void*, jit::HandlerCtx* ctx, const u
     return jit::HandlerResult::make_yield_payload(7, jit::YieldKind::Timer, 25).pack();
 }
 
+static u64 state_invariant_wait_recv_then_status(
+    void*, jit::HandlerCtx* ctx, const u8*, u32, void*) {
+    if (ctx && ctx->state == 7) {
+        const bool got_recv = ctx->resume_event_kind == static_cast<u32>(jit::YieldKind::Recv) &&
+                              ctx->resume_event_result == 12;
+        return jit::HandlerResult::make_status(got_recv ? 204 : 500).pack();
+    }
+    return jit::HandlerResult::make_yield(7, jit::YieldKind::Recv).pack();
+}
+
+static jit::HandlerResult g_state_invariant_jit_result = jit::HandlerResult::make_status(204);
+
+static u64 state_invariant_configured_jit_result(void*, jit::HandlerCtx*, const u8*, u32, void*) {
+    return g_state_invariant_jit_result.pack();
+}
+
 TEST(state_invariant, static_dispatch_keeps_slots_consistent) {
     SmallLoop loop;
     loop.setup();
@@ -8847,6 +9024,7 @@ TEST(state_invariant, jit_timer_yield_keeps_exec_handler_slots_clear) {
     outcome.timer_ms = 25;
     handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_then_status, true);
     check_exec_handler_yield_invariant(_tc, c, &state_invariant_wait_then_status, 7);
+    CHECK_EQ(static_cast<u8>(c->pending_yield_kind), static_cast<u8>(jit::YieldKind::Timer));
     CHECK_EQ(loop.last_yield_ms, outcome.timer_ms);
 
     loop.dispatch(make_ev(c->id, IoEventType::Timeout, 0));
@@ -8854,6 +9032,614 @@ TEST(state_invariant, jit_timer_yield_keeps_exec_handler_slots_clear) {
     CHECK_EQ(c->pending_handler_fn, nullptr);
     CHECK_EQ(c->resp_status, 204);
     check_sending_response_invariant(_tc, c);
+}
+
+TEST(state_invariant, jit_event_yield_resumes_only_on_matching_event) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 7;
+    outcome.yield_kind = jit::YieldKind::Recv;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+    check_exec_handler_yield_invariant(_tc, c, &state_invariant_wait_recv_then_status, 7);
+    CHECK_EQ(static_cast<u8>(c->pending_yield_kind), static_cast<u8>(jit::YieldKind::Recv));
+    CHECK_EQ(loop.backend.count_ops(MockOp::Recv), 1u);
+
+    loop.dispatch(make_ev(c->id, IoEventType::Send, 1));
+    check_exec_handler_yield_invariant(_tc, c, &state_invariant_wait_recv_then_status, 7);
+
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 12));
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, 204);
+    check_sending_response_invariant(_tc, c);
+}
+
+TEST(state_invariant, jit_event_yield_fails_when_downstream_recv_not_armed) {
+    FailRecvAsyncSmallLoop loop;
+    loop.setup();
+    auto* c = loop.alloc_conn();
+    REQUIRE(c != nullptr);
+    c->fd = 42;
+    loop.timer.add(c, loop.keepalive_timeout);
+    c->recv_armed = false;
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 7;
+    outcome.yield_kind = jit::YieldKind::Recv;
+    loop.backend.clear_ops();
+    handle_jit_outcome<FailRecvAsyncSmallLoop>(
+        &loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK(c->on_send != nullptr);
+    CHECK_EQ(c->resp_status, 500);
+}
+
+TEST(state_invariant, jit_any_timer_yield_disarms_timer_when_downstream_recv_fails) {
+    FailRecvAsyncSmallLoop loop;
+    loop.setup();
+    auto* c = loop.alloc_conn();
+    REQUIRE(c != nullptr);
+    c->fd = 42;
+    loop.timer.add(c, loop.keepalive_timeout);
+    c->recv_armed = false;
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 7;
+    outcome.yield_kind = jit::YieldKind::Any;
+    outcome.timer_ms = 25;
+    loop.backend.clear_ops();
+    handle_jit_outcome<FailRecvAsyncSmallLoop>(
+        &loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK(c->on_send != nullptr);
+    CHECK_EQ(c->resp_status, 500);
+    CHECK(!c->yield_armed);
+    CHECK(!c->timer_node.empty());
+}
+
+TEST(state_invariant, jit_downstream_send_yield_fails_closed) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 3;
+    outcome.yield_kind = jit::YieldKind::Send;
+    outcome.timer_ms = 202;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+    CHECK_EQ(c->resp_status, 500);
+}
+
+TEST(state_invariant, response_sent_clears_stale_upstream_fd_on_keepalive) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    c->upstream_fd = dup(2);
+    REQUIRE(c->upstream_fd >= 0);
+    c->state = ConnState::Sending;
+    c->keep_alive = true;
+    c->resp_status = 204;
+    format_static_response(*c, 204, true);
+    c->set_slots(nullptr, &on_response_sent<SmallLoop>, nullptr, nullptr);
+
+    loop.dispatch(make_ev(c->id, IoEventType::Send, static_cast<i32>(c->send_buf.len())));
+    CHECK_EQ(c->upstream_fd, -1);
+    CHECK_EQ(c->state, ConnState::ReadingHeader);
+    CHECK_SLOTS(c, &on_header_received<SmallLoop>, nullptr, nullptr, nullptr);
+}
+
+TEST(state_invariant, jit_dispatch_classifies_all_event_yields) {
+    struct Case {
+        jit::YieldKind kind;
+        u32 payload;
+    };
+    const Case cases[] = {{jit::YieldKind::Any, 25},
+                          {jit::YieldKind::Recv, 0},
+                          {jit::YieldKind::Send, 202},
+                          {jit::YieldKind::UpstreamConnect, 1},
+                          {jit::YieldKind::UpstreamRecv, 0},
+                          {jit::YieldKind::UpstreamSend, 0}};
+
+    jit::HandlerCtx ctx{};
+    for (const auto& tc : cases) {
+        g_state_invariant_jit_result =
+            jit::HandlerResult::make_yield_payload(11, tc.kind, tc.payload);
+        const auto out = invoke_jit_handler(
+            &state_invariant_configured_jit_result, nullptr, ctx, nullptr, 0, nullptr);
+        CHECK_EQ(out.kind, JitDispatchOutcome::Kind::EventYield);
+        CHECK_EQ(out.next_state, 11u);
+        CHECK_EQ(static_cast<u8>(out.yield_kind), static_cast<u8>(tc.kind));
+        CHECK_EQ(out.timer_ms, tc.payload);
+    }
+
+    g_state_invariant_jit_result = jit::HandlerResult::make_yield(12, jit::YieldKind::HttpGet);
+    const auto unsupported = invoke_jit_handler(
+        &state_invariant_configured_jit_result, nullptr, ctx, nullptr, 0, nullptr);
+    CHECK_EQ(unsupported.kind, JitDispatchOutcome::Kind::Error);
+}
+
+TEST(state_invariant, jit_event_helpers_map_runtime_events) {
+    CHECK(yield_kind_matches_event(jit::YieldKind::Any, IoEventType::Recv));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Any, IoEventType::Send));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Any, IoEventType::UpstreamConnect));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Any, IoEventType::UpstreamRecv));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Any, IoEventType::UpstreamSend));
+    CHECK(yield_kind_matches_event(jit::YieldKind::Any, IoEventType::Timeout));
+    CHECK(yield_kind_matches_event(jit::YieldKind::Any, IoEventType::HandlerTimer));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Any, IoEventType::Accept));
+
+    CHECK(yield_kind_matches_event(jit::YieldKind::Recv, IoEventType::Recv));
+    CHECK(yield_kind_matches_event(jit::YieldKind::Send, IoEventType::Send));
+    CHECK(yield_kind_matches_event(jit::YieldKind::UpstreamConnect, IoEventType::UpstreamConnect));
+    CHECK(yield_kind_matches_event(jit::YieldKind::UpstreamRecv, IoEventType::UpstreamRecv));
+    CHECK(yield_kind_matches_event(jit::YieldKind::UpstreamSend, IoEventType::UpstreamSend));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Timer, IoEventType::Recv));
+
+    CHECK_EQ(static_cast<u8>(yield_kind_from_event(IoEventType::Recv)),
+             static_cast<u8>(jit::YieldKind::Recv));
+    CHECK_EQ(static_cast<u8>(yield_kind_from_event(IoEventType::Send)),
+             static_cast<u8>(jit::YieldKind::Send));
+    CHECK_EQ(static_cast<u8>(yield_kind_from_event(IoEventType::UpstreamConnect)),
+             static_cast<u8>(jit::YieldKind::UpstreamConnect));
+    CHECK_EQ(static_cast<u8>(yield_kind_from_event(IoEventType::UpstreamRecv)),
+             static_cast<u8>(jit::YieldKind::UpstreamRecv));
+    CHECK_EQ(static_cast<u8>(yield_kind_from_event(IoEventType::UpstreamSend)),
+             static_cast<u8>(jit::YieldKind::UpstreamSend));
+    CHECK_EQ(static_cast<u8>(yield_kind_from_event(IoEventType::Timeout)),
+             static_cast<u8>(jit::YieldKind::Timer));
+}
+
+TEST(state_invariant, iouring_user_data_preserves_full_timer_generation) {
+    u32 conn_id = 0;
+    IoEventType type = IoEventType::Accept;
+    u32 aux = 0;
+
+    auto data = IoUringBackend::encode_user_data(0xFFFFFEu, IoEventType::HandlerTimer, 0xFFFFFFFFu);
+    IoUringBackend::decode_user_data(data, conn_id, type, aux);
+    CHECK_EQ(conn_id, 0xFFFFFEu);
+    CHECK_EQ(static_cast<u8>(type), static_cast<u8>(IoEventType::HandlerTimer));
+    CHECK_EQ(aux, 0xFFFFFFFFu);
+
+    data = IoUringBackend::encode_user_data(16383u, IoEventType::Recv, 0x80000000u);
+    IoUringBackend::decode_user_data(data, conn_id, type, aux);
+    CHECK_EQ(conn_id, 16383u);
+    CHECK_EQ(static_cast<u8>(type), static_cast<u8>(IoEventType::Recv));
+    CHECK_EQ(aux, 0x80000000u);
+}
+
+TEST(state_invariant, stale_handler_timer_keeps_active_yield_armed) {
+    AsyncSmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    c->pending_handler_fn = &state_invariant_wait_recv_then_status;
+    c->handler_state = 7;
+    c->pending_yield_kind = jit::YieldKind::Any;
+    c->state = ConnState::ExecHandler;
+    c->set_slots(nullptr, nullptr, nullptr, nullptr);
+    c->yield_armed = true;
+    c->yield_timer_gen = 2;
+    c->pending_ops = 2;
+
+    loop.dispatch(make_ev(c->id, IoEventType::HandlerTimer, 1));
+    CHECK(c->yield_armed);
+    CHECK_EQ(c->pending_ops, 1u);
+    CHECK_EQ(c->pending_handler_fn, &state_invariant_wait_recv_then_status);
+
+    loop.dispatch(make_ev(c->id, IoEventType::HandlerTimer, 2));
+    CHECK(!c->yield_armed);
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, 500u);
+}
+
+TEST(state_invariant, jit_any_wait_ignores_undeclared_upstream_events) {
+    SmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    c->pending_handler_fn = &state_invariant_wait_recv_then_status;
+    c->handler_state = 7;
+    c->pending_yield_kind = jit::YieldKind::Any;
+    c->state = ConnState::ExecHandler;
+    c->set_slots(nullptr, nullptr, nullptr, nullptr);
+
+    loop.dispatch(make_ev(c->id, IoEventType::UpstreamRecv, 12));
+    CHECK_EQ(c->pending_handler_fn, &state_invariant_wait_recv_then_status);
+    CHECK_EQ(c->state, ConnState::ExecHandler);
+
+    loop.dispatch(make_ev(c->id, IoEventType::Recv, 12));
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, 204u);
+}
+
+TEST(state_invariant, stale_handler_timer_rejects_24bit_generation_wrap) {
+    AsyncSmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    c->pending_handler_fn = &state_invariant_wait_recv_then_status;
+    c->handler_state = 7;
+    c->pending_yield_kind = jit::YieldKind::Any;
+    c->state = ConnState::ExecHandler;
+    c->set_slots(nullptr, nullptr, nullptr, nullptr);
+    c->yield_armed = true;
+    c->yield_timer_gen = 0x01000001u;
+    c->pending_ops = 2;
+
+    loop.dispatch(make_ev(c->id, IoEventType::HandlerTimer, 1));
+    CHECK(c->yield_armed);
+    CHECK_EQ(c->pending_ops, 1u);
+    CHECK_EQ(c->pending_handler_fn, &state_invariant_wait_recv_then_status);
+
+    loop.dispatch(make_ev(c->id, IoEventType::HandlerTimer, static_cast<i32>(0x01000001u)));
+    CHECK(!c->yield_armed);
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, 500u);
+}
+
+TEST(state_invariant, stale_handler_timer_does_not_reclaim_live_iouring_slot) {
+    AsyncSmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    const u32 free_top_before = loop.free_top;
+    c->pending_handler_fn = nullptr;
+    c->pending_yield_kind = jit::YieldKind::Any;
+    c->state = ConnState::ReadingHeader;
+    c->yield_armed = false;
+    c->yield_timer_gen = 2;
+    c->pending_ops = 1;
+
+    loop.dispatch(make_ev(c->id, IoEventType::HandlerTimer, 1));
+    CHECK_EQ(c->pending_ops, 0u);
+    CHECK_EQ(c->fd, 42);
+    CHECK_EQ(loop.free_top, free_top_before);
+    CHECK_EQ(loop.find_fd(42), c);
+}
+
+TEST(state_invariant, event_resume_refreshes_existing_keepalive_timer) {
+    SmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    CHECK(!c->timer_node.empty());
+
+    c->pending_handler_fn = &state_invariant_wait_recv_then_status;
+    c->handler_state = 7;
+    c->pending_yield_kind = jit::YieldKind::Recv;
+    c->state = ConnState::ExecHandler;
+    c->set_slots(nullptr, nullptr, nullptr, nullptr);
+
+    loop.dispatch(make_ev(c->id, IoEventType::Recv, 12));
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, 204u);
+    CHECK(!c->timer_node.empty());
+}
+
+TEST(state_invariant, jit_event_yield_starts_runtime_operations) {
+    SmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* any = loop.find_fd(42);
+    REQUIRE(any != nullptr);
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 5;
+    outcome.yield_kind = jit::YieldKind::Any;
+    outcome.timer_ms = 25;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(
+        &loop, *any, outcome, &state_invariant_wait_recv_then_status, true);
+    check_exec_handler_yield_invariant(_tc, any, &state_invariant_wait_recv_then_status, 5);
+    CHECK_EQ(loop.last_yield_ms, 25u);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Recv), 1u);
+    CHECK_EQ(loop.backend.count_ops(MockOp::PauseRecv), 0u);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 43));
+    auto* up_send = loop.find_fd(43);
+    REQUIRE(up_send != nullptr);
+    up_send->upstream_fd = 77;
+    up_send->upstream_idx = 0;
+    static const char kBody[] = "body";
+    up_send->recv_buf.write(reinterpret_cast<const u8*>(kBody), sizeof(kBody) - 1);
+    outcome = {};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 6;
+    outcome.yield_kind = jit::YieldKind::UpstreamSend;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(
+        &loop, *up_send, outcome, &state_invariant_wait_recv_then_status, true);
+    CHECK(!up_send->timer_node.empty());
+    const MockOp* send_op = loop.backend.last_op(MockOp::Send);
+    REQUIRE(send_op != nullptr);
+    CHECK_EQ(send_op->fd, 77);
+    CHECK_EQ(send_op->send_len, sizeof(kBody) - 1);
+    CHECK_EQ(loop.backend.count_ops(MockOp::PauseRecv), 1u);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 44));
+    auto* up_recv = loop.find_fd(44);
+    REQUIRE(up_recv != nullptr);
+    up_recv->upstream_fd = 88;
+    up_recv->upstream_idx = 0;
+    outcome = {};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 7;
+    outcome.yield_kind = jit::YieldKind::UpstreamRecv;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(
+        &loop, *up_recv, outcome, &state_invariant_wait_recv_then_status, true);
+    const MockOp* recv_op = loop.backend.last_op(MockOp::Recv);
+    REQUIRE(recv_op != nullptr);
+    CHECK_EQ(recv_op->fd, 88);
+    CHECK_EQ(loop.backend.count_ops(MockOp::PauseRecv), 1u);
+}
+
+TEST(state_invariant, jit_upstream_wait_target_mismatch_fails_closed) {
+    SmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    c->upstream_fd = 77;
+    c->upstream_idx = 0;
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 5;
+    outcome.yield_kind = jit::YieldKind::UpstreamRecv;
+    outcome.timer_ms = 2;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, kStatusBadGateway);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Recv), 0u);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+}
+
+TEST(state_invariant, jit_event_yield_failures_send_error_responses) {
+    SmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* bad_timer = loop.find_fd(42);
+    REQUIRE(bad_timer != nullptr);
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 5;
+    outcome.yield_kind = jit::YieldKind::Any;
+    outcome.timer_ms = TimerWheel::kSlots * 1000u;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(
+        &loop, *bad_timer, outcome, &state_invariant_wait_recv_then_status, true);
+    CHECK_EQ(bad_timer->pending_handler_fn, nullptr);
+    CHECK_EQ(bad_timer->resp_status, 500);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 43));
+    auto* bad_upstream = loop.find_fd(43);
+    REQUIRE(bad_upstream != nullptr);
+    outcome = {};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 6;
+    outcome.yield_kind = jit::YieldKind::UpstreamConnect;
+    outcome.timer_ms = 1;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(
+        &loop, *bad_upstream, outcome, &state_invariant_wait_recv_then_status, true);
+    CHECK_EQ(bad_upstream->pending_handler_fn, nullptr);
+    CHECK_EQ(bad_upstream->resp_status, kStatusBadGateway);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 44));
+    auto* missing_send_fd = loop.find_fd(44);
+    REQUIRE(missing_send_fd != nullptr);
+    outcome = {};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 7;
+    outcome.yield_kind = jit::YieldKind::UpstreamSend;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(
+        &loop, *missing_send_fd, outcome, &state_invariant_wait_recv_then_status, true);
+    CHECK_EQ(missing_send_fd->pending_handler_fn, nullptr);
+    CHECK_EQ(missing_send_fd->resp_status, kStatusBadGateway);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 45));
+    auto* missing_recv_fd = loop.find_fd(45);
+    REQUIRE(missing_recv_fd != nullptr);
+    outcome = {};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 8;
+    outcome.yield_kind = jit::YieldKind::UpstreamRecv;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(
+        &loop, *missing_recv_fd, outcome, &state_invariant_wait_recv_then_status, true);
+    CHECK_EQ(missing_recv_fd->pending_handler_fn, nullptr);
+    CHECK_EQ(missing_recv_fd->resp_status, kStatusBadGateway);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 47));
+    auto* failed_send_submit = loop.find_fd(47);
+    REQUIRE(failed_send_submit != nullptr);
+    failed_send_submit->upstream_fd = 77;
+    failed_send_submit->upstream_idx = 0;
+    outcome = {};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 9;
+    outcome.yield_kind = jit::YieldKind::UpstreamSend;
+    loop.backend.clear_ops();
+    loop.backend.fail_upstream_send = true;
+    handle_jit_outcome<SmallLoop>(
+        &loop, *failed_send_submit, outcome, &state_invariant_wait_recv_then_status, true);
+    loop.backend.fail_upstream_send = false;
+    CHECK_EQ(failed_send_submit->pending_handler_fn, nullptr);
+    CHECK_EQ(failed_send_submit->resp_status, kStatusBadGateway);
+    REQUIRE_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+    REQUIRE(loop.backend.last_op(MockOp::Send) != nullptr);
+    CHECK_EQ(loop.backend.last_op(MockOp::Send)->fd, failed_send_submit->fd);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 48));
+    auto* failed_recv_submit = loop.find_fd(48);
+    REQUIRE(failed_recv_submit != nullptr);
+    failed_recv_submit->upstream_fd = 88;
+    failed_recv_submit->upstream_idx = 0;
+    outcome = {};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 10;
+    outcome.yield_kind = jit::YieldKind::UpstreamRecv;
+    loop.backend.clear_ops();
+    loop.backend.fail_upstream_recv = true;
+    handle_jit_outcome<SmallLoop>(
+        &loop, *failed_recv_submit, outcome, &state_invariant_wait_recv_then_status, true);
+    loop.backend.fail_upstream_recv = false;
+    CHECK_EQ(failed_recv_submit->pending_handler_fn, nullptr);
+    CHECK_EQ(failed_recv_submit->resp_status, kStatusBadGateway);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Recv), 0u);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+
+    RouteConfig cfg;
+    auto upstream = cfg.add_upstream("api", 0x7F000001, 9000);
+    REQUIRE(upstream.has_value());
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 46));
+    auto* failed_connect_submit = loop.find_fd(46);
+    REQUIRE(failed_connect_submit != nullptr);
+    failed_connect_submit->request_config = &cfg;
+    outcome = {};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 9;
+    outcome.yield_kind = jit::YieldKind::UpstreamConnect;
+    outcome.timer_ms = upstream.value() + 1;
+    loop.backend.clear_ops();
+    loop.backend.fail_connect = true;
+    handle_jit_outcome<SmallLoop>(
+        &loop, *failed_connect_submit, outcome, &state_invariant_wait_recv_then_status, true);
+    CHECK_EQ(failed_connect_submit->pending_handler_fn, nullptr);
+    CHECK_EQ(failed_connect_submit->upstream_fd, -1);
+    CHECK_EQ(failed_connect_submit->resp_status, kStatusBadGateway);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Connect), 0u);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+}
+
+TEST(state_invariant, jit_upstream_connect_resets_old_upstream_armed_state) {
+    RouteConfig cfg;
+    auto upstream = cfg.add_upstream("api", 0x7F000001, 9000);
+    REQUIRE(upstream.has_value());
+    SmallLoop loop;
+    loop.setup();
+
+    i32 fds[2];
+    REQUIRE(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    ScopedFakeSocket fake_socket(fds[0]);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    c->request_config = &cfg;
+    c->upstream_fd = fds[1];
+    c->upstream_idx = 0;
+    c->upstream_recv_armed = true;
+    c->upstream_send_armed = true;
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 9;
+    outcome.yield_kind = jit::YieldKind::UpstreamConnect;
+    outcome.timer_ms = upstream.value() + 1;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+
+    CHECK_EQ(c->upstream_recv_armed, false);
+    CHECK_EQ(c->upstream_send_armed, false);
+    CHECK_EQ(c->upstream_idx, upstream.value());
+    CHECK_EQ(loop.backend.count_ops(MockOp::Connect), 1u);
+    CHECK_EQ(loop.backend.count_ops(MockOp::PauseRecv), 1u);
+    if (c->upstream_fd >= 0) {
+        close(c->upstream_fd);
+        c->upstream_fd = -1;
+    }
+}
+
+TEST(state_invariant, jit_forward_closes_prior_wait_connect_socket) {
+    RouteConfig cfg;
+    auto upstream = cfg.add_upstream("api", 0x7F000001, 9000);
+    REQUIRE(upstream.has_value());
+    SmallLoop loop;
+    loop.setup();
+
+    i32 old_fds[2];
+    REQUIRE(socketpair(AF_UNIX, SOCK_STREAM, 0, old_fds) == 0);
+    i32 new_fds[2];
+    REQUIRE(socketpair(AF_UNIX, SOCK_STREAM, 0, new_fds) == 0);
+    ScopedFakeSocket fake_socket(new_fds[0]);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    c->request_config = &cfg;
+    c->upstream_fd = old_fds[1];
+    c->upstream_idx = upstream.value();
+    c->upstream_recv_armed = true;
+    c->upstream_send_armed = true;
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::Forward;
+    outcome.upstream_id = upstream.value();
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+
+    CHECK_EQ(fcntl(old_fds[1], F_GETFD), -1);
+    CHECK_EQ(errno, EBADF);
+    CHECK_EQ(c->upstream_fd, new_fds[0]);
+    CHECK_EQ(c->upstream_recv_armed, false);
+    CHECK_EQ(c->upstream_send_armed, false);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Connect), 1u);
+
+    if (c->upstream_fd >= 0) {
+        close(c->upstream_fd);
+        c->upstream_fd = -1;
+    }
+    close(old_fds[0]);
+    close(new_fds[1]);
 }
 
 // State 1: Accept → ReadingHeader {on_recv=header, rest=null}
@@ -10322,6 +11108,43 @@ TEST(route_coverage, proxy_route_creates_socket) {
     }
     close(fds[1]);
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 0));
+}
+
+TEST(route_coverage, proxy_route_connect_submit_failure_sends_502) {
+    RouteConfig cfg;
+    auto up = cfg.add_upstream("backend", 0x7F000001, 9999);
+    REQUIRE(up.has_value());
+    cfg.add_proxy("/api", 0, static_cast<u16>(up.value()));
+    const RouteConfig* active = &cfg;
+
+    SmallLoop loop;
+    loop.setup();
+    loop.config_ptr = &active;
+    loop.backend.fail_connect = true;
+
+    i32 fds[2];
+    REQUIRE(socketpair(AF_UNIX, SOCK_STREAM, 0, fds) == 0);
+    ScopedFakeSocket fake_socket(fds[0]);
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    c->recv_buf.reset();
+    const char req[] = "GET /api/test HTTP/1.1\r\nHost: x\r\n\r\n";
+    c->recv_buf.write(reinterpret_cast<const u8*>(req), sizeof(req) - 1);
+    IoEvent rev = {c->id, static_cast<i32>(sizeof(req) - 1), 0, 0, IoEventType::Recv, 0};
+    loop.backend.inject(rev);
+    IoEvent events[8];
+    u32 n = loop.backend.wait(events, 8);
+    for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
+
+    CHECK_EQ(c->upstream_fd, -1);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->resp_status, kStatusBadGateway);
+    CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Connect), 0u);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+    close(fds[1]);
 }
 
 TEST(async_coverage, proxy_route_creates_socket) {


### PR DESCRIPTION
## Summary

- Extend `wait(...)` from timer/event completion waits into operation-start waits for downstream and upstream IO.
- Replace the temporary `io.*` syntax with explicit resource receivers: `downstream.recv/send` and `upstream(api).connect/send/recv`.
- Add wait result propagation through HIR/MIR/RIR, JIT ABI/codegen, and runtime resume paths so handlers can branch on `kind`, `result`, `ok`, and `eof`.
- Document the current wait surface and limitations, including status-only `downstream.send(response(N))` and the current `wait(any(...))` payload boundary.

## Validation

- `clang-format --dry-run --Werror`
- `git diff --check`
- `env CCACHE_DISABLE=1 cmake --build /tmp/rut-build --target test_frontend test_jit test_network`
- `env CCACHE_DISABLE=1 cmake --build /tmp/rut-nojit-ci`
- `env CCACHE_DISABLE=1 CC=clang CXX=clang++ cmake -S . -B /tmp/rut-clang-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug`
- `env CCACHE_DISABLE=1 cmake --build /tmp/rut-clang-ci`
- `/tmp/rut-build/tests/test_frontend --filter=frontend.lex_recognizes_downstream_keyword,frontend.analyze_wait_event_statement_kinds,frontend.analyze_wait_io_arguments_start_operations,frontend.analyze_wait_connect_argument_records_upstream_payload,frontend.analyze_wait_any_records_event_payload,frontend.analyze_rejects_parameterized_wait_any_arms_until_rich_payloads`
- `/tmp/rut-build/tests/test_jit --filter=jit.frontend_route_event_waits_emit_event_yield_kinds,jit.frontend_route_parameterized_event_waits_emit_payloads,jit.frontend_route_wait_result_fields_drive_control_flow,jit.frontend_route_source_ordered_guard_waits`
- `/tmp/rut-build/tests/test_network --filter=jit_parameterized_event_yield_starts_send,jit_event_yield_resumes_only_on_matching_event`

Note: full local `ctest` cannot be used inside the sandbox for real-socket integration coverage; the relevant non-socket suites and CI-like builds above pass.