### PR TITLE
[codex] Complete match support

### DIFF
--- a/docs/match.md
+++ b/docs/match.md
@@ -195,3 +195,7 @@ func pick(result: Result) -> i32 {
     }
 }
 ```
+
+If any function match arm uses an `if` guard, include a wildcard arm so unmatched or
+guard-false values have an explicit result. Unguarded boolean and variant matches may omit
+the wildcard only when all cases are exhaustive.

--- a/docs/match.md
+++ b/docs/match.md
@@ -144,31 +144,9 @@ route GET "/nested" {
 }
 ```
 
-Blocks may put `let` statements before the final nested match.
-
-```rut
-variant Auth { ok, denied }
-
-route GET "/nested-block" {
-    let auth = Auth.ok
-    match auth {
-    case .ok: {
-        let path = "/users"
-        match path {
-        case "/users":
-            return 200
-        case _:
-            return 404
-        }
-    }
-    case .denied:
-        return 403
-    }
-}
-```
-
-Nested route match currently rejects inner arm guards and inner payload bindings. Prefix `guard`
-statements before the nested match are also unsupported.
+Nested route match currently rejects inner arm guards, inner payload bindings, and prefix
+statements before the nested match. Keep any values used by the inner match in route scope instead
+of declaring them inside the outer arm.
 
 ## Source Function Match
 

--- a/docs/match.md
+++ b/docs/match.md
@@ -1,0 +1,197 @@
+# Match
+
+Rut supports `match` in routes and source functions.
+
+## Route Match
+
+```rut
+route GET "/status" {
+    let code = 200
+    match code {
+    case 200:
+        return 200
+    case _:
+        return 404
+    }
+}
+```
+
+Route match patterns can be integer, boolean, string, and variant cases. Non-exhaustive scalar
+matches need a wildcard arm.
+
+```rut
+route GET "/path" {
+    let path = "/users"
+    match path {
+    case "/users":
+        return 200
+    case _:
+        return 404
+    }
+}
+```
+
+Boolean matches are exhaustive when both `true` and `false` are present.
+
+```rut
+route GET "/enabled" {
+    let enabled = true
+    match enabled {
+    case true:
+        return 200
+    case false:
+        return 503
+    }
+}
+```
+
+## Variant Cases
+
+Variant cases can be matched with `.case` when the subject type is already known, or with
+`Variant.case` when the variant must be named explicitly.
+
+```rut
+variant Auth { ok, denied }
+
+route GET "/auth" {
+    let auth = Auth.ok
+    match auth {
+    case .ok:
+        return 200
+    case .denied:
+        return 403
+    }
+}
+```
+
+Payload cases can bind the payload for the arm body and arm guard.
+
+```rut
+variant Result { ok(i32), err }
+
+route GET "/result" {
+    let result = Result.ok(200)
+    match result {
+    case .ok(code) if code == 200:
+        return 200
+    case _:
+        return 500
+    }
+}
+```
+
+## Arm Guards
+
+An arm can add `if <bool-expr>` after the pattern. When the pattern matches but the guard is false,
+control falls through to the next arm.
+
+```rut
+route GET "/guarded" {
+    let code = 200
+    match code {
+    case 200 if false:
+        return 500
+    case _:
+        return 404
+    }
+}
+```
+
+Guarded route matches require a wildcard fallback unless the guard is produced by a supported nested
+match expansion.
+
+## Const Match
+
+`match const` selects an arm during analysis. The subject and selected pattern must be compile-time
+known.
+
+```rut
+route GET "/const" {
+    let path = "/users"
+    match const path {
+    case "/users":
+        return 200
+    case _:
+        return 404
+    }
+}
+```
+
+`match const` arms do not support arm guards.
+
+## Nested Route Match
+
+A route match arm can end in another route match. The compiler expands this into guarded outer arms,
+so the runtime path remains a flat branch chain.
+
+```rut
+variant Auth { ok, denied }
+
+route GET "/nested" {
+    let auth = Auth.ok
+    let path = "/users"
+    match auth {
+    case .ok:
+        match path {
+        case "/users":
+            return 200
+        case _:
+            return 404
+        }
+    case .denied:
+        return 403
+    }
+}
+```
+
+Blocks may put `let` statements before the final nested match.
+
+```rut
+variant Auth { ok, denied }
+
+route GET "/nested-block" {
+    let auth = Auth.ok
+    match auth {
+    case .ok: {
+        let path = "/users"
+        match path {
+        case "/users":
+            return 200
+        case _:
+            return 404
+        }
+    }
+    case .denied:
+        return 403
+    }
+}
+```
+
+Nested route match currently rejects inner arm guards and inner payload bindings. Prefix `guard`
+statements before the nested match are also unsupported.
+
+## Source Function Match
+
+Source functions use `=>` arms and return expressions.
+
+```rut
+func status(path: str) -> i32 {
+    match path {
+    case "/users" => 200
+    case _ => 404
+    }
+}
+```
+
+Function match supports arm guards and payload bindings.
+
+```rut
+variant Result { ok(i32), err }
+
+func pick(result: Result) -> i32 {
+    match result {
+    case .ok(code) if code == 200 => code
+    case _ => 404
+    }
+}
+```

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -180,6 +180,8 @@ struct AstStatement {
         Span span{};
         bool is_wildcard = false;
         AstExpr pattern{};
+        bool has_guard = false;
+        AstExpr* guard = nullptr;
         AstStatement* stmt = nullptr;
     };
     FixedVec<MatchArm, kMaxMatchArms> match_arms;
@@ -453,6 +455,7 @@ private:
         }
         for (u32 i = 0; i < stmt.match_arms.len; i++) {
             rebase_expr(other, stmt.match_arms[i].pattern);
+            rebase_expr_ptr(other, stmt.match_arms[i].guard);
             rebase_stmt_ptr(other, stmt.match_arms[i].stmt);
         }
     }

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -87,6 +87,7 @@ enum class HirExprKind : u8 {
     ValueOf,
     MissingOf,
     MatchPayload,
+    VariantTag,
     ProtocolCall,
     WaitResult,
     WaitField,

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -673,6 +673,8 @@ struct HirMatchArm {
     HirTypeKind bind_tuple_types[kMaxTupleSlots]{};
     u32 bind_tuple_variant_indices[kMaxTupleSlots]{};
     u32 bind_tuple_struct_indices[kMaxTupleSlots]{};
+    bool has_arm_guard = false;
+    HirExpr arm_guard{};
     BodyKind body_kind = BodyKind::Direct;
     static constexpr u32 kMaxPreludeGuards = 4;
     FixedVec<HirGuard, kMaxPreludeGuards> guards;
@@ -887,6 +889,7 @@ private:
         rebase_expr(control.match_expr, other);
         for (u32 i = 0; i < control.match_arms.len; i++) {
             rebase_expr(control.match_arms[i].pattern, other);
+            rebase_expr(control.match_arms[i].arm_guard, other);
             for (u32 gi = 0; gi < control.match_arms[i].guards.len; gi++) {
                 rebase_expr(control.match_arms[i].guards[gi].cond, other);
             }

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -45,6 +45,7 @@ enum class MirValueKind : u8 {
     ValueOf,
     MissingOf,
     MatchPayload,
+    VariantTag,
     WaitResult,
     WaitField,
 };

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5721,6 +5721,16 @@ static FrontendResult<void> collect_named_error_cases(
         auto rhs = collect_named_error_cases(*expr.rhs, cases);
         if (!rhs) return rhs;
     }
+    for (u32 i = 0; i < expr.field_inits.len; i++) {
+        if (expr.field_inits[i].value == nullptr) continue;
+        auto value = collect_named_error_cases(*expr.field_inits[i].value, cases);
+        if (!value) return value;
+    }
+    for (u32 i = 0; i < expr.args.len; i++) {
+        if (expr.args[i] == nullptr) continue;
+        auto arg = collect_named_error_cases(*expr.args[i], cases);
+        if (!arg) return arg;
+    }
     return {};
 }
 
@@ -5752,6 +5762,14 @@ static void patch_named_error_variant(
     }
     if (expr->lhs != nullptr) patch_named_error_variant(expr->lhs, variant_index, cases);
     if (expr->rhs != nullptr) patch_named_error_variant(expr->rhs, variant_index, cases);
+    for (u32 i = 0; i < expr->field_inits.len; i++) {
+        if (expr->field_inits[i].value != nullptr)
+            patch_named_error_variant(expr->field_inits[i].value, variant_index, cases);
+    }
+    for (u32 i = 0; i < expr->args.len; i++) {
+        if (expr->args[i] != nullptr)
+            patch_named_error_variant(expr->args[i], variant_index, cases);
+    }
 }
 
 static void patch_error_variant_refs(HirExpr* expr, u32 variant_index) {
@@ -5760,6 +5778,13 @@ static void patch_error_variant_refs(HirExpr* expr, u32 variant_index) {
         expr->error_variant_index = variant_index;
     if (expr->lhs != nullptr) patch_error_variant_refs(expr->lhs, variant_index);
     if (expr->rhs != nullptr) patch_error_variant_refs(expr->rhs, variant_index);
+    for (u32 i = 0; i < expr->field_inits.len; i++) {
+        if (expr->field_inits[i].value != nullptr)
+            patch_error_variant_refs(expr->field_inits[i].value, variant_index);
+    }
+    for (u32 i = 0; i < expr->args.len; i++) {
+        if (expr->args[i] != nullptr) patch_error_variant_refs(expr->args[i], variant_index);
+    }
 }
 
 static FrontendResult<HirTerminator> analyze_term(const AstStatement& stmt, const HirModule& mod) {
@@ -6662,17 +6687,21 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         if (matched && arm.has_guard) {
                             if (arm.guard == nullptr)
                                 return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                            const u32 expr_len_before_guard = route->exprs.len;
                             auto guard =
                                 analyze_expr(*arm.guard, route, mod, locals, local_count, binding);
                             if (!guard) return core::make_unexpected(guard.error());
                             if (guard->type != HirTypeKind::Bool || guard->may_nil ||
-                                guard->may_error)
+                                guard->may_error) {
+                                route->exprs.len = expr_len_before_guard;
                                 return frontend_error(FrontendError::UnsupportedSyntax,
                                                       arm.guard->span);
+                            }
                             ConstValue guard_value{};
-                            if (!const_eval_expr(
-                                    guard.value(), locals, local_count, &guard_value, 0) ||
-                                guard_value.type != HirTypeKind::Bool) {
+                            const bool const_guard = const_eval_expr(
+                                guard.value(), locals, local_count, &guard_value, 0);
+                            route->exprs.len = expr_len_before_guard;
+                            if (!const_guard || guard_value.type != HirTypeKind::Bool) {
                                 can_use_known_error_shortcut = false;
                                 break;
                             }
@@ -10932,6 +10961,11 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 collected = collect_named_error_cases(route.control.match_arms[ai].pattern,
                                                       named_error_cases);
                 if (!collected) return core::make_unexpected(collected.error());
+                if (route.control.match_arms[ai].has_arm_guard) {
+                    collected = collect_named_error_cases(route.control.match_arms[ai].arm_guard,
+                                                          named_error_cases);
+                    if (!collected) return core::make_unexpected(collected.error());
+                }
                 for (u32 gi = 0; gi < route.control.match_arms[ai].guards.len; gi++) {
                     collected = collect_named_error_cases(
                         route.control.match_arms[ai].guards[gi].cond, named_error_cases);
@@ -11009,6 +11043,13 @@ static FrontendResult<HirModule*> analyze_file_internal(
                                               named_error_cases);
                     patch_error_variant_refs(&route.control.match_arms[ai].pattern,
                                              route.error_variant_index);
+                    if (route.control.match_arms[ai].has_arm_guard) {
+                        patch_named_error_variant(&route.control.match_arms[ai].arm_guard,
+                                                  route.error_variant_index,
+                                                  named_error_cases);
+                        patch_error_variant_refs(&route.control.match_arms[ai].arm_guard,
+                                                 route.error_variant_index);
+                    }
                     for (u32 gi = 0; gi < route.control.match_arms[ai].guards.len; gi++) {
                         patch_named_error_variant(&route.control.match_arms[ai].guards[gi].cond,
                                                   route.error_variant_index,

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6167,6 +6167,8 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
         return analyze_match_arm_body(
             *selected_arm->stmt, arm, route, mod, locals, local_count, selected_binding_ptr);
     }
+    if (stmt.kind == AstStmtKind::Match)
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
     if (stmt.kind == AstStmtKind::Block) {
         FixedVec<HirLocal, HirRoute::kMaxLocals> scoped_locals;
         for (u32 i = 0; i < local_count; i++) {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5571,13 +5571,20 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
     }
     HirExpr analyzed_args[AstExpr::kMaxArgs]{};
     u32 placeholder_count = 0;
+    const HirExpr* placeholder_source = pipe_lhs;
     for (u32 i = 0; i < expr.args.len; i++) {
         const auto& arg_expr = *expr.args[i];
         if (arg_expr.kind == AstExprKind::Placeholder) {
             if (pipe_lhs == nullptr)
                 return frontend_error(FrontendError::UnsupportedSyntax, arg_expr.span);
             placeholder_count++;
-            auto slot_expr = placeholder_slot_expr(*pipe_lhs, arg_expr.int_value, arg_expr.span);
+            if (placeholder_source == pipe_lhs) {
+                if (!route->exprs.push(*pipe_lhs))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                placeholder_source = &route->exprs[route->exprs.len - 1];
+            }
+            auto slot_expr =
+                placeholder_slot_expr(*placeholder_source, arg_expr.int_value, arg_expr.span);
             if (!slot_expr) return core::make_unexpected(slot_expr.error());
             analyzed_args[i] = slot_expr.value();
         } else {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6820,68 +6820,10 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 nested_match_stmt = arm.stmt;
             } else if (can_expand_nested_match && arm.stmt != nullptr &&
                        arm.stmt->kind == AstStmtKind::Block && arm.stmt->block_stmts.len != 0) {
-                bool prefix_ok = true;
-                for (u32 bi = 0; bi + 1 < arm.stmt->block_stmts.len; bi++) {
-                    const auto& prefix = *arm.stmt->block_stmts[bi];
-                    if (prefix.kind != AstStmtKind::Let) {
-                        prefix_ok = false;
-                        break;
-                    }
-                }
                 const auto* last = arm.stmt->block_stmts[arm.stmt->block_stmts.len - 1];
-                if (prefix_ok && last->kind == AstStmtKind::Match && !last->is_const &&
-                    arm.stmt->block_stmts.len > 1) {
-                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
-                }
-                if (prefix_ok && last->kind == AstStmtKind::Match && !last->is_const) {
-                    for (u32 bi = 0; bi + 1 < arm.stmt->block_stmts.len; bi++) {
-                        const auto& prefix = *arm.stmt->block_stmts[bi];
-                        auto init = analyze_expr(
-                            prefix.expr, route, mod, nested_locals, nested_local_count, binding);
-                        if (!init) return core::make_unexpected(init.error());
-                        if (init->kind == HirExprKind::ArrayLit)
-                            return frontend_error(FrontendError::UnsupportedSyntax,
-                                                  prefix.expr.span);
-                        auto typed = apply_declared_type_to_expr(&init.value(), mod, prefix);
-                        if (!typed) return core::make_unexpected(typed.error());
-                        HirLocal local{};
-                        local.span = prefix.span;
-                        local.name = prefix.name;
-                        local.ref_index =
-                            next_local_ref_index(route, nested_locals, nested_local_count);
-                        local.type = init->type;
-                        local.generic_index = init->generic_index;
-                        local.generic_has_error_constraint = init->generic_has_error_constraint;
-                        local.generic_has_eq_constraint = init->generic_has_eq_constraint;
-                        local.generic_has_ord_constraint = init->generic_has_ord_constraint;
-                        local.generic_protocol_index = init->generic_protocol_index;
-                        local.generic_protocol_count = init->generic_protocol_count;
-                        for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
-                            local.generic_protocol_indices[cpi] =
-                                init->generic_protocol_indices[cpi];
-                        local.may_nil = init->may_nil;
-                        local.may_error = init->may_error;
-                        local.variant_index = init->variant_index;
-                        local.struct_index = init->struct_index;
-                        local.tuple_len = init->tuple_len;
-                        for (u32 ti = 0; ti < init->tuple_len; ti++) {
-                            local.tuple_types[ti] = init->tuple_types[ti];
-                            local.tuple_variant_indices[ti] = init->tuple_variant_indices[ti];
-                            local.tuple_struct_indices[ti] = init->tuple_struct_indices[ti];
-                        }
-                        local.error_struct_index = init->error_struct_index;
-                        local.error_variant_index = init->error_variant_index;
-                        local.shape_index = init->shape_index;
-                        local.init = init.value();
-                        if (!route->locals.push(local))
-                            return frontend_error(FrontendError::TooManyItems, prefix.span);
-                        auto inserted = insert_scoped_local(nested_locals,
-                                                            nested_local_count,
-                                                            HirRoute::kMaxLocals,
-                                                            local,
-                                                            prefix.span);
-                        if (!inserted) return core::make_unexpected(inserted.error());
-                    }
+                if (last->kind == AstStmtKind::Match && !last->is_const) {
+                    if (arm.stmt->block_stmts.len != 1)
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                     nested_match_stmt = last;
                 }
             }

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6547,6 +6547,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
             if (state != KnownValueState::Unknown) {
                 const AstStatement::MatchArm* wildcard_arm = nullptr;
                 const AstStatement::MatchArm* selected_arm = nullptr;
+                bool can_use_known_error_shortcut = true;
                 if (state == KnownValueState::Error) {
                     const auto err_case = known_error_case(subject.value(), locals, local_count, 0);
                     if (!err_case.known)
@@ -6571,6 +6572,25 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         } else {
                             matched = arm.pattern.str_value.eq(err_name);
                         }
+                        if (matched && arm.has_guard) {
+                            if (arm.guard == nullptr)
+                                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                            auto guard =
+                                analyze_expr(*arm.guard, route, mod, locals, local_count, binding);
+                            if (!guard) return core::make_unexpected(guard.error());
+                            if (guard->type != HirTypeKind::Bool || guard->may_nil ||
+                                guard->may_error)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      arm.guard->span);
+                            ConstValue guard_value{};
+                            if (!const_eval_expr(
+                                    guard.value(), locals, local_count, &guard_value, 0) ||
+                                guard_value.type != HirTypeKind::Bool) {
+                                can_use_known_error_shortcut = false;
+                                break;
+                            }
+                            if (!guard_value.bool_value) continue;
+                        }
                         if (matched) {
                             selected_arm = &arm;
                             break;
@@ -6585,10 +6605,12 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     }
                 }
 
-                if (selected_arm == nullptr) selected_arm = wildcard_arm;
-                if (selected_arm == nullptr)
-                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
-                return analyze_control_stmt(*selected_arm->stmt, route, mod, binding);
+                if (can_use_known_error_shortcut) {
+                    if (selected_arm == nullptr) selected_arm = wildcard_arm;
+                    if (selected_arm == nullptr)
+                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                    return analyze_control_stmt(*selected_arm->stmt, route, mod, binding);
+                }
             }
         }
 
@@ -6712,6 +6734,73 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                                                   nested_local_count,
                                                   binding);
                 if (!inner_subject) return core::make_unexpected(inner_subject.error());
+                if (nested_match_stmt->is_const) {
+                    ConstValue subject_value{};
+                    if (!const_eval_expr(inner_subject.value(),
+                                         nested_locals,
+                                         nested_local_count,
+                                         &subject_value,
+                                         0))
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              nested_match_stmt->expr.span);
+
+                    const AstStatement::MatchArm* wildcard_arm = nullptr;
+                    const AstStatement::MatchArm* selected_arm = nullptr;
+                    for (u32 iai = 0; iai < nested_match_stmt->match_arms.len; iai++) {
+                        const auto& inner_arm = nested_match_stmt->match_arms[iai];
+                        if (inner_arm.has_guard || inner_arm.pattern.lhs != nullptr)
+                            return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
+                        if (inner_arm.is_wildcard) {
+                            wildcard_arm = &inner_arm;
+                            continue;
+                        }
+                        auto inner_pattern = analyze_match_pattern(inner_arm.pattern,
+                                                                   inner_subject.value(),
+                                                                   route,
+                                                                   mod,
+                                                                   nested_locals,
+                                                                   nested_local_count);
+                        if (!inner_pattern) return core::make_unexpected(inner_pattern.error());
+                        bool matched = false;
+                        if (inner_pattern->kind == HirExprKind::BoolLit &&
+                            subject_value.type == HirTypeKind::Bool) {
+                            matched = inner_pattern->bool_value == subject_value.bool_value;
+                        } else if (inner_pattern->kind == HirExprKind::IntLit &&
+                                   subject_value.type == HirTypeKind::I32) {
+                            matched = inner_pattern->int_value == subject_value.int_value;
+                        } else if (inner_pattern->kind == HirExprKind::StrLit &&
+                                   subject_value.type == HirTypeKind::Str) {
+                            matched = inner_pattern->str_value.eq(subject_value.str_value);
+                        } else if (inner_pattern->kind == HirExprKind::VariantCase &&
+                                   subject_value.type == HirTypeKind::Variant) {
+                            matched = inner_pattern->variant_index == subject_value.variant_index &&
+                                      inner_pattern->case_index == subject_value.case_index;
+                        }
+                        if (matched) {
+                            selected_arm = &inner_arm;
+                            break;
+                        }
+                    }
+                    if (selected_arm == nullptr) selected_arm = wildcard_arm;
+                    if (selected_arm == nullptr)
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              nested_match_stmt->span);
+
+                    HirMatchArm hir_arm{};
+                    hir_arm.span = selected_arm->span;
+                    hir_arm.pattern = outer_pattern.value();
+                    auto body = analyze_match_arm_body(*selected_arm->stmt,
+                                                       &hir_arm,
+                                                       route,
+                                                       mod,
+                                                       nested_locals,
+                                                       nested_local_count,
+                                                       binding);
+                    if (!body) return core::make_unexpected(body.error());
+                    if (!route->control.match_arms.push(hir_arm))
+                        return frontend_error(FrontendError::TooManyItems, selected_arm->span);
+                    continue;
+                }
                 bool inner_seen_wildcard = false;
                 bool inner_seen_bool_true = false;
                 bool inner_seen_bool_false = false;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6738,14 +6738,16 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     !(subject_is_error_kind && outer_pattern->kind == HirExprKind::VariantCase))
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 if (outer_pattern->kind == HirExprKind::BoolLit) {
-                    bool& seen_bool_case =
-                        outer_pattern->bool_value ? seen_bool_true : seen_bool_false;
-                    if (seen_bool_case)
+                    bool& seen_unguarded_bool_case = outer_pattern->bool_value
+                                                         ? seen_unguarded_bool_true
+                                                         : seen_unguarded_bool_false;
+                    if (seen_unguarded_bool_case)
                         return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                     if (outer_pattern->bool_value)
                         seen_bool_true = true;
                     else
                         seen_bool_false = true;
+                    seen_unguarded_bool_case = true;
                 }
                 if (outer_pattern->kind == HirExprKind::VariantCase) {
                     if ((subject_is_error_kind &&

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3781,7 +3781,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 auto guard =
                     analyze_expr(*arm.guard, scratch, mod, locals, local_count, arm_binding_ptr);
                 if (!guard) return core::make_unexpected(guard.error());
-                if (guard->type != HirTypeKind::Bool)
+                if (guard->type != HirTypeKind::Bool || guard->may_nil || guard->may_error)
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.guard->span);
                 auto guarded = make_ifelse_expr(arm.span, guard.value(), body_expr, result);
                 if (!guarded) return core::make_unexpected(guarded.error());
@@ -6676,6 +6676,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 }
             }
             if (nested_match_stmt != nullptr) {
+                const u32 expanded_arm_start = route->control.match_arms.len;
                 if (seen_wildcard)
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 auto outer_pattern = analyze_match_pattern(
@@ -6784,17 +6785,27 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         return frontend_error(FrontendError::TooManyItems, inner_arm.span);
                 }
                 if (!inner_seen_wildcard) {
+                    bool inner_is_exhaustive = false;
                     if (inner_subject->type == HirTypeKind::Bool && inner_seen_bool_true &&
                         inner_seen_bool_false) {
-                        continue;
+                        inner_is_exhaustive = true;
+                    } else if (inner_subject->type == HirTypeKind::Variant) {
+                        const auto& variant = mod.variants[inner_subject->variant_index];
+                        inner_is_exhaustive = inner_seen_variant_case_count == variant.cases.len;
+                    } else {
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              nested_match_stmt->span);
                     }
-                    if (inner_subject->type != HirTypeKind::Variant)
+                    if (!inner_is_exhaustive)
                         return frontend_error(FrontendError::UnsupportedSyntax,
                                               nested_match_stmt->span);
-                    const auto& variant = mod.variants[inner_subject->variant_index];
-                    if (inner_seen_variant_case_count != variant.cases.len)
+                    if (route->control.match_arms.len <= expanded_arm_start)
                         return frontend_error(FrontendError::UnsupportedSyntax,
                                               nested_match_stmt->span);
+                    auto& fallback_arm =
+                        route->control.match_arms[route->control.match_arms.len - 1];
+                    fallback_arm.has_arm_guard = false;
+                    fallback_arm.arm_guard = HirExpr{};
                 }
                 continue;
             }
@@ -6894,7 +6905,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 auto guard =
                     analyze_expr(*arm.guard, route, mod, locals, local_count, arm_binding_ptr);
                 if (!guard) return core::make_unexpected(guard.error());
-                if (guard->type != HirTypeKind::Bool)
+                if (guard->type != HirTypeKind::Bool || guard->may_nil || guard->may_error)
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.guard->span);
                 hir_arm.has_arm_guard = true;
                 hir_arm.arm_guard = guard.value();

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -238,6 +238,7 @@ struct ConstValue {
     HirTypeKind type = HirTypeKind::Unknown;
     bool bool_value = false;
     i32 int_value = 0;
+    Str str_value{};
     u32 variant_index = 0;
     u32 case_index = 0;
 };
