### PR TITLE
[codex] Follow up wait result semantics

### DIFF
--- a/docs/wait.md
+++ b/docs/wait.md
@@ -158,8 +158,7 @@ route POST "/upload" {
 }
 ```
 
-The older `wait(any(...))` expression form remains available and returns the
-same result surface as other event waits:
+The older `wait(any(...))` expression form remains available and returns the same result surface as other event waits:
 
 ```rut
 route POST "/upload" {
@@ -254,7 +253,8 @@ route GET "/x" {
 In other words:
 
 ```text
-let* ; (guard | wait)* ; terminal_control
+let* ;
+(guard | wait)*; terminal_control
 ```
 
 `let` bindings may appear before the first `wait`. Top-level guards may appear
@@ -330,8 +330,8 @@ The following are future work rather than current behavior:
 - Response starts inside `wait(downstream.send(response(...)))`; use terminal
   `return response(...)` for downstream responses until route completion can
   model "send and finish" without a second terminal response.
-- Exact event subsets inside `wait(any(...))`; today it uses current-connection
-  `Any` once the listed forms validate.
+- Exact event subsets inside `wait(any(...))`; today it uses current-connection `Any`
+  once the listed forms validate.
 - Parameterized IO starts inside `wait(any(...))`; start the operation before a
   later race wait until that payload has a richer representation.
 - `wait any` arm result binding such as `r = downstream.recv() => { ... }`.

--- a/docs/wait.md
+++ b/docs/wait.md
@@ -24,6 +24,10 @@ wait(upstream(api).connect())
 wait(upstream(api).recv())
 wait(upstream(api).send(req.body))
 wait(any(downstream.recv(), timer(250)))
+wait any {
+    downstream.recv() => { return 204 }
+    timer(250) => { return 408 }
+}
 wait(250)
 ```
 
@@ -42,6 +46,19 @@ The forms are either operation-start waits or completion waits:
 `downstream.recv()` plus an optional `timer(N)` timeout arm; `N` is
 milliseconds.
 
+When the route needs different control flow for each winning arm, prefer
+statement-form `wait any`. The first slice supports a downstream recv arm and a
+timer arm, with direct terminal branch bodies:
+
+```rut
+route POST "/upload" {
+    wait any {
+        downstream.recv() => { return 204 }
+        timer(2000) => { return 408 }
+    }
+}
+```
+
 ## Result Values
 
 `wait(...)` may be bound to a local. The result currently exposes these fields:
@@ -54,6 +71,9 @@ milliseconds.
 - `ok`: true when `result >= 0`.
 - `eof`: true only for recv-like events (`downstream.recv` and
   `upstream.recv`) when `result == 0`; false for timer/connect/send events.
+- `timer`, `recv`, `send`, `upstream_connect`, `upstream_recv`, and
+  `upstream_send`: boolean predicates derived from `kind`, provided so routes
+  do not need to hard-code numeric `YieldKind` values.
 
 Wait for downstream activity on the current connection:
 
@@ -105,23 +125,51 @@ route POST "/proxy" {
 }
 ```
 
-The bound result is backed by the event that most recently resumed the handler.
-Do not rely on an older wait result after a later `wait(...)` until frame-slot
-storage is added.
+Each bound wait result is stored in the handler frame. Older wait results stay
+available after later waits:
+
+```rut
+route POST "/upload" {
+    let first = wait(any(downstream.recv(), timer(2000)))
+    let second = wait(downstream.recv())
+    if first.timer {
+        return 408
+    } else {
+        guard second.ok else { return 400 }
+        return 204
+    }
+}
+```
 
 Wait routes support direct `return`, `if`, and `match` terminal control after
 the ordered wait/guard sequence.
 
 ## Race Waits
 
-`wait(any(...))` returns the same result surface as other event waits:
+`wait any` is the clearest form when each winning event should run different
+route logic:
+
+```rut
+route POST "/upload" {
+    wait any {
+        downstream.recv() => { return 204 }
+        timer(2000) => { return 408 }
+    }
+}
+```
+
+The older `wait(any(...))` expression form remains available and returns the
+same result surface as other event waits:
 
 ```rut
 route POST "/upload" {
     let ev = wait(any(downstream.recv(), timer(2000)))
-    if ev.kind == 3 { return 408 }
-    guard ev.ok else { return 400 }
-    return 200
+    if ev.timer {
+        return 408
+    } else {
+        guard ev.ok else { return 400 }
+        return 200
+    }
 }
 ```
 
@@ -215,9 +263,8 @@ arming later waits. A `let` after a `wait`, or a `wait` after terminal control
 (`if` / `match` / `return` / `forward`), is rejected today.
 
 The current codegen re-materializes pure pre-wait local initializers when the
-handler reaches the terminal state. Dedicated `HandlerCtx` slot storage for
-values that truly live across yield boundaries is reserved for a later
-state-machine lowering pass.
+handler reaches the terminal state. Wait result `kind` / `result` pairs are
+stored in dedicated `HandlerCtx` frame slots so they survive later waits.
 
 ## Runtime Behavior
 
@@ -250,6 +297,13 @@ Event `wait(...)` compiles to an event yield:
    next_state`.
 4. Non-matching events do not resume the pending handler.
 
+Offline simulation uses the same handler frame shape as production. The
+simulator drives each yielded handler state to completion immediately, records a
+successful synthetic completion in `HandlerCtx`, and keeps the wait-result
+slots allocated across later waits. This lets capture replay exercise branches
+such as `first.timer` after a later `wait(...)` without opening sockets or
+waiting for real timers.
+
 ## Decorators
 
 Decorated wait routes are supported for the direct terminal subset:
@@ -271,7 +325,8 @@ and non-direct terminal control such as `if` / `match`.
 
 The following are future work rather than current behavior:
 
-- Rich result payloads beyond `kind`, `result`, `ok`, and `eof`.
+- Rich result payloads beyond the current scalar fields and event-kind
+  predicates.
 - Response starts inside `wait(downstream.send(response(...)))`; use terminal
   `return response(...)` for downstream responses until route completion can
   model "send and finish" without a second terminal response.
@@ -279,7 +334,6 @@ The following are future work rather than current behavior:
   `Any` once the listed forms validate.
 - Parameterized IO starts inside `wait(any(...))`; start the operation before a
   later race wait until that payload has a richer representation.
-- `HandlerCtx` frame slots for older wait results that must survive a later
-  wait.
+- `wait any` arm result binding such as `r = downstream.recv() => { ... }`.
 - Non-wait `let` bindings after a `wait(...)`.
 - Waits inside nested blocks, loops, branches, or decorator bodies.

--- a/include/rut/common/wait_limits.h
+++ b/include/rut/common/wait_limits.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "rut/common/types.h"
+
+namespace rut {
+
+inline constexpr u32 kMaxRouteWaits = 4;
+inline constexpr u32 kWaitResultSlotsPerWait = 2;
+inline constexpr u32 kMaxJitHandlerSlots = kMaxRouteWaits * kWaitResultSlotsPerWait;
+
+}  // namespace rut

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -27,6 +27,7 @@ enum class AstStmtKind : u8 {
     Match,
     Block,
     Wait,  // `wait(N)` / `wait(2s)` — suspend handler for a timer duration.
+    WaitAny,
     // `for <name> in <expr> { <body> }`. Fields reused from AstStatement:
     //   - name        = loop variable identifier (e.g., "item" in `for item in xs`)
     //   - expr        = iteration source expression (must type-check as Array<T>)

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rut/common/types.h"
+#include "rut/common/wait_limits.h"
 #include "rut/compiler/ast.h"
 #include "rut/compiler/diagnostic.h"
 #include <deque>
@@ -761,7 +762,7 @@ struct HirRoute {
     static constexpr u32 kMaxGuards = 8;
     static constexpr u32 kMaxExprs = 64;
     static constexpr u32 kMaxDecorators = 8;
-    static constexpr u32 kMaxWaits = 4;
+    static constexpr u32 kMaxWaits = kMaxRouteWaits;
     // 2 for-loops per route covers realistic DSL patterns (one allowlist
     // check + one server-pool iteration) while keeping HirRoute under the
     // stack budget. Each HirForLoop is ~10 KB even at kMaxGuards=2; a

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rut/common/types.h"
+#include "rut/common/wait_limits.h"
 #include "rut/compiler/ast.h"
 #include "rut/compiler/diagnostic.h"
 
@@ -243,7 +244,7 @@ struct MirFunction {
     static constexpr u32 kMaxLocals = 16;
     static constexpr u32 kMaxBlocks = 16;
     static constexpr u32 kMaxValues = 64;
-    static constexpr u32 kMaxWaits = 4;
+    static constexpr u32 kMaxWaits = kMaxRouteWaits;
     FixedVec<MirValue, kMaxValues> values;
     FixedVec<MirLocal, kMaxLocals> locals;
     FixedVec<MirBlock, kMaxBlocks> blocks;

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -157,6 +157,7 @@ struct MirValue {
     bool is_wait_result = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;
+    u32 wait_index = 0xffffffffu;
     static constexpr u32 kMaxFieldInits = 8;
     static constexpr u32 kMaxArgs = 8;
     FixedVec<FieldInit, kMaxFieldInits> field_inits;
@@ -182,6 +183,7 @@ struct MirLocal {
     bool is_wait_result = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;
+    u32 wait_index = 0xffffffffu;
     MirValue init{};
 };
 

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -149,11 +149,10 @@ enum class Opcode : u8 {
     ReqPath,            // %r = req.path                 → str
     ResumeEventKind,    // %r = ctx.resume_event_kind    → i32
     ResumeEventResult,  // %r = ctx.resume_event_result → i32
-    CtxLoadSlotI32,     // %r = ctx.slot[i]            → i32
-                        // Falls back to current resume metadata when
-                        // slot data is unavailable: even index slots
-                        // read resume_event_kind, odd index slots read
-                        // resume_event_result.
+    CtxLoadSlotI32,     // %r = ctx.slot[i] if i < ctx.slot_count → i32
+                        // Otherwise reads current resume metadata:
+                        // even index slots read resume_event_kind,
+                        // odd index slots read resume_event_result.
     ReqRemoteAddr,      // %r = req.remote_addr          → IP
     ReqContentLength,   // %r = req.content_length       → ByteSize
     ReqCookie,          // %r = req.cookie "name"        → Optional(str)
@@ -161,7 +160,9 @@ enum class Opcode : u8 {
     // ── Request mutation ──
     ReqSetHeader,     // req.set_header "Name", %val
     ReqSetPath,       // req.set_path %path
-    CtxStoreSlotI32,  // ctx.slot[i] = %val (stored as zero-extended i64 slot)
+    CtxStoreSlotI32,  // if i < ctx.slot_count: ctx.slot[i] = %val
+                      // Stored as a zero-extended i64 slot. If no slot
+                      // is available, the write is ignored.
 
     // ── String operations ──
     StrHasPrefix,    // %r = str.has_prefix %s, %pfx    → bool

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -150,10 +150,10 @@ enum class Opcode : u8 {
     ResumeEventKind,    // %r = ctx.resume_event_kind    → i32
     ResumeEventResult,  // %r = ctx.resume_event_result → i32
     CtxLoadSlotI32,     // %r = ctx.slot[i]            → i32
-                          // Falls back to current resume metadata when
-                          // slot data is unavailable: even index slots
-                          // read resume_event_kind, odd index slots read
-                          // resume_event_result.
+                        // Falls back to current resume metadata when
+                        // slot data is unavailable: even index slots
+                        // read resume_event_kind, odd index slots read
+                        // resume_event_result.
     ReqRemoteAddr,      // %r = req.remote_addr          → IP
     ReqContentLength,   // %r = req.content_length       → ByteSize
     ReqCookie,          // %r = req.cookie "name"        → Optional(str)

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -148,8 +148,12 @@ enum class Opcode : u8 {
     ReqMethod,          // %r = req.method               → Method
     ReqPath,            // %r = req.path                 → str
     ResumeEventKind,    // %r = ctx.resume_event_kind    → i32
-    ResumeEventResult,  // %r = ctx.resume_event_result  → i32
-    CtxLoadSlotI32,     // %r = ctx.slot[i]              → i32
+    ResumeEventResult,  // %r = ctx.resume_event_result → i32
+    CtxLoadSlotI32,     // %r = ctx.slot[i]            → i32
+                          // Falls back to current resume metadata when
+                          // slot data is unavailable: even index slots
+                          // read resume_event_kind, odd index slots read
+                          // resume_event_result.
     ReqRemoteAddr,      // %r = req.remote_addr          → IP
     ReqContentLength,   // %r = req.content_length       → ByteSize
     ReqCookie,          // %r = req.cookie "name"        → Optional(str)
@@ -157,7 +161,7 @@ enum class Opcode : u8 {
     // ── Request mutation ──
     ReqSetHeader,     // req.set_header "Name", %val
     ReqSetPath,       // req.set_path %path
-    CtxStoreSlotI32,  // ctx.slot[i] = %val
+    CtxStoreSlotI32,  // ctx.slot[i] = %val (stored as zero-extended i64 slot)
 
     // ── String operations ──
     StrHasPrefix,    // %r = str.has_prefix %s, %pfx    → bool

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -149,13 +149,15 @@ enum class Opcode : u8 {
     ReqPath,            // %r = req.path                 → str
     ResumeEventKind,    // %r = ctx.resume_event_kind    → i32
     ResumeEventResult,  // %r = ctx.resume_event_result  → i32
+    CtxLoadSlotI32,     // %r = ctx.slot[i]              → i32
     ReqRemoteAddr,      // %r = req.remote_addr          → IP
     ReqContentLength,   // %r = req.content_length       → ByteSize
     ReqCookie,          // %r = req.cookie "name"        → Optional(str)
 
     // ── Request mutation ──
-    ReqSetHeader,  // req.set_header "Name", %val
-    ReqSetPath,    // req.set_path %path
+    ReqSetHeader,     // req.set_header "Name", %val
+    ReqSetPath,       // req.set_path %path
+    CtxStoreSlotI32,  // ctx.slot[i] = %val
 
     // ── String operations ──
     StrHasPrefix,    // %r = str.has_prefix %s, %pfx    → bool

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -453,6 +453,13 @@ struct Builder {
         return TRY(emit(Opcode::ResumeEventResult, ty, loc)).vid;
     }
 
+    Result<ValueId> emit_ctx_load_slot_i32(u32 slot, SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::I32));
+        auto [inst, vid] = TRY(emit(Opcode::CtxLoadSlotI32, ty, loc));
+        inst->imm.i32_val = static_cast<i32>(slot);
+        return vid;
+    }
+
     Result<ValueId> emit_req_remote_addr(SourceLoc loc = {}) {
         auto* ty = TRY(make_type(TypeKind::IP));
         return TRY(emit(Opcode::ReqRemoteAddr, ty, loc)).vid;
@@ -486,6 +493,15 @@ struct Builder {
         if (!val_has_type(path, TypeKind::Str)) return err(RirError::InvalidState);
         auto r = TRY(emit(Opcode::ReqSetPath, nullptr, loc));
         r.inst->operands[0] = path;
+        r.inst->operand_count = 1;
+        return {};
+    }
+
+    VoidResult emit_ctx_store_slot_i32(u32 slot, ValueId value, SourceLoc loc = {}) {
+        if (!val_has_type(value, TypeKind::I32)) return err(RirError::InvalidState);
+        auto r = TRY(emit(Opcode::CtxStoreSlotI32, nullptr, loc));
+        r.inst->imm.i32_val = static_cast<i32>(slot);
+        r.inst->operands[0] = value;
         r.inst->operand_count = 1;
         return {};
     }

--- a/include/rut/jit/handler_abi.h
+++ b/include/rut/jit/handler_abi.h
@@ -123,7 +123,7 @@ struct HandlerResult {
 // Each slot is 8-byte aligned. The number and types of slots are
 // determined at compile time by the state-splitting pass.
 
-struct HandlerCtx {
+struct alignas(alignof(u64)) HandlerCtx {
     u16 state;                // current state machine state
     u16 handler_idx;          // index into CompiledHandlers::handlers[]
     u32 slot_count;           // number of 8-byte slots following this header
@@ -155,6 +155,9 @@ struct HandlerCtx {
 };
 
 static_assert(sizeof(HandlerCtx) == 16, "HandlerCtx header must be 16 bytes");
+static_assert(alignof(HandlerCtx) >= alignof(u64), "HandlerCtx must be 8-byte aligned");
+static_assert(sizeof(HandlerCtx) % alignof(u64) == 0,
+              "HandlerCtx slots must start at an 8-byte-aligned offset");
 
 // ── Handler Function Pointer ───────────────────────────────────────
 // JIT-compiled handlers return u64 (not a struct) to guarantee

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -285,13 +285,13 @@ void on_header_received(void* lp, Connection& conn, IoEvent ev) {
     } else if (route && route->action == RouteAction::JitHandler && route->fn) {
         conn.state = ConnState::ExecHandler;
         conn.handler_state = 0;  // entry state
-        jit::HandlerCtx ctx{};
-        ctx.state = 0;
-        ctx.resume_event_kind = static_cast<u32>(jit::YieldKind::Timer);
-        ctx.resume_event_result = 0;
+        auto* ctx = conn.reset_jit_ctx();
+        ctx->state = 0;
+        ctx->resume_event_kind = static_cast<u32>(jit::YieldKind::Timer);
+        ctx->resume_event_result = 0;
         auto outcome = invoke_jit_handler(route->fn,
                                           static_cast<void*>(&conn),
-                                          ctx,
+                                          *ctx,
                                           conn.recv_buf.data(),
                                           conn.recv_buf.len(),
                                           /*arena=*/nullptr);
@@ -684,13 +684,13 @@ void resume_jit_handler(Loop* loop, Connection& conn) {
     // refresh handles both without double-inserting the intrusive node.
     loop->timer.refresh(&conn, loop->keepalive_timeout);
     auto* fn = conn.pending_handler_fn;
-    jit::HandlerCtx ctx{};
-    ctx.state = conn.handler_state;
-    ctx.resume_event_kind = static_cast<u32>(conn.resume_event_kind);
-    ctx.resume_event_result = conn.resume_event_result;
+    auto* ctx = conn.jit_ctx();
+    ctx->state = conn.handler_state;
+    ctx->resume_event_kind = static_cast<u32>(conn.resume_event_kind);
+    ctx->resume_event_result = conn.resume_event_result;
     auto outcome = invoke_jit_handler(fn,
                                       static_cast<void*>(&conn),
-                                      ctx,
+                                      *ctx,
                                       conn.recv_buf.data(),
                                       conn.recv_buf.len(),
                                       /*arena=*/nullptr);

--- a/include/rut/runtime/connection_base.h
+++ b/include/rut/runtime/connection_base.h
@@ -2,7 +2,7 @@
 
 #include "rut/common/buffer.h"
 #include "rut/common/types.h"
-#include "rut/compiler/mir.h"
+#include "rut/common/wait_limits.h"
 #include "rut/jit/handler_abi.h"
 #include "rut/runtime/chunked_parser.h"
 #include "rut/runtime/io_event.h"
@@ -34,9 +34,9 @@ struct ConnectionBase {
     static constexpr u32 kMaxReqPathLen = 64;
     static constexpr u32 kMaxUpstreamNameLen = 24;
     static constexpr u16 kMaxPipelineDepth = 16;
-    // Keep persistent wait fields coupled to compiler wait limit: every wait
-    // stores kind/result in two i64 slots.
-    static constexpr u32 kMaxJitHandlerSlots = MirFunction::kMaxWaits * 2u;
+    // Keep persistent wait fields coupled to the shared route wait limit:
+    // every wait stores kind/result in two i64 slots.
+    static constexpr u32 kMaxJitHandlerSlots = rut::kMaxJitHandlerSlots;
     static_assert(kMaxJitHandlerSlots >= 2u, "JIT wait frame must hold at least one wait result");
     // Event callback type — void* loop to avoid circular dependency.
     using Callback = void (*)(void* loop, ConnectionBase& conn, IoEvent ev);
@@ -94,7 +94,7 @@ struct ConnectionBase {
     i32 resume_event_result;
     void* handler_ctx;
     jit::HandlerFn pending_handler_fn;
-    alignas(alignof(jit::HandlerCtx)) u8
+    alignas(alignof(u64)) u8
         handler_ctx_storage[sizeof(jit::HandlerCtx) +
                             static_cast<size_t>(kMaxJitHandlerSlots) * 8]{};
 

--- a/include/rut/runtime/connection_base.h
+++ b/include/rut/runtime/connection_base.h
@@ -94,9 +94,8 @@ struct ConnectionBase {
     i32 resume_event_result;
     void* handler_ctx;
     jit::HandlerFn pending_handler_fn;
-    alignas(alignof(u64)) u8
-        handler_ctx_storage[sizeof(jit::HandlerCtx) +
-                            static_cast<size_t>(kMaxJitHandlerSlots) * 8]{};
+    alignas(alignof(u64)) u8 handler_ctx_storage[sizeof(jit::HandlerCtx) +
+                                                 static_cast<size_t>(kMaxJitHandlerSlots) * 8]{};
 
     jit::HandlerCtx* reset_jit_ctx() {
         __builtin_memset(handler_ctx_storage, 0, sizeof(handler_ctx_storage));

--- a/include/rut/runtime/connection_base.h
+++ b/include/rut/runtime/connection_base.h
@@ -2,6 +2,7 @@
 
 #include "rut/common/buffer.h"
 #include "rut/common/types.h"
+#include "rut/compiler/mir.h"
 #include "rut/jit/handler_abi.h"
 #include "rut/runtime/chunked_parser.h"
 #include "rut/runtime/io_event.h"
@@ -33,7 +34,10 @@ struct ConnectionBase {
     static constexpr u32 kMaxReqPathLen = 64;
     static constexpr u32 kMaxUpstreamNameLen = 24;
     static constexpr u16 kMaxPipelineDepth = 16;
-    static constexpr u32 kMaxJitHandlerSlots = 8;
+    // Keep persistent wait fields coupled to compiler wait limit: every wait
+    // stores kind/result in two i64 slots.
+    static constexpr u32 kMaxJitHandlerSlots = MirFunction::kMaxWaits * 2u;
+    static_assert(kMaxJitHandlerSlots >= 2u, "JIT wait frame must hold at least one wait result");
     // Event callback type — void* loop to avoid circular dependency.
     using Callback = void (*)(void* loop, ConnectionBase& conn, IoEvent ev);
 
@@ -90,8 +94,9 @@ struct ConnectionBase {
     i32 resume_event_result;
     void* handler_ctx;
     jit::HandlerFn pending_handler_fn;
-    alignas(8) u8 handler_ctx_storage[sizeof(jit::HandlerCtx) +
-                                      static_cast<size_t>(kMaxJitHandlerSlots) * 8]{};
+    alignas(alignof(jit::HandlerCtx)) u8
+        handler_ctx_storage[sizeof(jit::HandlerCtx) +
+                            static_cast<size_t>(kMaxJitHandlerSlots) * 8]{};
 
     jit::HandlerCtx* reset_jit_ctx() {
         __builtin_memset(handler_ctx_storage, 0, sizeof(handler_ctx_storage));

--- a/include/rut/runtime/connection_base.h
+++ b/include/rut/runtime/connection_base.h
@@ -33,6 +33,7 @@ struct ConnectionBase {
     static constexpr u32 kMaxReqPathLen = 64;
     static constexpr u32 kMaxUpstreamNameLen = 24;
     static constexpr u16 kMaxPipelineDepth = 16;
+    static constexpr u32 kMaxJitHandlerSlots = 8;
     // Event callback type — void* loop to avoid circular dependency.
     using Callback = void (*)(void* loop, ConnectionBase& conn, IoEvent ev);
 
@@ -76,9 +77,9 @@ struct ConnectionBase {
     // JIT handler state.
     //   handler_state: current state-machine index; handler reads this at
     //     entry and dispatches. On yield the runtime stores next_state here.
-    //   handler_ctx:   reserved for future frame / slot storage (SlicePool
-    //     slice or arena-allocated HandlerCtx). Slice 0 (wait only) keeps
-    //     this null and uses a stack-local HandlerCtx.
+    //   handler_ctx:   points at handler_ctx_storage while a JIT handler is
+    //     running. The first slots store wait result kind/result pairs across
+    //     resume boundaries.
     //   pending_handler_fn: non-null while the handler has yielded and is
     //     waiting for its timer/io completion. The tick callback uses this
     //     to distinguish "resume JIT handler" from "keepalive expired,
@@ -89,6 +90,21 @@ struct ConnectionBase {
     i32 resume_event_result;
     void* handler_ctx;
     jit::HandlerFn pending_handler_fn;
+    alignas(8) u8 handler_ctx_storage[sizeof(jit::HandlerCtx) +
+                                      static_cast<size_t>(kMaxJitHandlerSlots) * 8]{};
+
+    jit::HandlerCtx* reset_jit_ctx() {
+        __builtin_memset(handler_ctx_storage, 0, sizeof(handler_ctx_storage));
+        auto* ctx = reinterpret_cast<jit::HandlerCtx*>(handler_ctx_storage);
+        ctx->slot_count = kMaxJitHandlerSlots;
+        handler_ctx = ctx;
+        return ctx;
+    }
+
+    jit::HandlerCtx* jit_ctx() {
+        if (handler_ctx == nullptr) return reset_jit_ctx();
+        return reinterpret_cast<jit::HandlerCtx*>(handler_ctx);
+    }
 
     // Per-request generation counter. Incremented on every new request
     // (in on_header_received) so the epoll YieldHeap can filter out
@@ -147,12 +163,13 @@ struct ConnectionBase {
     bool send_armed;
     bool upstream_recv_armed;
     bool upstream_send_armed;
-    // True between schedule_yield_timer (io_uring: IORING_OP_TIMEOUT SQE
-    // submitted) and the matching HandlerTimer CQE. Mirrors the other
-    // *_armed flags so close_conn_impl can submit a cancel SQE, keeping
-    // the slot pinned until the timer CQE is harvested — otherwise a
-    // late-arriving stale CQE could resume a handler on a reused slot.
+    // True while a handler yield timer is logically armed. For io_uring,
+    // the timer may be backed either by an IORING_OP_TIMEOUT SQE or by the
+    // coarse timer wheel fallback.
     bool yield_armed;
+    // True only when an IORING_OP_TIMEOUT SQE is in flight for the yield.
+    // Used to avoid cancel SQEs for wheel-backed yields.
+    bool yield_timeout_armed;
 
     // Response status (set by handler/proxy, used by access log)
     u16 resp_status;
@@ -264,6 +281,7 @@ struct ConnectionBase {
         upstream_recv_armed = false;
         upstream_send_armed = false;
         yield_armed = false;
+        yield_timeout_armed = false;
         resp_status = 0;
         req_method = 0;
         req_size = 0;

--- a/include/rut/runtime/iouring_event_loop.h
+++ b/include/rut/runtime/iouring_event_loop.h
@@ -379,7 +379,7 @@ public:
                                             c.upstream_recv_armed,
                                             c.upstream_send_armed,
                                             c.upstream_fd >= 0,
-                                            c.yield_armed,
+                                            c.yield_timeout_armed,
                                             c.yield_timer_gen);
         }
         if (c.fd >= 0) {
@@ -448,6 +448,7 @@ public:
         // inject data.
         if (backend.add_yield_timeout(conn.id, conn, ms)) {
             conn.yield_armed = true;
+            conn.yield_timeout_armed = true;
             conn.pending_ops++;
             return true;
         }
@@ -464,6 +465,7 @@ public:
         // analyze rejects wait(0) upstream, so this is defence-in-depth.
         if (secs == 0) secs = 1;
         conn.yield_armed = true;
+        conn.yield_timeout_armed = false;
         timer.add(&conn, secs);
         return true;
     }
@@ -471,10 +473,12 @@ public:
     void disarm_yield_timer(Connection& conn) {
         if (!conn.yield_armed) return;
         const u32 old_gen = conn.yield_timer_gen;
+        const bool timeout_armed = conn.yield_timeout_armed;
         conn.yield_armed = false;
+        conn.yield_timeout_armed = false;
         conn.yield_timer_gen++;
         timer.remove(&conn);
-        (void)backend.cancel_yield_timeout(conn.id, old_gen);
+        if (timeout_armed) (void)backend.cancel_yield_timeout(conn.id, old_gen);
     }
 
     void dispatch(const IoEvent& ev) {
@@ -497,7 +501,10 @@ public:
                 if (c.pending_ops > 0) c.pending_ops--;
                 const bool matching_generation = ev.result == static_cast<i32>(c.yield_timer_gen);
                 const bool was_yield_armed = c.yield_armed;
-                if (matching_generation) c.yield_armed = false;
+                if (matching_generation) {
+                    c.yield_armed = false;
+                    c.yield_timeout_armed = false;
+                }
                 if (c.pending_handler_fn && matching_generation &&
                     (c.pending_yield_kind == jit::YieldKind::Timer ||
                      (was_yield_armed &&
@@ -526,6 +533,7 @@ public:
                          (c->yield_armed &&
                           yield_kind_matches_event(c->pending_yield_kind, IoEventType::Timeout)))) {
                         c->yield_armed = false;
+                        c->yield_timeout_armed = false;
                         c->resume_event_kind = jit::YieldKind::Timer;
                         c->resume_event_result = 0;
                         resume_jit_handler<IoUringEventLoop>(this, *c);

--- a/include/rut/runtime/jit_dispatch.h
+++ b/include/rut/runtime/jit_dispatch.h
@@ -104,9 +104,10 @@ inline jit::YieldKind yield_kind_from_event(IoEventType type) {
 // `ctx.state = out.next_state` and calling this function again after the
 // requested timer or event fires.
 //
-// Caller owns storage for `ctx`. For Layer 0 (no live-across-yield
-// locals) `ctx.slot_count == 0` and the same `ctx` is reused across
-// resumes; the entry call must set `ctx.state = 0`.
+// Caller owns storage for `ctx`. If the handler reads wait result fields after
+// a resume, `ctx` must include the frame slots advertised by `slot_count`, and
+// the same storage must be reused across resumes. The entry call must set
+// `ctx.state = 0`.
 inline JitDispatchOutcome invoke_jit_handler(jit::HandlerFn fn,
                                              void* conn,
                                              jit::HandlerCtx& ctx,

--- a/include/rut/runtime/jit_dispatch.h
+++ b/include/rut/runtime/jit_dispatch.h
@@ -105,9 +105,9 @@ inline jit::YieldKind yield_kind_from_event(IoEventType type) {
 // requested timer or event fires.
 //
 // Caller owns storage for `ctx`. If the handler reads wait result fields after
-// a resume, `ctx` must include the frame slots advertised by `slot_count`, and
-// the same storage must be reused across resumes. The entry call must set
-// `ctx.state = 0`.
+// a resume, `ctx` must include the 8-byte-aligned frame slots advertised by
+// `slot_count`, and the same 8-byte-aligned storage must be reused across
+// resumes. The entry call must set `ctx.state = 0`.
 inline JitDispatchOutcome invoke_jit_handler(jit::HandlerFn fn,
                                              void* conn,
                                              jit::HandlerCtx& ctx,

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -7608,28 +7608,10 @@ static FrontendResult<void> analyze_wait_any_stmt_control(const AstStatement& st
     const u32 wait_index = route.waits.len;
     if (!route.waits.push(wait)) return frontend_error(FrontendError::TooManyItems, stmt.span);
 
-    HirLocal local{};
-    local.span = stmt.span;
-    local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
-    local.type = HirTypeKind::Unknown;
-    local.is_wait_result = true;
-    local.wait_event_kind = WaitEventKind::Any;
-    local.wait_payload = timer_ms;
-    local.wait_index = wait_index;
-    local.init.kind = HirExprKind::WaitResult;
-    local.init.type = HirTypeKind::Unknown;
-    local.init.span = stmt.span;
-    local.init.is_wait_result = true;
-    local.init.wait_event_kind = WaitEventKind::Any;
-    local.init.wait_payload = timer_ms;
-    local.init.wait_index = wait_index;
-    if (!route.locals.push(local)) return frontend_error(FrontendError::TooManyItems, stmt.span);
-
     HirExpr base{};
-    base.kind = HirExprKind::LocalRef;
+    base.kind = HirExprKind::WaitResult;
     base.type = HirTypeKind::Unknown;
     base.span = stmt.span;
-    base.local_index = local.ref_index;
     base.is_wait_result = true;
     base.wait_event_kind = WaitEventKind::Any;
     base.wait_payload = timer_ms;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -4420,15 +4420,16 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         if (base->is_wait_result) {
             if (base->kind != HirExprKind::LocalRef)
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-            if (base->wait_index + 1 != route->waits.len)
-                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
             out.kind = HirExprKind::WaitField;
             out.span = expr.span;
             out.str_value = expr.name;
             out.is_wait_result = false;
             if (expr.name.eq({"kind", 4}) || expr.name.eq({"result", 6})) {
                 out.type = HirTypeKind::I32;
-            } else if (expr.name.eq({"ok", 2}) || expr.name.eq({"eof", 3})) {
+            } else if (expr.name.eq({"ok", 2}) || expr.name.eq({"eof", 3}) ||
+                       expr.name.eq({"timer", 5}) || expr.name.eq({"recv", 4}) ||
+                       expr.name.eq({"send", 4}) || expr.name.eq({"upstream_connect", 16}) ||
+                       expr.name.eq({"upstream_recv", 13}) || expr.name.eq({"upstream_send", 13})) {
                 out.type = HirTypeKind::Bool;
             } else {
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
@@ -7565,6 +7566,94 @@ static FrontendResult<WaitSpec> analyze_wait_stmt_spec(const AstStatement& stmt,
     return analyze_wait_io_op_spec(expr, mod);
 }
 
+static FrontendResult<void> analyze_wait_any_stmt_control(const AstStatement& stmt,
+                                                          HirRoute& route,
+                                                          const HirModule& mod) {
+    if (stmt.match_arms.len != 2)
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+
+    u32 timer_ms = 0;
+    const AstStatement* timer_stmt = nullptr;
+    const AstStatement* recv_stmt = nullptr;
+    for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+        const auto& arm = stmt.match_arms[ai];
+        u32 arm_timer_ms = 0;
+        if (wait_timer_call_ms(arm.pattern, arm_timer_ms)) {
+            if (timer_stmt != nullptr)
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            timer_ms = arm_timer_ms;
+            timer_stmt = arm.stmt;
+            continue;
+        }
+        auto event_spec = analyze_wait_io_op_spec(arm.pattern, mod);
+        if (!event_spec) return core::make_unexpected(event_spec.error());
+        if (event_spec->kind != WaitEventKind::Recv || event_spec->payload != 0)
+            return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+        if (recv_stmt != nullptr) return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+        recv_stmt = arm.stmt;
+    }
+    if (timer_stmt == nullptr || recv_stmt == nullptr || timer_ms == 0)
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+    if (timer_stmt->kind != AstStmtKind::ReturnStatus &&
+        timer_stmt->kind != AstStmtKind::ForwardUpstream)
+        return frontend_error(FrontendError::UnsupportedSyntax, timer_stmt->span);
+    if (recv_stmt->kind != AstStmtKind::ReturnStatus &&
+        recv_stmt->kind != AstStmtKind::ForwardUpstream)
+        return frontend_error(FrontendError::UnsupportedSyntax, recv_stmt->span);
+
+    HirRoute::Wait wait{};
+    wait.span = stmt.span;
+    wait.event_kind = WaitEventKind::Any;
+    wait.ms = timer_ms;
+    const u32 wait_index = route.waits.len;
+    if (!route.waits.push(wait)) return frontend_error(FrontendError::TooManyItems, stmt.span);
+
+    HirLocal local{};
+    local.span = stmt.span;
+    local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
+    local.type = HirTypeKind::Unknown;
+    local.is_wait_result = true;
+    local.wait_event_kind = WaitEventKind::Any;
+    local.wait_payload = timer_ms;
+    local.wait_index = wait_index;
+    local.init.kind = HirExprKind::WaitResult;
+    local.init.type = HirTypeKind::Unknown;
+    local.init.span = stmt.span;
+    local.init.is_wait_result = true;
+    local.init.wait_event_kind = WaitEventKind::Any;
+    local.init.wait_payload = timer_ms;
+    local.init.wait_index = wait_index;
+    if (!route.locals.push(local)) return frontend_error(FrontendError::TooManyItems, stmt.span);
+
+    HirExpr base{};
+    base.kind = HirExprKind::LocalRef;
+    base.type = HirTypeKind::Unknown;
+    base.span = stmt.span;
+    base.local_index = local.ref_index;
+    base.is_wait_result = true;
+    base.wait_event_kind = WaitEventKind::Any;
+    base.wait_payload = timer_ms;
+    base.wait_index = wait_index;
+    if (!route.exprs.push(base)) return frontend_error(FrontendError::TooManyItems, stmt.span);
+
+    HirExpr cond{};
+    cond.kind = HirExprKind::WaitField;
+    cond.type = HirTypeKind::Bool;
+    cond.span = stmt.span;
+    cond.str_value = {"timer", 5};
+    cond.lhs = &route.exprs[route.exprs.len - 1];
+
+    route.control.kind = HirControlKind::If;
+    route.control.cond = cond;
+    auto then_term = analyze_term(*timer_stmt, mod);
+    if (!then_term) return core::make_unexpected(then_term.error());
+    auto else_term = analyze_term(*recv_stmt, mod);
+    if (!else_term) return core::make_unexpected(else_term.error());
+    route.control.then_term = then_term.value();
+    route.control.else_term = else_term.value();
+    return {};
+}
+
 static FrontendResult<HirModule*> analyze_file_internal(
     const AstFile& file,
     Str source_path,
@@ -10258,6 +10347,16 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 if (!route.guards.push(guard))
                     return frontend_error(FrontendError::TooManyItems, stmt.span);
                 continue;
+            }
+            if (stmt.kind == AstStmtKind::WaitAny) {
+                if (seen_for) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                auto wait_any = analyze_wait_any_stmt_control(stmt, route, mod);
+                if (!wait_any) return core::make_unexpected(wait_any.error());
+                seen_wait = true;
+                if (si + 1 != item.route.statements.len)
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          item.route.statements[si + 1].span);
+                break;
             }
             if (stmt.kind == AstStmtKind::For) {
                 seen_for = true;

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -3195,6 +3195,10 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 const Span store_span = mir.functions[i].blocks[bi].term.span;
                 for (u32 wi = 0; wi < mir.functions[i].waits.len; wi++) {
                     if (mir.functions[i].resume_blocks[wi + 1] != bi) continue;
+                    // Slot persistence is optional at runtime: some callers run
+                    // handlers without frame slots by leaving ctx.slot_count==0.
+                    // Codegen defends against this by guarding slot writes with
+                    // the stored slot_count.
                     auto kind = b.emit_resume_event_kind({store_span.line, store_span.col});
                     if (!kind ||
                         !b.emit_ctx_store_slot_i32(

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -27,6 +27,14 @@ static u8 yield_kind_abi(WaitEventKind kind) {
     return static_cast<u8>(jit::YieldKind::Timer);
 }
 
+static constexpr u32 wait_kind_slot(u32 wait_index) {
+    return wait_index * 2;
+}
+
+static constexpr u32 wait_result_slot(u32 wait_index) {
+    return wait_index * 2 + 1;
+}
+
 struct VariantLoweringInfo {
     const rir::Type* struct_type = nullptr;
     const rir::Type* payload_bool_type = nullptr;
@@ -1422,12 +1430,15 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
         return frontend_error(FrontendError::UnsupportedSyntax, span);
     }
     if (value.kind == MirValueKind::WaitField) {
+        const u32 wait_index = value.wait_index;
+        if (wait_index == 0xffffffffu)
+            return frontend_error(FrontendError::UnsupportedSyntax, span, value.str_value);
         if (value.str_value.eq({"kind", 4})) {
-            auto v = b.emit_resume_event_kind({span.line, span.col});
+            auto v = b.emit_ctx_load_slot_i32(wait_kind_slot(wait_index), {span.line, span.col});
             if (!v) return frontend_error(FrontendError::OutOfMemory, span);
             return v.value();
         }
-        auto result = b.emit_resume_event_result({span.line, span.col});
+        auto result = b.emit_ctx_load_slot_i32(wait_result_slot(wait_index), {span.line, span.col});
         if (!result) return frontend_error(FrontendError::OutOfMemory, span);
         if (value.str_value.eq({"result", 6})) return result.value();
         auto zero = b.emit_const_i32(0, {span.line, span.col});
@@ -1439,7 +1450,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
             return cmp.value();
         }
         if (value.str_value.eq({"eof", 3})) {
-            auto event_kind = b.emit_resume_event_kind({span.line, span.col});
+            auto event_kind =
+                b.emit_ctx_load_slot_i32(wait_kind_slot(wait_index), {span.line, span.col});
             if (!event_kind) return frontend_error(FrontendError::OutOfMemory, span);
             auto recv_kind =
                 b.emit_const_i32(static_cast<i32>(jit::YieldKind::Recv), {span.line, span.col});
@@ -1471,6 +1483,30 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                      {span.line, span.col});
             if (!eof) return frontend_error(FrontendError::OutOfMemory, span);
             return eof.value();
+        }
+        u32 wanted = 0xffffffffu;
+        if (value.str_value.eq({"timer", 5}))
+            wanted = static_cast<u32>(jit::YieldKind::Timer);
+        else if (value.str_value.eq({"recv", 4}))
+            wanted = static_cast<u32>(jit::YieldKind::Recv);
+        else if (value.str_value.eq({"send", 4}))
+            wanted = static_cast<u32>(jit::YieldKind::Send);
+        else if (value.str_value.eq({"upstream_connect", 16}))
+            wanted = static_cast<u32>(jit::YieldKind::UpstreamConnect);
+        else if (value.str_value.eq({"upstream_recv", 13}))
+            wanted = static_cast<u32>(jit::YieldKind::UpstreamRecv);
+        else if (value.str_value.eq({"upstream_send", 13}))
+            wanted = static_cast<u32>(jit::YieldKind::UpstreamSend);
+        if (wanted != 0xffffffffu) {
+            auto event_kind =
+                b.emit_ctx_load_slot_i32(wait_kind_slot(wait_index), {span.line, span.col});
+            if (!event_kind) return frontend_error(FrontendError::OutOfMemory, span);
+            auto kind_const = b.emit_const_i32(static_cast<i32>(wanted), {span.line, span.col});
+            if (!kind_const) return frontend_error(FrontendError::OutOfMemory, span);
+            auto cmp = b.emit_cmp(
+                rir::Opcode::CmpEq, event_kind.value(), kind_const.value(), {span.line, span.col});
+            if (!cmp) return frontend_error(FrontendError::OutOfMemory, span);
+            return cmp.value();
         }
         return frontend_error(FrontendError::UnsupportedSyntax, span, value.str_value);
     }
@@ -3155,6 +3191,26 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
 
         for (u32 bi = 0; bi < mir.functions[i].blocks.len; bi++) {
             b.set_insert_point(fn.value(), block_ids[bi]);
+            if (mir.functions[i].has_explicit_resume_blocks) {
+                const Span store_span = mir.functions[i].blocks[bi].term.span;
+                for (u32 wi = 0; wi < mir.functions[i].waits.len; wi++) {
+                    if (mir.functions[i].resume_blocks[wi + 1] != bi) continue;
+                    auto kind = b.emit_resume_event_kind({store_span.line, store_span.col});
+                    if (!kind ||
+                        !b.emit_ctx_store_slot_i32(
+                            wait_kind_slot(wi), kind.value(), {store_span.line, store_span.col})) {
+                        out.destroy();
+                        return frontend_error(FrontendError::OutOfMemory, store_span);
+                    }
+                    auto result = b.emit_resume_event_result({store_span.line, store_span.col});
+                    if (!result || !b.emit_ctx_store_slot_i32(wait_result_slot(wi),
+                                                              result.value(),
+                                                              {store_span.line, store_span.col})) {
+                        out.destroy();
+                        return frontend_error(FrontendError::OutOfMemory, store_span);
+                    }
+                }
+            }
             auto emitted = emit_term(mir.functions[i].blocks[bi].term,
                                      mir,
                                      variant_infos,

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -574,6 +574,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.is_wait_result = expr.is_wait_result;
         v.wait_event_kind = expr.wait_event_kind;
         v.wait_payload = expr.wait_payload;
+        v.wait_index = expr.wait_index;
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
         v.local_index = expr.local_index;
@@ -588,6 +589,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.is_wait_result = true;
         v.wait_event_kind = expr.wait_event_kind;
         v.wait_payload = expr.wait_payload;
+        v.wait_index = expr.wait_index;
         return v;
     }
     if (expr.kind == HirExprKind::WaitField) {
@@ -599,6 +601,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.type = mir_type_kind(expr.type);
         v.str_value = expr.str_value;
         v.lhs = &fn->values[fn->values.len - 1];
+        v.wait_index = lhs->wait_index;
         return v;
     }
     return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
@@ -811,6 +814,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             local.is_wait_result = module.routes[i].locals[li].is_wait_result;
             local.wait_event_kind = module.routes[i].locals[li].wait_event_kind;
             local.wait_payload = module.routes[i].locals[li].wait_payload;
+            local.wait_index = module.routes[i].locals[li].wait_index;
             auto init = mir_value(module.routes[i].locals[li].init, module, &fn);
             if (!init) return core::make_unexpected(init.error());
             local.init = init.value();

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1022,6 +1022,40 @@ struct Parser {
             return stmt;
         }
         if (take(TokenType::KwWait)) {
+            if (cur().type == TokenType::Ident && cur().text.eq({"any", 3}) &&
+                peek().type == TokenType::LBrace) {
+                const Token any_tok = cur();
+                pos++;
+                auto lbrace = expect(TokenType::LBrace);
+                if (!lbrace) return core::make_unexpected(lbrace.error());
+                AstStatement stmt{};
+                stmt.kind = AstStmtKind::WaitAny;
+                stmt.span = Span{start.start, any_tok.end, start.line, start.col};
+                while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+                    AstStatement::MatchArm arm{};
+                    arm.span = span_from(cur());
+                    auto event = parse_expr();
+                    if (!event) return core::make_unexpected(event.error());
+                    arm.pattern = event.value();
+                    auto arrow = expect(TokenType::Arrow);
+                    if (!arrow) return core::make_unexpected(arrow.error());
+                    auto body_lbrace = expect(TokenType::LBrace);
+                    if (!body_lbrace) return core::make_unexpected(body_lbrace.error());
+                    auto body = parse_braced_stmt_body(*body_lbrace.value());
+                    if (!body) return core::make_unexpected(body.error());
+                    auto body_ptr = alloc_stmt(body.value());
+                    if (!body_ptr) return core::make_unexpected(body_ptr.error());
+                    arm.stmt = body_ptr.value();
+                    arm.span =
+                        Span{arm.span.start, body.value().span.end, arm.span.line, arm.span.col};
+                    if (!stmt.match_arms.push(arm))
+                        return frontend_error(FrontendError::TooManyItems, arm.span);
+                }
+                auto rbrace = expect(TokenType::RBrace);
+                if (!rbrace) return core::make_unexpected(rbrace.error());
+                stmt.span = Span{start.start, rbrace.value()->end, start.line, start.col};
+                return stmt;
+            }
             auto lparen = expect(TokenType::LParen);
             if (!lparen) return core::make_unexpected(lparen.error());
             AstStatement stmt{};

--- a/src/compiler/rir_printer.cc
+++ b/src/compiler/rir_printer.cc
@@ -157,6 +157,9 @@ void print_opcode(PrintBuf& buf, Opcode op) {
         case Opcode::ResumeEventResult:
             buf.put_cstr("resume.event_result");
             break;
+        case Opcode::CtxLoadSlotI32:
+            buf.put_cstr("ctx.load_slot_i32");
+            break;
         case Opcode::ReqRemoteAddr:
             buf.put_cstr("req.remote_addr");
             break;
@@ -171,6 +174,9 @@ void print_opcode(PrintBuf& buf, Opcode op) {
             break;
         case Opcode::ReqSetPath:
             buf.put_cstr("req.set_path");
+            break;
+        case Opcode::CtxStoreSlotI32:
+            buf.put_cstr("ctx.store_slot_i32");
             break;
         case Opcode::StrHasPrefix:
             buf.put_cstr("str.has_prefix");
@@ -478,6 +484,11 @@ void print_instruction(PrintBuf& buf, const Instruction& inst, const Function& f
         case Opcode::ReqPath:
         case Opcode::ResumeEventKind:
         case Opcode::ResumeEventResult:
+            break;
+        case Opcode::CtxLoadSlotI32:
+            buf.put(' ');
+            buf.put_i64(static_cast<i64>(inst.imm.i32_val));
+            break;
         case Opcode::ReqRemoteAddr:
         case Opcode::ReqContentLength:
         case Opcode::TimeNow:
@@ -491,6 +502,12 @@ void print_instruction(PrintBuf& buf, const Instruction& inst, const Function& f
             break;
         case Opcode::ReqSetPath:
             buf.put(' ');
+            print_value_ref(buf, inst.operands[0]);
+            break;
+        case Opcode::CtxStoreSlotI32:
+            buf.put(' ');
+            buf.put_i64(static_cast<i64>(inst.imm.i32_val));
+            buf.put_cstr(", ");
             print_value_ref(buf, inst.operands[0]);
             break;
         case Opcode::StrHasPrefix:

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -92,9 +92,10 @@ struct Ctx {
     LLVMValueRef fn_str_regex_match;
     LLVMValueRef fn_str_trim_prefix;
 
-    // Scratch storage for conditional slot stores when the handler frame
+    // Scratch storage for conditional slot accesses when the handler frame
     // does not provide per-resume slots. This keeps codegen branchless
-    // by redirecting disabled writes to an internal i64 sink.
+    // by redirecting disabled writes and missing-slot reads to an internal
+    // i64 sink.
     LLVMValueRef ctx_store_sink = nullptr;
 
     // Cache for map_type: LLVM literal structs (Optional<composite>, Struct
@@ -549,30 +550,36 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             LLVMValueRef off = LLVMConstInt(c.i32_ty, byte_offset, 0);
             LLVMValueRef ptr =
                 LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &off, 1, "ctx.slot.ptr");
-            LLVMTypeRef slot_ptr_ty = LLVMPointerType(c.i32_ty, 0);
-            LLVMValueRef slot_i32_ptr =
-                LLVMBuildBitCast(c.builder, ptr, slot_ptr_ty, "ctx.slot.ptr32");
+            LLVMTypeRef slot_i64_ptr_ty = LLVMPointerType(c.i64_ty, 0);
+            LLVMValueRef slot_i64_ptr =
+                LLVMBuildBitCast(c.builder, ptr, slot_i64_ptr_ty, "ctx.slot.ptr64");
 
+            LLVMTypeRef fallback_ptr_ty = LLVMPointerType(c.i32_ty, 0);
             LLVMValueRef fallback_ptr = nullptr;
             if ((slot & 1u) == 0) {
                 LLVMValueRef kind_off = LLVMConstInt(
                     c.i32_ty, static_cast<u32>(offsetof(HandlerCtx, resume_event_kind)), 0);
                 LLVMValueRef kind_ptr =
                     LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &kind_off, 1, "ev.kind.ptr");
-                fallback_ptr =
-                    LLVMBuildBitCast(c.builder, kind_ptr, slot_ptr_ty, "ctx.slot.fallback.ptr32");
+                fallback_ptr = LLVMBuildBitCast(
+                    c.builder, kind_ptr, fallback_ptr_ty, "ctx.slot.fallback.ptr32");
             } else {
                 LLVMValueRef result_off = LLVMConstInt(
                     c.i32_ty, static_cast<u32>(offsetof(HandlerCtx, resume_event_result)), 0);
                 LLVMValueRef result_ptr =
                     LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &result_off, 1, "ev.result.ptr");
-                fallback_ptr =
-                    LLVMBuildBitCast(c.builder, result_ptr, slot_ptr_ty, "ctx.slot.fallback.ptr32");
+                fallback_ptr = LLVMBuildBitCast(
+                    c.builder, result_ptr, fallback_ptr_ty, "ctx.slot.fallback.ptr32");
             }
-            LLVMValueRef slot_or_fallback_ptr = LLVMBuildSelect(
-                c.builder, has_slot, slot_i32_ptr, fallback_ptr, "ctx.slot.ptr.sel");
-            LLVMValueRef v =
-                LLVMBuildLoad2(c.builder, c.i32_ty, slot_or_fallback_ptr, "ctx.slot.value");
+            LLVMValueRef fallback_i32 =
+                LLVMBuildLoad2(c.builder, c.i32_ty, fallback_ptr, "ctx.slot.fallback");
+            LLVMValueRef fallback_i64 =
+                LLVMBuildZExt(c.builder, fallback_i32, c.i64_ty, "ctx.slot.fallback64");
+            LLVMBuildStore(c.builder, fallback_i64, c.ctx_store_sink);
+            LLVMValueRef selected_ptr = LLVMBuildSelect(
+                c.builder, has_slot, slot_i64_ptr, c.ctx_store_sink, "ctx.slot.ptr.sel");
+            LLVMValueRef slot_i64 = LLVMBuildLoad2(c.builder, c.i64_ty, selected_ptr, "ctx.slot64");
+            LLVMValueRef v = LLVMBuildTrunc(c.builder, slot_i64, c.i32_ty, "ctx.slot.value");
             c.set_value(inst.result, v);
             break;
         }
@@ -859,8 +866,8 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             LLVMTypeRef slot_ptr_ty = LLVMPointerType(c.i64_ty, 0);
             LLVMValueRef slot_ptr = LLVMBuildBitCast(c.builder, ptr, slot_ptr_ty, "ctx.slot.ptr64");
 
-            LLVMValueRef slot_store_ptr =
-                LLVMBuildSelect(c.builder, has_slot, slot_ptr, c.ctx_store_sink, "ctx.slot.store.ptr");
+            LLVMValueRef slot_store_ptr = LLVMBuildSelect(
+                c.builder, has_slot, slot_ptr, c.ctx_store_sink, "ctx.slot.store.ptr");
             LLVMValueRef value64 =
                 LLVMBuildZExt(c.builder, c.get_value(inst.operands[0]), c.i64_ty, "ctx.slot.value");
             LLVMBuildStore(c.builder, value64, slot_store_ptr);

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -869,8 +869,11 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             LLVMValueRef off = LLVMConstInt(c.i32_ty, byte_offset, 0);
             LLVMValueRef ptr =
                 LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &off, 1, "ctx.slot.ptr");
-            LLVMValueRef v = c.get_value(inst.operands[0]);
-            LLVMBuildStore(c.builder, v, ptr);
+            LLVMTypeRef slot_ptr_ty = LLVMPointerType(c.i64_ty, 0);
+            LLVMValueRef slot_ptr = LLVMBuildBitCast(c.builder, ptr, slot_ptr_ty, "ctx.slot.ptr64");
+            LLVMValueRef value64 =
+                LLVMBuildZExt(c.builder, c.get_value(inst.operands[0]), c.i64_ty, "ctx.slot.value");
+            LLVMBuildStore(c.builder, value64, slot_ptr);
             LLVMBuildBr(c.builder, cont_bb);
 
             LLVMPositionBuilderAtEnd(c.builder, cont_bb);

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -530,6 +530,55 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             c.set_value(inst.result, v);
             break;
         }
+        case rir::Opcode::CtxLoadSlotI32: {
+            const u32 slot = static_cast<u32>(inst.imm.i32_val);
+            LLVMValueRef count_off =
+                LLVMConstInt(c.i32_ty, static_cast<u32>(offsetof(HandlerCtx, slot_count)), 0);
+            LLVMValueRef count_ptr =
+                LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &count_off, 1, "ctx.slot.count.ptr");
+            LLVMValueRef count = LLVMBuildLoad2(c.builder, c.i32_ty, count_ptr, "ctx.slot.count");
+            LLVMValueRef has_slot = LLVMBuildICmp(
+                c.builder, LLVMIntUGT, count, LLVMConstInt(c.i32_ty, slot, 0), "ctx.has.slot");
+            LLVMValueRef fallback = nullptr;
+            if ((slot & 1u) == 0) {
+                LLVMValueRef kind_off = LLVMConstInt(
+                    c.i32_ty, static_cast<u32>(offsetof(HandlerCtx, resume_event_kind)), 0);
+                LLVMValueRef kind_ptr =
+                    LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &kind_off, 1, "ev.kind.ptr");
+                fallback = LLVMBuildLoad2(c.builder, c.i32_ty, kind_ptr, "ev.kind");
+            } else {
+                LLVMValueRef result_off = LLVMConstInt(
+                    c.i32_ty, static_cast<u32>(offsetof(HandlerCtx, resume_event_result)), 0);
+                LLVMValueRef result_ptr =
+                    LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &result_off, 1, "ev.result.ptr");
+                fallback = LLVMBuildLoad2(c.builder, c.i32_ty, result_ptr, "ev.result");
+            }
+
+            LLVMBasicBlockRef cur_bb = LLVMGetInsertBlock(c.builder);
+            LLVMValueRef fn = LLVMGetBasicBlockParent(cur_bb);
+            LLVMBasicBlockRef load_bb =
+                LLVMAppendBasicBlockInContext(c.llvm_ctx, fn, "ctx.slot.load");
+            LLVMBasicBlockRef cont_bb =
+                LLVMAppendBasicBlockInContext(c.llvm_ctx, fn, "ctx.slot.load.cont");
+            LLVMBuildCondBr(c.builder, has_slot, load_bb, cont_bb);
+
+            LLVMPositionBuilderAtEnd(c.builder, load_bb);
+            const u32 byte_offset = static_cast<u32>(sizeof(HandlerCtx)) + slot * 8u;
+            LLVMValueRef off = LLVMConstInt(c.i32_ty, byte_offset, 0);
+            LLVMValueRef ptr =
+                LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &off, 1, "ctx.slot.ptr");
+            LLVMValueRef loaded = LLVMBuildLoad2(c.builder, c.i32_ty, ptr, "ctx.slot");
+            LLVMBuildBr(c.builder, cont_bb);
+            LLVMBasicBlockRef loaded_bb = LLVMGetInsertBlock(c.builder);
+
+            LLVMPositionBuilderAtEnd(c.builder, cont_bb);
+            LLVMValueRef v = LLVMBuildPhi(c.builder, c.i32_ty, "ctx.slot.value");
+            LLVMValueRef incoming[] = {loaded, fallback};
+            LLVMBasicBlockRef incoming_bbs[] = {loaded_bb, cur_bb};
+            LLVMAddIncoming(v, incoming, incoming_bbs, 2);
+            c.set_value(inst.result, v);
+            break;
+        }
         case rir::Opcode::ReqHeader: {
             Str name = inst.imm.str_val;
             LLVMValueRef name_ptr = c.make_global_str(name, "hdr.name");
@@ -795,6 +844,36 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             LLVMValueRef else_v = c.get_value(inst.operands[2]);
             LLVMValueRef v = LLVMBuildSelect(c.builder, cond, then_v, else_v, "sel");
             c.set_value(inst.result, v);
+            break;
+        }
+        case rir::Opcode::CtxStoreSlotI32: {
+            const u32 slot = static_cast<u32>(inst.imm.i32_val);
+            LLVMValueRef count_off =
+                LLVMConstInt(c.i32_ty, static_cast<u32>(offsetof(HandlerCtx, slot_count)), 0);
+            LLVMValueRef count_ptr =
+                LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &count_off, 1, "ctx.slot.count.ptr");
+            LLVMValueRef count = LLVMBuildLoad2(c.builder, c.i32_ty, count_ptr, "ctx.slot.count");
+            LLVMValueRef has_slot = LLVMBuildICmp(
+                c.builder, LLVMIntUGT, count, LLVMConstInt(c.i32_ty, slot, 0), "ctx.has.slot");
+
+            LLVMBasicBlockRef cur_bb = LLVMGetInsertBlock(c.builder);
+            LLVMValueRef fn = LLVMGetBasicBlockParent(cur_bb);
+            LLVMBasicBlockRef store_bb =
+                LLVMAppendBasicBlockInContext(c.llvm_ctx, fn, "ctx.slot.store");
+            LLVMBasicBlockRef cont_bb =
+                LLVMAppendBasicBlockInContext(c.llvm_ctx, fn, "ctx.slot.store.cont");
+            LLVMBuildCondBr(c.builder, has_slot, store_bb, cont_bb);
+
+            LLVMPositionBuilderAtEnd(c.builder, store_bb);
+            const u32 byte_offset = static_cast<u32>(sizeof(HandlerCtx)) + slot * 8u;
+            LLVMValueRef off = LLVMConstInt(c.i32_ty, byte_offset, 0);
+            LLVMValueRef ptr =
+                LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &off, 1, "ctx.slot.ptr");
+            LLVMValueRef v = c.get_value(inst.operands[0]);
+            LLVMBuildStore(c.builder, v, ptr);
+            LLVMBuildBr(c.builder, cont_bb);
+
+            LLVMPositionBuilderAtEnd(c.builder, cont_bb);
             break;
         }
         case rir::Opcode::StructCreate: {

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -92,6 +92,11 @@ struct Ctx {
     LLVMValueRef fn_str_regex_match;
     LLVMValueRef fn_str_trim_prefix;
 
+    // Scratch storage for conditional slot stores when the handler frame
+    // does not provide per-resume slots. This keeps codegen branchless
+    // by redirecting disabled writes to an internal i64 sink.
+    LLVMValueRef ctx_store_sink = nullptr;
+
     // Cache for map_type: LLVM literal structs (Optional<composite>, Struct
     // with a StructDef) are identity-compared, so emitting a fresh
     // LLVMStructTypeInContext call per lookup produces *different* LLVM types
@@ -847,28 +852,24 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             LLVMValueRef count = LLVMBuildLoad2(c.builder, c.i32_ty, count_ptr, "ctx.slot.count");
             LLVMValueRef has_slot = LLVMBuildICmp(
                 c.builder, LLVMIntUGT, count, LLVMConstInt(c.i32_ty, slot, 0), "ctx.has.slot");
-
-            LLVMBasicBlockRef cur_bb = LLVMGetInsertBlock(c.builder);
-            LLVMValueRef fn = LLVMGetBasicBlockParent(cur_bb);
-            LLVMBasicBlockRef store_bb =
-                LLVMAppendBasicBlockInContext(c.llvm_ctx, fn, "ctx.slot.store");
-            LLVMBasicBlockRef cont_bb =
-                LLVMAppendBasicBlockInContext(c.llvm_ctx, fn, "ctx.slot.store.cont");
-            LLVMBuildCondBr(c.builder, has_slot, store_bb, cont_bb);
-
-            LLVMPositionBuilderAtEnd(c.builder, store_bb);
             const u32 byte_offset = static_cast<u32>(sizeof(HandlerCtx)) + slot * 8u;
             LLVMValueRef off = LLVMConstInt(c.i32_ty, byte_offset, 0);
             LLVMValueRef ptr =
                 LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &off, 1, "ctx.slot.ptr");
             LLVMTypeRef slot_ptr_ty = LLVMPointerType(c.i64_ty, 0);
             LLVMValueRef slot_ptr = LLVMBuildBitCast(c.builder, ptr, slot_ptr_ty, "ctx.slot.ptr64");
+
+            if (!c.ctx_store_sink) {
+                LLVMBasicBlockRef sink_bb = LLVMGetInsertBlock(c.builder);
+                c.ctx_store_sink = LLVMBuildAlloca(c.builder, c.i64_ty, "ctx.slot.store.sink");
+                LLVMPositionBuilderAtEnd(c.builder, sink_bb);
+            }
+
+            LLVMValueRef slot_store_ptr =
+                LLVMBuildSelect(c.builder, has_slot, slot_ptr, c.ctx_store_sink, "ctx.slot.store.ptr");
             LLVMValueRef value64 =
                 LLVMBuildZExt(c.builder, c.get_value(inst.operands[0]), c.i64_ty, "ctx.slot.value");
-            LLVMBuildStore(c.builder, value64, slot_ptr);
-            LLVMBuildBr(c.builder, cont_bb);
-
-            LLVMPositionBuilderAtEnd(c.builder, cont_bb);
+            LLVMBuildStore(c.builder, value64, slot_store_ptr);
             break;
         }
         case rir::Opcode::StructCreate: {
@@ -1012,6 +1013,7 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
 
 static bool emit_function(Ctx& c, const rir::Function& fn) {
     c.cur_fn = &fn;
+    c.ctx_store_sink = nullptr;
 
     // Build function name: "handler_<name>"
     char fname[256];

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -859,12 +859,6 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             LLVMTypeRef slot_ptr_ty = LLVMPointerType(c.i64_ty, 0);
             LLVMValueRef slot_ptr = LLVMBuildBitCast(c.builder, ptr, slot_ptr_ty, "ctx.slot.ptr64");
 
-            if (!c.ctx_store_sink) {
-                LLVMBasicBlockRef sink_bb = LLVMGetInsertBlock(c.builder);
-                c.ctx_store_sink = LLVMBuildAlloca(c.builder, c.i64_ty, "ctx.slot.store.sink");
-                LLVMPositionBuilderAtEnd(c.builder, sink_bb);
-            }
-
             LLVMValueRef slot_store_ptr =
                 LLVMBuildSelect(c.builder, has_slot, slot_ptr, c.ctx_store_sink, "ctx.slot.store.ptr");
             LLVMValueRef value64 =
@@ -1086,6 +1080,7 @@ static bool emit_function(Ctx& c, const rir::Function& fn) {
         LLVMMoveBasicBlockBefore(dispatch_bb, c.block_map[fn.blocks[0].id.id]);
 
         LLVMPositionBuilderAtEnd(c.builder, dispatch_bb);
+        c.ctx_store_sink = LLVMBuildAlloca(c.builder, c.i64_ty, "ctx.slot.store.sink");
         // HandlerCtx layout: state (u16) @ offset 0.
         LLVMValueRef state = LLVMBuildLoad2(c.builder, c.i16_ty, c.param_ctx, "state");
 
@@ -1134,6 +1129,9 @@ static bool emit_function(Ctx& c, const rir::Function& fn) {
             LLVMBuildRet(c.builder, result);
             LLVMAddCase(sw, LLVMConstInt(c.i16_ty, si, 0), yield_bb);
         }
+    } else {
+        LLVMPositionBuilderAtEnd(c.builder, c.block_map[fn.blocks[0].id.id]);
+        c.ctx_store_sink = LLVMBuildAlloca(c.builder, c.i64_ty, "ctx.slot.store.sink");
     }
 
     // Emit instructions block by block.

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -539,43 +539,35 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             LLVMValueRef count = LLVMBuildLoad2(c.builder, c.i32_ty, count_ptr, "ctx.slot.count");
             LLVMValueRef has_slot = LLVMBuildICmp(
                 c.builder, LLVMIntUGT, count, LLVMConstInt(c.i32_ty, slot, 0), "ctx.has.slot");
-            LLVMValueRef fallback = nullptr;
+
+            const u32 byte_offset = static_cast<u32>(sizeof(HandlerCtx)) + slot * 8u;
+            LLVMValueRef off = LLVMConstInt(c.i32_ty, byte_offset, 0);
+            LLVMValueRef ptr =
+                LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &off, 1, "ctx.slot.ptr");
+            LLVMTypeRef slot_ptr_ty = LLVMPointerType(c.i32_ty, 0);
+            LLVMValueRef slot_i32_ptr =
+                LLVMBuildBitCast(c.builder, ptr, slot_ptr_ty, "ctx.slot.ptr32");
+
+            LLVMValueRef fallback_ptr = nullptr;
             if ((slot & 1u) == 0) {
                 LLVMValueRef kind_off = LLVMConstInt(
                     c.i32_ty, static_cast<u32>(offsetof(HandlerCtx, resume_event_kind)), 0);
                 LLVMValueRef kind_ptr =
                     LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &kind_off, 1, "ev.kind.ptr");
-                fallback = LLVMBuildLoad2(c.builder, c.i32_ty, kind_ptr, "ev.kind");
+                fallback_ptr =
+                    LLVMBuildBitCast(c.builder, kind_ptr, slot_ptr_ty, "ctx.slot.fallback.ptr32");
             } else {
                 LLVMValueRef result_off = LLVMConstInt(
                     c.i32_ty, static_cast<u32>(offsetof(HandlerCtx, resume_event_result)), 0);
                 LLVMValueRef result_ptr =
                     LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &result_off, 1, "ev.result.ptr");
-                fallback = LLVMBuildLoad2(c.builder, c.i32_ty, result_ptr, "ev.result");
+                fallback_ptr =
+                    LLVMBuildBitCast(c.builder, result_ptr, slot_ptr_ty, "ctx.slot.fallback.ptr32");
             }
-
-            LLVMBasicBlockRef cur_bb = LLVMGetInsertBlock(c.builder);
-            LLVMValueRef fn = LLVMGetBasicBlockParent(cur_bb);
-            LLVMBasicBlockRef load_bb =
-                LLVMAppendBasicBlockInContext(c.llvm_ctx, fn, "ctx.slot.load");
-            LLVMBasicBlockRef cont_bb =
-                LLVMAppendBasicBlockInContext(c.llvm_ctx, fn, "ctx.slot.load.cont");
-            LLVMBuildCondBr(c.builder, has_slot, load_bb, cont_bb);
-
-            LLVMPositionBuilderAtEnd(c.builder, load_bb);
-            const u32 byte_offset = static_cast<u32>(sizeof(HandlerCtx)) + slot * 8u;
-            LLVMValueRef off = LLVMConstInt(c.i32_ty, byte_offset, 0);
-            LLVMValueRef ptr =
-                LLVMBuildGEP2(c.builder, c.i8_ty, c.param_ctx, &off, 1, "ctx.slot.ptr");
-            LLVMValueRef loaded = LLVMBuildLoad2(c.builder, c.i32_ty, ptr, "ctx.slot");
-            LLVMBuildBr(c.builder, cont_bb);
-            LLVMBasicBlockRef loaded_bb = LLVMGetInsertBlock(c.builder);
-
-            LLVMPositionBuilderAtEnd(c.builder, cont_bb);
-            LLVMValueRef v = LLVMBuildPhi(c.builder, c.i32_ty, "ctx.slot.value");
-            LLVMValueRef incoming[] = {loaded, fallback};
-            LLVMBasicBlockRef incoming_bbs[] = {loaded_bb, cur_bb};
-            LLVMAddIncoming(v, incoming, incoming_bbs, 2);
+            LLVMValueRef slot_or_fallback_ptr = LLVMBuildSelect(
+                c.builder, has_slot, slot_i32_ptr, fallback_ptr, "ctx.slot.ptr.sel");
+            LLVMValueRef v =
+                LLVMBuildLoad2(c.builder, c.i32_ty, slot_or_fallback_ptr, "ctx.slot.value");
             c.set_value(inst.result, v);
             break;
         }

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -619,7 +619,12 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
         // wake-up event. For wait(any), choose a concrete event kind so
         // event predicates observe a deterministic branch in offline tests.
         jit::YieldKind resume_kind = unpacked.yield_kind;
-        if (resume_kind == jit::YieldKind::Any) resume_kind = jit::YieldKind::Recv;
+        if (resume_kind == jit::YieldKind::Any) {
+            // Use the timeout winner when a timer arm exists (Any with
+            // non-zero payload), otherwise fall back to recv.
+            resume_kind = (unpacked.yield_payload_u32() == 0u) ? jit::YieldKind::Recv
+                                                                : jit::YieldKind::Timer;
+        }
         ctx.resume_event_kind = static_cast<u32>(resume_kind);
         ctx.resume_event_result = (resume_kind == jit::YieldKind::Timer) ? 0 : 1;
         ctx.state = unpacked.next_state;

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -9,6 +9,7 @@
 #include "rut/runtime/access_log.h"
 #include "rut/runtime/arena.h"
 #include "rut/runtime/connection.h"
+#include "rut/runtime/connection_base.h"
 #include "rut/runtime/http_parser.h"
 #include "rut/runtime/route_method.h"
 #include "rut/runtime/traffic_capture.h"
@@ -399,9 +400,9 @@ bool load_manifest(const char* path, Manifest& out) {
                 munmap(map, static_cast<u64>(st.st_size));
                 return false;
             }
-            const u32 pattern_len = tokens[2].len;
-            for (u32 i = 0; i < pattern_len; i++) route.pattern[i] = tokens[2].ptr[i];
-            route.pattern[pattern_len] = '\0';
+            const u32 kPatternLen = tokens[2].len;
+            for (u32 i = 0; i < kPatternLen; i++) route.pattern[i] = tokens[2].ptr[i];
+            route.pattern[kPatternLen] = '\0';
 
             if (tokens[3].len == 6 && __builtin_memcmp(tokens[3].ptr, "status", 6) == 0) {
                 u32 code = 0;
@@ -431,16 +432,16 @@ bool load_manifest(const char* path, Manifest& out) {
         return false;
     }
 
-    const bool ok = validate_manifest(parsed);
+    const bool kOk = validate_manifest(parsed);
     munmap(map, static_cast<u64>(st.st_size));
-    if (ok) out = parsed;
-    return ok;
+    if (kOk) out = parsed;
+    return kOk;
 }
 
 bool build_module_from_manifest(const Manifest& manifest, ModuleContext& ctx) {
     if (manifest.route_count > Manifest::kMaxRoutes) return false;
     if (!ctx.init(manifest.route_count == 0 ? 1 : manifest.route_count)) return false;
-    const auto fail = [&ctx]() {
+    const auto kFail = [&ctx]() {
         ctx.destroy();
         return false;
     };
@@ -472,26 +473,26 @@ bool build_module_from_manifest(const Manifest& manifest, ModuleContext& ctx) {
         name_buf[pos] = '\0';
 
         Str name;
-        if (!copy_str_into_arena(ctx.arena, name_buf, cstr_len(name_buf), &name)) return fail();
+        if (!copy_str_into_arena(ctx.arena, name_buf, cstr_len(name_buf), &name)) return kFail();
         Str pattern;
         if (!copy_str_into_arena(ctx.arena,
                                  manifest.routes[i].pattern,
                                  cstr_len(manifest.routes[i].pattern),
                                  &pattern))
-            return fail();
+            return kFail();
 
         auto fn = b.create_function(name, pattern, manifest.routes[i].method);
-        if (!fn) return fail();
+        if (!fn) return kFail();
         auto entry = b.create_block(fn.value(), {"entry", 5});
-        if (!entry) return fail();
+        if (!entry) return kFail();
         b.set_insert_point(fn.value(), entry.value());
 
         if (manifest.routes[i].action == ManifestAction::ReturnStatus) {
-            if (!b.emit_ret_status(manifest.routes[i].status_code)) return fail();
+            if (!b.emit_ret_status(manifest.routes[i].status_code)) return kFail();
         } else {
             auto upstream = b.emit_const_i32(manifest.routes[i].upstream_id);
-            if (!upstream) return fail();
-            if (!b.emit_ret_forward(upstream.value())) return fail();
+            if (!upstream) return kFail();
+            if (!b.emit_ret_forward(upstream.value())) return kFail();
         }
     }
 
@@ -585,10 +586,14 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
 
     Connection conn;
     conn.reset();
-    jit::HandlerCtx ctx{};
+    struct HandlerFrame {
+        jit::HandlerCtx ctx{};
+        u64 slots[ConnectionBase::kMaxJitHandlerSlots]{};
+    } frame;
+    jit::HandlerCtx& ctx = frame.ctx;
     ctx.state = 0;
     ctx.handler_idx = 0;
-    ctx.slot_count = 0;
+    ctx.slot_count = ConnectionBase::kMaxJitHandlerSlots;
 
     // Drive the handler's state machine to completion. Yields are the
     // handler's signal "I need I/O, resume me with state=next_state".
@@ -602,37 +607,40 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
     // is deliberately small: real handlers yield at most a handful of times
     // per spec (submit + wait batches, not loops).
     static constexpr u32 kMaxHandlerYields = 32;
-    jit::HandlerResult kUnpacked{};
+    jit::HandlerResult unpacked{};
     for (u32 iter = 0; iter < kMaxHandlerYields; iter++) {
         const u64 kPacked =
             route->fn(&conn, &ctx, entry.raw_headers, entry.raw_header_len, nullptr);
-        kUnpacked = jit::HandlerResult::unpack(kPacked);
-        if (kUnpacked.action != jit::HandlerAction::Yield) break;
+        unpacked = jit::HandlerResult::unpack(kPacked);
+        if (unpacked.action != jit::HandlerAction::Yield) break;
         result.yield_count++;
-        // Advance to the continuation segment. Next-state is encoded in
-        // the HandlerResult; the status_code slot carries the yield
-        // payload (ms for Timer, etc.) which we ignore in sim mode.
-        ctx.state = kUnpacked.next_state;
+        // Advance to the continuation segment. Simulate mode treats the
+        // requested wait as immediately completed with a successful result,
+        // which lets wait-result frame slots preserve branch behavior without
+        // opening sockets or ticking timers.
+        ctx.resume_event_kind = static_cast<u32>(unpacked.yield_kind);
+        ctx.resume_event_result = 1;
+        ctx.state = unpacked.next_state;
     }
-    if (kUnpacked.action == jit::HandlerAction::Yield) {
+    if (unpacked.action == jit::HandlerAction::Yield) {
         // Exceeded the cap — treat as failure rather than silently
         // returning a stale state.
         result.verdict = Verdict::Failed;
         return result;
     }
-    result.action = kUnpacked.action;
+    result.action = unpacked.action;
 
-    if (kUnpacked.action == jit::HandlerAction::ReturnStatus) {
-        result.actual_status = kUnpacked.status_code;
+    if (unpacked.action == jit::HandlerAction::ReturnStatus) {
+        result.actual_status = unpacked.status_code;
         result.verdict =
-            (kUnpacked.status_code == entry.resp_status && entry.upstream_name[0] == '\0')
+            (unpacked.status_code == entry.resp_status && entry.upstream_name[0] == '\0')
                 ? Verdict::Match
                 : Verdict::Mismatch;
         return result;
     }
 
-    if (kUnpacked.action == jit::HandlerAction::Forward) {
-        const auto* upstream = find_upstream(engine, kUnpacked.upstream_id);
+    if (unpacked.action == jit::HandlerAction::Forward) {
+        const auto* upstream = find_upstream(engine, unpacked.upstream_id);
         if (!upstream) {
             result.verdict = Verdict::Failed;
             return result;

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -209,12 +209,49 @@ static void init_sim_handler_frame(SimHandlerFrame& frame) {
     frame.ctx.slot_count = ConnectionBase::kMaxJitHandlerSlots;
 }
 
+static i32 synthetic_resume_result(jit::YieldKind kind) {
+    switch (kind) {
+        case jit::YieldKind::Timer:
+        case jit::YieldKind::UpstreamConnect:
+            return 0;
+        case jit::YieldKind::Recv:
+        case jit::YieldKind::Send:
+        case jit::YieldKind::UpstreamRecv:
+        case jit::YieldKind::UpstreamSend:
+        case jit::YieldKind::HttpGet:
+        case jit::YieldKind::HttpPost:
+        case jit::YieldKind::Forward:
+        case jit::YieldKind::Any:
+            return 1;
+    }
+    return 1;
+}
+
 static void apply_synthetic_resume(jit::HandlerCtx& ctx,
                                    const jit::HandlerResult& yielded,
                                    jit::YieldKind kind) {
     ctx.resume_event_kind = static_cast<u32>(kind);
-    ctx.resume_event_result = (kind == jit::YieldKind::Timer) ? 0 : 1;
+    ctx.resume_event_result = synthetic_resume_result(kind);
     ctx.state = yielded.next_state;
+}
+
+static u8 non_match_verdict_rank(Verdict verdict) {
+    switch (verdict) {
+        case Verdict::Mismatch:
+            return 0;
+        case Verdict::Unsupported:
+            return 1;
+        case Verdict::Failed:
+            return 2;
+        case Verdict::Match:
+            return 3;
+    }
+    return 2;
+}
+
+static SimulateResult prefer_non_match_result(const SimulateResult& lhs,
+                                              const SimulateResult& rhs) {
+    return non_match_verdict_rank(lhs.verdict) <= non_match_verdict_rank(rhs.verdict) ? lhs : rhs;
 }
 
 static const char* verdict_str(Verdict verdict) {
@@ -554,19 +591,121 @@ static SimulateResult finalize_handler_result(const Engine& engine,
     return result;
 }
 
+static SimulateResult drive_handler_to_completion(const Engine& engine,
+                                                  const Engine::CompiledRoute& route,
+                                                  const CaptureEntry& entry,
+                                                  Connection& conn,
+                                                  SimHandlerFrame frame,
+                                                  SimulateResult result,
+                                                  u32 max_yields);
+
+template <u32 N>
+static void copy_char_array(char (&dst)[N], const char (&src)[N]) {
+    for (u32 i = 0; i < N; i++) dst[i] = src[i];
+}
+
+static Str copy_req_path_canon(const Connection& src, Connection& dst) {
+    const char* src_begin = src.req_path;
+    const char* src_end = src.req_path + Connection::kMaxReqPathLen;
+    if (src.req_path_canon.ptr >= src_begin && src.req_path_canon.ptr < src_end) {
+        const auto offset = static_cast<u32>(src.req_path_canon.ptr - src_begin);
+        if (offset < Connection::kMaxReqPathLen) {
+            return {dst.req_path + offset, src.req_path_canon.len};
+        }
+    }
+    return src.req_path_canon;
+}
+
+static void copy_sim_connection_state(Connection& dst, const Connection& src) {
+    dst.reset();
+
+    dst.on_recv = src.on_recv;
+    dst.on_send = src.on_send;
+    dst.on_upstream_recv = src.on_upstream_recv;
+    dst.on_upstream_send = src.on_upstream_send;
+    dst.fd = src.fd;
+    dst.id = src.id;
+    dst.state = src.state;
+    dst.shard_id = src.shard_id;
+    dst.flags = src.flags;
+    dst.timer_slot = src.timer_slot;
+    dst.upstream_fd = src.upstream_fd;
+    dst.upstream_idx = src.upstream_idx;
+    dst.handler_state = src.handler_state;
+    dst.pending_yield_kind = src.pending_yield_kind;
+    dst.resume_event_kind = src.resume_event_kind;
+    dst.resume_event_result = src.resume_event_result;
+    dst.handler_ctx = nullptr;
+    dst.pending_handler_fn = src.pending_handler_fn;
+    dst.handler_gen = src.handler_gen;
+    dst.request_config = src.request_config;
+    dst.yield_timespec = src.yield_timespec;
+    dst.yield_timer_gen = src.yield_timer_gen;
+    dst.keep_alive = src.keep_alive;
+    dst.tls_active = src.tls_active;
+    dst.tls_handshake_complete = src.tls_handshake_complete;
+    dst.tls = src.tls;
+    dst.pipeline_depth = src.pipeline_depth;
+    dst.pipeline_stash_len = src.pipeline_stash_len;
+    dst.req_header_end = src.req_header_end;
+    dst.req_content_length = src.req_content_length;
+    dst.req_initial_send_len = src.req_initial_send_len;
+    dst.req_malformed = src.req_malformed;
+    dst.req_body_mode = src.req_body_mode;
+    dst.req_body_remaining = src.req_body_remaining;
+    dst.req_chunk_parser = src.req_chunk_parser;
+    dst.resp_body_mode = src.resp_body_mode;
+    dst.resp_body_remaining = src.resp_body_remaining;
+    dst.resp_chunk_parser = src.resp_chunk_parser;
+    dst.resp_body_sent = src.resp_body_sent;
+    dst.upstream_send_len = src.upstream_send_len;
+    dst.recv_armed = src.recv_armed;
+    dst.send_armed = src.send_armed;
+    dst.upstream_recv_armed = src.upstream_recv_armed;
+    dst.upstream_send_armed = src.upstream_send_armed;
+    dst.yield_armed = src.yield_armed;
+    dst.yield_timeout_armed = src.yield_timeout_armed;
+    dst.resp_status = src.resp_status;
+    dst.req_method = src.req_method;
+    dst.req_size = src.req_size;
+    dst.peer_addr = src.peer_addr;
+    copy_char_array(dst.req_path, src.req_path);
+    dst.req_path_canon = copy_req_path_canon(src, dst);
+    dst.upstream_us = src.upstream_us;
+    copy_char_array(dst.upstream_name, src.upstream_name);
+    dst.upstream_start_us = src.upstream_start_us;
+    dst.capture_buf = src.capture_buf;
+    dst.capture_header_len = src.capture_header_len;
+    dst.req_start_us = src.req_start_us;
+    dst.pending_ops = src.pending_ops;
+}
+
 static SimulateResult simulate_resume_candidate(const Engine& engine,
                                                 const Engine::CompiledRoute& route,
                                                 const CaptureEntry& entry,
+                                                Connection& conn,
                                                 SimHandlerFrame frame,
                                                 const jit::HandlerResult& yielded,
                                                 jit::YieldKind resume_kind,
                                                 SimulateResult result,
                                                 u32 max_yields) {
-    Connection conn;
-    conn.reset();
     apply_synthetic_resume(frame.ctx, yielded, resume_kind);
+    return drive_handler_to_completion(engine, route, entry, conn, frame, result, max_yields);
+}
 
-    jit::HandlerResult unpacked = yielded;
+static SimulateResult drive_handler_to_completion(const Engine& engine,
+                                                  const Engine::CompiledRoute& route,
+                                                  const CaptureEntry& entry,
+                                                  Connection& conn,
+                                                  SimHandlerFrame frame,
+                                                  SimulateResult result,
+                                                  u32 max_yields) {
+    if (result.yield_count >= max_yields) {
+        result.verdict = Verdict::Failed;
+        return result;
+    }
+
+    jit::HandlerResult unpacked{};
     for (u32 iter = result.yield_count; iter < max_yields; iter++) {
         const u64 kPacked =
             route.fn(&conn, &frame.ctx, entry.raw_headers, entry.raw_header_len, nullptr);
@@ -574,12 +713,38 @@ static SimulateResult simulate_resume_candidate(const Engine& engine,
         if (unpacked.action != jit::HandlerAction::Yield) break;
         result.yield_count++;
 
-        jit::YieldKind next_kind = unpacked.yield_kind;
-        if (next_kind == jit::YieldKind::Any) {
-            next_kind =
-                (unpacked.yield_payload_u32() == 0u) ? jit::YieldKind::Recv : jit::YieldKind::Timer;
+        if (unpacked.yield_kind == jit::YieldKind::Any && unpacked.yield_payload_u32() != 0u) {
+            Connection recv_conn;
+            copy_sim_connection_state(recv_conn, conn);
+            const SimulateResult recv_result = simulate_resume_candidate(engine,
+                                                                         route,
+                                                                         entry,
+                                                                         recv_conn,
+                                                                         frame,
+                                                                         unpacked,
+                                                                         jit::YieldKind::Recv,
+                                                                         result,
+                                                                         max_yields);
+            if (recv_result.verdict == Verdict::Match) return recv_result;
+
+            Connection timer_conn;
+            copy_sim_connection_state(timer_conn, conn);
+            const SimulateResult timer_result = simulate_resume_candidate(engine,
+                                                                          route,
+                                                                          entry,
+                                                                          timer_conn,
+                                                                          frame,
+                                                                          unpacked,
+                                                                          jit::YieldKind::Timer,
+                                                                          result,
+                                                                          max_yields);
+            if (timer_result.verdict == Verdict::Match) return timer_result;
+            return prefer_non_match_result(recv_result, timer_result);
         }
-        apply_synthetic_resume(frame.ctx, unpacked, next_kind);
+
+        jit::YieldKind resume_kind = unpacked.yield_kind;
+        if (resume_kind == jit::YieldKind::Any) resume_kind = jit::YieldKind::Recv;
+        apply_synthetic_resume(frame.ctx, unpacked, resume_kind);
     }
 
     return finalize_handler_result(engine, entry, result, unpacked);
@@ -674,7 +839,6 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
     conn.reset();
     SimHandlerFrame frame;
     init_sim_handler_frame(frame);
-    jit::HandlerCtx& ctx = frame.ctx;
 
     // Drive the handler's state machine to completion. Yields are the
     // handler's signal "I need I/O, resume me with state=next_state".
@@ -688,51 +852,8 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
     // is deliberately small: real handlers yield at most a handful of times
     // per spec (submit + wait batches, not loops).
     static constexpr u32 kMaxHandlerYields = 32;
-    jit::HandlerResult unpacked{};
-    for (u32 iter = 0; iter < kMaxHandlerYields; iter++) {
-        const u64 kPacked =
-            route->fn(&conn, &ctx, entry.raw_headers, entry.raw_header_len, nullptr);
-        unpacked = jit::HandlerResult::unpack(kPacked);
-        if (unpacked.action != jit::HandlerAction::Yield) break;
-        result.yield_count++;
-
-        if (unpacked.yield_kind == jit::YieldKind::Any && unpacked.yield_payload_u32() != 0u) {
-            const SimulateResult recv_result = simulate_resume_candidate(engine,
-                                                                         *route,
-                                                                         entry,
-                                                                         frame,
-                                                                         unpacked,
-                                                                         jit::YieldKind::Recv,
-                                                                         result,
-                                                                         kMaxHandlerYields);
-            if (recv_result.verdict == Verdict::Match) return recv_result;
-
-            const SimulateResult timer_result = simulate_resume_candidate(engine,
-                                                                          *route,
-                                                                          entry,
-                                                                          frame,
-                                                                          unpacked,
-                                                                          jit::YieldKind::Timer,
-                                                                          result,
-                                                                          kMaxHandlerYields);
-            if (timer_result.verdict == Verdict::Match) return timer_result;
-            return recv_result;
-        }
-
-        // Advance to the continuation segment. Simulate mode treats the
-        // requested wait as immediately completed and sets the synthetic
-        // wake-up event. For wait(any), choose a concrete event kind so
-        // event predicates observe a deterministic branch in offline tests.
-        jit::YieldKind resume_kind = unpacked.yield_kind;
-        if (resume_kind == jit::YieldKind::Any) {
-            // Use the timeout winner when a timer arm exists (Any with
-            // non-zero payload), otherwise fall back to recv.
-            resume_kind = (unpacked.yield_payload_u32() == 0u) ? jit::YieldKind::Recv
-                                                                : jit::YieldKind::Timer;
-        }
-        apply_synthetic_resume(ctx, unpacked, resume_kind);
-    }
-    return finalize_handler_result(engine, entry, result, unpacked);
+    return drive_handler_to_completion(
+        engine, *route, entry, conn, frame, result, kMaxHandlerYields);
 }
 
 SimulateSummary simulate_file(Engine& engine, ReplayReader& reader) {

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -198,6 +198,25 @@ static u32 visible_path_len(Str path) {
     return n;
 }
 
+struct SimHandlerFrame {
+    jit::HandlerCtx ctx{};
+    u64 slots[ConnectionBase::kMaxJitHandlerSlots]{};
+};
+
+static void init_sim_handler_frame(SimHandlerFrame& frame) {
+    frame.ctx.state = 0;
+    frame.ctx.handler_idx = 0;
+    frame.ctx.slot_count = ConnectionBase::kMaxJitHandlerSlots;
+}
+
+static void apply_synthetic_resume(jit::HandlerCtx& ctx,
+                                   const jit::HandlerResult& yielded,
+                                   jit::YieldKind kind) {
+    ctx.resume_event_kind = static_cast<u32>(kind);
+    ctx.resume_event_result = (kind == jit::YieldKind::Timer) ? 0 : 1;
+    ctx.state = yielded.next_state;
+}
+
 static const char* verdict_str(Verdict verdict) {
     switch (verdict) {
         case Verdict::Match:
@@ -499,6 +518,73 @@ bool build_module_from_manifest(const Manifest& manifest, ModuleContext& ctx) {
     return true;
 }
 
+static SimulateResult finalize_handler_result(const Engine& engine,
+                                              const CaptureEntry& entry,
+                                              SimulateResult result,
+                                              const jit::HandlerResult& unpacked) {
+    if (unpacked.action == jit::HandlerAction::Yield) {
+        result.verdict = Verdict::Failed;
+        return result;
+    }
+
+    result.action = unpacked.action;
+    if (unpacked.action == jit::HandlerAction::ReturnStatus) {
+        result.actual_status = unpacked.status_code;
+        result.verdict =
+            (unpacked.status_code == entry.resp_status && entry.upstream_name[0] == '\0')
+                ? Verdict::Match
+                : Verdict::Mismatch;
+        return result;
+    }
+
+    if (unpacked.action == jit::HandlerAction::Forward) {
+        const auto* upstream = find_upstream(engine, unpacked.upstream_id);
+        if (!upstream) {
+            result.verdict = Verdict::Failed;
+            return result;
+        }
+        copy_cstr(result.actual_upstream, sizeof(result.actual_upstream), upstream->name);
+        result.verdict = streq(result.actual_upstream, result.expected_upstream)
+                             ? Verdict::Match
+                             : Verdict::Mismatch;
+        return result;
+    }
+
+    result.verdict = Verdict::Unsupported;
+    return result;
+}
+
+static SimulateResult simulate_resume_candidate(const Engine& engine,
+                                                const Engine::CompiledRoute& route,
+                                                const CaptureEntry& entry,
+                                                SimHandlerFrame frame,
+                                                const jit::HandlerResult& yielded,
+                                                jit::YieldKind resume_kind,
+                                                SimulateResult result,
+                                                u32 max_yields) {
+    Connection conn;
+    conn.reset();
+    apply_synthetic_resume(frame.ctx, yielded, resume_kind);
+
+    jit::HandlerResult unpacked = yielded;
+    for (u32 iter = result.yield_count; iter < max_yields; iter++) {
+        const u64 kPacked =
+            route.fn(&conn, &frame.ctx, entry.raw_headers, entry.raw_header_len, nullptr);
+        unpacked = jit::HandlerResult::unpack(kPacked);
+        if (unpacked.action != jit::HandlerAction::Yield) break;
+        result.yield_count++;
+
+        jit::YieldKind next_kind = unpacked.yield_kind;
+        if (next_kind == jit::YieldKind::Any) {
+            next_kind =
+                (unpacked.yield_payload_u32() == 0u) ? jit::YieldKind::Recv : jit::YieldKind::Timer;
+        }
+        apply_synthetic_resume(frame.ctx, unpacked, next_kind);
+    }
+
+    return finalize_handler_result(engine, entry, result, unpacked);
+}
+
 bool Engine::init(const rir::Module& module,
                   const ManifestUpstream* upstream_list,
                   u32 upstreams_len) {
@@ -586,14 +672,9 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
 
     Connection conn;
     conn.reset();
-    struct HandlerFrame {
-        jit::HandlerCtx ctx{};
-        u64 slots[ConnectionBase::kMaxJitHandlerSlots]{};
-    } frame;
+    SimHandlerFrame frame;
+    init_sim_handler_frame(frame);
     jit::HandlerCtx& ctx = frame.ctx;
-    ctx.state = 0;
-    ctx.handler_idx = 0;
-    ctx.slot_count = ConnectionBase::kMaxJitHandlerSlots;
 
     // Drive the handler's state machine to completion. Yields are the
     // handler's signal "I need I/O, resume me with state=next_state".
@@ -614,6 +695,30 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
         unpacked = jit::HandlerResult::unpack(kPacked);
         if (unpacked.action != jit::HandlerAction::Yield) break;
         result.yield_count++;
+
+        if (unpacked.yield_kind == jit::YieldKind::Any && unpacked.yield_payload_u32() != 0u) {
+            const SimulateResult recv_result = simulate_resume_candidate(engine,
+                                                                         *route,
+                                                                         entry,
+                                                                         frame,
+                                                                         unpacked,
+                                                                         jit::YieldKind::Recv,
+                                                                         result,
+                                                                         kMaxHandlerYields);
+            if (recv_result.verdict == Verdict::Match) return recv_result;
+
+            const SimulateResult timer_result = simulate_resume_candidate(engine,
+                                                                          *route,
+                                                                          entry,
+                                                                          frame,
+                                                                          unpacked,
+                                                                          jit::YieldKind::Timer,
+                                                                          result,
+                                                                          kMaxHandlerYields);
+            if (timer_result.verdict == Verdict::Match) return timer_result;
+            return recv_result;
+        }
+
         // Advance to the continuation segment. Simulate mode treats the
         // requested wait as immediately completed and sets the synthetic
         // wake-up event. For wait(any), choose a concrete event kind so
@@ -625,42 +730,9 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
             resume_kind = (unpacked.yield_payload_u32() == 0u) ? jit::YieldKind::Recv
                                                                 : jit::YieldKind::Timer;
         }
-        ctx.resume_event_kind = static_cast<u32>(resume_kind);
-        ctx.resume_event_result = (resume_kind == jit::YieldKind::Timer) ? 0 : 1;
-        ctx.state = unpacked.next_state;
+        apply_synthetic_resume(ctx, unpacked, resume_kind);
     }
-    if (unpacked.action == jit::HandlerAction::Yield) {
-        // Exceeded the cap — treat as failure rather than silently
-        // returning a stale state.
-        result.verdict = Verdict::Failed;
-        return result;
-    }
-    result.action = unpacked.action;
-
-    if (unpacked.action == jit::HandlerAction::ReturnStatus) {
-        result.actual_status = unpacked.status_code;
-        result.verdict =
-            (unpacked.status_code == entry.resp_status && entry.upstream_name[0] == '\0')
-                ? Verdict::Match
-                : Verdict::Mismatch;
-        return result;
-    }
-
-    if (unpacked.action == jit::HandlerAction::Forward) {
-        const auto* upstream = find_upstream(engine, unpacked.upstream_id);
-        if (!upstream) {
-            result.verdict = Verdict::Failed;
-            return result;
-        }
-        copy_cstr(result.actual_upstream, sizeof(result.actual_upstream), upstream->name);
-        result.verdict = streq(result.actual_upstream, result.expected_upstream)
-                             ? Verdict::Match
-                             : Verdict::Mismatch;
-        return result;
-    }
-
-    result.verdict = Verdict::Unsupported;
-    return result;
+    return finalize_handler_result(engine, entry, result, unpacked);
 }
 
 SimulateSummary simulate_file(Engine& engine, ReplayReader& reader) {

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -615,11 +615,13 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
         if (unpacked.action != jit::HandlerAction::Yield) break;
         result.yield_count++;
         // Advance to the continuation segment. Simulate mode treats the
-        // requested wait as immediately completed with a successful result,
-        // which lets wait-result frame slots preserve branch behavior without
-        // opening sockets or ticking timers.
-        ctx.resume_event_kind = static_cast<u32>(unpacked.yield_kind);
-        ctx.resume_event_result = 1;
+        // requested wait as immediately completed and sets the synthetic
+        // wake-up event. For wait(any), choose a concrete event kind so
+        // event predicates observe a deterministic branch in offline tests.
+        jit::YieldKind resume_kind = unpacked.yield_kind;
+        if (resume_kind == jit::YieldKind::Any) resume_kind = jit::YieldKind::Recv;
+        ctx.resume_event_kind = static_cast<u32>(resume_kind);
+        ctx.resume_event_result = (resume_kind == jit::YieldKind::Timer) ? 0 : 1;
         ctx.state = unpacked.next_state;
     }
     if (unpacked.action == jit::HandlerAction::Yield) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1257,6 +1257,25 @@ TEST(frontend, parse_route_accepts_wait_statement) {
     CHECK_EQ(route.statements[2].status_code, 200);
 }
 
+TEST(frontend, parse_route_accepts_wait_any_statement) {
+    const char* src =
+        "route GET \"/x\" { wait any { downstream.recv() => { return 204 } timer(250) => { "
+        "return 408 } } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    const auto& route = ast->items[0].route;
+    REQUIRE_EQ(route.statements.len, 1u);
+    CHECK_EQ(static_cast<u8>(route.statements[0].kind), static_cast<u8>(AstStmtKind::WaitAny));
+    REQUIRE_EQ(route.statements[0].match_arms.len, 2u);
+    CHECK_EQ(static_cast<u8>(route.statements[0].match_arms[0].pattern.kind),
+             static_cast<u8>(AstExprKind::MethodCall));
+    CHECK_EQ(static_cast<u8>(route.statements[0].match_arms[1].pattern.kind),
+             static_cast<u8>(AstExprKind::Call));
+}
+
 TEST(frontend, analyze_records_wait_in_hir_route) {
     const char* src = "route GET \"/sleep\" { wait(1000) return 200 }\n";
     auto lexed = lex(lit(src));
@@ -1268,6 +1287,26 @@ TEST(frontend, analyze_records_wait_in_hir_route) {
     REQUIRE_EQ(hir->routes.len, 1u);
     REQUIRE_EQ(hir->routes[0].waits.len, 1u);
     CHECK_EQ(hir->routes[0].waits[0].ms, 1000);
+}
+
+TEST(frontend, analyze_wait_any_statement_lowers_to_any_wait_and_if_control) {
+    const char* src =
+        "route GET \"/x\" { wait any { downstream.recv() => { return 204 } timer(250) => { "
+        "return 408 } } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+    CHECK_EQ(hir->routes[0].waits[0].event_kind, WaitEventKind::Any);
+    CHECK_EQ(hir->routes[0].waits[0].ms, 250u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::If));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.cond.kind),
+             static_cast<u8>(HirExprKind::WaitField));
+    CHECK_EQ(hir->routes[0].control.then_term.status_code, 408u);
+    CHECK_EQ(hir->routes[0].control.else_term.status_code, 204u);
 }
 
 TEST(frontend, analyze_records_multiple_waits_in_order) {
@@ -1651,6 +1690,28 @@ TEST(frontend, analyze_wait_result_fields) {
              static_cast<u8>(HirExprKind::WaitField));
 }
 
+TEST(frontend, analyze_wait_result_event_predicate_fields) {
+    const char* src =
+        "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(250))) "
+        "guard ev.timer else { return 500 } guard ev.recv else { return 501 } "
+        "guard ev.send else { return 502 } guard ev.upstream_connect else { return 503 } "
+        "guard ev.upstream_recv else { return 504 } guard ev.upstream_send else { return 505 } "
+        "return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].guards.len, 6u);
+    for (u32 i = 0; i < hir->routes[0].guards.len; i++) {
+        CHECK_EQ(static_cast<u8>(hir->routes[0].guards[i].cond.kind),
+                 static_cast<u8>(HirExprKind::WaitField));
+        CHECK_EQ(static_cast<u8>(hir->routes[0].guards[i].cond.type),
+                 static_cast<u8>(HirTypeKind::Bool));
+    }
+}
+
 TEST(frontend, analyze_rejects_unbound_wait_result_field) {
     const char* src =
         "route GET \"/x\" { guard wait(downstream.recv()).ok else { return 500 } return 204 }\n";
@@ -1677,7 +1738,7 @@ TEST(frontend, analyze_rejects_wait_expression_outside_let_initializer) {
     }
 }
 
-TEST(frontend, analyze_rejects_stale_wait_result_field_after_later_wait) {
+TEST(frontend, analyze_allows_wait_result_field_after_later_wait) {
     const char* src =
         "upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { let first = "
         "wait(downstream.recv()) let second = "
@@ -1687,7 +1748,11 @@ TEST(frontend, analyze_rejects_stale_wait_result_field_after_later_wait) {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE(!hir);
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 2u);
+    REQUIRE_EQ(hir->routes[0].guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].cond.kind),
+             static_cast<u8>(HirExprKind::WaitField));
 }
 
 TEST(frontend, lower_wait_result_then_guard_let_preserves_local_refs) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1305,8 +1305,35 @@ TEST(frontend, analyze_wait_any_statement_lowers_to_any_wait_and_if_control) {
     CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::If));
     CHECK_EQ(static_cast<u8>(hir->routes[0].control.cond.kind),
              static_cast<u8>(HirExprKind::WaitField));
+    REQUIRE(hir->routes[0].control.cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.cond.lhs->kind),
+             static_cast<u8>(HirExprKind::WaitResult));
+    CHECK_EQ(hir->routes[0].locals.len, 0u);
     CHECK_EQ(hir->routes[0].control.then_term.status_code, 408u);
     CHECK_EQ(hir->routes[0].control.else_term.status_code, 204u);
+}
+
+TEST(frontend, wait_any_statement_does_not_consume_local_slot) {
+    const char* src =
+        "route GET \"/x\" { "
+        "let a0 = 0 let a1 = 1 let a2 = 2 let a3 = 3 "
+        "let a4 = 4 let a5 = 5 let a6 = 6 let a7 = 7 "
+        "let a8 = 8 let a9 = 9 let a10 = 10 let a11 = 11 "
+        "let a12 = 12 let a13 = 13 let a14 = 14 "
+        "wait any { downstream.recv() => { return 204 } timer(250) => { return 408 } } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 15u);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::If));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 15u);
 }
 
 TEST(frontend, analyze_records_multiple_waits_in_order) {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -34,9 +34,9 @@ static Str lit(const char* s) {
 
 struct TestHandlerCtxFrame {
     HandlerCtx ctx{};
-    u64 slots[8]{};
+    u64 slots[ConnectionBase::kMaxJitHandlerSlots]{};
 
-    TestHandlerCtxFrame() { ctx.slot_count = 8; }
+    TestHandlerCtxFrame() { ctx.slot_count = ConnectionBase::kMaxJitHandlerSlots; }
 };
 
 // RAII wrapper — frontend APIs (parse_file/analyze_file/build_mir) all
@@ -15021,7 +15021,8 @@ route GET "/sleep" { wait(1500) return 200 }
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    HandlerCtx ctx{};
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
     ctx.state = 0;
 
     // First call: TimerYield carrying raw 1500 ms payload.
@@ -15077,7 +15078,8 @@ route GET "/long" { wait(100000) return 200 }
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    HandlerCtx ctx{};
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
     ctx.state = 0;
     auto outcome = invoke_jit_handler(handler,
                                       nullptr,

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -32,6 +32,13 @@ static Str lit(const char* s) {
     return {s, n};
 }
 
+struct TestHandlerCtxFrame {
+    HandlerCtx ctx{};
+    u64 slots[8]{};
+
+    TestHandlerCtxFrame() { ctx.slot_count = 8; }
+};
+
 // RAII wrapper — frontend APIs (parse_file/analyze_file/build_mir) all
 // .release() a unique_ptr. Without ownership the raw pointer leaks; the
 // test suite was leaking ~75 MB per test case before this guard landed.
@@ -14133,7 +14140,8 @@ route {
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    HandlerCtx ctx{};
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
     ctx.state = 0;
     auto r = HandlerResult::unpack(handler(nullptr,
                                            &ctx,
@@ -14174,7 +14182,8 @@ route {
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    HandlerCtx ctx{};
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
     ctx.state = 0;
     auto r0 = HandlerResult::unpack(handler(nullptr,
                                             &ctx,
@@ -14226,7 +14235,8 @@ route {
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    HandlerCtx ctx{};
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
     ctx.state = 0;
     const u32 expected_ms[] = {100u, 200u};
     for (u16 state = 0; state < 2; state++) {
@@ -14280,10 +14290,10 @@ route GET "/sleep" { wait(1000) return 200 }
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    HandlerCtx ctx{};
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
     ctx.state = 0;
     ctx.handler_idx = 0;
-    ctx.slot_count = 0;
 
     // First call: state=0 → yield
     auto r0 = HandlerResult::unpack(handler(nullptr,
@@ -14353,7 +14363,8 @@ TEST(jit, frontend_route_event_waits_emit_event_yield_kinds) {
         auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
         REQUIRE(handler != nullptr);
 
-        HandlerCtx ctx{};
+        TestHandlerCtxFrame frame{};
+        HandlerCtx& ctx = frame.ctx;
         ctx.state = 0;
         auto r0 = HandlerResult::unpack(handler(nullptr,
                                                 &ctx,
@@ -14377,6 +14388,80 @@ TEST(jit, frontend_route_event_waits_emit_event_yield_kinds) {
         engine.shutdown();
         rir.destroy();
     }
+}
+
+TEST(jit, frontend_route_wait_any_statement_branches_on_winning_event) {
+    const auto src = R"rut(
+route GET "/x" {
+    wait any {
+        downstream.recv() => { return 204 }
+        timer(250) => { return 408 }
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    TestHandlerCtxFrame recv_frame{};
+    HandlerCtx& recv_ctx = recv_frame.ctx;
+    auto first = HandlerResult::unpack(handler(nullptr,
+                                               &recv_ctx,
+                                               reinterpret_cast<const u8*>(kGetRootRequest),
+                                               sizeof(kGetRootRequest) - 1,
+                                               nullptr));
+    REQUIRE_EQ(static_cast<u8>(first.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(first.next_state, 1);
+    CHECK_EQ(static_cast<u8>(first.yield_kind), static_cast<u8>(YieldKind::Any));
+    CHECK_EQ(first.yield_payload_u32(), 250u);
+
+    recv_ctx.state = first.next_state;
+    recv_ctx.resume_event_kind = static_cast<u32>(YieldKind::Recv);
+    recv_ctx.resume_event_result = 8;
+    auto recv_done = HandlerResult::unpack(handler(nullptr,
+                                                   &recv_ctx,
+                                                   reinterpret_cast<const u8*>(kGetRootRequest),
+                                                   sizeof(kGetRootRequest) - 1,
+                                                   nullptr));
+    CHECK_EQ(static_cast<u8>(recv_done.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(recv_done.status_code, 204);
+
+    TestHandlerCtxFrame timer_frame{};
+    HandlerCtx& timer_ctx = timer_frame.ctx;
+    auto timer_first = HandlerResult::unpack(handler(nullptr,
+                                                     &timer_ctx,
+                                                     reinterpret_cast<const u8*>(kGetRootRequest),
+                                                     sizeof(kGetRootRequest) - 1,
+                                                     nullptr));
+    REQUIRE_EQ(static_cast<u8>(timer_first.action), static_cast<u8>(HandlerAction::Yield));
+    timer_ctx.state = timer_first.next_state;
+    timer_ctx.resume_event_kind = static_cast<u32>(YieldKind::Timer);
+    timer_ctx.resume_event_result = 0;
+    auto timer_done = HandlerResult::unpack(handler(nullptr,
+                                                    &timer_ctx,
+                                                    reinterpret_cast<const u8*>(kGetRootRequest),
+                                                    sizeof(kGetRootRequest) - 1,
+                                                    nullptr));
+    CHECK_EQ(static_cast<u8>(timer_done.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(timer_done.status_code, 408);
+
+    engine.shutdown();
+    rir.destroy();
 }
 
 TEST(jit, decorated_route_prologue_yields_preserve_event_kind) {
@@ -14406,7 +14491,8 @@ route {
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    HandlerCtx ctx{};
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
     auto first = HandlerResult::unpack(handler(nullptr,
                                                &ctx,
                                                reinterpret_cast<const u8*>(kGetRootRequest),
@@ -14468,7 +14554,8 @@ route GET "/x" {
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    HandlerCtx ctx{};
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
     ctx.state = 0;
     auto r0 = HandlerResult::unpack(handler(nullptr,
                                             &ctx,
@@ -14523,6 +14610,61 @@ route GET "/x" {
     rir.destroy();
 }
 
+TEST(jit, frontend_route_wait_result_store_skips_missing_frame_slots) {
+    const auto src = R"rut(
+route GET "/x" {
+    let ev = wait(downstream.recv())
+    if ev.recv { return 204 } else { return 500 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    struct NoSlotCtx {
+        HandlerCtx ctx{};
+        u64 canary0 = 0x1122334455667788ull;
+        u64 canary1 = 0x8877665544332211ull;
+    } frame;
+
+    auto first = HandlerResult::unpack(handler(nullptr,
+                                               &frame.ctx,
+                                               reinterpret_cast<const u8*>(kGetRootRequest),
+                                               sizeof(kGetRootRequest) - 1,
+                                               nullptr));
+    REQUIRE_EQ(static_cast<u8>(first.action), static_cast<u8>(HandlerAction::Yield));
+    frame.ctx.state = first.next_state;
+    frame.ctx.resume_event_kind = static_cast<u32>(YieldKind::Recv);
+    frame.ctx.resume_event_result = 8;
+    auto done = HandlerResult::unpack(handler(nullptr,
+                                              &frame.ctx,
+                                              reinterpret_cast<const u8*>(kGetRootRequest),
+                                              sizeof(kGetRootRequest) - 1,
+                                              nullptr));
+    CHECK_EQ(static_cast<u8>(done.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(done.status_code, 204);
+    CHECK_EQ(frame.canary0, 0x1122334455667788ull);
+    CHECK_EQ(frame.canary1, 0x8877665544332211ull);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_route_parameterized_event_waits_emit_payloads) {
     struct Case {
         const char* src;
@@ -14555,7 +14697,8 @@ TEST(jit, frontend_route_parameterized_event_waits_emit_payloads) {
         auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
         REQUIRE(handler != nullptr);
 
-        HandlerCtx ctx{};
+        TestHandlerCtxFrame frame{};
+        HandlerCtx& ctx = frame.ctx;
         ctx.state = 0;
         auto r0 = HandlerResult::unpack(handler(nullptr,
                                                 &ctx,
@@ -14569,6 +14712,154 @@ TEST(jit, frontend_route_parameterized_event_waits_emit_payloads) {
         engine.shutdown();
         rir.destroy();
     }
+}
+
+TEST(jit, frontend_route_wait_event_predicate_fields_drive_control_flow) {
+    struct Case {
+        const char* wait_src;
+        const char* field;
+        YieldKind resume_kind;
+    };
+    const Case cases[] = {
+        {"wait(any(downstream.recv(), timer(250)))", "timer", YieldKind::Timer},
+        {"wait(downstream.recv())", "recv", YieldKind::Recv},
+        {"wait(downstream.recv())", "send", YieldKind::Send},
+        {"wait(upstream(api).connect())", "upstream_connect", YieldKind::UpstreamConnect},
+        {"wait(upstream(api).recv())", "upstream_recv", YieldKind::UpstreamRecv},
+        {"wait(upstream(api).send(req.body))", "upstream_send", YieldKind::UpstreamSend},
+    };
+    for (const auto& c : cases) {
+        char src[320];
+        int n = snprintf(src,
+                         sizeof(src),
+                         "upstream api at \"127.0.0.1:9000\"\n"
+                         "route GET \"/x\" { let ev = %s if ev.%s { return 204 } else { return "
+                         "500 } }\n",
+                         c.wait_src,
+                         c.field);
+        REQUIRE(n > 0);
+        REQUIRE(static_cast<size_t>(n) < sizeof(src));
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(hir);
+        auto mir = build_mir_heap(hir.value());
+        REQUIRE(mir);
+        FrontendRirModule rir{};
+        auto lowered = lower_to_rir(mir.value(), rir);
+        REQUIRE(lowered);
+        auto cg = codegen(rir.module);
+        REQUIRE(cg.ok);
+        JitEngine engine;
+        REQUIRE(engine.init());
+        REQUIRE(engine.compile(cg.mod, cg.ctx));
+        auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+        REQUIRE(handler != nullptr);
+
+        TestHandlerCtxFrame frame{};
+        HandlerCtx& ctx = frame.ctx;
+        ctx.state = 0;
+        auto yielded = HandlerResult::unpack(handler(nullptr,
+                                                     &ctx,
+                                                     reinterpret_cast<const u8*>(kGetRootRequest),
+                                                     sizeof(kGetRootRequest) - 1,
+                                                     nullptr));
+        REQUIRE_EQ(static_cast<u8>(yielded.action), static_cast<u8>(HandlerAction::Yield));
+        ctx.state = yielded.next_state;
+        ctx.resume_event_kind = static_cast<u32>(c.resume_kind);
+        ctx.resume_event_result = 1;
+        auto matched = HandlerResult::unpack(handler(nullptr,
+                                                     &ctx,
+                                                     reinterpret_cast<const u8*>(kGetRootRequest),
+                                                     sizeof(kGetRootRequest) - 1,
+                                                     nullptr));
+        CHECK_EQ(static_cast<u8>(matched.action), static_cast<u8>(HandlerAction::ReturnStatus));
+        CHECK_EQ(matched.status_code, 204);
+
+        ctx.resume_event_kind = static_cast<u32>(YieldKind::Timer);
+        if (c.resume_kind == YieldKind::Timer)
+            ctx.resume_event_kind = static_cast<u32>(YieldKind::Recv);
+        auto missed = HandlerResult::unpack(handler(nullptr,
+                                                    &ctx,
+                                                    reinterpret_cast<const u8*>(kGetRootRequest),
+                                                    sizeof(kGetRootRequest) - 1,
+                                                    nullptr));
+        CHECK_EQ(static_cast<u8>(missed.action), static_cast<u8>(HandlerAction::ReturnStatus));
+        CHECK_EQ(missed.status_code, 500);
+
+        engine.shutdown();
+        rir.destroy();
+    }
+}
+
+TEST(jit, frontend_route_wait_result_fields_survive_later_waits) {
+    const auto src = R"rut(
+route GET "/x" {
+    let first = wait(any(downstream.recv(), timer(250)))
+    let second = wait(downstream.recv())
+    if first.timer {
+        if second.recv { return 204 } else { return 501 }
+    } else {
+        return 500
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
+    ctx.state = 0;
+    auto first_yield = HandlerResult::unpack(handler(nullptr,
+                                                     &ctx,
+                                                     reinterpret_cast<const u8*>(kGetRootRequest),
+                                                     sizeof(kGetRootRequest) - 1,
+                                                     nullptr));
+    REQUIRE_EQ(static_cast<u8>(first_yield.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(static_cast<u8>(first_yield.yield_kind), static_cast<u8>(YieldKind::Any));
+
+    ctx.state = first_yield.next_state;
+    ctx.resume_event_kind = static_cast<u32>(YieldKind::Timer);
+    ctx.resume_event_result = 0;
+    auto second_yield = HandlerResult::unpack(handler(nullptr,
+                                                      &ctx,
+                                                      reinterpret_cast<const u8*>(kGetRootRequest),
+                                                      sizeof(kGetRootRequest) - 1,
+                                                      nullptr));
+    REQUIRE_EQ(static_cast<u8>(second_yield.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(static_cast<u8>(second_yield.yield_kind), static_cast<u8>(YieldKind::Recv));
+
+    ctx.state = second_yield.next_state;
+    ctx.resume_event_kind = static_cast<u32>(YieldKind::Recv);
+    ctx.resume_event_result = 8;
+    auto done = HandlerResult::unpack(handler(nullptr,
+                                              &ctx,
+                                              reinterpret_cast<const u8*>(kGetRootRequest),
+                                              sizeof(kGetRootRequest) - 1,
+                                              nullptr));
+    CHECK_EQ(static_cast<u8>(done.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(done.status_code, 204);
+
+    engine.shutdown();
+    rir.destroy();
 }
 
 TEST(jit, frontend_route_multiple_waits_chain_through_states) {
@@ -14595,7 +14886,8 @@ route GET "/sleep" { wait(500) wait(1000) return 201 }
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    HandlerCtx ctx{};
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
     ctx.state = 0;
     ctx.handler_idx = 0;
 
@@ -14653,7 +14945,8 @@ route GET "/" {
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    HandlerCtx ctx{};
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
     ctx.state = 0;
     auto r0 = HandlerResult::unpack(handler(nullptr,
                                             &ctx,

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -470,6 +470,42 @@ TEST(simulate_engine, wait_result_fields_survive_later_waits) {
     rir.destroy();
 }
 
+TEST(simulate_engine, wait_any_statement_uses_concrete_wait_kind) {
+    const char* src =
+        "route GET \"/x\" { wait any { downstream.recv() => { return 204 } timer(50) => { return 408 } } }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 204u);
+    CHECK_EQ(result.yield_count, 1u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(simulate_engine, timer_wait_result_matches_runtime_zero) {
+    const char* src =
+        "route GET \"/x\" { let ev = wait(50) if ev.result == 0 { return 204 } else { return 500 } }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 204u);
+    CHECK_EQ(result.yield_count, 1u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(simulate_engine, forward_upstream_match) {
     Manifest manifest{};
     manifest.upstream_count = 1;

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -472,7 +472,7 @@ TEST(simulate_engine, wait_result_fields_survive_later_waits) {
     Engine engine;
     REQUIRE(engine.init(rir.module, nullptr, 0));
 
-    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 408));
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
     CHECK_EQ(result.verdict, Verdict::Match);
     CHECK_EQ(result.actual_status, 204u);
     CHECK_EQ(result.yield_count, 2u);

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -472,7 +472,8 @@ TEST(simulate_engine, wait_result_fields_survive_later_waits) {
 
 TEST(simulate_engine, wait_any_statement_uses_concrete_wait_kind) {
     const char* src =
-        "route GET \"/x\" { wait any { downstream.recv() => { return 204 } timer(50) => { return 408 } } }\n";
+        "route GET \"/x\" { wait any { downstream.recv() => { return 204 } timer(50) => { return "
+        "408 } } }\n";
     FrontendRirModule rir{};
     REQUIRE(compile_to_rir(src, rir));
 
@@ -490,7 +491,8 @@ TEST(simulate_engine, wait_any_statement_uses_concrete_wait_kind) {
 
 TEST(simulate_engine, timer_wait_result_matches_runtime_zero) {
     const char* src =
-        "route GET \"/x\" { let ev = wait(50) if ev.result == 0 { return 204 } else { return 500 } }\n";
+        "route GET \"/x\" { let ev = wait(50) if ev.result == 0 { return 204 } else { return 500 } "
+        "}\n";
     FrontendRirModule rir{};
     REQUIRE(compile_to_rir(src, rir));
 

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -451,6 +451,25 @@ TEST(simulate_engine, multiple_waits_all_drive_then_return) {
     rir.destroy();
 }
 
+TEST(simulate_engine, wait_result_fields_survive_later_waits) {
+    const char* src =
+        "route GET \"/x\" { let first = wait(50) let second = wait(downstream.recv()) if "
+        "first.timer { guard second.ok else { return 500 } return 204 } else { return 502 } }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 204u);
+    CHECK_EQ(result.yield_count, 2u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(simulate_engine, forward_upstream_match) {
     Manifest manifest{};
     manifest.upstream_count = 1;

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -504,6 +504,25 @@ TEST(simulate_engine, wait_any_statement_uses_concrete_wait_kind) {
     rir.destroy();
 }
 
+TEST(simulate_engine, wait_any_statement_can_match_recv_winner) {
+    const char* src =
+        "route GET \"/x\" { wait any { downstream.recv() => { return 204 } timer(50) => { return "
+        "408 } } }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 204u);
+    CHECK_EQ(result.yield_count, 1u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(simulate_engine, wait_any_expression_can_resume_with_timer_predicate) {
     const char* src =
         "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(50))) if ev.timer { "
@@ -517,6 +536,25 @@ TEST(simulate_engine, wait_any_expression_can_resume_with_timer_predicate) {
     const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 408));
     CHECK_EQ(result.verdict, Verdict::Match);
     CHECK_EQ(result.actual_status, 408u);
+    CHECK_EQ(result.yield_count, 1u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(simulate_engine, wait_any_expression_can_match_recv_predicate) {
+    const char* src =
+        "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(50))) if ev.timer { "
+        "return 408 } else { return 204 } }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 204u);
     CHECK_EQ(result.yield_count, 1u);
 
     engine.shutdown();

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -357,18 +357,29 @@ TEST(simulate_engine, static_status_match) {
 // The caller must keep `rir` alive for as long as the Engine.
 static bool compile_to_rir(const char* src, FrontendRirModule& rir) {
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
-    if (!lexed) return false;
+    if (!lexed) {
+        return false;
+    }
     auto ast = parse_file(lexed.value());
-    if (!ast) return false;
+    if (!ast) {
+        return false;
+    }
     std::unique_ptr<AstFile> ast_owned(ast.value());
     auto hir = analyze_file(*ast_owned);
-    if (!hir) return false;
+    if (!hir) {
+        return false;
+    }
     std::unique_ptr<HirModule> hir_owned(hir.value());
     auto mir = build_mir(*hir_owned);
-    if (!mir) return false;
+    if (!mir) {
+        return false;
+    }
     std::unique_ptr<MirModule> mir_owned(mir.value());
     auto lowered = lower_to_rir(*mir_owned, rir);
-    return lowered.has_value();
+    if (!lowered) {
+        return false;
+    }
+    return true;
 }
 
 TEST(simulate_engine, wait_handler_drives_state_machine_to_terminal_status) {
@@ -461,7 +472,7 @@ TEST(simulate_engine, wait_result_fields_survive_later_waits) {
     Engine engine;
     REQUIRE(engine.init(rir.module, nullptr, 0));
 
-    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 408));
     CHECK_EQ(result.verdict, Verdict::Match);
     CHECK_EQ(result.actual_status, 204u);
     CHECK_EQ(result.yield_count, 2u);
@@ -476,13 +487,36 @@ TEST(simulate_engine, wait_any_statement_uses_concrete_wait_kind) {
         "408 } } }\n";
     FrontendRirModule rir{};
     REQUIRE(compile_to_rir(src, rir));
+    REQUIRE_GE(rir.module.func_count, 1u);
+    REQUIRE_GE(rir.module.functions[0].yield_count, 1u);
+    CHECK_EQ(rir.module.functions[0].yield_kinds[0], static_cast<u8>(jit::YieldKind::Any));
+    CHECK_EQ(rir.module.functions[0].yield_payload[0], 50u);
 
     Engine engine;
     REQUIRE(engine.init(rir.module, nullptr, 0));
 
-    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 408));
     CHECK_EQ(result.verdict, Verdict::Match);
-    CHECK_EQ(result.actual_status, 204u);
+    CHECK_EQ(result.actual_status, 408u);
+    CHECK_EQ(result.yield_count, 1u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(simulate_engine, wait_any_expression_can_resume_with_timer_predicate) {
+    const char* src =
+        "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(50))) if ev.timer { "
+        "return 408 } else { return 204 } }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 408));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 408u);
     CHECK_EQ(result.yield_count, 1u);
 
     engine.shutdown();

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -3,6 +3,7 @@
 #include "rut/compiler/lower_rir.h"
 #include "rut/compiler/mir_build.h"
 #include "rut/compiler/parser.h"
+#include "rut/compiler/rir_builder.h"
 #include "rut/runtime/route_method.h"
 #include "rut/sim/simulate_engine.h"
 #include "test.h"
@@ -462,6 +463,41 @@ TEST(simulate_engine, multiple_waits_all_drive_then_return) {
     rir.destroy();
 }
 
+TEST(simulate_engine, repeated_yield_at_cap_fails_without_status_zero_mismatch) {
+    ModuleContext ctx{};
+    REQUIRE(ctx.init(1));
+
+    rir::Builder b;
+    b.init(&ctx.module);
+
+    auto fn_res = b.create_function({"loop", 4}, {"/loop", 5}, kRouteMethodGet);
+    REQUIRE(fn_res);
+    auto* fn = fn_res.value();
+    auto entry_res = b.create_block(fn, {"entry", 5});
+    REQUIRE(entry_res);
+
+    const u32 payloads[] = {1};
+    const u8 kinds[] = {static_cast<u8>(jit::YieldKind::Timer)};
+    REQUIRE(b.set_yield_payload(fn, payloads, 1, kinds));
+    const rir::BlockId resume_blocks[] = {entry_res.value(), entry_res.value()};
+    REQUIRE(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry_res.value());
+    REQUIRE(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 1, 1));
+
+    Engine engine;
+    REQUIRE(engine.init(ctx.module, nullptr, 0));
+
+    const auto result =
+        simulate_one(engine, make_entry("GET /loop HTTP/1.1\r\nHost: x\r\n\r\n", 200));
+    CHECK_EQ(result.verdict, Verdict::Failed);
+    CHECK_EQ(result.actual_status, 0u);
+    CHECK_EQ(result.yield_count, 32u);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
 TEST(simulate_engine, wait_result_fields_survive_later_waits) {
     const char* src =
         "route GET \"/x\" { let first = wait(50) let second = wait(downstream.recv()) if "
@@ -561,10 +597,74 @@ TEST(simulate_engine, wait_any_expression_can_match_recv_predicate) {
     rir.destroy();
 }
 
+TEST(simulate_engine, nested_wait_any_can_match_later_recv_winner) {
+    const char* src =
+        "route GET \"/x\" { "
+        "let first = wait(any(downstream.recv(), timer(50))) "
+        "guard first.recv else { return 408 } "
+        "let second = wait(any(downstream.recv(), timer(50))) "
+        "if second.recv { return 204 } else { return 409 } "
+        "}\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 204u);
+    CHECK_EQ(result.yield_count, 2u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(simulate_engine, wait_any_prefers_terminal_mismatch_over_failed_candidate) {
+    const char* src =
+        "upstream api\n"
+        "route GET \"/x\" { wait any { downstream.recv() => { return forward(api) } timer(50) => "
+        "{ return 408 } } }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Mismatch);
+    CHECK_EQ(result.action, jit::HandlerAction::ReturnStatus);
+    CHECK_EQ(result.actual_status, 408u);
+    CHECK_EQ(result.yield_count, 1u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(simulate_engine, timer_wait_result_matches_runtime_zero) {
     const char* src =
         "route GET \"/x\" { let ev = wait(50) if ev.result == 0 { return 204 } else { return 500 } "
         "}\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 204u);
+    CHECK_EQ(result.yield_count, 1u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(simulate_engine, upstream_connect_wait_result_matches_runtime_zero) {
+    const char* src =
+        "upstream api at \"127.0.0.1:9000\"\n"
+        "route GET \"/x\" { let ev = wait(upstream(api).connect()) if ev.result == 0 { return "
+        "204 } else { return 500 } }\n";
     FrontendRirModule rir{};
     REQUIRE(compile_to_rir(src, rir));
 


### PR DESCRIPTION
## Summary
- persist wait result kind/result in handler frame slots so older wait results survive later waits
- add event predicate fields on wait results, including timer/recv/send/upstream_* booleans
- add statement-form wait any syntax for recv-vs-timer branch control
- document current wait forms, result fields, race waits, and remaining gaps

## Tests
- /tmp/rut-build/tests/test_frontend
- /tmp/rut-build/tests/test_jit