@@ -3532,6 +3533,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
 
         for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
             const auto& arm = stmt.match_arms[ai];
+            if (arm.has_guard) return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
             if (arm.is_wildcard) {
                 wildcard_arm = &arm;
                 continue;
@@ -3546,6 +3548,9 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
             } else if (pattern->kind == HirExprKind::IntLit &&
                        subject_value.type == HirTypeKind::I32) {
                 matched = pattern->int_value == subject_value.int_value;
+            } else if (pattern->kind == HirExprKind::StrLit &&
+                       subject_value.type == HirTypeKind::Str) {
+                matched = pattern->str_value.eq(subject_value.str_value);
             } else if (pattern->kind == HirExprKind::VariantCase &&
                        subject_value.type == HirTypeKind::Variant) {
                 matched = pattern->variant_index == subject_value.variant_index &&
@@ -3635,14 +3640,63 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
         const HirExpr* subject_ptr = &scratch->exprs[scratch->exprs.len - 1];
 
         bool seen_wildcard = false;
+        bool seen_guarded_arm = false;
+        bool seen_bool_true = false;
+        bool seen_bool_false = false;
         bool seen_variant_cases[HirVariant::kMaxCases]{};
         u32 seen_variant_case_count = 0;
         HirExpr result{};
         bool have_result = false;
+        auto make_ifelse_expr = [&](Span span,
+                                    const HirExpr& cond,
+                                    const HirExpr& then_expr,
+                                    const HirExpr& else_expr) -> FrontendResult<HirExpr> {
+            HirExpr merged_shape{};
+            if (!merge_expr_shape(then_expr, else_expr, &merged_shape))
+                return frontend_error(FrontendError::UnsupportedSyntax, span);
+            HirExpr out{};
+            out.kind = HirExprKind::IfElse;
+            out.type = merged_shape.type;
+            out.generic_index = merged_shape.generic_index;
+            out.generic_has_error_constraint = merged_shape.generic_has_error_constraint;
+            out.generic_has_eq_constraint = merged_shape.generic_has_eq_constraint;
+            out.generic_has_ord_constraint = merged_shape.generic_has_ord_constraint;
+            out.generic_protocol_index = merged_shape.generic_protocol_index;
+            out.generic_protocol_count = merged_shape.generic_protocol_count;
+            for (u32 cpi = 0; cpi < out.generic_protocol_count; cpi++)
+                out.generic_protocol_indices[cpi] = merged_shape.generic_protocol_indices[cpi];
+            out.may_nil = merged_shape.may_nil;
+            out.may_error = merged_shape.may_error;
+            out.variant_index = merged_shape.variant_index;
+            out.struct_index = merged_shape.struct_index;
+            out.tuple_len = merged_shape.tuple_len;
+            for (u32 i = 0; i < merged_shape.tuple_len; i++) {
+                out.tuple_types[i] = merged_shape.tuple_types[i];
+                out.tuple_variant_indices[i] = merged_shape.tuple_variant_indices[i];
+                out.tuple_struct_indices[i] = merged_shape.tuple_struct_indices[i];
+            }
+            out.error_struct_index = merged_shape.error_struct_index;
+            out.error_variant_index = merged_shape.error_variant_index;
+            out.shape_index = merged_shape.shape_index;
+            out.span = span;
+            if (!scratch->exprs.push(cond))
+                return frontend_error(FrontendError::TooManyItems, span);
+            out.lhs = &scratch->exprs[scratch->exprs.len - 1];
+            if (!scratch->exprs.push(then_expr))
+                return frontend_error(FrontendError::TooManyItems, span);
+            out.rhs = &scratch->exprs[scratch->exprs.len - 1];
+            if (!scratch->exprs.push(else_expr))
+                return frontend_error(FrontendError::TooManyItems, span);
+            if (!out.args.push(&scratch->exprs[scratch->exprs.len - 1]))
+                return frontend_error(FrontendError::TooManyItems, span);
+            return out;
+        };
 
         for (i32 ai = static_cast<i32>(stmt.match_arms.len) - 1; ai >= 0; ai--) {
             const auto& arm = stmt.match_arms[static_cast<u32>(ai)];
             if (arm.is_wildcard) {
+                if (arm.has_guard)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 if (seen_wildcard)
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 seen_wildcard = true;
@@ -3658,7 +3712,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 arm.pattern, subject.value(), scratch, mod, locals, local_count);
             if (!pattern) return core::make_unexpected(pattern.error());
             if (pattern->kind != HirExprKind::BoolLit && pattern->kind != HirExprKind::IntLit &&
-                pattern->kind != HirExprKind::VariantCase)
+                pattern->kind != HirExprKind::StrLit && pattern->kind != HirExprKind::VariantCase)
                 return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
             if (pattern->type != subject->type)
                 return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
@@ -3672,6 +3726,11 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 seen_variant_cases[case_index] = true;
                 seen_variant_case_count++;
+            } else if (pattern->type == HirTypeKind::Bool) {
+                if (pattern->bool_value)
+                    seen_bool_true = true;
+                else
+                    seen_bool_false = true;
             }
 
             MatchPayloadBinding arm_binding{};
@@ -3714,14 +3773,26 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
             auto body = analyze_function_body_stmt(
                 *arm.stmt, scratch, mod, locals, local_count, arm_binding_ptr);
             if (!body) return core::make_unexpected(body.error());
+            HirExpr body_expr = body.value();
+            if (arm.has_guard) {
+                if (!have_result) return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (arm.guard == nullptr)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                auto guard =
+                    analyze_expr(*arm.guard, scratch, mod, locals, local_count, arm_binding_ptr);
+                if (!guard) return core::make_unexpected(guard.error());
+                if (guard->type != HirTypeKind::Bool)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.guard->span);
+                auto guarded = make_ifelse_expr(arm.span, guard.value(), body_expr, result);
+                if (!guarded) return core::make_unexpected(guarded.error());
+                body_expr = guarded.value();
+                seen_guarded_arm = true;
+            }
             if (!have_result) {
-                result = body.value();
+                result = body_expr;
                 have_result = true;
                 continue;
             }
-            HirExpr merged_shape{};
-            if (!merge_expr_shape(body.value(), result, &merged_shape))
-                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
 
             HirExpr cond{};
             cond.kind = HirExprKind::Eq;
@@ -3734,48 +3805,19 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 return frontend_error(FrontendError::TooManyItems, arm.span);
             cond.rhs = &scratch->exprs[scratch->exprs.len - 1];
 
-            HirExpr out{};
-            out.kind = HirExprKind::IfElse;
-            out.type = merged_shape.type;
-            out.generic_index = merged_shape.generic_index;
-            out.generic_has_error_constraint = merged_shape.generic_has_error_constraint;
-            out.generic_has_eq_constraint = merged_shape.generic_has_eq_constraint;
-            out.generic_has_ord_constraint = merged_shape.generic_has_ord_constraint;
-            out.generic_protocol_index = merged_shape.generic_protocol_index;
-            out.generic_protocol_count = merged_shape.generic_protocol_count;
-            for (u32 cpi = 0; cpi < out.generic_protocol_count; cpi++)
-                out.generic_protocol_indices[cpi] = merged_shape.generic_protocol_indices[cpi];
-            out.may_nil = merged_shape.may_nil;
-            out.may_error = merged_shape.may_error;
-            out.variant_index = merged_shape.variant_index;
-            out.struct_index = merged_shape.struct_index;
-            out.tuple_len = merged_shape.tuple_len;
-            for (u32 i = 0; i < merged_shape.tuple_len; i++) {
-                out.tuple_types[i] = merged_shape.tuple_types[i];
-                out.tuple_variant_indices[i] = merged_shape.tuple_variant_indices[i];
-                out.tuple_struct_indices[i] = merged_shape.tuple_struct_indices[i];
-            }
-            out.error_struct_index = merged_shape.error_struct_index;
-            out.error_variant_index = merged_shape.error_variant_index;
-            out.shape_index = merged_shape.shape_index;
-            out.span = stmt.span;
-            if (!scratch->exprs.push(cond))
-                return frontend_error(FrontendError::TooManyItems, arm.span);
-            out.lhs = &scratch->exprs[scratch->exprs.len - 1];
-            if (!scratch->exprs.push(body.value()))
-                return frontend_error(FrontendError::TooManyItems, arm.span);
-            out.rhs = &scratch->exprs[scratch->exprs.len - 1];
-            if (!scratch->exprs.push(result))
-                return frontend_error(FrontendError::TooManyItems, arm.span);
-            if (!out.args.push(&scratch->exprs[scratch->exprs.len - 1]))
-                return frontend_error(FrontendError::TooManyItems, arm.span);
-            result = out;
+            auto out = make_ifelse_expr(stmt.span, cond, body_expr, result);
+            if (!out) return core::make_unexpected(out.error());
+            result = out.value();
         }
 
         if (!have_result) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
         if (result.type == HirTypeKind::Unknown && !result.may_nil && !result.may_error)
             return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
         if (!seen_wildcard) {
+            if (seen_guarded_arm)
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+            if (subject->type == HirTypeKind::Bool && seen_bool_true && seen_bool_false)
+                return result;
             if (subject->type != HirTypeKind::Variant)
                 return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
             const auto& variant = mod.variants[subject->variant_index];
@@ -5905,6 +5947,11 @@ static bool const_eval_expr(
         out->int_value = expr.int_value;
         return true;
     }
+    if (expr.kind == HirExprKind::StrLit) {
+        out->type = HirTypeKind::Str;
+        out->str_value = expr.str_value;
+        return true;
+    }
     if (expr.kind == HirExprKind::ConstMethod) {
         // Method literals (POST, GET, …) are compile-time constants;
         // fold them so `if const POST == GET { ... }` works.
@@ -5937,6 +5984,10 @@ static bool const_eval_expr(
             }
             if (lhs.type == HirTypeKind::I32 || lhs.type == HirTypeKind::Method) {
                 out->bool_value = lhs.int_value == rhs.int_value;
+                return true;
+            }
+            if (lhs.type == HirTypeKind::Str) {
+                out->bool_value = lhs.str_value.eq(rhs.str_value);
                 return true;
             }
             if (lhs.type == HirTypeKind::Variant) {
@@ -6320,6 +6371,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
 
         for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
             const auto& arm = stmt.match_arms[ai];
+            if (arm.has_guard) return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
             if (arm.is_wildcard) {
                 wildcard_arm = &arm;
                 continue;
@@ -6334,6 +6386,9 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
             } else if (pattern->kind == HirExprKind::IntLit &&
                        subject_value.type == HirTypeKind::I32) {
                 matched = pattern->int_value == subject_value.int_value;
+            } else if (pattern->kind == HirExprKind::StrLit &&
+                       subject_value.type == HirTypeKind::Str) {
+                matched = pattern->str_value.eq(subject_value.str_value);
             } else if (pattern->kind == HirExprKind::VariantCase &&
                        subject_value.type == HirTypeKind::Variant) {
                 matched = pattern->variant_index == subject_value.variant_index &&
@@ -6539,24 +6594,214 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         route->control.kind = HirControlKind::Match;
         route->control.match_expr = subject.value();
         bool seen_wildcard = false;
+        bool seen_guarded_arm = false;
+        bool seen_bool_true = false;
+        bool seen_bool_false = false;
         bool seen_variant_cases[HirVariant::kMaxCases]{};
         u32 seen_variant_case_count = 0;
         route->control.match_arms.len = 0;
         for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
             const auto& arm = stmt.match_arms[ai];
+            const AstStatement* nested_match_stmt = nullptr;
+            HirLocal nested_locals[HirRoute::kMaxLocals]{};
+            u32 nested_local_count = local_count;
+            for (u32 li = 0; li < local_count; li++) nested_locals[li] = locals[li];
+            const bool can_expand_nested_match =
+                !arm.is_wildcard && !arm.has_guard && arm.pattern.lhs == nullptr;
+            if (can_expand_nested_match && arm.stmt != nullptr &&
+                arm.stmt->kind == AstStmtKind::Match) {
+                nested_match_stmt = arm.stmt;
+            } else if (can_expand_nested_match && arm.stmt != nullptr &&
+                       arm.stmt->kind == AstStmtKind::Block && arm.stmt->block_stmts.len != 0) {
+                bool prefix_ok = true;
+                for (u32 bi = 0; bi + 1 < arm.stmt->block_stmts.len; bi++) {
+                    const auto& prefix = *arm.stmt->block_stmts[bi];
+                    if (prefix.kind != AstStmtKind::Let) {
+                        prefix_ok = false;
+                        break;
+                    }
+                    auto init = analyze_expr(
+                        prefix.expr, route, mod, nested_locals, nested_local_count, binding);
+                    if (!init) return core::make_unexpected(init.error());
+                    if (init->kind == HirExprKind::ArrayLit)
+                        return frontend_error(FrontendError::UnsupportedSyntax, prefix.expr.span);
+                    auto typed = apply_declared_type_to_expr(&init.value(), mod, prefix);
+                    if (!typed) return core::make_unexpected(typed.error());
+                    if (nested_local_count >= HirRoute::kMaxLocals)
+                        return frontend_error(FrontendError::TooManyItems, prefix.span);
+                    HirLocal local{};
+                    local.span = prefix.span;
+                    local.name = prefix.name;
+                    local.ref_index =
+                        next_local_ref_index(route, nested_locals, nested_local_count);
+                    local.type = init->type;
+                    local.generic_index = init->generic_index;
+                    local.generic_has_error_constraint = init->generic_has_error_constraint;
+                    local.generic_has_eq_constraint = init->generic_has_eq_constraint;
+                    local.generic_has_ord_constraint = init->generic_has_ord_constraint;
+                    local.generic_protocol_index = init->generic_protocol_index;
+                    local.generic_protocol_count = init->generic_protocol_count;
+                    for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                        local.generic_protocol_indices[cpi] = init->generic_protocol_indices[cpi];
+                    local.may_nil = init->may_nil;
+                    local.may_error = init->may_error;
+                    local.variant_index = init->variant_index;
+                    local.struct_index = init->struct_index;
+                    local.tuple_len = init->tuple_len;
+                    for (u32 ti = 0; ti < init->tuple_len; ti++) {
+                        local.tuple_types[ti] = init->tuple_types[ti];
+                        local.tuple_variant_indices[ti] = init->tuple_variant_indices[ti];
+                        local.tuple_struct_indices[ti] = init->tuple_struct_indices[ti];
+                    }
+                    local.error_struct_index = init->error_struct_index;
+                    local.error_variant_index = init->error_variant_index;
+                    local.shape_index = init->shape_index;
+                    local.init = init.value();
+                    if (!route->locals.push(local))
+                        return frontend_error(FrontendError::TooManyItems, prefix.span);
+                    nested_locals[nested_local_count++] = local;
+                }
+                const auto* last = arm.stmt->block_stmts[arm.stmt->block_stmts.len - 1];
+                if (prefix_ok && last->kind == AstStmtKind::Match) nested_match_stmt = last;
+            }
+            if (nested_match_stmt != nullptr) {
+                if (seen_wildcard)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                auto outer_pattern = analyze_match_pattern(
+                    arm.pattern, subject.value(), route, mod, locals, local_count);
+                if (!outer_pattern) return core::make_unexpected(outer_pattern.error());
+                if (outer_pattern->kind != HirExprKind::BoolLit &&
+                    outer_pattern->kind != HirExprKind::IntLit &&
+                    outer_pattern->kind != HirExprKind::StrLit &&
+                    outer_pattern->kind != HirExprKind::VariantCase)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (outer_pattern->type != subject->type &&
+                    !(subject_is_error_kind && outer_pattern->kind == HirExprKind::VariantCase))
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (outer_pattern->kind == HirExprKind::BoolLit) {
+                    if (outer_pattern->bool_value)
+                        seen_bool_true = true;
+                    else
+                        seen_bool_false = true;
+                }
+                if (outer_pattern->kind == HirExprKind::VariantCase) {
+                    const u32 case_index = static_cast<u32>(outer_pattern->int_value);
+                    if (case_index >= HirVariant::kMaxCases)
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                    if (!seen_variant_cases[case_index]) {
+                        seen_variant_cases[case_index] = true;
+                        seen_variant_case_count++;
+                    }
+                }
+                auto inner_subject = analyze_expr(nested_match_stmt->expr,
+                                                  route,
+                                                  mod,
+                                                  nested_locals,
+                                                  nested_local_count,
+                                                  binding);
+                if (!inner_subject) return core::make_unexpected(inner_subject.error());
+                bool inner_seen_wildcard = false;
+                bool inner_seen_bool_true = false;
+                bool inner_seen_bool_false = false;
+                bool inner_seen_variant_cases[HirVariant::kMaxCases]{};
+                u32 inner_seen_variant_case_count = 0;
+                for (u32 iai = 0; iai < nested_match_stmt->match_arms.len; iai++) {
+                    const auto& inner_arm = nested_match_stmt->match_arms[iai];
+                    if (inner_arm.has_guard || inner_arm.pattern.lhs != nullptr)
+                        return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
+                    if (inner_seen_wildcard)
+                        return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
+                    HirMatchArm hir_arm{};
+                    hir_arm.span = inner_arm.span;
+                    hir_arm.pattern = outer_pattern.value();
+                    if (!inner_arm.is_wildcard) {
+                        auto inner_pattern = analyze_match_pattern(inner_arm.pattern,
+                                                                   inner_subject.value(),
+                                                                   route,
+                                                                   mod,
+                                                                   nested_locals,
+                                                                   nested_local_count);
+                        if (!inner_pattern) return core::make_unexpected(inner_pattern.error());
+                        if (inner_pattern->kind != HirExprKind::BoolLit &&
+                            inner_pattern->kind != HirExprKind::IntLit &&
+                            inner_pattern->kind != HirExprKind::StrLit &&
+                            inner_pattern->kind != HirExprKind::VariantCase)
+                            return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
+                        if (inner_pattern->type != inner_subject->type)
+                            return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
+                        if (inner_pattern->kind == HirExprKind::BoolLit) {
+                            if (inner_pattern->bool_value)
+                                inner_seen_bool_true = true;
+                            else
+                                inner_seen_bool_false = true;
+                        }
+                        if (inner_pattern->kind == HirExprKind::VariantCase) {
+                            const u32 case_index = static_cast<u32>(inner_pattern->int_value);
+                            if (case_index >= HirVariant::kMaxCases)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_arm.span);
+                            if (inner_seen_variant_cases[case_index])
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_arm.span);
+                            inner_seen_variant_cases[case_index] = true;
+                            inner_seen_variant_case_count++;
+                        }
+                        HirExpr cond{};
+                        cond.kind = HirExprKind::Eq;
+                        cond.type = HirTypeKind::Bool;
+                        cond.span = inner_arm.span;
+                        if (!route->exprs.push(inner_subject.value()))
+                            return frontend_error(FrontendError::TooManyItems, inner_arm.span);
+                        cond.lhs = &route->exprs[route->exprs.len - 1];
+                        if (!route->exprs.push(inner_pattern.value()))
+                            return frontend_error(FrontendError::TooManyItems, inner_arm.span);
+                        cond.rhs = &route->exprs[route->exprs.len - 1];
+                        hir_arm.has_arm_guard = true;
+                        hir_arm.arm_guard = cond;
+                    } else {
+                        inner_seen_wildcard = true;
+                    }
+                    auto body = analyze_match_arm_body(*inner_arm.stmt,
+                                                       &hir_arm,
+                                                       route,
+                                                       mod,
+                                                       nested_locals,
+                                                       nested_local_count,
+                                                       binding);
+                    if (!body) return core::make_unexpected(body.error());
+                    if (!route->control.match_arms.push(hir_arm))
+                        return frontend_error(FrontendError::TooManyItems, inner_arm.span);
+                }
+                if (!inner_seen_wildcard) {
+                    if (inner_subject->type == HirTypeKind::Bool && inner_seen_bool_true &&
+                        inner_seen_bool_false) {
+                        continue;
+                    }
+                    if (inner_subject->type != HirTypeKind::Variant)
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              nested_match_stmt->span);
+                    const auto& variant = mod.variants[inner_subject->variant_index];
+                    if (inner_seen_variant_case_count != variant.cases.len)
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              nested_match_stmt->span);
+                }
+                continue;
+            }
             HirMatchArm hir_arm{};
             hir_arm.span = arm.span;
             hir_arm.is_wildcard = arm.is_wildcard;
             MatchPayloadBinding arm_binding{};
             const MatchPayloadBinding* arm_binding_ptr = binding;
             if (seen_wildcard) return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+            if (arm.is_wildcard && arm.has_guard)
+                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
             if (!arm.is_wildcard) {
                 auto analyzed_pattern = analyze_match_pattern(
                     arm.pattern, subject.value(), route, mod, locals, local_count);
                 if (!analyzed_pattern) return core::make_unexpected(analyzed_pattern.error());
                 HirExpr pattern = analyzed_pattern.value();
                 if (pattern.kind != HirExprKind::BoolLit && pattern.kind != HirExprKind::IntLit &&
-                    pattern.kind != HirExprKind::VariantCase)
+                    pattern.kind != HirExprKind::StrLit && pattern.kind != HirExprKind::VariantCase)
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 if (pattern.type != subject->type &&
                     !(subject_is_error_kind && pattern.kind == HirExprKind::VariantCase))
@@ -6566,6 +6811,12 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                       pattern.variant_index != subject->error_variant_index) ||
                      (!subject_is_error_kind && pattern.variant_index != subject->variant_index)))
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (pattern.kind == HirExprKind::BoolLit) {
+                    if (pattern.bool_value)
+                        seen_bool_true = true;
+                    else
+                        seen_bool_false = true;
+                }
                 if (pattern.kind == HirExprKind::VariantCase) {
                     const u32 case_index = static_cast<u32>(pattern.int_value);
                     if (case_index >= HirVariant::kMaxCases)
@@ -6626,6 +6877,18 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
             } else {
                 seen_wildcard = true;
             }
+            if (arm.has_guard) {
+                if (arm.guard == nullptr)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                auto guard =
+                    analyze_expr(*arm.guard, route, mod, locals, local_count, arm_binding_ptr);
+                if (!guard) return core::make_unexpected(guard.error());
+                if (guard->type != HirTypeKind::Bool)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.guard->span);
+                hir_arm.has_arm_guard = true;
+                hir_arm.arm_guard = guard.value();
+                seen_guarded_arm = true;
+            }
             auto body = analyze_match_arm_body(
                 *arm.stmt, &hir_arm, route, mod, locals, local_count, arm_binding_ptr);
             if (!body) return core::make_unexpected(body.error());
@@ -6633,6 +6896,9 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 return frontend_error(FrontendError::TooManyItems, arm.span);
         }
         if (!seen_wildcard) {
+            if (seen_guarded_arm)
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+            if (subject->type == HirTypeKind::Bool && seen_bool_true && seen_bool_false) return {};
             if (subject->type != HirTypeKind::Variant && !subject_is_error_kind)
                 return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
             const auto& variant = mod.variants[subject_is_error_kind ? subject->error_variant_index

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6820,11 +6820,14 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 nested_match_stmt = arm.stmt;
             } else if (can_expand_nested_match && arm.stmt != nullptr &&
                        arm.stmt->kind == AstStmtKind::Block && arm.stmt->block_stmts.len != 0) {
-                const auto* last = arm.stmt->block_stmts[arm.stmt->block_stmts.len - 1];
-                if (last->kind == AstStmtKind::Match && !last->is_const) {
-                    if (arm.stmt->block_stmts.len != 1)
+                if (arm.stmt->block_stmts.len == 1) {
+                    const auto* only = arm.stmt->block_stmts[0];
+                    if (only->kind == AstStmtKind::Match && !only->is_const)
+                        nested_match_stmt = only;
+                } else {
+                    const auto* last = arm.stmt->block_stmts[arm.stmt->block_stmts.len - 1];
+                    if (last->kind == AstStmtKind::Match && !last->is_const)
                         return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
-                    nested_match_stmt = last;
                 }
             }
             if (nested_match_stmt != nullptr) {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5691,6 +5691,10 @@ static FrontendResult<void> collect_named_error_cases_ast(
     for (u32 i = 0; i < stmt.match_arms.len; i++) {
         auto pattern_cases = collect_named_error_cases_ast_expr(stmt.match_arms[i].pattern, cases);
         if (!pattern_cases) return pattern_cases;
+        if (stmt.match_arms[i].guard != nullptr) {
+            auto guard_cases = collect_named_error_cases_ast_expr(*stmt.match_arms[i].guard, cases);
+            if (!guard_cases) return guard_cases;
+        }
         if (stmt.match_arms[i].stmt != nullptr) {
             auto body_cases = collect_named_error_cases_ast(*stmt.match_arms[i].stmt, cases);
             if (!body_cases) return body_cases;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3670,6 +3670,44 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 return frontend_error(FrontendError::TooManyItems, span);
             return out;
         };
+        auto make_match_condition = [&](Span span,
+                                        const HirExpr& subject_expr,
+                                        const HirExpr& pattern_expr) -> FrontendResult<HirExpr> {
+            HirExpr cond{};
+            cond.kind = HirExprKind::Eq;
+            cond.type = HirTypeKind::Bool;
+            cond.span = span;
+            if (pattern_expr.kind == HirExprKind::VariantCase) {
+                HirExpr tag{};
+                tag.kind = HirExprKind::VariantTag;
+                tag.type = HirTypeKind::I32;
+                tag.span = span;
+                tag.variant_index = pattern_expr.variant_index;
+                if (!scratch->exprs.push(subject_expr))
+                    return frontend_error(FrontendError::TooManyItems, span);
+                tag.lhs = &scratch->exprs[scratch->exprs.len - 1];
+
+                HirExpr case_index{};
+                case_index.kind = HirExprKind::IntLit;
+                case_index.type = HirTypeKind::I32;
+                case_index.span = span;
+                case_index.int_value = pattern_expr.int_value;
+                if (!scratch->exprs.push(tag))
+                    return frontend_error(FrontendError::TooManyItems, span);
+                cond.lhs = &scratch->exprs[scratch->exprs.len - 1];
+                if (!scratch->exprs.push(case_index))
+                    return frontend_error(FrontendError::TooManyItems, span);
+                cond.rhs = &scratch->exprs[scratch->exprs.len - 1];
+                return cond;
+            }
+            if (!scratch->exprs.push(subject_expr))
+                return frontend_error(FrontendError::TooManyItems, span);
+            cond.lhs = &scratch->exprs[scratch->exprs.len - 1];
+            if (!scratch->exprs.push(pattern_expr))
+                return frontend_error(FrontendError::TooManyItems, span);
+            cond.rhs = &scratch->exprs[scratch->exprs.len - 1];
+            return cond;
+        };
 
         for (i32 ai = static_cast<i32>(stmt.match_arms.len) - 1; ai >= 0; ai--) {
             const auto& arm = stmt.match_arms[static_cast<u32>(ai)];
@@ -3720,11 +3758,8 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 const u32 case_index = static_cast<u32>(pattern->int_value);
                 const auto& case_decl = mod.variants[pattern->variant_index].cases[case_index];
                 if (case_decl.has_payload && arm.pattern.lhs != nullptr) {
-                    bind_match_payload(&arm_binding,
-                                       arm.pattern.lhs->name,
-                                       case_decl,
-                                       case_index,
-                                       subject_ptr);
+                    bind_match_payload(
+                        &arm_binding, arm.pattern.lhs->name, case_decl, case_index, subject_ptr);
                     arm_binding_ptr = &arm_binding;
                 }
             }
@@ -3753,18 +3788,10 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 continue;
             }
 
-            HirExpr cond{};
-            cond.kind = HirExprKind::Eq;
-            cond.type = HirTypeKind::Bool;
-            cond.span = arm.span;
-            if (!scratch->exprs.push(*subject_ptr))
-                return frontend_error(FrontendError::TooManyItems, arm.span);
-            cond.lhs = &scratch->exprs[scratch->exprs.len - 1];
-            if (!scratch->exprs.push(pattern.value()))
-                return frontend_error(FrontendError::TooManyItems, arm.span);
-            cond.rhs = &scratch->exprs[scratch->exprs.len - 1];
+            auto cond = make_match_condition(arm.span, *subject_ptr, pattern.value());
+            if (!cond) return core::make_unexpected(cond.error());
 
-            auto out = make_ifelse_expr(stmt.span, cond, body_expr, result);
+            auto out = make_ifelse_expr(stmt.span, cond.value(), body_expr, result);
             if (!out) return core::make_unexpected(out.error());
             result = out.value();
         }
@@ -6555,25 +6582,25 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
             (subject->error_variant_index != 0xffffffffu ||
              (state == KnownValueState::Error && err_name.len != 0))) {
             if (state != KnownValueState::Unknown) {
-            const AstStatement::MatchArm* wildcard_arm = nullptr;
-            const AstStatement::MatchArm* selected_arm = nullptr;
-            bool can_use_known_error_shortcut = true;
-            for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
-                if (stmt.match_arms[ai].is_wildcard && stmt.match_arms[ai].has_guard)
-                    return frontend_error(FrontendError::UnsupportedSyntax,
-                                          stmt.match_arms[ai].span);
-            }
-            if (state == KnownValueState::Error) {
-                const auto err_case = known_error_case(subject.value(), locals, local_count, 0);
-                if (!err_case.known)
-                    if (err_name.len == 0)
-                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                const AstStatement::MatchArm* wildcard_arm = nullptr;
+                const AstStatement::MatchArm* selected_arm = nullptr;
+                bool can_use_known_error_shortcut = true;
                 for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
-                    const auto& arm = stmt.match_arms[ai];
-                    if (arm.is_wildcard) {
-                        wildcard_arm = &arm;
-                        continue;
-                    }
+                    if (stmt.match_arms[ai].is_wildcard && stmt.match_arms[ai].has_guard)
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              stmt.match_arms[ai].span);
+                }
+                if (state == KnownValueState::Error) {
+                    const auto err_case = known_error_case(subject.value(), locals, local_count, 0);
+                    if (!err_case.known)
+                        if (err_name.len == 0)
+                            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                    for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+                        const auto& arm = stmt.match_arms[ai];
+                        if (arm.is_wildcard) {
+                            wildcard_arm = &arm;
+                            continue;
+                        }
                         if (arm.pattern.kind != AstExprKind::VariantCase)
                             return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                         bool matched = false;
@@ -6636,11 +6663,11 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         }
                     }
                 } else {
-                for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
-                    if (stmt.match_arms[ai].is_wildcard) {
-                        wildcard_arm = &stmt.match_arms[ai];
-                        break;
-                    }
+                    for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+                        if (stmt.match_arms[ai].is_wildcard) {
+                            wildcard_arm = &stmt.match_arms[ai];
+                            break;
+                        }
                     }
                 }
 

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5814,6 +5814,7 @@ static FrontendResult<void> analyze_guard_match_arms(
     guard->fail_match_count = 0;
     for (u32 ai = 0; ai < ast_arms.len; ai++) {
         const auto& arm = ast_arms[ai];
+        if (arm.has_guard) return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
         HirGuardMatchArm hir_arm{};
         hir_arm.span = arm.span;
         hir_arm.is_wildcard = arm.is_wildcard;
@@ -6620,49 +6621,59 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         prefix_ok = false;
                         break;
                     }
-                    auto init = analyze_expr(
-                        prefix.expr, route, mod, nested_locals, nested_local_count, binding);
-                    if (!init) return core::make_unexpected(init.error());
-                    if (init->kind == HirExprKind::ArrayLit)
-                        return frontend_error(FrontendError::UnsupportedSyntax, prefix.expr.span);
-                    auto typed = apply_declared_type_to_expr(&init.value(), mod, prefix);
-                    if (!typed) return core::make_unexpected(typed.error());
-                    if (nested_local_count >= HirRoute::kMaxLocals)
-                        return frontend_error(FrontendError::TooManyItems, prefix.span);
-                    HirLocal local{};
-                    local.span = prefix.span;
-                    local.name = prefix.name;
-                    local.ref_index =
-                        next_local_ref_index(route, nested_locals, nested_local_count);
-                    local.type = init->type;
-                    local.generic_index = init->generic_index;
-                    local.generic_has_error_constraint = init->generic_has_error_constraint;
-                    local.generic_has_eq_constraint = init->generic_has_eq_constraint;
-                    local.generic_has_ord_constraint = init->generic_has_ord_constraint;
-                    local.generic_protocol_index = init->generic_protocol_index;
-                    local.generic_protocol_count = init->generic_protocol_count;
-                    for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
-                        local.generic_protocol_indices[cpi] = init->generic_protocol_indices[cpi];
-                    local.may_nil = init->may_nil;
-                    local.may_error = init->may_error;
-                    local.variant_index = init->variant_index;
-                    local.struct_index = init->struct_index;
-                    local.tuple_len = init->tuple_len;
-                    for (u32 ti = 0; ti < init->tuple_len; ti++) {
-                        local.tuple_types[ti] = init->tuple_types[ti];
-                        local.tuple_variant_indices[ti] = init->tuple_variant_indices[ti];
-                        local.tuple_struct_indices[ti] = init->tuple_struct_indices[ti];
-                    }
-                    local.error_struct_index = init->error_struct_index;
-                    local.error_variant_index = init->error_variant_index;
-                    local.shape_index = init->shape_index;
-                    local.init = init.value();
-                    if (!route->locals.push(local))
-                        return frontend_error(FrontendError::TooManyItems, prefix.span);
-                    nested_locals[nested_local_count++] = local;
                 }
                 const auto* last = arm.stmt->block_stmts[arm.stmt->block_stmts.len - 1];
-                if (prefix_ok && last->kind == AstStmtKind::Match) nested_match_stmt = last;
+                if (prefix_ok && last->kind == AstStmtKind::Match) {
+                    for (u32 bi = 0; bi + 1 < arm.stmt->block_stmts.len; bi++) {
+                        const auto& prefix = *arm.stmt->block_stmts[bi];
+                        auto init = analyze_expr(
+                            prefix.expr, route, mod, nested_locals, nested_local_count, binding);
+                        if (!init) return core::make_unexpected(init.error());
+                        if (init->kind == HirExprKind::ArrayLit)
+                            return frontend_error(FrontendError::UnsupportedSyntax,
+                                                  prefix.expr.span);
+                        auto typed = apply_declared_type_to_expr(&init.value(), mod, prefix);
+                        if (!typed) return core::make_unexpected(typed.error());
+                        HirLocal local{};
+                        local.span = prefix.span;
+                        local.name = prefix.name;
+                        local.ref_index =
+                            next_local_ref_index(route, nested_locals, nested_local_count);
+                        local.type = init->type;
+                        local.generic_index = init->generic_index;
+                        local.generic_has_error_constraint = init->generic_has_error_constraint;
+                        local.generic_has_eq_constraint = init->generic_has_eq_constraint;
+                        local.generic_has_ord_constraint = init->generic_has_ord_constraint;
+                        local.generic_protocol_index = init->generic_protocol_index;
+                        local.generic_protocol_count = init->generic_protocol_count;
+                        for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                            local.generic_protocol_indices[cpi] =
+                                init->generic_protocol_indices[cpi];
+                        local.may_nil = init->may_nil;
+                        local.may_error = init->may_error;
+                        local.variant_index = init->variant_index;
+                        local.struct_index = init->struct_index;
+                        local.tuple_len = init->tuple_len;
+                        for (u32 ti = 0; ti < init->tuple_len; ti++) {
+                            local.tuple_types[ti] = init->tuple_types[ti];
+                            local.tuple_variant_indices[ti] = init->tuple_variant_indices[ti];
+                            local.tuple_struct_indices[ti] = init->tuple_struct_indices[ti];
+                        }
+                        local.error_struct_index = init->error_struct_index;
+                        local.error_variant_index = init->error_variant_index;
+                        local.shape_index = init->shape_index;
+                        local.init = init.value();
+                        if (!route->locals.push(local))
+                            return frontend_error(FrontendError::TooManyItems, prefix.span);
+                        auto inserted = insert_scoped_local(nested_locals,
+                                                            nested_local_count,
+                                                            HirRoute::kMaxLocals,
+                                                            local,
+                                                            prefix.span);
+                        if (!inserted) return core::make_unexpected(inserted.error());
+                    }
+                    nested_match_stmt = last;
+                }
             }
             if (nested_match_stmt != nullptr) {
                 if (seen_wildcard)

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6807,10 +6807,10 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     const u32 case_index = static_cast<u32>(outer_pattern->int_value);
                     if (case_index >= HirVariant::kMaxCases)
                         return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
-                    if (!seen_variant_cases[case_index]) {
-                        seen_variant_cases[case_index] = true;
-                        seen_variant_case_count++;
-                    }
+                    if (seen_variant_cases[case_index])
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                    seen_variant_cases[case_index] = true;
+                    seen_variant_case_count++;
                 }
                 auto inner_subject = analyze_expr(nested_match_stmt->expr,
                                                   route,

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6818,12 +6818,35 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         cond.kind = HirExprKind::Eq;
                         cond.type = HirTypeKind::Bool;
                         cond.span = inner_arm.span;
-                        if (!route->exprs.push(inner_subject.value()))
-                            return frontend_error(FrontendError::TooManyItems, inner_arm.span);
-                        cond.lhs = &route->exprs[route->exprs.len - 1];
-                        if (!route->exprs.push(inner_pattern.value()))
-                            return frontend_error(FrontendError::TooManyItems, inner_arm.span);
-                        cond.rhs = &route->exprs[route->exprs.len - 1];
+                        if (inner_pattern->kind == HirExprKind::VariantCase) {
+                            HirExpr tag{};
+                            tag.kind = HirExprKind::VariantTag;
+                            tag.type = HirTypeKind::I32;
+                            tag.span = inner_arm.span;
+                            tag.variant_index = inner_pattern->variant_index;
+                            if (!route->exprs.push(inner_subject.value()))
+                                return frontend_error(FrontendError::TooManyItems, inner_arm.span);
+                            tag.lhs = &route->exprs[route->exprs.len - 1];
+
+                            HirExpr case_index{};
+                            case_index.kind = HirExprKind::IntLit;
+                            case_index.type = HirTypeKind::I32;
+                            case_index.span = inner_arm.span;
+                            case_index.int_value = inner_pattern->int_value;
+                            if (!route->exprs.push(tag))
+                                return frontend_error(FrontendError::TooManyItems, inner_arm.span);
+                            cond.lhs = &route->exprs[route->exprs.len - 1];
+                            if (!route->exprs.push(case_index))
+                                return frontend_error(FrontendError::TooManyItems, inner_arm.span);
+                            cond.rhs = &route->exprs[route->exprs.len - 1];
+                        } else {
+                            if (!route->exprs.push(inner_subject.value()))
+                                return frontend_error(FrontendError::TooManyItems, inner_arm.span);
+                            cond.lhs = &route->exprs[route->exprs.len - 1];
+                            if (!route->exprs.push(inner_pattern.value()))
+                                return frontend_error(FrontendError::TooManyItems, inner_arm.span);
+                            cond.rhs = &route->exprs[route->exprs.len - 1];
+                        }
                         hir_arm.has_arm_guard = true;
                         hir_arm.arm_guard = cond;
                     } else {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3722,10 +3722,12 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 const u32 case_index = static_cast<u32>(pattern->int_value);
                 if (case_index >= HirVariant::kMaxCases)
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
-                if (seen_variant_cases[case_index])
+                if (seen_variant_cases[case_index] && !arm.has_guard)
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
-                seen_variant_cases[case_index] = true;
-                seen_variant_case_count++;
+                if (!seen_variant_cases[case_index]) {
+                    seen_variant_cases[case_index] = true;
+                    seen_variant_case_count++;
+                }
             } else if (pattern->type == HirTypeKind::Bool) {
                 if (pattern->bool_value)
                     seen_bool_true = true;
@@ -6749,6 +6751,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         bool seen_bool_true = false;
         bool seen_bool_false = false;
         bool seen_variant_cases[HirVariant::kMaxCases]{};
+        bool seen_unguarded_variant_cases[HirVariant::kMaxCases]{};
         u32 seen_variant_case_count = 0;
         route->control.match_arms.len = 0;
         for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
@@ -6853,6 +6856,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     if (seen_variant_cases[case_index])
                         return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                     seen_variant_cases[case_index] = true;
+                    seen_unguarded_variant_cases[case_index] = true;
                     seen_variant_case_count++;
                 }
                 auto inner_subject = analyze_expr(nested_match_stmt->expr,
@@ -6996,10 +7000,13 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     const u32 case_index = static_cast<u32>(pattern.int_value);
                     if (case_index >= HirVariant::kMaxCases)
                         return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
-                    if (seen_variant_cases[case_index])
+                    if (seen_unguarded_variant_cases[case_index])
                         return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
-                    seen_variant_cases[case_index] = true;
-                    seen_variant_case_count++;
+                    if (!seen_variant_cases[case_index]) {
+                        seen_variant_cases[case_index] = true;
+                        seen_variant_case_count++;
+                    }
+                    if (!arm.has_guard) seen_unguarded_variant_cases[case_index] = true;
                     const auto& variant = mod.variants[pattern.variant_index];
                     const auto& case_decl = variant.cases[case_index];
                     if (case_decl.has_payload && arm.pattern.lhs != nullptr) {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3589,62 +3589,13 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
             if (pattern->kind == HirExprKind::VariantCase &&
                 mod.variants[pattern->variant_index].cases[pattern->case_index].has_payload &&
                 arm.pattern.lhs != nullptr) {
-                selected_binding.name = arm.pattern.lhs->name;
-                selected_binding.type =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_type;
-                selected_binding.generic_index = mod.variants[pattern->variant_index]
-                                                     .cases[pattern->case_index]
-                                                     .payload_generic_index;
-                selected_binding.generic_has_error_constraint =
-                    mod.variants[pattern->variant_index]
-                        .cases[pattern->case_index]
-                        .payload_generic_has_error_constraint;
-                selected_binding.generic_has_eq_constraint = mod.variants[pattern->variant_index]
-                                                                 .cases[pattern->case_index]
-                                                                 .payload_generic_has_eq_constraint;
-                selected_binding.generic_has_ord_constraint =
-                    mod.variants[pattern->variant_index]
-                        .cases[pattern->case_index]
-                        .payload_generic_has_ord_constraint;
-                selected_binding.generic_protocol_index = mod.variants[pattern->variant_index]
-                                                              .cases[pattern->case_index]
-                                                              .payload_generic_protocol_index;
-                selected_binding.generic_protocol_count = mod.variants[pattern->variant_index]
-                                                              .cases[pattern->case_index]
-                                                              .payload_generic_protocol_count;
-                for (u32 cpi = 0; cpi < selected_binding.generic_protocol_count; cpi++) {
-                    selected_binding.generic_protocol_indices[cpi] =
-                        mod.variants[pattern->variant_index]
-                            .cases[pattern->case_index]
-                            .payload_generic_protocol_indices[cpi];
-                }
-                selected_binding.variant_index = mod.variants[pattern->variant_index]
-                                                     .cases[pattern->case_index]
-                                                     .payload_variant_index;
-                selected_binding.struct_index = mod.variants[pattern->variant_index]
-                                                    .cases[pattern->case_index]
-                                                    .payload_struct_index;
-                selected_binding.shape_index = mod.variants[pattern->variant_index]
-                                                   .cases[pattern->case_index]
-                                                   .payload_shape_index;
-                selected_binding.tuple_len = mod.variants[pattern->variant_index]
-                                                 .cases[pattern->case_index]
-                                                 .payload_tuple_len;
-                for (u32 ti = 0; ti < selected_binding.tuple_len; ti++) {
-                    selected_binding.tuple_types[ti] = mod.variants[pattern->variant_index]
-                                                           .cases[pattern->case_index]
-                                                           .payload_tuple_types[ti];
-                    selected_binding.tuple_variant_indices[ti] =
-                        mod.variants[pattern->variant_index]
-                            .cases[pattern->case_index]
-                            .payload_tuple_variant_indices[ti];
-                    selected_binding.tuple_struct_indices[ti] =
-                        mod.variants[pattern->variant_index]
-                            .cases[pattern->case_index]
-                            .payload_tuple_struct_indices[ti];
-                }
-                selected_binding.case_index = pattern->case_index;
-                selected_binding.subject = subject_ptr;
+                const auto& case_decl =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index];
+                bind_match_payload(&selected_binding,
+                                   arm.pattern.lhs->name,
+                                   case_decl,
+                                   pattern->case_index,
+                                   subject_ptr);
                 selected_binding_ptr = &selected_binding;
             }
             break;
@@ -3769,33 +3720,11 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 const u32 case_index = static_cast<u32>(pattern->int_value);
                 const auto& case_decl = mod.variants[pattern->variant_index].cases[case_index];
                 if (case_decl.has_payload && arm.pattern.lhs != nullptr) {
-                    arm_binding.name = arm.pattern.lhs->name;
-                    arm_binding.type = case_decl.payload_type;
-                    arm_binding.generic_index = case_decl.payload_generic_index;
-                    arm_binding.generic_has_error_constraint =
-                        case_decl.payload_generic_has_error_constraint;
-                    arm_binding.generic_has_eq_constraint =
-                        case_decl.payload_generic_has_eq_constraint;
-                    arm_binding.generic_has_ord_constraint =
-                        case_decl.payload_generic_has_ord_constraint;
-                    arm_binding.generic_protocol_index = case_decl.payload_generic_protocol_index;
-                    arm_binding.generic_protocol_count = case_decl.payload_generic_protocol_count;
-                    for (u32 cpi = 0; cpi < arm_binding.generic_protocol_count; cpi++)
-                        arm_binding.generic_protocol_indices[cpi] =
-                            case_decl.payload_generic_protocol_indices[cpi];
-                    arm_binding.variant_index = case_decl.payload_variant_index;
-                    arm_binding.struct_index = case_decl.payload_struct_index;
-                    arm_binding.shape_index = case_decl.payload_shape_index;
-                    arm_binding.tuple_len = case_decl.payload_tuple_len;
-                    for (u32 ti = 0; ti < arm_binding.tuple_len; ti++) {
-                        arm_binding.tuple_types[ti] = case_decl.payload_tuple_types[ti];
-                        arm_binding.tuple_variant_indices[ti] =
-                            case_decl.payload_tuple_variant_indices[ti];
-                        arm_binding.tuple_struct_indices[ti] =
-                            case_decl.payload_tuple_struct_indices[ti];
-                    }
-                    arm_binding.case_index = case_index;
-                    arm_binding.subject = subject_ptr;
+                    bind_match_payload(&arm_binding,
+                                       arm.pattern.lhs->name,
+                                       case_decl,
+                                       case_index,
+                                       subject_ptr);
                     arm_binding_ptr = &arm_binding;
                 }
             }
@@ -6171,34 +6100,11 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
                 inner_arm.pattern.lhs != nullptr) {
                 const auto& case_decl =
                     mod.variants[pattern->variant_index].cases[pattern->case_index];
-                selected_binding = {};
-                selected_binding.name = inner_arm.pattern.lhs->name;
-                selected_binding.type = case_decl.payload_type;
-                selected_binding.generic_index = case_decl.payload_generic_index;
-                selected_binding.generic_has_error_constraint =
-                    case_decl.payload_generic_has_error_constraint;
-                selected_binding.generic_has_eq_constraint =
-                    case_decl.payload_generic_has_eq_constraint;
-                selected_binding.generic_has_ord_constraint =
-                    case_decl.payload_generic_has_ord_constraint;
-                selected_binding.generic_protocol_index = case_decl.payload_generic_protocol_index;
-                selected_binding.generic_protocol_count = case_decl.payload_generic_protocol_count;
-                for (u32 cpi = 0; cpi < selected_binding.generic_protocol_count; cpi++)
-                    selected_binding.generic_protocol_indices[cpi] =
-                        case_decl.payload_generic_protocol_indices[cpi];
-                selected_binding.variant_index = case_decl.payload_variant_index;
-                selected_binding.struct_index = case_decl.payload_struct_index;
-                selected_binding.shape_index = case_decl.payload_shape_index;
-                selected_binding.case_index = pattern->case_index;
-                selected_binding.tuple_len = case_decl.payload_tuple_len;
-                for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
-                    selected_binding.tuple_types[ti] = case_decl.payload_tuple_types[ti];
-                    selected_binding.tuple_variant_indices[ti] =
-                        case_decl.payload_tuple_variant_indices[ti];
-                    selected_binding.tuple_struct_indices[ti] =
-                        case_decl.payload_tuple_struct_indices[ti];
-                }
-                selected_binding.subject = subject_ptr;
+                bind_match_payload(&selected_binding,
+                                   inner_arm.pattern.lhs->name,
+                                   case_decl,
+                                   pattern->case_index,
+                                   subject_ptr);
                 selected_binding_ptr = &selected_binding;
             }
             break;
@@ -6555,63 +6461,13 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
             if (pattern->kind == HirExprKind::VariantCase &&
                 mod.variants[pattern->variant_index].cases[pattern->case_index].has_payload &&
                 arm.pattern.lhs != nullptr) {
-                selected_binding = {};
-                selected_binding.name = arm.pattern.lhs->name;
-                selected_binding.type =
-                    mod.variants[pattern->variant_index].cases[pattern->case_index].payload_type;
-                selected_binding.generic_index = mod.variants[pattern->variant_index]
-                                                     .cases[pattern->case_index]
-                                                     .payload_generic_index;
-                selected_binding.generic_has_error_constraint =
-                    mod.variants[pattern->variant_index]
-                        .cases[pattern->case_index]
-                        .payload_generic_has_error_constraint;
-                selected_binding.generic_has_eq_constraint = mod.variants[pattern->variant_index]
-                                                                 .cases[pattern->case_index]
-                                                                 .payload_generic_has_eq_constraint;
-                selected_binding.generic_has_ord_constraint =
-                    mod.variants[pattern->variant_index]
-                        .cases[pattern->case_index]
-                        .payload_generic_has_ord_constraint;
-                selected_binding.generic_protocol_index = mod.variants[pattern->variant_index]
-                                                              .cases[pattern->case_index]
-                                                              .payload_generic_protocol_index;
-                selected_binding.generic_protocol_count = mod.variants[pattern->variant_index]
-                                                              .cases[pattern->case_index]
-                                                              .payload_generic_protocol_count;
-                for (u32 cpi = 0; cpi < selected_binding.generic_protocol_count; cpi++) {
-                    selected_binding.generic_protocol_indices[cpi] =
-                        mod.variants[pattern->variant_index]
-                            .cases[pattern->case_index]
-                            .payload_generic_protocol_indices[cpi];
-                }
-                selected_binding.variant_index = mod.variants[pattern->variant_index]
-                                                     .cases[pattern->case_index]
-                                                     .payload_variant_index;
-                selected_binding.struct_index = mod.variants[pattern->variant_index]
-                                                    .cases[pattern->case_index]
-                                                    .payload_struct_index;
-                selected_binding.shape_index = mod.variants[pattern->variant_index]
-                                                   .cases[pattern->case_index]
-                                                   .payload_shape_index;
-                selected_binding.tuple_len = mod.variants[pattern->variant_index]
-                                                 .cases[pattern->case_index]
-                                                 .payload_tuple_len;
-                for (u32 ti = 0; ti < selected_binding.tuple_len; ti++) {
-                    selected_binding.tuple_types[ti] = mod.variants[pattern->variant_index]
-                                                           .cases[pattern->case_index]
-                                                           .payload_tuple_types[ti];
-                    selected_binding.tuple_variant_indices[ti] =
-                        mod.variants[pattern->variant_index]
-                            .cases[pattern->case_index]
-                            .payload_tuple_variant_indices[ti];
-                    selected_binding.tuple_struct_indices[ti] =
-                        mod.variants[pattern->variant_index]
-                            .cases[pattern->case_index]
-                            .payload_tuple_struct_indices[ti];
-                }
-                selected_binding.case_index = pattern->case_index;
-                selected_binding.subject = subject_ptr;
+                const auto& case_decl =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index];
+                bind_match_payload(&selected_binding,
+                                   arm.pattern.lhs->name,
+                                   case_decl,
+                                   pattern->case_index,
+                                   subject_ptr);
                 selected_binding_ptr = &selected_binding;
             }
             break;
@@ -6699,22 +6555,25 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
             (subject->error_variant_index != 0xffffffffu ||
              (state == KnownValueState::Error && err_name.len != 0))) {
             if (state != KnownValueState::Unknown) {
-                const AstStatement::MatchArm* wildcard_arm = nullptr;
-                const AstStatement::MatchArm* selected_arm = nullptr;
-                bool can_use_known_error_shortcut = true;
-                if (state == KnownValueState::Error) {
-                    const auto err_case = known_error_case(subject.value(), locals, local_count, 0);
-                    if (!err_case.known)
-                        if (err_name.len == 0)
-                            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
-                    for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
-                        const auto& arm = stmt.match_arms[ai];
-                        if (arm.is_wildcard) {
-                            if (arm.has_guard)
-                                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
-                            wildcard_arm = &arm;
-                            continue;
-                        }
+            const AstStatement::MatchArm* wildcard_arm = nullptr;
+            const AstStatement::MatchArm* selected_arm = nullptr;
+            bool can_use_known_error_shortcut = true;
+            for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+                if (stmt.match_arms[ai].is_wildcard && stmt.match_arms[ai].has_guard)
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          stmt.match_arms[ai].span);
+            }
+            if (state == KnownValueState::Error) {
+                const auto err_case = known_error_case(subject.value(), locals, local_count, 0);
+                if (!err_case.known)
+                    if (err_name.len == 0)
+                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+                    const auto& arm = stmt.match_arms[ai];
+                    if (arm.is_wildcard) {
+                        wildcard_arm = &arm;
+                        continue;
+                    }
                         if (arm.pattern.kind != AstExprKind::VariantCase)
                             return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                         bool matched = false;
@@ -6777,14 +6636,11 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         }
                     }
                 } else {
-                    for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
-                        if (stmt.match_arms[ai].is_wildcard) {
-                            if (stmt.match_arms[ai].has_guard)
-                                return frontend_error(FrontendError::UnsupportedSyntax,
-                                                      stmt.match_arms[ai].span);
-                            wildcard_arm = &stmt.match_arms[ai];
-                            break;
-                        }
+                for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+                    if (stmt.match_arms[ai].is_wildcard) {
+                        wildcard_arm = &stmt.match_arms[ai];
+                        break;
+                    }
                     }
                 }
 

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6850,6 +6850,11 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         seen_bool_false = true;
                 }
                 if (outer_pattern->kind == HirExprKind::VariantCase) {
+                    if ((subject_is_error_kind &&
+                         outer_pattern->variant_index != subject->error_variant_index) ||
+                        (!subject_is_error_kind &&
+                         outer_pattern->variant_index != subject->variant_index))
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                     const u32 case_index = static_cast<u32>(outer_pattern->int_value);
                     if (case_index >= HirVariant::kMaxCases)
                         return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
@@ -6905,6 +6910,9 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                                 inner_seen_bool_false = true;
                         }
                         if (inner_pattern->kind == HirExprKind::VariantCase) {
+                            if (inner_pattern->variant_index != inner_subject->variant_index)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_arm.span);
                             const u32 case_index = static_cast<u32>(inner_pattern->int_value);
                             if (case_index >= HirVariant::kMaxCases)
                                 return frontend_error(FrontendError::UnsupportedSyntax,

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6829,6 +6829,10 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     }
                 }
                 const auto* last = arm.stmt->block_stmts[arm.stmt->block_stmts.len - 1];
+                if (prefix_ok && last->kind == AstStmtKind::Match && !last->is_const &&
+                    arm.stmt->block_stmts.len > 1) {
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                }
                 if (prefix_ok && last->kind == AstStmtKind::Match && !last->is_const) {
                     for (u32 bi = 0; bi + 1 < arm.stmt->block_stmts.len; bi++) {
                         const auto& prefix = *arm.stmt->block_stmts[bi];
@@ -6911,11 +6915,13 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     const u32 case_index = static_cast<u32>(outer_pattern->int_value);
                     if (case_index >= HirVariant::kMaxCases)
                         return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
-                    if (seen_variant_cases[case_index])
+                    if (seen_unguarded_variant_cases[case_index])
                         return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
-                    seen_variant_cases[case_index] = true;
+                    if (!seen_variant_cases[case_index]) {
+                        seen_variant_cases[case_index] = true;
+                        seen_variant_case_count++;
+                    }
                     seen_unguarded_variant_cases[case_index] = true;
-                    seen_variant_case_count++;
                 }
                 auto inner_subject = analyze_expr(nested_match_stmt->expr,
                                                   route,

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -2896,6 +2896,34 @@ static FrontendResult<HirExpr> analyze_match_pattern(const AstExpr& pattern_expr
     return analyze_expr(pattern_expr, route, mod, locals, local_count, nullptr);
 }
 
+static void bind_match_payload(MatchPayloadBinding* binding,
+                               Str name,
+                               const HirVariant::CaseDecl& case_decl,
+                               u32 case_index,
+                               const HirExpr* subject) {
+    binding->name = name;
+    binding->type = case_decl.payload_type;
+    binding->generic_index = case_decl.payload_generic_index;
+    binding->generic_has_error_constraint = case_decl.payload_generic_has_error_constraint;
+    binding->generic_has_eq_constraint = case_decl.payload_generic_has_eq_constraint;
+    binding->generic_has_ord_constraint = case_decl.payload_generic_has_ord_constraint;
+    binding->generic_protocol_index = case_decl.payload_generic_protocol_index;
+    binding->generic_protocol_count = case_decl.payload_generic_protocol_count;
+    for (u32 cpi = 0; cpi < binding->generic_protocol_count; cpi++)
+        binding->generic_protocol_indices[cpi] = case_decl.payload_generic_protocol_indices[cpi];
+    binding->variant_index = case_decl.payload_variant_index;
+    binding->struct_index = case_decl.payload_struct_index;
+    binding->shape_index = case_decl.payload_shape_index;
+    binding->case_index = case_index;
+    binding->tuple_len = case_decl.payload_tuple_len;
+    for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
+        binding->tuple_types[ti] = case_decl.payload_tuple_types[ti];
+        binding->tuple_variant_indices[ti] = case_decl.payload_tuple_variant_indices[ti];
+        binding->tuple_struct_indices[ti] = case_decl.payload_tuple_struct_indices[ti];
+    }
+    binding->subject = subject;
+}
+
 static u8 route_method_key_from_token(u8 token_type) {
     switch (static_cast<TokenType>(token_type)) {
         case TokenType::KwGet:
@@ -6690,22 +6718,42 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         if (arm.pattern.kind != AstExprKind::VariantCase)
                             return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                         bool matched = false;
-                        if (err_case.known && arm.pattern.name.len != 0) {
+                        HirExpr matched_pattern{};
+                        bool has_matched_pattern = false;
+                        if (err_case.known) {
                             auto pattern = analyze_match_pattern(
                                 arm.pattern, subject.value(), route, mod, locals, local_count);
                             if (!pattern) return core::make_unexpected(pattern.error());
                             matched = pattern->kind == HirExprKind::VariantCase &&
                                       pattern->variant_index == err_case.variant_index &&
                                       pattern->case_index == err_case.case_index;
+                            if (matched) {
+                                matched_pattern = pattern.value();
+                                has_matched_pattern = true;
+                            }
                         } else {
                             matched = arm.pattern.str_value.eq(err_name);
                         }
                         if (matched && arm.has_guard) {
                             if (arm.guard == nullptr)
                                 return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                            MatchPayloadBinding arm_binding{};
+                            const MatchPayloadBinding* arm_binding_ptr = binding;
+                            if (has_matched_pattern && arm.pattern.lhs != nullptr) {
+                                const auto& case_decl = mod.variants[matched_pattern.variant_index]
+                                                            .cases[matched_pattern.case_index];
+                                if (case_decl.has_payload) {
+                                    bind_match_payload(&arm_binding,
+                                                       arm.pattern.lhs->name,
+                                                       case_decl,
+                                                       matched_pattern.case_index,
+                                                       &subject.value());
+                                    arm_binding_ptr = &arm_binding;
+                                }
+                            }
                             const u32 expr_len_before_guard = route->exprs.len;
-                            auto guard =
-                                analyze_expr(*arm.guard, route, mod, locals, local_count, binding);
+                            auto guard = analyze_expr(
+                                *arm.guard, route, mod, locals, local_count, arm_binding_ptr);
                             if (!guard) return core::make_unexpected(guard.error());
                             if (guard->type != HirTypeKind::Bool || guard->may_nil ||
                                 guard->may_error) {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5722,6 +5722,11 @@ static FrontendResult<void> collect_named_error_cases(
         if (!push_named_error_case(cases, expr.str_value))
             return frontend_error(FrontendError::TooManyItems, expr.span);
     }
+    if (expr.kind == HirExprKind::VariantCase && expr.variant_index == 0xffffffffu &&
+        expr.str_value.len != 0) {
+        if (!push_named_error_case(cases, expr.str_value))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+    }
     if (expr.lhs != nullptr) {
         auto lhs = collect_named_error_cases(*expr.lhs, cases);
         if (!lhs) return lhs;
@@ -6983,10 +6988,25 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
             if (arm.is_wildcard && arm.has_guard)
                 return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
             if (!arm.is_wildcard) {
-                auto analyzed_pattern = analyze_match_pattern(
-                    arm.pattern, subject.value(), route, mod, locals, local_count);
-                if (!analyzed_pattern) return core::make_unexpected(analyzed_pattern.error());
-                HirExpr pattern = analyzed_pattern.value();
+                HirExpr pattern{};
+                const bool can_use_unpatched_named_error_pattern =
+                    subject_is_error_kind && subject->error_variant_index == 0xffffffffu &&
+                    arm.pattern.kind == AstExprKind::VariantCase && arm.pattern.name.len == 0 &&
+                    arm.pattern.lhs == nullptr;
+                if (can_use_unpatched_named_error_pattern) {
+                    pattern.kind = HirExprKind::VariantCase;
+                    pattern.type = HirTypeKind::Variant;
+                    pattern.span = arm.pattern.span;
+                    pattern.variant_index = 0xffffffffu;
+                    pattern.case_index = 0xffffffffu;
+                    pattern.int_value = -1;
+                    pattern.str_value = arm.pattern.str_value;
+                } else {
+                    auto analyzed_pattern = analyze_match_pattern(
+                        arm.pattern, subject.value(), route, mod, locals, local_count);
+                    if (!analyzed_pattern) return core::make_unexpected(analyzed_pattern.error());
+                    pattern = analyzed_pattern.value();
+                }
                 if (pattern.kind != HirExprKind::BoolLit && pattern.kind != HirExprKind::IntLit &&
                     pattern.kind != HirExprKind::StrLit && pattern.kind != HirExprKind::VariantCase)
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
@@ -6994,7 +7014,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     !(subject_is_error_kind && pattern.kind == HirExprKind::VariantCase))
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 if (pattern.type == HirTypeKind::Variant &&
-                    ((subject_is_error_kind &&
+                    ((subject_is_error_kind && subject->error_variant_index != 0xffffffffu &&
                       pattern.variant_index != subject->error_variant_index) ||
                      (!subject_is_error_kind && pattern.variant_index != subject->variant_index)))
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
@@ -7005,6 +7025,37 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         seen_bool_false = true;
                 }
                 if (pattern.kind == HirExprKind::VariantCase) {
+                    if (pattern.variant_index == 0xffffffffu) {
+                        for (u32 pai = 0; pai < route->control.match_arms.len; pai++) {
+                            const auto& prior = route->control.match_arms[pai];
+                            if (!prior.has_arm_guard &&
+                                prior.pattern.kind == HirExprKind::VariantCase &&
+                                prior.pattern.variant_index == 0xffffffffu &&
+                                prior.pattern.str_value.eq(pattern.str_value))
+                                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                        }
+                        hir_arm.pattern = pattern;
+                        if (arm.has_guard) {
+                            if (arm.guard == nullptr)
+                                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                            auto guard = analyze_expr(
+                                *arm.guard, route, mod, locals, local_count, arm_binding_ptr);
+                            if (!guard) return core::make_unexpected(guard.error());
+                            if (guard->type != HirTypeKind::Bool || guard->may_nil ||
+                                guard->may_error)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      arm.guard->span);
+                            hir_arm.has_arm_guard = true;
+                            hir_arm.arm_guard = guard.value();
+                            seen_guarded_arm = true;
+                        }
+                        auto body = analyze_match_arm_body(
+                            *arm.stmt, &hir_arm, route, mod, locals, local_count, arm_binding_ptr);
+                        if (!body) return core::make_unexpected(body.error());
+                        if (!route->control.match_arms.push(hir_arm))
+                            return frontend_error(FrontendError::TooManyItems, arm.span);
+                        continue;
+                    }
                     const u32 case_index = static_cast<u32>(pattern.int_value);
                     if (case_index >= HirVariant::kMaxCases)
                         return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
@@ -7090,6 +7141,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
             if (subject->type == HirTypeKind::Bool && seen_bool_true && seen_bool_false) return {};
             if (subject->type != HirTypeKind::Variant && !subject_is_error_kind)
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+            if (subject_is_error_kind && subject->error_variant_index == 0xffffffffu)
                 return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
             const auto& variant = mod.variants[subject_is_error_kind ? subject->error_variant_index
                                                                      : subject->variant_index];

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3746,9 +3746,12 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                     seen_variant_case_count++;
                 }
             } else if (pattern->type == HirTypeKind::Bool) {
-                if (pattern->bool_value)
+                bool& seen_bool_case = pattern->bool_value ? seen_bool_true : seen_bool_false;
+                if (seen_bool_case && !arm.has_guard)
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (pattern->bool_value && !seen_bool_case)
                     seen_bool_true = true;
-                else
+                else if (!pattern->bool_value && !seen_bool_case)
                     seen_bool_false = true;
             }
 
@@ -6690,6 +6693,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
         bool seen_guarded_arm = false;
         bool seen_bool_true = false;
         bool seen_bool_false = false;
+        bool seen_unguarded_bool_true = false;
+        bool seen_unguarded_bool_false = false;
         bool seen_variant_cases[HirVariant::kMaxCases]{};
         bool seen_unguarded_variant_cases[HirVariant::kMaxCases]{};
         u32 seen_variant_case_count = 0;
@@ -6733,6 +6738,10 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     !(subject_is_error_kind && outer_pattern->kind == HirExprKind::VariantCase))
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 if (outer_pattern->kind == HirExprKind::BoolLit) {
+                    bool& seen_bool_case =
+                        outer_pattern->bool_value ? seen_bool_true : seen_bool_false;
+                    if (seen_bool_case)
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                     if (outer_pattern->bool_value)
                         seen_bool_true = true;
                     else
@@ -6795,6 +6804,12 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                         if (inner_pattern->type != inner_subject->type)
                             return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
                         if (inner_pattern->kind == HirExprKind::BoolLit) {
+                            bool& seen_bool_case = inner_pattern->bool_value
+                                                       ? inner_seen_bool_true
+                                                       : inner_seen_bool_false;
+                            if (seen_bool_case)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_arm.span);
                             if (inner_pattern->bool_value)
                                 inner_seen_bool_true = true;
                             else
@@ -6928,10 +6943,16 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                      (!subject_is_error_kind && pattern.variant_index != subject->variant_index)))
                     return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 if (pattern.kind == HirExprKind::BoolLit) {
-                    if (pattern.bool_value)
+                    bool& seen_bool_case = pattern.bool_value ? seen_bool_true : seen_bool_false;
+                    bool& seen_unguarded_bool_case =
+                        pattern.bool_value ? seen_unguarded_bool_true : seen_unguarded_bool_false;
+                    if (seen_unguarded_bool_case)
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                    if (pattern.bool_value && !seen_bool_case)
                         seen_bool_true = true;
-                    else
+                    else if (!pattern.bool_value && !seen_bool_case)
                         seen_bool_false = true;
+                    if (!arm.has_guard) seen_unguarded_bool_case = true;
                 }
                 if (pattern.kind == HirExprKind::VariantCase) {
                     if (pattern.variant_index == 0xffffffffu) {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6641,6 +6641,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
                         const auto& arm = stmt.match_arms[ai];
                         if (arm.is_wildcard) {
+                            if (arm.has_guard)
+                                return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                             wildcard_arm = &arm;
                             continue;
                         }
@@ -6684,6 +6686,9 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 } else {
                     for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
                         if (stmt.match_arms[ai].is_wildcard) {
+                            if (stmt.match_arms[ai].has_guard)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      stmt.match_arms[ai].span);
                             wildcard_arm = &stmt.match_arms[ai];
                             break;
                         }

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6057,6 +6057,91 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
                                                    const HirLocal* locals,
                                                    u32 local_count,
                                                    const MatchPayloadBinding* binding) {
+    if (stmt.kind == AstStmtKind::Match && stmt.is_const) {
+        auto subject = analyze_expr(stmt.expr, route, mod, locals, local_count, binding);
+        if (!subject) return core::make_unexpected(subject.error());
+        ConstValue subject_value{};
+        if (!const_eval_expr(subject.value(), locals, local_count, &subject_value, 0))
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+        if (!route->exprs.push(subject.value()))
+            return frontend_error(FrontendError::TooManyItems, stmt.span);
+        const HirExpr* subject_ptr = &route->exprs[route->exprs.len - 1];
+
+        const AstStatement::MatchArm* wildcard_arm = nullptr;
+        const AstStatement::MatchArm* selected_arm = nullptr;
+        MatchPayloadBinding selected_binding{};
+        const MatchPayloadBinding* selected_binding_ptr = binding;
+
+        for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
+            const auto& inner_arm = stmt.match_arms[ai];
+            if (inner_arm.has_guard)
+                return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
+            if (inner_arm.is_wildcard) {
+                wildcard_arm = &inner_arm;
+                continue;
+            }
+            auto pattern = analyze_match_pattern(
+                inner_arm.pattern, subject.value(), route, mod, locals, local_count);
+            if (!pattern) return core::make_unexpected(pattern.error());
+            bool matched = false;
+            if (pattern->kind == HirExprKind::BoolLit && subject_value.type == HirTypeKind::Bool) {
+                matched = pattern->bool_value == subject_value.bool_value;
+            } else if (pattern->kind == HirExprKind::IntLit &&
+                       subject_value.type == HirTypeKind::I32) {
+                matched = pattern->int_value == subject_value.int_value;
+            } else if (pattern->kind == HirExprKind::StrLit &&
+                       subject_value.type == HirTypeKind::Str) {
+                matched = pattern->str_value.eq(subject_value.str_value);
+            } else if (pattern->kind == HirExprKind::VariantCase &&
+                       subject_value.type == HirTypeKind::Variant) {
+                matched = pattern->variant_index == subject_value.variant_index &&
+                          pattern->case_index == subject_value.case_index;
+            }
+            if (!matched) continue;
+            selected_arm = &inner_arm;
+            if (pattern->kind == HirExprKind::VariantCase &&
+                mod.variants[pattern->variant_index].cases[pattern->case_index].has_payload &&
+                inner_arm.pattern.lhs != nullptr) {
+                const auto& case_decl =
+                    mod.variants[pattern->variant_index].cases[pattern->case_index];
+                selected_binding = {};
+                selected_binding.name = inner_arm.pattern.lhs->name;
+                selected_binding.type = case_decl.payload_type;
+                selected_binding.generic_index = case_decl.payload_generic_index;
+                selected_binding.generic_has_error_constraint =
+                    case_decl.payload_generic_has_error_constraint;
+                selected_binding.generic_has_eq_constraint =
+                    case_decl.payload_generic_has_eq_constraint;
+                selected_binding.generic_has_ord_constraint =
+                    case_decl.payload_generic_has_ord_constraint;
+                selected_binding.generic_protocol_index = case_decl.payload_generic_protocol_index;
+                selected_binding.generic_protocol_count = case_decl.payload_generic_protocol_count;
+                for (u32 cpi = 0; cpi < selected_binding.generic_protocol_count; cpi++)
+                    selected_binding.generic_protocol_indices[cpi] =
+                        case_decl.payload_generic_protocol_indices[cpi];
+                selected_binding.variant_index = case_decl.payload_variant_index;
+                selected_binding.struct_index = case_decl.payload_struct_index;
+                selected_binding.shape_index = case_decl.payload_shape_index;
+                selected_binding.case_index = pattern->case_index;
+                selected_binding.tuple_len = case_decl.payload_tuple_len;
+                for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
+                    selected_binding.tuple_types[ti] = case_decl.payload_tuple_types[ti];
+                    selected_binding.tuple_variant_indices[ti] =
+                        case_decl.payload_tuple_variant_indices[ti];
+                    selected_binding.tuple_struct_indices[ti] =
+                        case_decl.payload_tuple_struct_indices[ti];
+                }
+                selected_binding.subject = subject_ptr;
+                selected_binding_ptr = &selected_binding;
+            }
+            break;
+        }
+        if (selected_arm == nullptr) selected_arm = wildcard_arm;
+        if (selected_arm == nullptr)
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        return analyze_match_arm_body(
+            *selected_arm->stmt, arm, route, mod, locals, local_count, selected_binding_ptr);
+    }
     if (stmt.kind == AstStmtKind::Block) {
         FixedVec<HirLocal, HirRoute::kMaxLocals> scoped_locals;
         for (u32 i = 0; i < local_count; i++) {
@@ -6632,7 +6717,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
             const bool can_expand_nested_match =
                 !arm.is_wildcard && !arm.has_guard && arm.pattern.lhs == nullptr;
             if (can_expand_nested_match && arm.stmt != nullptr &&
-                arm.stmt->kind == AstStmtKind::Match) {
+                arm.stmt->kind == AstStmtKind::Match && !arm.stmt->is_const) {
                 nested_match_stmt = arm.stmt;
             } else if (can_expand_nested_match && arm.stmt != nullptr &&
                        arm.stmt->kind == AstStmtKind::Block && arm.stmt->block_stmts.len != 0) {
@@ -6645,7 +6730,7 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                     }
                 }
                 const auto* last = arm.stmt->block_stmts[arm.stmt->block_stmts.len - 1];
-                if (prefix_ok && last->kind == AstStmtKind::Match) {
+                if (prefix_ok && last->kind == AstStmtKind::Match && !last->is_const) {
                     for (u32 bi = 0; bi + 1 < arm.stmt->block_stmts.len; bi++) {
                         const auto& prefix = *arm.stmt->block_stmts[bi];
                         auto init = analyze_expr(
@@ -6734,73 +6819,6 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                                                   nested_local_count,
                                                   binding);
                 if (!inner_subject) return core::make_unexpected(inner_subject.error());
-                if (nested_match_stmt->is_const) {
-                    ConstValue subject_value{};
-                    if (!const_eval_expr(inner_subject.value(),
-                                         nested_locals,
-                                         nested_local_count,
-                                         &subject_value,
-                                         0))
-                        return frontend_error(FrontendError::UnsupportedSyntax,
-                                              nested_match_stmt->expr.span);
-
-                    const AstStatement::MatchArm* wildcard_arm = nullptr;
-                    const AstStatement::MatchArm* selected_arm = nullptr;
-                    for (u32 iai = 0; iai < nested_match_stmt->match_arms.len; iai++) {
-                        const auto& inner_arm = nested_match_stmt->match_arms[iai];
-                        if (inner_arm.has_guard || inner_arm.pattern.lhs != nullptr)
-                            return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
-                        if (inner_arm.is_wildcard) {
-                            wildcard_arm = &inner_arm;
-                            continue;
-                        }
-                        auto inner_pattern = analyze_match_pattern(inner_arm.pattern,
-                                                                   inner_subject.value(),
-                                                                   route,
-                                                                   mod,
-                                                                   nested_locals,
-                                                                   nested_local_count);
-                        if (!inner_pattern) return core::make_unexpected(inner_pattern.error());
-                        bool matched = false;
-                        if (inner_pattern->kind == HirExprKind::BoolLit &&
-                            subject_value.type == HirTypeKind::Bool) {
-                            matched = inner_pattern->bool_value == subject_value.bool_value;
-                        } else if (inner_pattern->kind == HirExprKind::IntLit &&
-                                   subject_value.type == HirTypeKind::I32) {
-                            matched = inner_pattern->int_value == subject_value.int_value;
-                        } else if (inner_pattern->kind == HirExprKind::StrLit &&
-                                   subject_value.type == HirTypeKind::Str) {
-                            matched = inner_pattern->str_value.eq(subject_value.str_value);
-                        } else if (inner_pattern->kind == HirExprKind::VariantCase &&
-                                   subject_value.type == HirTypeKind::Variant) {
-                            matched = inner_pattern->variant_index == subject_value.variant_index &&
-                                      inner_pattern->case_index == subject_value.case_index;
-                        }
-                        if (matched) {
-                            selected_arm = &inner_arm;
-                            break;
-                        }
-                    }
-                    if (selected_arm == nullptr) selected_arm = wildcard_arm;
-                    if (selected_arm == nullptr)
-                        return frontend_error(FrontendError::UnsupportedSyntax,
-                                              nested_match_stmt->span);
-
-                    HirMatchArm hir_arm{};
-                    hir_arm.span = selected_arm->span;
-                    hir_arm.pattern = outer_pattern.value();
-                    auto body = analyze_match_arm_body(*selected_arm->stmt,
-                                                       &hir_arm,
-                                                       route,
-                                                       mod,
-                                                       nested_locals,
-                                                       nested_local_count,
-                                                       binding);
-                    if (!body) return core::make_unexpected(body.error());
-                    if (!route->control.match_arms.push(hir_arm))
-                        return frontend_error(FrontendError::TooManyItems, selected_arm->span);
-                    continue;
-                }
                 bool inner_seen_wildcard = false;
                 bool inner_seen_bool_true = false;
                 bool inner_seen_bool_false = false;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6819,6 +6819,9 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                                                   nested_local_count,
                                                   binding);
                 if (!inner_subject) return core::make_unexpected(inner_subject.error());
+                if (inner_subject->may_nil || inner_subject->may_error)
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          nested_match_stmt->expr.span);
                 bool inner_seen_wildcard = false;
                 bool inner_seen_bool_true = false;
                 bool inner_seen_bool_false = false;

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2053,6 +2053,34 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
         if (!unwrapped) return frontend_error(FrontendError::OutOfMemory, span);
         return unwrapped.value();
     }
+    if (value.kind == MirValueKind::VariantTag) {
+        auto subject = materialize_value(*value.lhs,
+                                         mir,
+                                         variant_infos,
+                                         tuple_infos,
+                                         tuple_info_count,
+                                         error_scalar_infos,
+                                         error_variant_infos,
+                                         error_struct_infos,
+                                         user_struct_defs,
+                                         b,
+                                         locals,
+                                         local_count,
+                                         span);
+        if (!subject) return core::make_unexpected(subject.error());
+        const auto subject_shape = resolved_shape(mir, *value.lhs);
+        if (subject_shape.type != MirTypeKind::Variant ||
+            subject_shape.variant_index >= mir.variants.len)
+            return frontend_error(FrontendError::UnsupportedSyntax, span);
+        if (variant_infos[subject_shape.variant_index].struct_type == nullptr)
+            return subject.value();
+        auto i32_ty = b.make_type(rir::TypeKind::I32);
+        if (!i32_ty) return frontend_error(FrontendError::OutOfMemory, span);
+        auto tag =
+            b.emit_struct_field(subject.value(), lit("tag"), i32_ty.value(), {span.line, span.col});
+        if (!tag) return frontend_error(FrontendError::OutOfMemory, span);
+        return tag.value();
+    }
     if (value.kind == MirValueKind::Eq || value.kind == MirValueKind::Lt ||
         value.kind == MirValueKind::Gt) {
         const MirValue& lhs_expr = *value.lhs;

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -1114,10 +1114,11 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             } else if (module.routes[i].control.kind == HirControlKind::Match) {
                 auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
                 if (!subject) return core::make_unexpected(subject.error());
-                auto arm_fallthrough_target = [&](u32 ai) {
+                auto arm_fallthrough_target = [&](u32 ai) -> FrontendResult<u32> {
                     if (ai + 1 < match_test_count) return terminal_index + ai + 1;
                     if (ai + 1 < match_arm_count) return match_arm_block_index[ai + 1];
-                    return match_arm_body_index[ai];
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          module.routes[i].control.match_arms[ai].span);
                 };
                 if (match_test_count == 0) {
                     MirBlock case_block{};
@@ -1132,7 +1133,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         case_block.term.then_block = arm.guards.len != 0
                                                          ? match_arm_guard_index[0][0]
                                                          : match_arm_body_index[0];
-                        case_block.term.else_block = arm_fallthrough_target(0);
+                        auto fallback = arm_fallthrough_target(0);
+                        if (!fallback) return core::make_unexpected(fallback.error());
+                        case_block.term.else_block = fallback.value();
                     } else if (arm.guards.len != 0) {
                         auto cond = mir_value(arm.guards[0].cond, module, &fn);
                         if (!cond) return core::make_unexpected(cond.error());
@@ -1239,7 +1242,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                             case_block.term.then_block = arm.guards.len != 0
                                                              ? match_arm_guard_index[ai][0]
                                                              : match_arm_body_index[ai];
-                            case_block.term.else_block = arm_fallthrough_target(ai);
+                            auto fallback = arm_fallthrough_target(ai);
+                            if (!fallback) return core::make_unexpected(fallback.error());
+                            case_block.term.else_block = fallback.value();
                         } else if (arm.guards.len != 0) {
                             auto cond = mir_value(arm.guards[0].cond, module, &fn);
                             if (!cond) return core::make_unexpected(cond.error());
@@ -1696,10 +1701,11 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
 
                 auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
                 if (!subject) return core::make_unexpected(subject.error());
-                auto arm_fallthrough_target = [&](u32 ai) {
+                auto arm_fallthrough_target = [&](u32 ai) -> FrontendResult<u32> {
                     if (ai + 1 < test_count) return guard_count + ai + 1;
                     if (ai + 1 < arm_count) return arm_block_index[ai + 1];
-                    return arm_body_index[ai];
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          module.routes[i].control.match_arms[ai].span);
                 };
                 for (u32 ai = 0; ai < test_count; ai++) {
                     MirBlock test_block{};
@@ -1731,7 +1737,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         case_block.term.cond = cond.value();
                         case_block.term.then_block =
                             arm.guards.len != 0 ? arm_guard_index[ai][0] : arm_body_index[ai];
-                        case_block.term.else_block = arm_fallthrough_target(ai);
+                        auto fallback = arm_fallthrough_target(ai);
+                        if (!fallback) return core::make_unexpected(fallback.error());
+                        case_block.term.else_block = fallback.value();
                     } else if (arm.guards.len != 0) {
                         auto cond = mir_value(arm.guards[0].cond, module, &fn);
                         if (!cond) return core::make_unexpected(cond.error());
@@ -1867,10 +1875,11 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             }
             auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
             if (!subject) return core::make_unexpected(subject.error());
-            auto arm_fallthrough_target = [&](u32 ai) {
+            auto arm_fallthrough_target = [&](u32 ai) -> FrontendResult<u32> {
                 if (ai + 1 < test_count) return ai + 1;
                 if (ai + 1 < arm_count) return arm_block_index[ai + 1];
-                return arm_body_index[ai];
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      module.routes[i].control.match_arms[ai].span);
             };
             if (test_count == 0) {
                 MirBlock case_block{};
@@ -1884,7 +1893,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     case_block.term.cond = cond.value();
                     case_block.term.then_block =
                         arm.guards.len != 0 ? arm_guard_index[0][0] : arm_body_index[0];
-                    case_block.term.else_block = arm_fallthrough_target(0);
+                    auto fallback = arm_fallthrough_target(0);
+                    if (!fallback) return core::make_unexpected(fallback.error());
+                    case_block.term.else_block = fallback.value();
                 } else if (arm.guards.len != 0) {
                     auto cond = mir_value(arm.guards[0].cond, module, &fn);
                     if (!cond) return core::make_unexpected(cond.error());
@@ -1986,7 +1997,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         case_block.term.cond = cond.value();
                         case_block.term.then_block =
                             arm.guards.len != 0 ? arm_guard_index[ai][0] : arm_body_index[ai];
-                        case_block.term.else_block = arm_fallthrough_target(ai);
+                        auto fallback = arm_fallthrough_target(ai);
+                        if (!fallback) return core::make_unexpected(fallback.error());
+                        case_block.term.else_block = fallback.value();
                     } else if (arm.guards.len != 0) {
                         auto cond = mir_value(arm.guards[0].cond, module, &fn);
                         if (!cond) return core::make_unexpected(cond.error());

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -1015,6 +1015,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     const auto& arm = module.routes[i].control.match_arms[ai];
                     match_arm_block_index[ai] = next_index++;
                     if (arm.guards.len != 0) {
+                        if (arm.has_arm_guard) match_arm_guard_index[ai][0] = next_index++;
                         for (u32 gi = 1; gi < arm.guards.len; gi++)
                             match_arm_guard_index[ai][gi] = next_index++;
                         match_arm_body_index[ai] = next_index++;
@@ -1022,6 +1023,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                             match_arm_guard_fail_index[ai][gi] = next_index;
                             next_index += guard_fail_block_count(arm.guards[gi]);
                         }
+                    } else if (arm.has_arm_guard) {
+                        match_arm_body_index[ai] = next_index++;
                     } else {
                         match_arm_body_index[ai] = match_arm_block_index[ai];
                     }
@@ -1111,11 +1114,26 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             } else if (module.routes[i].control.kind == HirControlKind::Match) {
                 auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
                 if (!subject) return core::make_unexpected(subject.error());
+                auto arm_fallthrough_target = [&](u32 ai) {
+                    if (ai + 1 < match_test_count) return terminal_index + ai + 1;
+                    if (ai + 1 < match_arm_count) return match_arm_block_index[ai + 1];
+                    return match_arm_block_index[ai];
+                };
                 if (match_test_count == 0) {
                     MirBlock case_block{};
                     const auto& arm = module.routes[i].control.match_arms[0];
                     case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
-                    if (arm.guards.len != 0) {
+                    if (arm.has_arm_guard) {
+                        auto cond = mir_value(arm.arm_guard, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        case_block.term.kind = MirTerminatorKind::Branch;
+                        case_block.term.span = arm.arm_guard.span;
+                        case_block.term.cond = cond.value();
+                        case_block.term.then_block = arm.guards.len != 0
+                                                         ? match_arm_guard_index[0][0]
+                                                         : match_arm_body_index[0];
+                        case_block.term.else_block = arm_fallthrough_target(0);
+                    } else if (arm.guards.len != 0) {
                         auto cond = mir_value(arm.guards[0].cond, module, &fn);
                         if (!cond) return core::make_unexpected(cond.error());
                         case_block.term.kind = MirTerminatorKind::Branch;
@@ -1138,7 +1156,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     }
                     if (!fn.blocks.push(case_block))
                         return frontend_error(FrontendError::TooManyItems, fn.span);
-                    for (u32 gi = 1; gi < arm.guards.len; gi++) {
+                    const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
+                    for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
                         MirBlock guard_block{};
                         guard_block.label = cont_label();
                         auto cond = mir_value(arm.guards[gi].cond, module, &fn);
@@ -1153,7 +1172,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         if (!fn.blocks.push(guard_block))
                             return frontend_error(FrontendError::TooManyItems, fn.span);
                     }
-                    if (arm.guards.len != 0) {
+                    if (arm.guards.len != 0 || arm.has_arm_guard) {
                         MirBlock body_block{};
                         body_block.label = cont_label();
                         if (arm.body_kind == HirMatchArm::BodyKind::If) {
@@ -1211,7 +1230,17 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         const auto& arm = module.routes[i].control.match_arms[ai];
                         case_block.label =
                             arm.is_wildcard ? match_default_label() : match_case_label();
-                        if (arm.guards.len != 0) {
+                        if (arm.has_arm_guard) {
+                            auto cond = mir_value(arm.arm_guard, module, &fn);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            case_block.term.kind = MirTerminatorKind::Branch;
+                            case_block.term.span = arm.arm_guard.span;
+                            case_block.term.cond = cond.value();
+                            case_block.term.then_block = arm.guards.len != 0
+                                                             ? match_arm_guard_index[ai][0]
+                                                             : match_arm_body_index[ai];
+                            case_block.term.else_block = arm_fallthrough_target(ai);
+                        } else if (arm.guards.len != 0) {
                             auto cond = mir_value(arm.guards[0].cond, module, &fn);
                             if (!cond) return core::make_unexpected(cond.error());
                             case_block.term.kind = MirTerminatorKind::Branch;
@@ -1234,7 +1263,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         }
                         if (!fn.blocks.push(case_block))
                             return frontend_error(FrontendError::TooManyItems, fn.span);
-                        for (u32 gi = 1; gi < arm.guards.len; gi++) {
+                        const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
+                        for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
                             MirBlock guard_block{};
                             guard_block.label = cont_label();
                             auto cond = mir_value(arm.guards[gi].cond, module, &fn);
@@ -1249,7 +1279,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                             if (!fn.blocks.push(guard_block))
                                 return frontend_error(FrontendError::TooManyItems, fn.span);
                         }
-                        if (arm.guards.len != 0) {
+                        if (arm.guards.len != 0 || arm.has_arm_guard) {
                             MirBlock body_block{};
                             body_block.label = cont_label();
                             if (arm.body_kind == HirMatchArm::BodyKind::If) {
@@ -1611,6 +1641,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     const auto& arm = module.routes[i].control.match_arms[ai];
                     arm_block_index[ai] = next_index++;
                     if (arm.guards.len != 0) {
+                        if (arm.has_arm_guard) arm_guard_index[ai][0] = next_index++;
                         for (u32 gi = 1; gi < arm.guards.len; gi++)
                             arm_guard_index[ai][gi] = next_index++;
                         arm_body_index[ai] = next_index++;
@@ -1618,6 +1649,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                             arm_guard_fail_index[ai][gi] = next_index;
                             next_index += guard_fail_block_count(arm.guards[gi]);
                         }
+                    } else if (arm.has_arm_guard) {
+                        arm_body_index[ai] = next_index++;
                     } else {
                         arm_body_index[ai] = arm_block_index[ai];
                     }
@@ -1663,6 +1696,11 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
 
                 auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
                 if (!subject) return core::make_unexpected(subject.error());
+                auto arm_fallthrough_target = [&](u32 ai) {
+                    if (ai + 1 < test_count) return ai + 2;
+                    if (ai + 1 < arm_count) return arm_block_index[ai + 1];
+                    return arm_block_index[ai];
+                };
                 for (u32 ai = 0; ai < test_count; ai++) {
                     MirBlock test_block{};
                     test_block.label = ai == 0 ? cont_label() : match_test_label();
@@ -1685,7 +1723,16 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     MirBlock case_block{};
                     const auto& arm = module.routes[i].control.match_arms[ai];
                     case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
-                    if (arm.guards.len != 0) {
+                    if (arm.has_arm_guard) {
+                        auto cond = mir_value(arm.arm_guard, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        case_block.term.kind = MirTerminatorKind::Branch;
+                        case_block.term.span = arm.arm_guard.span;
+                        case_block.term.cond = cond.value();
+                        case_block.term.then_block =
+                            arm.guards.len != 0 ? arm_guard_index[ai][0] : arm_body_index[ai];
+                        case_block.term.else_block = arm_fallthrough_target(ai);
+                    } else if (arm.guards.len != 0) {
                         auto cond = mir_value(arm.guards[0].cond, module, &fn);
                         if (!cond) return core::make_unexpected(cond.error());
                         case_block.term.kind = MirTerminatorKind::Branch;
@@ -1707,7 +1754,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     }
                     if (!fn.blocks.push(case_block))
                         return frontend_error(FrontendError::TooManyItems, fn.span);
-                    for (u32 gi = 1; gi < arm.guards.len; gi++) {
+                    const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
+                    for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
                         MirBlock guard_block{};
                         guard_block.label = cont_label();
                         auto cond = mir_value(arm.guards[gi].cond, module, &fn);
@@ -1722,7 +1770,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         if (!fn.blocks.push(guard_block))
                             return frontend_error(FrontendError::TooManyItems, fn.span);
                     }
-                    if (arm.guards.len != 0) {
+                    if (arm.guards.len != 0 || arm.has_arm_guard) {
                         MirBlock body_block{};
                         body_block.label = cont_label();
                         if (arm.body_kind == HirMatchArm::BodyKind::If) {
@@ -1799,6 +1847,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 const auto& arm = module.routes[i].control.match_arms[ai];
                 arm_block_index[ai] = next_index++;
                 if (arm.guards.len != 0) {
+                    if (arm.has_arm_guard) arm_guard_index[ai][0] = next_index++;
                     for (u32 gi = 1; gi < arm.guards.len; gi++)
                         arm_guard_index[ai][gi] = next_index++;
                     arm_body_index[ai] = next_index++;
@@ -1806,6 +1855,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         arm_guard_fail_index[ai][gi] = next_index;
                         next_index += guard_fail_block_count(arm.guards[gi]);
                     }
+                } else if (arm.has_arm_guard) {
+                    arm_body_index[ai] = next_index++;
                 } else {
                     arm_body_index[ai] = arm_block_index[ai];
                 }
@@ -1816,11 +1867,25 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             }
             auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
             if (!subject) return core::make_unexpected(subject.error());
+            auto arm_fallthrough_target = [&](u32 ai) {
+                if (ai + 1 < test_count) return ai + 1;
+                if (ai + 1 < arm_count) return arm_block_index[ai + 1];
+                return arm_block_index[ai];
+            };
             if (test_count == 0) {
                 MirBlock case_block{};
                 const auto& arm = module.routes[i].control.match_arms[0];
                 case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
-                if (arm.guards.len != 0) {
+                if (arm.has_arm_guard) {
+                    auto cond = mir_value(arm.arm_guard, module, &fn);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    case_block.term.kind = MirTerminatorKind::Branch;
+                    case_block.term.span = arm.arm_guard.span;
+                    case_block.term.cond = cond.value();
+                    case_block.term.then_block =
+                        arm.guards.len != 0 ? arm_guard_index[0][0] : arm_body_index[0];
+                    case_block.term.else_block = arm_fallthrough_target(0);
+                } else if (arm.guards.len != 0) {
                     auto cond = mir_value(arm.guards[0].cond, module, &fn);
                     if (!cond) return core::make_unexpected(cond.error());
                     case_block.term.kind = MirTerminatorKind::Branch;
@@ -1842,7 +1907,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 }
                 if (!fn.blocks.push(case_block))
                     return frontend_error(FrontendError::TooManyItems, fn.span);
-                for (u32 gi = 1; gi < arm.guards.len; gi++) {
+                const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
+                for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
                     MirBlock guard_block{};
                     guard_block.label = cont_label();
                     auto cond = mir_value(arm.guards[gi].cond, module, &fn);
@@ -1856,7 +1922,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     if (!fn.blocks.push(guard_block))
                         return frontend_error(FrontendError::TooManyItems, fn.span);
                 }
-                if (arm.guards.len != 0) {
+                if (arm.guards.len != 0 || arm.has_arm_guard) {
                     MirBlock body_block{};
                     body_block.label = cont_label();
                     if (arm.body_kind == HirMatchArm::BodyKind::If) {
@@ -1912,7 +1978,16 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     MirBlock case_block{};
                     const auto& arm = module.routes[i].control.match_arms[ai];
                     case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
-                    if (arm.guards.len != 0) {
+                    if (arm.has_arm_guard) {
+                        auto cond = mir_value(arm.arm_guard, module, &fn);
+                        if (!cond) return core::make_unexpected(cond.error());
+                        case_block.term.kind = MirTerminatorKind::Branch;
+                        case_block.term.span = arm.arm_guard.span;
+                        case_block.term.cond = cond.value();
+                        case_block.term.then_block =
+                            arm.guards.len != 0 ? arm_guard_index[ai][0] : arm_body_index[ai];
+                        case_block.term.else_block = arm_fallthrough_target(ai);
+                    } else if (arm.guards.len != 0) {
                         auto cond = mir_value(arm.guards[0].cond, module, &fn);
                         if (!cond) return core::make_unexpected(cond.error());
                         case_block.term.kind = MirTerminatorKind::Branch;
@@ -1934,7 +2009,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     }
                     if (!fn.blocks.push(case_block))
                         return frontend_error(FrontendError::TooManyItems, fn.span);
-                    for (u32 gi = 1; gi < arm.guards.len; gi++) {
+                    const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
+                    for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
                         MirBlock guard_block{};
                         guard_block.label = cont_label();
                         auto cond = mir_value(arm.guards[gi].cond, module, &fn);
@@ -1949,7 +2025,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         if (!fn.blocks.push(guard_block))
                             return frontend_error(FrontendError::TooManyItems, fn.span);
                     }
-                    if (arm.guards.len != 0) {
+                    if (arm.guards.len != 0 || arm.has_arm_guard) {
                         MirBlock body_block{};
                         body_block.label = cont_label();
                         if (arm.body_kind == HirMatchArm::BodyKind::If) {

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -1697,7 +1697,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
                 if (!subject) return core::make_unexpected(subject.error());
                 auto arm_fallthrough_target = [&](u32 ai) {
-                    if (ai + 1 < test_count) return ai + 2;
+                    if (ai + 1 < test_count) return guard_count + ai + 1;
                     if (ai + 1 < arm_count) return arm_block_index[ai + 1];
                     return arm_block_index[ai];
                 };
@@ -1714,7 +1714,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     test_block.term.rhs = arm_pattern.value();
                     test_block.term.then_block = arm_block_index[ai];
                     test_block.term.else_block =
-                        ai + 1 < test_count ? (ai + 2) : arm_block_index[test_count];
+                        ai + 1 < test_count ? guard_count + ai + 1 : arm_block_index[test_count];
                     if (!fn.blocks.push(test_block))
                         return frontend_error(FrontendError::TooManyItems, fn.span);
                 }

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -550,6 +550,17 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         apply_expr_shape_if_available(module, expr, &v);
         return v;
     }
+    if (expr.kind == HirExprKind::VariantTag) {
+        auto lhs = mir_value(*expr.lhs, module, fn, ctx);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        if (!fn->values.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        v.kind = MirValueKind::VariantTag;
+        v.type = MirTypeKind::I32;
+        v.variant_index = expr.variant_index;
+        v.lhs = &fn->values[fn->values.len - 1];
+        return v;
+    }
     if (expr.kind == HirExprKind::LocalRef) {
         // For-loop unroll (Phase 4b): when lowering a body expression for
         // iteration j, ctx carries the loop var's ref_index and the element

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -1117,7 +1117,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 auto arm_fallthrough_target = [&](u32 ai) {
                     if (ai + 1 < match_test_count) return terminal_index + ai + 1;
                     if (ai + 1 < match_arm_count) return match_arm_block_index[ai + 1];
-                    return match_arm_block_index[ai];
+                    return match_arm_body_index[ai];
                 };
                 if (match_test_count == 0) {
                     MirBlock case_block{};
@@ -1699,7 +1699,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 auto arm_fallthrough_target = [&](u32 ai) {
                     if (ai + 1 < test_count) return guard_count + ai + 1;
                     if (ai + 1 < arm_count) return arm_block_index[ai + 1];
-                    return arm_block_index[ai];
+                    return arm_body_index[ai];
                 };
                 for (u32 ai = 0; ai < test_count; ai++) {
                     MirBlock test_block{};
@@ -1870,7 +1870,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             auto arm_fallthrough_target = [&](u32 ai) {
                 if (ai + 1 < test_count) return ai + 1;
                 if (ai + 1 < arm_count) return arm_block_index[ai + 1];
-                return arm_block_index[ai];
+                return arm_body_index[ai];
             };
             if (test_count == 0) {
                 MirBlock case_block{};

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -959,6 +959,44 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             }
             return {};
         };
+        auto set_match_arm_guard_branch = [&](MirBlock& block,
+                                              const HirMatchArm& arm,
+                                              u32 first_guard_index,
+                                              u32 body_index,
+                                              auto&& fallthrough) -> FrontendResult<void> {
+            auto cond = mir_value(arm.arm_guard, module, &fn);
+            if (!cond) return core::make_unexpected(cond.error());
+            block.term.kind = MirTerminatorKind::Branch;
+            block.term.span = arm.arm_guard.span;
+            block.term.cond = cond.value();
+            block.term.then_block = arm.guards.len != 0 ? first_guard_index : body_index;
+            auto fallback = fallthrough();
+            if (!fallback) return core::make_unexpected(fallback.error());
+            block.term.else_block = fallback.value();
+            return {};
+        };
+        auto emit_match_prelude_guard_blocks = [&](const HirMatchArm& arm,
+                                                   u32 ai,
+                                                   auto guard_index,
+                                                   auto guard_fail_index,
+                                                   const u32* body_index) -> FrontendResult<void> {
+            const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
+            for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
+                MirBlock guard_block{};
+                guard_block.label = cont_label();
+                auto cond = mir_value(arm.guards[gi].cond, module, &fn);
+                if (!cond) return core::make_unexpected(cond.error());
+                guard_block.term.kind = MirTerminatorKind::Branch;
+                guard_block.term.span = arm.guards[gi].span;
+                guard_block.term.cond = cond.value();
+                guard_block.term.then_block =
+                    gi + 1 < arm.guards.len ? guard_index[ai][gi + 1] : body_index[ai];
+                guard_block.term.else_block = guard_fail_index[ai][gi];
+                if (!fn.blocks.push(guard_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+            }
+            return {};
+        };
 
         if (fn.waits.len != 0 && module.routes[i].for_loops.len == 0) {
             if (module.routes[i].control.kind != HirControlKind::Direct &&
@@ -1125,17 +1163,13 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     const auto& arm = module.routes[i].control.match_arms[0];
                     case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
                     if (arm.has_arm_guard) {
-                        auto cond = mir_value(arm.arm_guard, module, &fn);
-                        if (!cond) return core::make_unexpected(cond.error());
-                        case_block.term.kind = MirTerminatorKind::Branch;
-                        case_block.term.span = arm.arm_guard.span;
-                        case_block.term.cond = cond.value();
-                        case_block.term.then_block = arm.guards.len != 0
-                                                         ? match_arm_guard_index[0][0]
-                                                         : match_arm_body_index[0];
-                        auto fallback = arm_fallthrough_target(0);
-                        if (!fallback) return core::make_unexpected(fallback.error());
-                        case_block.term.else_block = fallback.value();
+                        auto guarded =
+                            set_match_arm_guard_branch(case_block,
+                                                       arm,
+                                                       match_arm_guard_index[0][0],
+                                                       match_arm_body_index[0],
+                                                       [&] { return arm_fallthrough_target(0); });
+                        if (!guarded) return core::make_unexpected(guarded.error());
                     } else if (arm.guards.len != 0) {
                         auto cond = mir_value(arm.guards[0].cond, module, &fn);
                         if (!cond) return core::make_unexpected(cond.error());
@@ -1159,22 +1193,12 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     }
                     if (!fn.blocks.push(case_block))
                         return frontend_error(FrontendError::TooManyItems, fn.span);
-                    const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
-                    for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
-                        MirBlock guard_block{};
-                        guard_block.label = cont_label();
-                        auto cond = mir_value(arm.guards[gi].cond, module, &fn);
-                        if (!cond) return core::make_unexpected(cond.error());
-                        guard_block.term.kind = MirTerminatorKind::Branch;
-                        guard_block.term.span = arm.guards[gi].span;
-                        guard_block.term.cond = cond.value();
-                        guard_block.term.then_block = gi + 1 < arm.guards.len
-                                                          ? match_arm_guard_index[0][gi + 1]
-                                                          : match_arm_body_index[0];
-                        guard_block.term.else_block = match_arm_guard_fail_index[0][gi];
-                        if (!fn.blocks.push(guard_block))
-                            return frontend_error(FrontendError::TooManyItems, fn.span);
-                    }
+                    auto guard_blocks = emit_match_prelude_guard_blocks(arm,
+                                                                        0,
+                                                                        match_arm_guard_index,
+                                                                        match_arm_guard_fail_index,
+                                                                        match_arm_body_index);
+                    if (!guard_blocks) return core::make_unexpected(guard_blocks.error());
                     if (arm.guards.len != 0 || arm.has_arm_guard) {
                         MirBlock body_block{};
                         body_block.label = cont_label();
@@ -1234,17 +1258,13 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         case_block.label =
                             arm.is_wildcard ? match_default_label() : match_case_label();
                         if (arm.has_arm_guard) {
-                            auto cond = mir_value(arm.arm_guard, module, &fn);
-                            if (!cond) return core::make_unexpected(cond.error());
-                            case_block.term.kind = MirTerminatorKind::Branch;
-                            case_block.term.span = arm.arm_guard.span;
-                            case_block.term.cond = cond.value();
-                            case_block.term.then_block = arm.guards.len != 0
-                                                             ? match_arm_guard_index[ai][0]
-                                                             : match_arm_body_index[ai];
-                            auto fallback = arm_fallthrough_target(ai);
-                            if (!fallback) return core::make_unexpected(fallback.error());
-                            case_block.term.else_block = fallback.value();
+                            auto guarded = set_match_arm_guard_branch(
+                                case_block,
+                                arm,
+                                match_arm_guard_index[ai][0],
+                                match_arm_body_index[ai],
+                                [&] { return arm_fallthrough_target(ai); });
+                            if (!guarded) return core::make_unexpected(guarded.error());
                         } else if (arm.guards.len != 0) {
                             auto cond = mir_value(arm.guards[0].cond, module, &fn);
                             if (!cond) return core::make_unexpected(cond.error());
@@ -1268,22 +1288,13 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                         }
                         if (!fn.blocks.push(case_block))
                             return frontend_error(FrontendError::TooManyItems, fn.span);
-                        const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
-                        for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
-                            MirBlock guard_block{};
-                            guard_block.label = cont_label();
-                            auto cond = mir_value(arm.guards[gi].cond, module, &fn);
-                            if (!cond) return core::make_unexpected(cond.error());
-                            guard_block.term.kind = MirTerminatorKind::Branch;
-                            guard_block.term.span = arm.guards[gi].span;
-                            guard_block.term.cond = cond.value();
-                            guard_block.term.then_block = gi + 1 < arm.guards.len
-                                                              ? match_arm_guard_index[ai][gi + 1]
-                                                              : match_arm_body_index[ai];
-                            guard_block.term.else_block = match_arm_guard_fail_index[ai][gi];
-                            if (!fn.blocks.push(guard_block))
-                                return frontend_error(FrontendError::TooManyItems, fn.span);
-                        }
+                        auto guard_blocks =
+                            emit_match_prelude_guard_blocks(arm,
+                                                            ai,
+                                                            match_arm_guard_index,
+                                                            match_arm_guard_fail_index,
+                                                            match_arm_body_index);
+                        if (!guard_blocks) return core::make_unexpected(guard_blocks.error());
                         if (arm.guards.len != 0 || arm.has_arm_guard) {
                             MirBlock body_block{};
                             body_block.label = cont_label();
@@ -1730,16 +1741,11 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     const auto& arm = module.routes[i].control.match_arms[ai];
                     case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
                     if (arm.has_arm_guard) {
-                        auto cond = mir_value(arm.arm_guard, module, &fn);
-                        if (!cond) return core::make_unexpected(cond.error());
-                        case_block.term.kind = MirTerminatorKind::Branch;
-                        case_block.term.span = arm.arm_guard.span;
-                        case_block.term.cond = cond.value();
-                        case_block.term.then_block =
-                            arm.guards.len != 0 ? arm_guard_index[ai][0] : arm_body_index[ai];
-                        auto fallback = arm_fallthrough_target(ai);
-                        if (!fallback) return core::make_unexpected(fallback.error());
-                        case_block.term.else_block = fallback.value();
+                        auto guarded = set_match_arm_guard_branch(
+                            case_block, arm, arm_guard_index[ai][0], arm_body_index[ai], [&] {
+                                return arm_fallthrough_target(ai);
+                            });
+                        if (!guarded) return core::make_unexpected(guarded.error());
                     } else if (arm.guards.len != 0) {
                         auto cond = mir_value(arm.guards[0].cond, module, &fn);
                         if (!cond) return core::make_unexpected(cond.error());
@@ -1762,22 +1768,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     }
                     if (!fn.blocks.push(case_block))
                         return frontend_error(FrontendError::TooManyItems, fn.span);
-                    const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
-                    for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
-                        MirBlock guard_block{};
-                        guard_block.label = cont_label();
-                        auto cond = mir_value(arm.guards[gi].cond, module, &fn);
-                        if (!cond) return core::make_unexpected(cond.error());
-                        guard_block.term.kind = MirTerminatorKind::Branch;
-                        guard_block.term.span = arm.guards[gi].span;
-                        guard_block.term.cond = cond.value();
-                        guard_block.term.then_block = gi + 1 < arm.guards.len
-                                                          ? arm_guard_index[ai][gi + 1]
-                                                          : arm_body_index[ai];
-                        guard_block.term.else_block = arm_guard_fail_index[ai][gi];
-                        if (!fn.blocks.push(guard_block))
-                            return frontend_error(FrontendError::TooManyItems, fn.span);
-                    }
+                    auto guard_blocks = emit_match_prelude_guard_blocks(
+                        arm, ai, arm_guard_index, arm_guard_fail_index, arm_body_index);
+                    if (!guard_blocks) return core::make_unexpected(guard_blocks.error());
                     if (arm.guards.len != 0 || arm.has_arm_guard) {
                         MirBlock body_block{};
                         body_block.label = cont_label();
@@ -1886,16 +1879,11 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 const auto& arm = module.routes[i].control.match_arms[0];
                 case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
                 if (arm.has_arm_guard) {
-                    auto cond = mir_value(arm.arm_guard, module, &fn);
-                    if (!cond) return core::make_unexpected(cond.error());
-                    case_block.term.kind = MirTerminatorKind::Branch;
-                    case_block.term.span = arm.arm_guard.span;
-                    case_block.term.cond = cond.value();
-                    case_block.term.then_block =
-                        arm.guards.len != 0 ? arm_guard_index[0][0] : arm_body_index[0];
-                    auto fallback = arm_fallthrough_target(0);
-                    if (!fallback) return core::make_unexpected(fallback.error());
-                    case_block.term.else_block = fallback.value();
+                    auto guarded = set_match_arm_guard_branch(
+                        case_block, arm, arm_guard_index[0][0], arm_body_index[0], [&] {
+                            return arm_fallthrough_target(0);
+                        });
+                    if (!guarded) return core::make_unexpected(guarded.error());
                 } else if (arm.guards.len != 0) {
                     auto cond = mir_value(arm.guards[0].cond, module, &fn);
                     if (!cond) return core::make_unexpected(cond.error());
@@ -1918,21 +1906,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 }
                 if (!fn.blocks.push(case_block))
                     return frontend_error(FrontendError::TooManyItems, fn.span);
-                const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
-                for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
-                    MirBlock guard_block{};
-                    guard_block.label = cont_label();
-                    auto cond = mir_value(arm.guards[gi].cond, module, &fn);
-                    if (!cond) return core::make_unexpected(cond.error());
-                    guard_block.term.kind = MirTerminatorKind::Branch;
-                    guard_block.term.span = arm.guards[gi].span;
-                    guard_block.term.cond = cond.value();
-                    guard_block.term.then_block =
-                        gi + 1 < arm.guards.len ? arm_guard_index[0][gi + 1] : arm_body_index[0];
-                    guard_block.term.else_block = arm_guard_fail_index[0][gi];
-                    if (!fn.blocks.push(guard_block))
-                        return frontend_error(FrontendError::TooManyItems, fn.span);
-                }
+                auto guard_blocks = emit_match_prelude_guard_blocks(
+                    arm, 0, arm_guard_index, arm_guard_fail_index, arm_body_index);
+                if (!guard_blocks) return core::make_unexpected(guard_blocks.error());
                 if (arm.guards.len != 0 || arm.has_arm_guard) {
                     MirBlock body_block{};
                     body_block.label = cont_label();
@@ -1990,16 +1966,11 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     const auto& arm = module.routes[i].control.match_arms[ai];
                     case_block.label = arm.is_wildcard ? match_default_label() : match_case_label();
                     if (arm.has_arm_guard) {
-                        auto cond = mir_value(arm.arm_guard, module, &fn);
-                        if (!cond) return core::make_unexpected(cond.error());
-                        case_block.term.kind = MirTerminatorKind::Branch;
-                        case_block.term.span = arm.arm_guard.span;
-                        case_block.term.cond = cond.value();
-                        case_block.term.then_block =
-                            arm.guards.len != 0 ? arm_guard_index[ai][0] : arm_body_index[ai];
-                        auto fallback = arm_fallthrough_target(ai);
-                        if (!fallback) return core::make_unexpected(fallback.error());
-                        case_block.term.else_block = fallback.value();
+                        auto guarded = set_match_arm_guard_branch(
+                            case_block, arm, arm_guard_index[ai][0], arm_body_index[ai], [&] {
+                                return arm_fallthrough_target(ai);
+                            });
+                        if (!guarded) return core::make_unexpected(guarded.error());
                     } else if (arm.guards.len != 0) {
                         auto cond = mir_value(arm.guards[0].cond, module, &fn);
                         if (!cond) return core::make_unexpected(cond.error());
@@ -2022,22 +1993,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     }
                     if (!fn.blocks.push(case_block))
                         return frontend_error(FrontendError::TooManyItems, fn.span);
-                    const u32 first_guard_index = arm.has_arm_guard ? 0 : 1;
-                    for (u32 gi = first_guard_index; gi < arm.guards.len; gi++) {
-                        MirBlock guard_block{};
-                        guard_block.label = cont_label();
-                        auto cond = mir_value(arm.guards[gi].cond, module, &fn);
-                        if (!cond) return core::make_unexpected(cond.error());
-                        guard_block.term.kind = MirTerminatorKind::Branch;
-                        guard_block.term.span = arm.guards[gi].span;
-                        guard_block.term.cond = cond.value();
-                        guard_block.term.then_block = gi + 1 < arm.guards.len
-                                                          ? arm_guard_index[ai][gi + 1]
-                                                          : arm_body_index[ai];
-                        guard_block.term.else_block = arm_guard_fail_index[ai][gi];
-                        if (!fn.blocks.push(guard_block))
-                            return frontend_error(FrontendError::TooManyItems, fn.span);
-                    }
+                    auto guard_blocks = emit_match_prelude_guard_blocks(
+                        arm, ai, arm_guard_index, arm_guard_fail_index, arm_body_index);
+                    if (!guard_blocks) return core::make_unexpected(guard_blocks.error());
                     if (arm.guards.len != 0 || arm.has_arm_guard) {
                         MirBlock body_block{};
                         body_block.label = cont_label();

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -113,8 +113,8 @@ struct Parser {
                     if (!pattern) return core::make_unexpected(pattern.error());
                     arm.pattern = pattern.value();
                 }
-                if (take(TokenType::KwIf))
-                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                if (const Token* kw_if = take(TokenType::KwIf))
+                    return frontend_error(FrontendError::UnsupportedSyntax, span_from(*kw_if));
                 auto arrow = expect(TokenType::Arrow);
                 if (!arrow) return core::make_unexpected(arrow.error());
                 auto arm_stmt = parse_func_body_stmt();
@@ -818,8 +818,8 @@ struct Parser {
                         if (!pattern) return core::make_unexpected(pattern.error());
                         arm.pattern = pattern.value();
                     }
-                    if (take(TokenType::KwIf))
-                        return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
+                    if (const Token* kw_if = take(TokenType::KwIf))
+                        return frontend_error(FrontendError::UnsupportedSyntax, span_from(*kw_if));
                     auto colon = expect(TokenType::Colon);
                     if (!colon) return core::make_unexpected(colon.error());
                     auto arm_stmt = parse_stmt();

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -824,14 +824,8 @@ struct Parser {
                         if (!pattern) return core::make_unexpected(pattern.error());
                         arm.pattern = pattern.value();
                     }
-                    if (take(TokenType::KwIf)) {
-                        auto guard = parse_expr();
-                        if (!guard) return core::make_unexpected(guard.error());
-                        auto guard_ptr = alloc_expr(guard.value());
-                        if (!guard_ptr) return core::make_unexpected(guard_ptr.error());
-                        arm.has_guard = true;
-                        arm.guard = guard_ptr.value();
-                    }
+                    if (take(TokenType::KwIf))
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                     auto colon = expect(TokenType::Colon);
                     if (!colon) return core::make_unexpected(colon.error());
                     auto arm_stmt = parse_stmt();

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -113,6 +113,14 @@ struct Parser {
                     if (!pattern) return core::make_unexpected(pattern.error());
                     arm.pattern = pattern.value();
                 }
+                if (take(TokenType::KwIf)) {
+                    auto guard = parse_expr();
+                    if (!guard) return core::make_unexpected(guard.error());
+                    auto guard_ptr = alloc_expr(guard.value());
+                    if (!guard_ptr) return core::make_unexpected(guard_ptr.error());
+                    arm.has_guard = true;
+                    arm.guard = guard_ptr.value();
+                }
                 auto arrow = expect(TokenType::Arrow);
                 if (!arrow) return core::make_unexpected(arrow.error());
                 auto arm_stmt = parse_func_body_stmt();
@@ -816,6 +824,14 @@ struct Parser {
                         if (!pattern) return core::make_unexpected(pattern.error());
                         arm.pattern = pattern.value();
                     }
+                    if (take(TokenType::KwIf)) {
+                        auto guard = parse_expr();
+                        if (!guard) return core::make_unexpected(guard.error());
+                        auto guard_ptr = alloc_expr(guard.value());
+                        if (!guard_ptr) return core::make_unexpected(guard_ptr.error());
+                        arm.has_guard = true;
+                        arm.guard = guard_ptr.value();
+                    }
                     auto colon = expect(TokenType::Colon);
                     if (!colon) return core::make_unexpected(colon.error());
                     auto arm_stmt = parse_stmt();
@@ -1198,12 +1214,19 @@ struct Parser {
                     if (!pattern) return core::make_unexpected(pattern.error());
                     arm.pattern = pattern.value();
                 }
+                if (take(TokenType::KwIf)) {
+                    auto guard = parse_expr();
+                    if (!guard) return core::make_unexpected(guard.error());
+                    auto guard_ptr = alloc_expr(guard.value());
+                    if (!guard_ptr) return core::make_unexpected(guard_ptr.error());
+                    arm.has_guard = true;
+                    arm.guard = guard_ptr.value();
+                }
                 auto colon = expect(TokenType::Colon);
                 if (!colon) return core::make_unexpected(colon.error());
                 auto arm_stmt = parse_stmt();
                 if (!arm_stmt) return core::make_unexpected(arm_stmt.error());
-                if (arm_stmt->kind == AstStmtKind::Let || arm_stmt->kind == AstStmtKind::Guard ||
-                    arm_stmt->kind == AstStmtKind::Match) {
+                if (arm_stmt->kind == AstStmtKind::Let || arm_stmt->kind == AstStmtKind::Guard) {
                     return frontend_error(FrontendError::UnsupportedSyntax, span_from(start));
                 }
                 auto arm_ptr = alloc_stmt(arm_stmt.value());
@@ -1399,6 +1422,14 @@ struct Parser {
                     auto pattern = parse_primary_expr();
                     if (!pattern) return core::make_unexpected(pattern.error());
                     arm.pattern = pattern.value();
+                }
+                if (take(TokenType::KwIf)) {
+                    auto guard = parse_expr();
+                    if (!guard) return core::make_unexpected(guard.error());
+                    auto guard_ptr = alloc_expr(guard.value());
+                    if (!guard_ptr) return core::make_unexpected(guard_ptr.error());
+                    arm.has_guard = true;
+                    arm.guard = guard_ptr.value();
                 }
                 auto arrow = expect(TokenType::Arrow);
                 if (!arrow) return core::make_unexpected(arrow.error());

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -113,14 +113,8 @@ struct Parser {
                     if (!pattern) return core::make_unexpected(pattern.error());
                     arm.pattern = pattern.value();
                 }
-                if (take(TokenType::KwIf)) {
-                    auto guard = parse_expr();
-                    if (!guard) return core::make_unexpected(guard.error());
-                    auto guard_ptr = alloc_expr(guard.value());
-                    if (!guard_ptr) return core::make_unexpected(guard_ptr.error());
-                    arm.has_guard = true;
-                    arm.guard = guard_ptr.value();
-                }
+                if (take(TokenType::KwIf))
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm.span);
                 auto arrow = expect(TokenType::Arrow);
                 if (!arrow) return core::make_unexpected(arrow.error());
                 auto arm_stmt = parse_func_body_stmt();

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8208,6 +8208,20 @@ TEST(frontend, route_match_arm_nested_match_const_selects_inner_case_only) {
     CHECK_FALSE(hir->routes[0].control.match_arms[0].has_arm_guard);
     CHECK_EQ(hir->routes[0].control.match_arms[0].direct_term.status_code, 200);
 }
+TEST(frontend, analyze_rejects_route_nested_match_duplicate_outer_variant_case) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let path = \"/users\" match auth { case .ok: "
+        "match path { case \"/users\": return 200 case _: return 404 } case .ok: return 201 case "
+        ".denied: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, route_match_arm_block_prefix_without_nested_match_inserts_local_once) {
     const char* src =
         "variant Auth { ok, denied }\n"

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8480,6 +8480,19 @@ TEST(frontend, analyze_rejects_route_nested_match_duplicate_bool_case) {
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
+TEST(frontend, analyze_rejects_route_nested_match_duplicate_outer_bool_case) {
+    const char* src =
+        "route GET \"/users\" { let ok = true let allowed = true match ok { case true: match "
+        "allowed { case true: return 200 case false: return 404 } case true: return 201 case "
+        "false: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, analyze_rejects_route_nested_match_inner_arm_guard) {
     const char* src =
         "variant Auth { ok, denied }\n"
@@ -8565,6 +8578,7 @@ TEST(frontend, analyze_rejects_guarded_outer_arm_with_nested_match) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_wildcard_outer_arm_with_nested_match) {
     const char* src =
@@ -8577,6 +8591,7 @@ TEST(frontend, analyze_rejects_wildcard_outer_arm_with_nested_match) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, guard_then_match_lowers_to_guard_and_match_blocks) {
     const char* src =

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8281,6 +8281,21 @@ TEST(frontend, analyze_rejects_route_nested_match_inner_payload_binding) {
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
+TEST(frontend, analyze_rejects_route_nested_match_optional_error_subject) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "func maybe_path(ok: bool) -> str { if ok { \"/users\" } else { error(.timeout) } }\n"
+        "route GET \"/users\" { let auth = Auth.ok let path = maybe_path(false) match auth { case "
+        ".ok: match path { case \"/users\": return 200 case _: return 404 } case .denied: return "
+        "403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, analyze_rejects_route_nested_match_after_guard_prefix) {
     const char* src =
         "variant Auth { ok, denied }\n"

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -6213,7 +6213,6 @@ TEST(frontend, analyze_rejects_non_error_struct_in_error_constructor) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
-    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_custom_error_constructor_missing_extra_fields) {
     const char* src =
@@ -6226,7 +6225,6 @@ TEST(frontend, analyze_rejects_custom_error_constructor_missing_extra_fields) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
-    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_custom_error_constructor_unknown_extra_field) {
     const char* src =
@@ -7411,6 +7409,31 @@ TEST(frontend, match_const_selects_variant_case_without_checking_other_arms) {
     REQUIRE(lowered);
     rir.destroy();
 }
+TEST(frontend, match_const_selects_string_case_without_checking_other_arms) {
+    const char* src =
+        "route GET \"/users\" { let path = \"/users\" match const path { case \"/users\": return "
+        "200 case \"/admin\": return forward(missing) } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Direct));
+    CHECK_EQ(hir->routes[0].control.direct_term.status_code, 200);
+}
+TEST(frontend, analyze_rejects_match_const_arm_guard) {
+    const char* src =
+        "route GET \"/users\" { let path = \"/users\" match const path { case \"/users\" if true: "
+        "return 200 case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, function_match_const_preserves_outer_payload_binding) {
     const char* src =
         "variant Result { ok(i32), err }\n"
@@ -7988,6 +8011,212 @@ TEST(frontend, match_lowers_to_cmp_eq_chain) {
     CHECK_EQ(static_cast<u8>(fn.blocks[1].insts[1].op), static_cast<u8>(rir::Opcode::RetForward));
     CHECK_EQ(static_cast<u8>(fn.blocks[2].insts[0].op), static_cast<u8>(rir::Opcode::RetStatus));
     rir.destroy();
+}
+TEST(frontend, string_match_lowers_to_cmp_eq_chain) {
+    const char* src =
+        "route GET \"/users\" { let path = \"/users\" match path { case \"/users\": return 200 "
+        "case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_EQ(fn.block_count, 3u);
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[2].op), static_cast<u8>(rir::Opcode::CmpEq));
+    rir.destroy();
+}
+TEST(frontend, bool_match_true_false_cases_are_exhaustive) {
+    const char* src =
+        "route GET \"/users\" { let ok = true match ok { case true: return 200 case false: return "
+        "500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+}
+TEST(frontend, route_match_arm_guard_falls_through_to_default) {
+    const char* src =
+        "route GET \"/users\" { let code = 200 match code { case 200 if false: return 500 case _: "
+        "return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.functions[0].block_count, 4u);
+    rir.destroy();
+}
+TEST(frontend, route_match_arm_guard_can_use_payload_binding) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(200) match state { case .ok(code) if code "
+        "== 200: return 200 case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, analyze_rejects_route_match_arm_guard_without_wildcard) {
+    const char* src =
+        "route GET \"/users\" { let code = 200 match code { case 200 if true: return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, route_match_arm_direct_nested_match_lowers) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let path = \"/users\" match auth { case .ok: "
+        "match path { case \"/users\": return 200 case _: return 404 } case .denied: return 403 } "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 3u);
+    CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, route_match_arm_nested_match_with_block_prefix_lowers) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok match auth { case .ok: { let path = "
+        "\"/users\" match path { case \"/users\": return 200 case _: return 404 } } case .denied: "
+        "return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 3u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, route_match_arm_nested_bool_match_is_exhaustive) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let allowed = true match auth { case .ok: match "
+        "allowed { case true: return 200 case false: return 404 } case .denied: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 3u);
+}
+TEST(frontend, analyze_rejects_route_nested_match_inner_arm_guard) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let path = \"/users\" match auth { case .ok: "
+        "match path { case \"/users\" if true: return 200 case _: return 404 } case .denied: "
+        "return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_route_nested_match_inner_payload_binding) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let auth = Auth.ok let result = Result.ok(200) match auth { case "
+        ".ok: match result { case .ok(code): return 200 case _: return 404 } case .denied: return "
+        "403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_route_nested_match_after_guard_prefix) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok match auth { case .ok: { guard true else { "
+        "return 401 } match true { case true: return 200 case false: return 404 } } case .denied: "
+        "return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+}
+TEST(frontend, analyze_rejects_guarded_outer_arm_with_nested_match) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok match auth { case .ok if true: match true { "
+        "case true: return 200 case false: return 404 } case .denied: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+}
+TEST(frontend, analyze_rejects_wildcard_outer_arm_with_nested_match) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok match auth { case .ok: return 200 case _: "
+        "match true { case true: return 201 case false: return 404 } } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
 }
 TEST(frontend, guard_then_match_lowers_to_guard_and_match_blocks) {
     const char* src =
@@ -13438,6 +13667,110 @@ route GET "/users" {
     CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
     REQUIRE_EQ(hir->routes[0].locals.len, 1u);
     CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_function_match_arm_guard_inlines) {
+    const auto src = R"(
+func pick(x: i32) -> i32 {
+    match x {
+        case 200 if false => 201
+        case _ => 404
+    }
+}
+route GET "/users" {
+    let code = pick(200)
+    if code == 404 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+}
+TEST(frontend, source_function_match_arm_guard_can_use_payload_binding) {
+    const auto src = R"(
+variant Result { ok(i32), err }
+func pick(result: Result) -> i32 {
+    match result {
+        case .ok(code) if code == 200 => code
+        case _ => 404
+    }
+}
+route GET "/users" {
+    let code = pick(Result.ok(200))
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+}
+TEST(frontend, source_function_bool_match_true_false_cases_are_exhaustive) {
+    const auto src = R"(
+func pick(ok: bool) -> i32 {
+    match ok {
+        case true => 200
+        case false => 500
+    }
+}
+route GET "/users" {
+    let code = pick(true)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_source_function_match_arm_guard_without_wildcard) {
+    const auto src = R"(
+func pick(x: i32) -> i32 {
+    match x {
+        case 200 if true => 200
+    }
+}
+route GET "/users" { let code = pick(200) return 200 }
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, source_function_string_match_inlines) {
+    const auto src = R"(
+func pick(path: str) -> i32 {
+    match path {
+        case "/users" => 200
+        case _ => 404
+    }
+}
+route GET "/users" {
+    let code = pick("/users")
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
 }
 TEST(frontend, source_function_infers_optional_return_from_match_without_annotation) {
     const auto src = R"(

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -7364,6 +7364,26 @@ TEST(frontend, known_named_error_match_selects_error_case) {
     REQUIRE(lowered);
     rir.destroy();
 }
+TEST(frontend, known_named_error_match_arm_guard_uses_runtime_fallthrough) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) match failed { case .timeout if "
+        "false: "
+        "return 503 case _: return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Direct));
+    CHECK_EQ(hir->routes[0].control.direct_term.status_code, 200);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
 TEST(frontend, if_const_selects_then_without_checking_else) {
     const char* src =
         "route GET \"/users\" { if const true { return 200 } else { return forward(missing) } }\n";
@@ -8168,6 +8188,23 @@ TEST(frontend, route_match_arm_nested_match_with_block_prefix_lowers) {
     auto lowered = lower_to_rir(mir.value(), rir);
     REQUIRE(lowered);
     rir.destroy();
+}
+TEST(frontend, route_match_arm_nested_match_const_selects_inner_case_only) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let path = \"/users\" match auth { case .ok: "
+        "match const path { case \"/users\": return 200 case \"/admin\": return forward(missing) } "
+        "case .denied: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK_FALSE(hir->routes[0].control.match_arms[0].has_arm_guard);
+    CHECK_EQ(hir->routes[0].control.match_arms[0].direct_term.status_code, 200);
 }
 TEST(frontend, route_match_arm_block_prefix_without_nested_match_inserts_local_once) {
     const char* src =

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8484,6 +8484,7 @@ TEST(frontend, analyze_rejects_route_nested_match_after_guard_prefix) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_guarded_outer_arm_with_nested_match) {
     const char* src =

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8203,6 +8203,20 @@ TEST(frontend, route_match_arm_nested_match_with_block_prefix_lowers) {
     REQUIRE(lowered);
     rir.destroy();
 }
+TEST(frontend, analyze_rejects_route_match_arm_nested_match_after_guard_prefix) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let path = \"/users\" match auth { case .ok: { "
+        "guard true else { return 401 } match path { case \"/users\": return 200 case _: return "
+        "404 } } case .denied: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, route_match_arm_nested_match_const_selects_inner_case_only) {
     const char* src =
         "variant Auth { ok, denied }\n"

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -7683,6 +7683,18 @@ TEST(frontend, analyze_rejects_duplicate_variant_match_case) {
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
+TEST(frontend, analyze_rejects_duplicate_bool_match_case) {
+    const char* src =
+        "route GET \"/users\" { let ok = true match ok { case true: return 200 case true: return "
+        "403 case false: return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, lower_forward_route_to_rir) {
     const char* src = "upstream api\nroute GET \"/users\" { return forward(api) }\n";
     auto lexed = lex(lit(src));
@@ -8160,6 +8172,20 @@ TEST(frontend, bool_match_true_false_cases_are_exhaustive) {
     CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
     REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
 }
+TEST(frontend, route_bool_match_guarded_duplicate_case_can_fall_through) {
+    const char* src =
+        "route GET \"/users\" { let ok = true match ok { case true if false: return 403 case true: "
+        "return 200 case _: return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 3u);
+    CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
+}
 TEST(frontend, route_match_arm_guard_falls_through_to_default) {
     const char* src =
         "route GET \"/users\" { let code = 200 match code { case 200 if false: return 500 case _: "
@@ -8439,6 +8465,20 @@ TEST(frontend, route_match_arm_nested_bool_match_is_exhaustive) {
     REQUIRE_EQ(hir->routes[0].control.match_arms.len, 3u);
     CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
     CHECK_FALSE(hir->routes[0].control.match_arms[1].has_arm_guard);
+}
+TEST(frontend, analyze_rejects_route_nested_match_duplicate_bool_case) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let allowed = true match auth { case .ok: match "
+        "allowed { case true: return 200 case true: return 201 case false: return 404 } case "
+        ".denied: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_route_nested_match_inner_arm_guard) {
     const char* src =
@@ -14115,6 +14155,43 @@ route GET "/users" {
     let code = pick(true)
     if code == 200 { return 200 } else { return 500 }
 }
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+TEST(frontend, analyze_rejects_source_function_duplicate_bool_match_case) {
+    const auto src = R"(
+func pick(ok: bool) -> i32 {
+    match ok {
+        case true => 200
+        case true => 201
+        case false => 500
+    }
+}
+route GET "/users" { let code = pick(true) return 200 }
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, source_function_bool_match_guarded_duplicate_case_can_fall_through) {
+    const auto src = R"(
+func pick(ok: bool) -> i32 {
+    match ok {
+        case true if false => 201
+        case true => 200
+        case _ => 500
+    }
+}
+route GET "/users" { let code = pick(true) return 200 }
 )";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -14009,6 +14009,9 @@ route GET "/users" {
     REQUIRE(hir);
     REQUIRE_EQ(hir->functions.len, 1u);
     CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
     FrontendRirModule rir{};
@@ -14038,6 +14041,9 @@ route GET "/users" {
     REQUIRE(hir);
     REQUIRE_EQ(hir->functions.len, 1u);
     CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
     FrontendRirModule rir{};

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -14009,6 +14009,12 @@ route GET "/users" {
     REQUIRE(hir);
     REQUIRE_EQ(hir->functions.len, 1u);
     CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
 }
 TEST(frontend, source_function_match_arm_guard_can_use_payload_binding) {
     const auto src = R"(
@@ -14032,6 +14038,12 @@ route GET "/users" {
     REQUIRE(hir);
     REQUIRE_EQ(hir->functions.len, 1u);
     CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
 }
 TEST(frontend, source_function_guarded_variant_case_falls_through_to_same_case) {
     const auto src = R"(

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -6213,6 +6213,7 @@ TEST(frontend, analyze_rejects_non_error_struct_in_error_constructor) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_custom_error_constructor_missing_extra_fields) {
     const char* src =
@@ -6225,6 +6226,7 @@ TEST(frontend, analyze_rejects_custom_error_constructor_missing_extra_fields) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_custom_error_constructor_unknown_extra_field) {
     const char* src =
@@ -7364,7 +7366,7 @@ TEST(frontend, known_named_error_match_selects_error_case) {
     REQUIRE(lowered);
     rir.destroy();
 }
-TEST(frontend, known_named_error_match_arm_guard_uses_runtime_fallthrough) {
+TEST(frontend, known_named_error_match_arm_guard_false_selects_wildcard) {
     const char* src =
         "route GET \"/users\" { let failed = error(.timeout) match failed { case .timeout if "
         "false: "

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -7466,6 +7466,18 @@ TEST(frontend, analyze_rejects_known_named_error_match_wildcard_arm_guard) {
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
+TEST(frontend, analyze_rejects_known_named_error_matched_arm_before_wildcard_guard) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) match failed { case .timeout: return "
+        "503 case _ if true: return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, if_const_selects_then_without_checking_else) {
     const char* src =
         "route GET \"/users\" { if const true { return 200 } else { return forward(missing) } }\n";

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -7386,6 +7386,26 @@ TEST(frontend, known_named_error_match_arm_guard_false_selects_wildcard) {
     REQUIRE(lowered);
     rir.destroy();
 }
+TEST(frontend, known_explicit_error_match_arm_guard_false_selects_wildcard) {
+    const char* src =
+        "variant AuthError { timeout, denied }\n"
+        "route GET \"/users\" { let failed = error(AuthError.timeout) match failed { case .timeout "
+        "if false: return 503 case _: return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Direct));
+    CHECK_EQ(hir->routes[0].control.direct_term.status_code, 200);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
 TEST(frontend, known_named_error_match_runtime_arm_guard_falls_back_to_match) {
     const char* src =
         "route GET \"/users\" { let failed = error(.timeout) let allow = req.method == GET match "

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8086,6 +8086,23 @@ TEST(frontend, route_match_arm_guard_can_use_payload_binding) {
     REQUIRE(lowered);
     rir.destroy();
 }
+TEST(frontend, route_match_arm_guard_after_route_guards_falls_through_to_next_test) {
+    const char* src =
+        "route GET \"/users\" { guard true else { return 401 } guard true else { return 402 } let "
+        "code = 200 match code { case 200 if false: return 500 case 201: return 201 case _: "
+        "return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_GE(mir->functions[0].blocks.len, 8u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.else_block, 3u);
+}
 TEST(frontend, analyze_rejects_route_match_arm_guard_without_wildcard) {
     const char* src =
         "route GET \"/users\" { let code = 200 match code { case 200 if true: return 200 } }\n";
@@ -8138,6 +8155,21 @@ TEST(frontend, route_match_arm_nested_match_with_block_prefix_lowers) {
     auto lowered = lower_to_rir(mir.value(), rir);
     REQUIRE(lowered);
     rir.destroy();
+}
+TEST(frontend, route_match_arm_block_prefix_without_nested_match_inserts_local_once) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok match auth { case .ok: { let path = "
+        "\"/users\" if path == \"/users\" { return 200 } else { return 404 } } case .denied: "
+        "return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[1].name.eq(lit("path")));
 }
 TEST(frontend, route_match_arm_nested_bool_match_is_exhaustive) {
     const char* src =
@@ -8287,6 +8319,18 @@ TEST(frontend, guard_match_lowers_to_fail_side_match_arms) {
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
     CHECK(mir->functions[0].blocks.len >= 5u);
+}
+TEST(frontend, analyze_rejects_guard_match_arm_guard) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case "
+        ".timeout if true: return 503 case _: return 500 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_guard_match_without_wildcard) {
     const char* src =

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8320,17 +8320,15 @@ TEST(frontend, guard_match_lowers_to_fail_side_match_arms) {
     REQUIRE(mir);
     CHECK(mir->functions[0].blocks.len >= 5u);
 }
-TEST(frontend, analyze_rejects_guard_match_arm_guard) {
+TEST(frontend, parse_rejects_guard_match_arm_guard) {
     const char* src =
         "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case "
         ".timeout if true: return 503 case _: return 500 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
-    REQUIRE(ast);
-    auto hir = analyze_file_heap(ast.value());
-    REQUIRE_FALSE(hir.has_value());
-    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    REQUIRE_FALSE(ast.has_value());
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_guard_match_without_wildcard) {
     const char* src =

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8103,6 +8103,19 @@ TEST(frontend, route_match_arm_guard_after_route_guards_falls_through_to_next_te
     CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 3u);
     CHECK_EQ(mir->functions[0].blocks[4].term.else_block, 3u);
 }
+TEST(frontend, analyze_rejects_route_match_arm_optional_error_guard) {
+    const char* src =
+        "func maybe(ok: bool) -> bool { if ok { true } else { error(.timeout) } }\n"
+        "route GET \"/users\" { let cond = maybe(false) let code = 200 match code { case 200 if "
+        "cond: return 200 case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, analyze_rejects_route_match_arm_guard_without_wildcard) {
     const char* src =
         "route GET \"/users\" { let code = 200 match code { case 200 if true: return 200 } }\n";
@@ -8183,6 +8196,8 @@ TEST(frontend, route_match_arm_nested_bool_match_is_exhaustive) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].control.match_arms.len, 3u);
+    CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
+    CHECK_FALSE(hir->routes[0].control.match_arms[1].has_arm_guard);
 }
 TEST(frontend, analyze_rejects_route_nested_match_inner_arm_guard) {
     const char* src =
@@ -13521,6 +13536,24 @@ route GET "/users" {
     CHECK_FALSE(hir->functions[1].body.may_nil);
     CHECK_FALSE(hir->functions[1].body.may_error);
 }
+TEST(frontend, parse_rejects_function_block_guard_match_arm_guard) {
+    const auto src = R"(
+func maybefail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func wrap(ok: bool) -> i32 {
+    let y = maybefail(ok)
+    guard match y else { case .timeout if true => 401 case _ => 500 }
+    200
+}
+route GET "/users" { return 200 }
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE_FALSE(ast.has_value());
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, analyze_rejects_function_block_guard_match_without_wildcard) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {
@@ -13783,6 +13816,31 @@ func pick(x: i32) -> i32 {
     }
 }
 route GET "/users" { let code = pick(200) return 200 }
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_source_function_match_arm_optional_error_guard) {
+    const auto src = R"(
+func maybe(ok: bool) -> bool {
+    if ok { true } else { error(.timeout) }
+}
+func pick(x: i32) -> i32 {
+    let cond = maybe(false)
+    match x {
+        case 200 if cond => 200
+        case _ => 404
+    }
+}
+route GET "/users" {
+    let code = pick(200)
+    return 200
+}
 )";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8302,7 +8302,7 @@ TEST(frontend, route_match_arm_direct_nested_match_lowers) {
     REQUIRE(lowered);
     rir.destroy();
 }
-TEST(frontend, route_match_arm_nested_match_with_block_prefix_lowers) {
+TEST(frontend, analyze_rejects_route_match_arm_nested_match_with_let_prefix) {
     const char* src =
         "variant Auth { ok, denied }\n"
         "route GET \"/users\" { let auth = Auth.ok match auth { case .ok: { let path = "
@@ -8313,8 +8313,24 @@ TEST(frontend, route_match_arm_nested_match_with_block_prefix_lowers) {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, route_match_arm_guarded_same_case_can_fall_through_to_nested_match) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let path = \"/users\" match auth { case .ok if "
+        "req.method == POST: return 401 case .ok: match path { case \"/users\": return 200 case "
+        "_: return 404 } case .denied: return 403 case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
-    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 3u);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 5u);
+    CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
+    CHECK(hir->routes[0].control.match_arms[1].has_arm_guard);
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
     FrontendRirModule rir{};

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -7386,6 +7386,54 @@ TEST(frontend, known_named_error_match_arm_guard_false_selects_wildcard) {
     REQUIRE(lowered);
     rir.destroy();
 }
+TEST(frontend, known_named_error_match_runtime_arm_guard_falls_back_to_match) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) let allow = req.method == GET match "
+        "failed { case .timeout if allow: return 503 case _: return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
+    CHECK_EQ(hir->routes[0].control.match_arms[0].pattern.variant_index,
+             hir->routes[0].error_variant_index);
+    CHECK_EQ(hir->routes[0].control.match_arms[0].pattern.case_index, 0u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
+TEST(frontend, known_named_error_match_runtime_guard_keeps_other_named_error_cases) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) let allow = req.method == GET match "
+        "failed { case .denied: return 403 case .timeout if allow: return 503 case _: return 200 "
+        "} }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 3u);
+    CHECK_EQ(hir->routes[0].control.match_arms[0].pattern.variant_index,
+             hir->routes[0].error_variant_index);
+    CHECK_EQ(hir->routes[0].control.match_arms[0].pattern.case_index, 1u);
+    CHECK_EQ(hir->routes[0].control.match_arms[1].pattern.case_index, 0u);
+    CHECK(hir->routes[0].control.match_arms[1].has_arm_guard);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
 TEST(frontend, analyze_rejects_known_named_error_match_wildcard_arm_guard) {
     const char* src =
         "route GET \"/users\" { let failed = error(.timeout) match failed { case .denied: return "

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8299,6 +8299,21 @@ TEST(frontend, analyze_rejects_route_nested_match_duplicate_outer_variant_case) 
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
+TEST(frontend, analyze_rejects_route_nested_match_foreign_outer_variant_case) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "variant Other { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let path = \"/users\" match auth { case "
+        "Other.ok: match path { case \"/users\": return 200 case _: return 404 } case .denied: "
+        "return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, route_match_arm_block_prefix_without_nested_match_inserts_local_once) {
     const char* src =
         "variant Auth { ok, denied }\n"
@@ -8350,6 +8365,22 @@ TEST(frontend, analyze_rejects_route_nested_match_inner_payload_binding) {
         "route GET \"/users\" { let auth = Auth.ok let result = Result.ok(200) match auth { case "
         ".ok: match result { case .ok(code): return 200 case _: return 404 } case .denied: return "
         "403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_route_nested_match_foreign_inner_variant_case) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "variant Result { ok, err }\n"
+        "variant Other { ok, err }\n"
+        "route GET \"/users\" { let auth = Auth.ok let result = Result.ok match auth { case .ok: "
+        "match result { case Other.ok: return 200 case _: return 404 } case .denied: return 403 } "
+        "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8161,6 +8161,35 @@ TEST(frontend, analyze_rejects_route_match_arm_guard_without_wildcard) {
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
+TEST(frontend, build_mir_rejects_last_match_arm_guard_fallthrough) {
+    auto* hir = new HirModule{};
+    HirRoute route{};
+    route.span = {1, 1, 1, 1};
+    route.method = 'G';
+    route.path = lit("/users");
+    route.control.kind = HirControlKind::Match;
+    route.control.match_expr.kind = HirExprKind::BoolLit;
+    route.control.match_expr.type = HirTypeKind::Bool;
+    route.control.match_expr.bool_value = true;
+
+    HirMatchArm arm{};
+    arm.span = route.span;
+    arm.pattern.kind = HirExprKind::BoolLit;
+    arm.pattern.type = HirTypeKind::Bool;
+    arm.pattern.bool_value = true;
+    arm.has_arm_guard = true;
+    arm.arm_guard.kind = HirExprKind::BoolLit;
+    arm.arm_guard.type = HirTypeKind::Bool;
+    arm.arm_guard.bool_value = false;
+    arm.direct_term.kind = HirTerminatorKind::ReturnStatus;
+    arm.direct_term.status_code = 200;
+    REQUIRE(route.control.match_arms.push(arm));
+    REQUIRE(hir->routes.push(route));
+
+    auto mir = build_mir(*hir);
+    REQUIRE_FALSE(mir.has_value());
+    CHECK_EQ(static_cast<u8>(mir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, route_match_arm_direct_nested_match_lowers) {
     const char* src =
         "variant Auth { ok, denied }\n"

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8120,6 +8120,28 @@ TEST(frontend, route_match_arm_guard_can_use_payload_binding) {
     REQUIRE(lowered);
     rir.destroy();
 }
+TEST(frontend, route_match_guarded_variant_case_falls_through_to_same_case) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/users\" { let state = Result.ok(201) match state { case .ok(code) if code "
+        "== 200: return 200 case .ok(code): return 201 case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 3u);
+    CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
+    CHECK_FALSE(hir->routes[0].control.match_arms[1].has_arm_guard);
+    CHECK(hir->routes[0].control.match_arms[1].bind_payload);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    rir.destroy();
+}
 TEST(frontend, route_match_arm_guard_after_route_guards_falls_through_to_next_test) {
     const char* src =
         "route GET \"/users\" { guard true else { return 401 } guard true else { return 402 } let "
@@ -13900,6 +13922,30 @@ func pick(result: Result) -> i32 {
 route GET "/users" {
     let code = pick(Result.ok(200))
     if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+}
+TEST(frontend, source_function_guarded_variant_case_falls_through_to_same_case) {
+    const auto src = R"(
+variant Result { ok(i32), err }
+func pick(result: Result) -> i32 {
+    match result {
+        case .ok(code) if code == 200 => 200
+        case .ok(code) => code
+        case _ => 404
+    }
+}
+route GET "/users" {
+    let code = pick(Result.ok(201))
+    if code == 201 { return 200 } else { return 500 }
 }
 )";
     auto lexed = lex(lit(src));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -7386,6 +7386,18 @@ TEST(frontend, known_named_error_match_arm_guard_false_selects_wildcard) {
     REQUIRE(lowered);
     rir.destroy();
 }
+TEST(frontend, analyze_rejects_known_named_error_match_wildcard_arm_guard) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) match failed { case .denied: return "
+        "403 case _ if true: return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, if_const_selects_then_without_checking_else) {
     const char* src =
         "route GET \"/users\" { if const true { return 200 } else { return forward(missing) } }\n";

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -2315,6 +2315,55 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_source_function_match_arm_guard_seeds_named_error_case) {
+    const auto src = R"(
+func pick(x: i32) -> i32 {
+    match x {
+        case 200 if error(.timeout, "timed out").code == 0 => 200
+        case _ => 500
+    }
+}
+route GET "/users" {
+    let code = pick(200)
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_variant_single_payload_match) {
     const char* src =
         "variant Result { ok(i32), err }\n"

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -2216,6 +2216,105 @@ TEST(jit, frontend_route_match_arm_guard_false_falls_through) {
     rir.destroy();
 }
 
+TEST(jit, frontend_source_function_match_arm_guard_false_executes_fallback) {
+    const auto src = R"(
+func pick(x: i32) -> i32 {
+    match x {
+        case 200 if false => 201
+        case _ => 404
+    }
+}
+route GET "/users" {
+    let code = pick(200)
+    if code == 404 { return 200 } else { return 500 }
+}
+)";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_source_function_match_arm_guard_payload_binding_executes_match) {
+    const auto src = R"(
+variant Result { ok(i32), err }
+func pick(result: Result) -> i32 {
+    match result {
+        case .ok(code) if code == 200 => code
+        case _ => 404
+    }
+}
+route GET "/users" {
+    let code = pick(Result.ok(200))
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_variant_single_payload_match) {
     const char* src =
         "variant Result { ok(i32), err }\n"

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -2128,6 +2128,94 @@ TEST(jit, frontend_variant_match) {
     rir.destroy();
 }
 
+TEST(jit, frontend_string_match_returns_matching_status_and_fallback) {
+    const char* src =
+        "route GET \"/users\" { let path = req.path match path { case \"/api/users\": return 200 "
+        "case _: return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto matched = HandlerResult::unpack(handler(nullptr,
+                                                 nullptr,
+                                                 reinterpret_cast<const u8*>(kGetApiRequest),
+                                                 sizeof(kGetApiRequest) - 1,
+                                                 nullptr));
+    CHECK(matched.action == HandlerAction::ReturnStatus);
+    CHECK(matched.status_code == 200);
+
+    auto fallback = HandlerResult::unpack(handler(nullptr,
+                                                  nullptr,
+                                                  reinterpret_cast<const u8*>(kGetRootRequest),
+                                                  sizeof(kGetRootRequest) - 1,
+                                                  nullptr));
+    CHECK(fallback.action == HandlerAction::ReturnStatus);
+    CHECK(fallback.status_code == 404);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_match_arm_guard_false_falls_through) {
+    const char* src =
+        "route GET \"/users\" { let code = 200 match code { case 200 if req.method == POST: "
+        "return 500 case _: return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 404);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_variant_single_payload_match) {
     const char* src =
         "variant Result { ok(i32), err }\n"

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -3078,6 +3078,102 @@ TEST(jit, frontend_known_named_error_match) {
     rir.destroy();
 }
 
+TEST(jit, frontend_known_named_error_runtime_guard_true_matches_case) {
+    const auto src = R"(
+route GET "/users" {
+    let failed = error(.timeout)
+    let allow = req.path == "/api/users"
+    match failed {
+    case .timeout if allow: return 503
+    case _: return 200
+    }
+}
+)";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 503);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_known_named_error_runtime_guard_false_falls_through) {
+    const auto src = R"(
+route GET "/users" {
+    let failed = error(.timeout)
+    let allow = req.path == "/missing"
+    match failed {
+    case .timeout if allow: return 503
+    case _: return 200
+    }
+}
+)";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_explicit_error_variant_match) {
     const char* src =
         "variant AuthError { timeout, forbidden }\n"

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -2364,6 +2364,60 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_route_nested_match_payload_variant_case_compares_tag) {
+    const auto src = R"(
+variant Auth { ok, denied }
+variant Result { ok(i32), err }
+route GET "/users" {
+    let auth = Auth.ok
+    let result = Result.ok(200)
+    match auth {
+    case .ok:
+        match result {
+        case .ok: return 200
+        case _: return 404
+        }
+    case .denied:
+        return 403
+    }
+}
+)";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_variant_single_payload_match) {
     const char* src =
         "variant Result { ok(i32), err }\n"


### PR DESCRIPTION
## Summary
- add string, bool-exhaustive, const-string, and guarded match arms for route/source function match
- lower route match arm guards with fallthrough and support supported nested route match expansion
- document match syntax, examples, and current boundaries

## Tests
- `/tmp/rut-match-pr-build/tests/test_frontend`