### PR TITLE
[codex] Add network request support

### DIFF
--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -83,6 +83,10 @@ enum class AstExprKind : u8 {
     MethodCall,
     Field,
     ReqHeader,
+    ReqParam,
+    ReqCookie,
+    ReqQuery,
+    ReqQueryString,
     // HTTP method literal as expression. The concrete method (GET,
     // POST, …) is encoded in int_value using the HttpMethod enum
     // values from rut/runtime/http_parser.h. Lets `POST` etc. appear

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -91,7 +91,21 @@ enum class HirExprKind : u8 {
     StructInit,
     Field,
     ReqHeader,
+    ReqParam,
+    ReqCookie,
+    ReqQuery,
+    ReqQueryString,
     ReqPath,
+    ReqPathOnly,
+    ReqBody,
+    ReqKeepAlive,
+    ReqChunked,
+    ReqHasContentLength,
+    ReqHttp10,
+    ReqHttp11,
+    ReqHttpVersion,
+    ReqContentLength,
+    ReqRemoteAddr,
     // HTTP method literal — int_value holds the HttpMethod enum
     // value (0=GET, 1=POST, …, matching rut/runtime/http_parser.h).
     ConstMethod,
@@ -126,6 +140,8 @@ enum class HirTypeKind : u8 {
     Tuple,
     Struct,
     Method,
+    ByteSize,
+    IP,
     // Homogeneous fixed-size sequence. Carrier for `for x in <arr>` iteration.
     // Type-shape info lives in HirTypeShape via `array_elem_shape_index`
     // alone; length is a *value* property on `HirExpr.array_len` so two

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -28,7 +28,21 @@ enum class MirValueKind : u8 {
     StructInit,
     Field,
     ReqHeader,
+    ReqParam,
+    ReqCookie,
+    ReqQuery,
+    ReqQueryString,
     ReqPath,
+    ReqPathOnly,
+    ReqBody,
+    ReqKeepAlive,
+    ReqChunked,
+    ReqHasContentLength,
+    ReqHttp10,
+    ReqHttp11,
+    ReqHttpVersion,
+    ReqContentLength,
+    ReqRemoteAddr,
     // HTTP method literal — int_value holds the HttpMethod enum value.
     ConstMethod,
     // Read of the parsed request method from the current connection.
@@ -59,6 +73,8 @@ enum class MirTypeKind : u8 {
     Tuple,
     Struct,
     Method,
+    ByteSize,
+    IP,
 };
 
 struct MirTypeShape {

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -143,19 +143,29 @@ enum class Opcode : u8 {
     ConstStatus,    // %r = const.status <code>       (printed as raw i32)
 
     // ── Request access ──
-    ReqHeader,          // %r = req.header "Name"        → Optional(str)
-    ReqParam,           // %r = req.param "id"           → str
-    ReqMethod,          // %r = req.method               → Method
-    ReqPath,            // %r = req.path                 → str
-    ResumeEventKind,    // %r = ctx.resume_event_kind    → i32
-    ResumeEventResult,  // %r = ctx.resume_event_result → i32
-    CtxLoadSlotI32,     // %r = ctx.slot[i] if i < ctx.slot_count → i32
-                        // Otherwise reads current resume metadata:
-                        // even index slots read resume_event_kind,
-                        // odd index slots read resume_event_result.
-    ReqRemoteAddr,      // %r = req.remote_addr          → IP
-    ReqContentLength,   // %r = req.content_length       → ByteSize
-    ReqCookie,          // %r = req.cookie "name"        → Optional(str)
+    ReqHeader,            // %r = req.header "Name"        → Optional(str)
+    ReqParam,             // %r = req.param "id"           → str
+    ReqQuery,             // %r = req.query "name"         → Optional(str)
+    ReqQueryString,       // %r = req.queryString          → Optional(str)
+    ReqMethod,            // %r = req.method               → Method
+    ReqPath,              // %r = req.path                 → str
+    ReqPathOnly,          // %r = req.pathOnly             → str
+    ReqBody,              // %r = req.body                 → str
+    ReqKeepAlive,         // %r = req.keepAlive            → bool
+    ReqChunked,           // %r = req.chunked              → bool
+    ReqHasContentLength,  // %r = req.hasContentLength   → bool
+    ReqHttp10,            // %r = req.http10               → bool
+    ReqHttp11,            // %r = req.http11               → bool
+    ReqHttpVersion,       // %r = req.httpVersion          → str
+    ResumeEventKind,      // %r = ctx.resume_event_kind    → i32
+    ResumeEventResult,    // %r = ctx.resume_event_result → i32
+    CtxLoadSlotI32,       // %r = ctx.slot[i] if i < ctx.slot_count → i32
+                          // Otherwise reads current resume metadata:
+                          // even index slots read resume_event_kind,
+                          // odd index slots read resume_event_result.
+    ReqRemoteAddr,        // %r = req.remote_addr          → IP
+    ReqContentLength,     // %r = req.content_length       → ByteSize
+    ReqCookie,            // %r = req.cookie "name"        → Optional(str)
 
     // ── Request mutation ──
     ReqSetHeader,     // req.set_header "Name", %val
@@ -263,7 +273,7 @@ struct Instruction {
 
     // Instruction-specific immediate data (tagged by opcode).
     union Immediate {
-        Str str_val;               // ConstStr, ReqHeader, ReqParam, ReqCookie, etc.
+        Str str_val;               // ConstStr, ReqHeader, ReqParam, ReqCookie, ReqQuery, etc.
         i32 i32_val;               // ConstI32, ConstStatus.
         i64 i64_val;               // ConstI64, ConstDuration, ConstByteSize;
                                    // RetStatus literal form packs

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -443,6 +443,46 @@ struct Builder {
         return TRY(emit(Opcode::ReqPath, ty, loc)).vid;
     }
 
+    Result<ValueId> emit_req_path_only(SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::Str));
+        return TRY(emit(Opcode::ReqPathOnly, ty, loc)).vid;
+    }
+
+    Result<ValueId> emit_req_body(SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::Str));
+        return TRY(emit(Opcode::ReqBody, ty, loc)).vid;
+    }
+
+    Result<ValueId> emit_req_keep_alive(SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::Bool));
+        return TRY(emit(Opcode::ReqKeepAlive, ty, loc)).vid;
+    }
+
+    Result<ValueId> emit_req_chunked(SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::Bool));
+        return TRY(emit(Opcode::ReqChunked, ty, loc)).vid;
+    }
+
+    Result<ValueId> emit_req_has_content_length(SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::Bool));
+        return TRY(emit(Opcode::ReqHasContentLength, ty, loc)).vid;
+    }
+
+    Result<ValueId> emit_req_http10(SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::Bool));
+        return TRY(emit(Opcode::ReqHttp10, ty, loc)).vid;
+    }
+
+    Result<ValueId> emit_req_http11(SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::Bool));
+        return TRY(emit(Opcode::ReqHttp11, ty, loc)).vid;
+    }
+
+    Result<ValueId> emit_req_http_version(SourceLoc loc = {}) {
+        auto* ty = TRY(make_type(TypeKind::Str));
+        return TRY(emit(Opcode::ReqHttpVersion, ty, loc)).vid;
+    }
+
     Result<ValueId> emit_resume_event_kind(SourceLoc loc = {}) {
         auto* ty = TRY(make_type(TypeKind::I32));
         return TRY(emit(Opcode::ResumeEventKind, ty, loc)).vid;
@@ -476,6 +516,20 @@ struct Builder {
         auto [inst, vid] = TRY(emit(Opcode::ReqCookie, ty, loc));
         inst->imm.str_val = name;
         return vid;
+    }
+
+    Result<ValueId> emit_req_query(Str name, SourceLoc loc = {}) {
+        auto* inner = TRY(make_type(TypeKind::Str));
+        auto* ty = TRY(make_type(TypeKind::Optional, inner));
+        auto [inst, vid] = TRY(emit(Opcode::ReqQuery, ty, loc));
+        inst->imm.str_val = name;
+        return vid;
+    }
+
+    Result<ValueId> emit_req_query_string(SourceLoc loc = {}) {
+        auto* inner = TRY(make_type(TypeKind::Str));
+        auto* ty = TRY(make_type(TypeKind::Optional, inner));
+        return TRY(emit(Opcode::ReqQueryString, ty, loc)).vid;
     }
 
     // ── Request mutation ────────────────────────────────────────────

--- a/include/rut/jit/handler_abi.h
+++ b/include/rut/jit/handler_abi.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rut/common/types.h"
+#include "rut/runtime/route_params.h"
 
 namespace rut {
 namespace jit {
@@ -119,7 +120,7 @@ struct HandlerResult {
 // Per-request mutable context, allocated from the scratch Arena.
 // Holds the state machine index and live-across-yield values.
 //
-// Layout: [HandlerCtx header] [slot_0] [slot_1] ... [slot_N]
+// Layout: [HandlerCtx header + route params] [slot_0] [slot_1] ... [slot_N]
 // Each slot is 8-byte aligned. The number and types of slots are
 // determined at compile time by the state-splitting pass.
 
@@ -129,6 +130,9 @@ struct alignas(alignof(u64)) HandlerCtx {
     u32 slot_count;           // number of 8-byte slots following this header
     u32 resume_event_kind;    // YieldKind value that resumed this handler
     i32 resume_event_result;  // IoEvent::result for event waits
+    u32 route_param_count;    // number of populated route_params entries
+    u32 reserved0;
+    RouteParam route_params[kMaxRouteParams];
 
     // Access slot storage (8-byte aligned, immediately after header).
     u8* slots() { return reinterpret_cast<u8*>(this + 1); }
@@ -154,7 +158,8 @@ struct alignas(alignof(u64)) HandlerCtx {
     }
 };
 
-static_assert(sizeof(HandlerCtx) == 16, "HandlerCtx header must be 16 bytes");
+static_assert(sizeof(HandlerCtx) % alignof(RouteParam) == 0,
+              "HandlerCtx route params must preserve alignment");
 static_assert(alignof(HandlerCtx) >= alignof(u64), "HandlerCtx must be 8-byte aligned");
 static_assert(sizeof(HandlerCtx) % alignof(u64) == 0,
               "HandlerCtx slots must start at an 8-byte-aligned offset");

--- a/include/rut/jit/runtime_helpers.h
+++ b/include/rut/jit/runtime_helpers.h
@@ -22,6 +22,33 @@ void rut_helper_req_path(const rut::u8* req_data,
                          const char** out_ptr,
                          rut::u32* out_len);
 
+// Extract request path without query or fragment suffix from raw HTTP request.
+// Sets *out_ptr and *out_len to a string view pointing into req_data.
+void rut_helper_req_path_only(const rut::u8* req_data,
+                              rut::u32 req_len,
+                              const char** out_ptr,
+                              rut::u32* out_len);
+
+// Extract the declared request body bytes, bounded by Content-Length.
+// Returns an empty string if headers are incomplete, Content-Length is absent,
+// or req_data does not contain the full declared body yet.
+void rut_helper_req_body(const rut::u8* req_data,
+                         rut::u32 req_len,
+                         const char** out_ptr,
+                         rut::u32* out_len);
+
+// Extract the HTTP version token from the request line as "HTTP/1.0",
+// "HTTP/1.1", or an empty string when parsing fails.
+void rut_helper_req_http_version(const rut::u8* req_data,
+                                 rut::u32 req_len,
+                                 const char** out_ptr,
+                                 rut::u32* out_len);
+
+// Read parsed request flags. flag=0 returns keep-alive, flag=1 returns chunked,
+// flag=2 returns whether Content-Length was present, flag=3 returns HTTP/1.0,
+// flag=4 returns HTTP/1.1.
+rut::u8 rut_helper_req_flag(const rut::u8* req_data, rut::u32 req_len, rut::u8 flag);
+
 // Extract HTTP method from raw request. Returns HttpMethod enum value.
 rut::u8 rut_helper_req_method(const rut::u8* req_data, rut::u32 req_len);
 
@@ -36,8 +63,47 @@ void rut_helper_req_header(const rut::u8* req_data,
                            const char** out_ptr,
                            rut::u32* out_len);
 
+// Look up a cookie by name from the Cookie request header.
+// Returns Optional(Str): *out_has_value = 1 if found, 0 if not.
+// If found, *out_ptr / *out_len point into req_data.
+void rut_helper_req_cookie(const rut::u8* req_data,
+                           rut::u32 req_len,
+                           const char* name,
+                           rut::u32 name_len,
+                           rut::u8* out_has_value,
+                           const char** out_ptr,
+                           rut::u32* out_len);
+
+// Look up a query value by name from request target.
+// Returns Optional(Str): *out_has_value = 1 if found, 0 if not.
+// If found, *out_ptr / *out_len point into req_data.
+void rut_helper_req_query(const rut::u8* req_data,
+                          rut::u32 req_len,
+                          const char* name,
+                          rut::u32 name_len,
+                          rut::u8* out_has_value,
+                          const char** out_ptr,
+                          rut::u32* out_len);
+
+// Extract the raw query string from request target, excluding '?' and '#fragment'.
+// Returns Optional(Str): *out_has_value = 1 if a query component exists.
+// If found, *out_ptr / *out_len point into req_data.
+void rut_helper_req_query_string(const rut::u8* req_data,
+                                 rut::u32 req_len,
+                                 rut::u8* out_has_value,
+                                 const char** out_ptr,
+                                 rut::u32* out_len);
+
+// Look up a route parameter captured by SegmentTrie route matching.
+// Returns an empty Str when the parameter is not present.
+void rut_helper_req_param(
+    void* ctx, const char* name, rut::u32 name_len, const char** out_ptr, rut::u32* out_len);
+
 // Get remote address from Connection. Returns IPv4 in network order.
 rut::u32 rut_helper_req_remote_addr(void* conn);
+
+// Get parsed Content-Length from request bytes. Returns 0 when absent or malformed.
+rut::u64 rut_helper_req_content_length(const rut::u8* req_data, rut::u32 req_len);
 
 // ── String Operations ──────────────────────────────────────────────
 

--- a/include/rut/runtime/callbacks.h
+++ b/include/rut/runtime/callbacks.h
@@ -85,6 +85,9 @@ template <typename Loop>
 void on_request_body_recvd(void* lp, Connection& conn, IoEvent ev);
 
 template <typename Loop>
+void on_jit_request_body_recvd(void* lp, Connection& conn, IoEvent ev);
+
+template <typename Loop>
 void on_early_upstream_recvd(void* lp, Connection& conn, IoEvent ev);
 
 // JIT handler dispatch — invoked from timer.tick when pending_handler_fn
@@ -110,6 +113,7 @@ extern template void on_response_body_recvd<EpollEventLoop>(void*, Connection&, 
 extern template void on_response_body_sent<EpollEventLoop>(void*, Connection&, IoEvent);
 extern template void on_request_body_sent<EpollEventLoop>(void*, Connection&, IoEvent);
 extern template void on_request_body_recvd<EpollEventLoop>(void*, Connection&, IoEvent);
+extern template void on_jit_request_body_recvd<EpollEventLoop>(void*, Connection&, IoEvent);
 extern template void on_early_upstream_recvd<EpollEventLoop>(void*, Connection&, IoEvent);
 extern template void on_early_upstream_recvd_send_inflight<EpollEventLoop>(void*,
                                                                            Connection&,
@@ -127,6 +131,7 @@ extern template void on_response_body_recvd<IoUringEventLoop>(void*, Connection&
 extern template void on_response_body_sent<IoUringEventLoop>(void*, Connection&, IoEvent);
 extern template void on_request_body_sent<IoUringEventLoop>(void*, Connection&, IoEvent);
 extern template void on_request_body_recvd<IoUringEventLoop>(void*, Connection&, IoEvent);
+extern template void on_jit_request_body_recvd<IoUringEventLoop>(void*, Connection&, IoEvent);
 extern template void on_early_upstream_recvd<IoUringEventLoop>(void*, Connection&, IoEvent);
 extern template void on_early_upstream_recvd_send_inflight<IoUringEventLoop>(void*,
                                                                              Connection&,

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -226,6 +226,8 @@ void on_header_received(void* lp, Connection& conn, IoEvent ev) {
     const RouteConfig* config = loop->config_ptr ? *loop->config_ptr : nullptr;
     conn.request_config = config;
     const RouteEntry* route = nullptr;
+    RouteParam route_params[kMaxRouteParams]{};
+    u32 route_param_count = 0;
     if (config) {
         const u8 kMethodKey = route_method_key(static_cast<LogHttpMethod>(conn.req_method));
         // Use the parser-supplied canonical view (PR #50 round 7 path A)
@@ -237,7 +239,8 @@ void on_header_received(void* lp, Connection& conn, IoEvent ev) {
         // nullptr (miss) so those targets cannot fall into a "/" catchall.
         // {non-null ptr, len=0} remains a legitimate canonical view of
         // the origin-form root "/" and dispatches normally.
-        route = config->match_canonical(conn.req_path_canon, kMethodKey);
+        route = config->match_canonical(
+            conn.req_path_canon, kMethodKey, route_params, &route_param_count, kMaxRouteParams);
     }
 
     if (route && route->action == RouteAction::Proxy) {
@@ -283,12 +286,31 @@ void on_header_received(void* lp, Connection& conn, IoEvent ev) {
         conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);
         loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
     } else if (route && route->action == RouteAction::JitHandler && route->fn) {
+        if (route->needs_req_body) {
+            if (conn.req_body_mode == BodyMode::Chunked) {
+                conn.state = ConnState::Sending;
+                conn.resp_status = 400;
+                format_static_response(conn, 400, /*keep_alive=*/false);
+                conn.keep_alive = false;
+                conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);
+                loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
+                return;
+            }
+            if (conn.req_body_mode == BodyMode::ContentLength && conn.req_body_remaining > 0) {
+                conn.state = ConnState::ReadingBody;
+                conn.set_slots(&on_jit_request_body_recvd<Loop>, nullptr, nullptr, nullptr);
+                loop->submit_recv(conn);
+                return;
+            }
+        }
         conn.state = ConnState::ExecHandler;
         conn.handler_state = 0;  // entry state
         auto* ctx = conn.reset_jit_ctx();
         ctx->state = 0;
         ctx->resume_event_kind = static_cast<u32>(jit::YieldKind::Timer);
         ctx->resume_event_result = 0;
+        ctx->route_param_count = route_param_count;
+        for (u32 i = 0; i < route_param_count; i++) ctx->route_params[i] = route_params[i];
         auto outcome = invoke_jit_handler(route->fn,
                                           static_cast<void*>(&conn),
                                           *ctx,
@@ -308,6 +330,65 @@ void on_header_received(void* lp, Connection& conn, IoEvent ev) {
         conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);
         loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
     }
+}
+
+template <typename Loop>
+void on_jit_request_body_recvd(void* lp, Connection& conn, IoEvent ev) {
+    auto* loop = static_cast<Loop*>(lp);
+
+    if (ev.result <= 0) {
+        loop->close_conn(conn);
+        return;
+    }
+
+    if (conn.req_body_mode != BodyMode::ContentLength || conn.req_body_remaining == 0) {
+        loop->close_conn(conn);
+        return;
+    }
+
+    u32 consume = static_cast<u32>(ev.result);
+    if (consume > conn.req_body_remaining) consume = conn.req_body_remaining;
+    conn.req_body_remaining -= consume;
+    conn.req_size += consume;
+    conn.req_initial_send_len =
+        conn.req_header_end + (conn.req_content_length - conn.req_body_remaining);
+
+    if (conn.req_body_remaining > 0) {
+        conn.state = ConnState::ReadingBody;
+        conn.set_slots(&on_jit_request_body_recvd<Loop>, nullptr, nullptr, nullptr);
+        loop->submit_recv(conn);
+        return;
+    }
+
+    const RouteConfig* config = conn.request_config;
+    const RouteEntry* route = nullptr;
+    RouteParam route_params[kMaxRouteParams]{};
+    u32 route_param_count = 0;
+    if (config) {
+        const u8 kMethodKey = route_method_key(static_cast<LogHttpMethod>(conn.req_method));
+        route = config->match_canonical(
+            conn.req_path_canon, kMethodKey, route_params, &route_param_count, kMaxRouteParams);
+    }
+    if (!route || route->action != RouteAction::JitHandler || !route->fn) {
+        loop->close_conn(conn);
+        return;
+    }
+
+    conn.state = ConnState::ExecHandler;
+    conn.handler_state = 0;
+    auto* ctx = conn.reset_jit_ctx();
+    ctx->state = 0;
+    ctx->resume_event_kind = static_cast<u32>(jit::YieldKind::Timer);
+    ctx->resume_event_result = 0;
+    ctx->route_param_count = route_param_count;
+    for (u32 i = 0; i < route_param_count; i++) ctx->route_params[i] = route_params[i];
+    auto outcome = invoke_jit_handler(route->fn,
+                                      static_cast<void*>(&conn),
+                                      *ctx,
+                                      conn.recv_buf.data(),
+                                      conn.recv_buf.len(),
+                                      /*arena=*/nullptr);
+    handle_jit_outcome<Loop>(loop, conn, outcome, route->fn, conn.keep_alive);
 }
 
 template <typename Loop>

--- a/include/rut/runtime/compile_to_config.h
+++ b/include/rut/runtime/compile_to_config.h
@@ -9,10 +9,11 @@
 // function, which is orthogonal to the declarative content here.
 // Callers typically:
 //   1. jit::codegen(rir.module) → LLVM IR module
-//   2. engine.compile(...); engine.lookup("handler_route_N") for each
+//   2. engine.compile(...)
 //   3. populate_route_config(cfg, rir.module) for upstreams / bodies /
 //      header sets
-//   4. cfg.add_jit_handler(path, method, fn) per route
+//   4. register_jit_routes(cfg, rir.module, engine) to select the
+//      correct dispatcher and add every route handler
 //
 // Two supported preconditions on `cfg`:
 //
@@ -43,9 +44,64 @@
 // it rather than try to reuse it.
 
 #include "rut/compiler/rir.h"
+#include "rut/jit/codegen.h"
+#include "rut/jit/jit_engine.h"
 #include "rut/runtime/route_table.h"
 
 namespace rut {
+
+inline bool rir_function_needs_req_body(const rir::Function& fn) {
+    if (fn.blocks == nullptr) return false;
+    for (u32 bi = 0; bi < fn.block_count; bi++) {
+        const auto& block = fn.blocks[bi];
+        if (block.insts == nullptr) continue;
+        for (u32 ii = 0; ii < block.inst_count; ii++) {
+            if (block.insts[ii].op == rir::Opcode::ReqBody) return true;
+        }
+    }
+    return false;
+}
+
+inline bool configure_route_dispatch(RouteConfig& cfg, const rir::Module& mod) {
+    if (cfg.route_count != 0) return false;
+    if (mod.func_count > RouteConfig::kMaxRoutes) return false;
+    if (mod.func_count > 0 && mod.functions == nullptr) return false;
+
+    Str paths[RouteConfig::kMaxRoutes];
+    for (u32 i = 0; i < mod.func_count; i++) {
+        paths[i] = mod.functions[i].route_pattern;
+        if (paths[i].len > 0 && paths[i].ptr == nullptr) return false;
+    }
+
+    if (needs_segment_aware(paths, mod.func_count)) return cfg.use_segment_trie();
+    return cfg.use_art();
+}
+
+inline bool register_jit_routes(RouteConfig& cfg, const rir::Module& mod, jit::JitEngine& engine) {
+    if (cfg.route_count != 0) return false;
+    if (!configure_route_dispatch(cfg, mod)) return false;
+
+    for (u32 i = 0; i < mod.func_count; i++) {
+        const auto& fn = mod.functions[i];
+        if (fn.route_pattern.len >= RouteEntry::kMaxPathLen) return false;
+        if (fn.route_pattern.len > 0 && fn.route_pattern.ptr == nullptr) return false;
+        if (fn.name.len > 0 && fn.name.ptr == nullptr) return false;
+
+        char path[RouteEntry::kMaxPathLen];
+        for (u32 j = 0; j < fn.route_pattern.len; j++) path[j] = fn.route_pattern.ptr[j];
+        path[fn.route_pattern.len] = '\0';
+
+        char symbol[256];
+        jit::format_handler_symbol(fn.name, symbol, sizeof(symbol));
+        auto* addr = engine.lookup(symbol);
+        if (!addr) return false;
+        auto handler = reinterpret_cast<jit::HandlerFn>(addr);
+        if (!cfg.add_jit_handler(path, fn.http_method, handler, rir_function_needs_req_body(fn)))
+            return false;
+    }
+
+    return true;
+}
 
 inline bool populate_route_config(RouteConfig& cfg, const rir::Module& mod) {
     // Bodies / header sets / routes must always start empty — there's

--- a/include/rut/runtime/route_art.h
+++ b/include/rut/runtime/route_art.h
@@ -64,7 +64,7 @@
 // ByteRadixTrie and the trie/hash family.
 //
 // What's intentionally NOT supported (matches ByteRadix):
-//   - `:param` segment capture — that's SegmentTrie's contract.
+//   - `:param` dynamic segment routing/capture — that's SegmentTrie's contract.
 //   - Segment-boundary-aware matching — selector won't pick this
 //     dispatch when boundary semantics are needed.
 

--- a/include/rut/runtime/route_params.h
+++ b/include/rut/runtime/route_params.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "rut/common/types.h"
+
+namespace rut {
+
+static constexpr u32 kMaxRouteParams = 16;
+
+struct RouteParam {
+    const char* name = nullptr;
+    u32 name_len = 0;
+    const char* value = nullptr;
+    u32 value_len = 0;
+};
+
+}  // namespace rut

--- a/include/rut/runtime/route_select.h
+++ b/include/rut/runtime/route_select.h
@@ -7,10 +7,8 @@
 //     covers all configs that don't need segment-aware semantics
 //   - SegmentTrie: segment-aware matching for boundary-sensitive
 //     overlap (e.g., `/api` registered alongside `/apix`).
-//     Note: `:param`-style route paths are currently rejected at
-//     add_* time — neither ART nor SegmentTrie implements runtime
-//     parameter capture yet. SegmentTrie is not routed to for
-//     `:param` routes; those are a planned future feature.
+//     Note: `:param`-style route paths require SegmentTrie. They are
+//     supported as dynamic segments with request-time parameter capture.
 //
 // The picker is a single boolean:
 //

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -65,6 +65,7 @@ struct RouteEntry {
     u16 upstream_id;              // index into RouteConfig::upstreams (if action == Proxy)
     u16 status_code;              // status code (if action == Static, e.g., 200, 404)
     jit::HandlerFn fn = nullptr;  // JIT-compiled handler (if action == JitHandler)
+    bool needs_req_body = false;  // JIT handler reads req.body and needs the full body buffered
 };
 
 // RouteConfig — immutable after construction, atomically swappable.
@@ -132,9 +133,8 @@ struct RouteConfig {
         SegmentTrie,  // segment-aware trie (boundary-sensitive overlap;
                       //   the only correct choice when
                       //   needs_segment_aware() returns true).
-                      //   Note: `:param` route paths are currently
-                      //   rejected at add_* time — runtime param capture
-                      //   is a future feature.
+                      //   `:param` route paths are supported here for
+                      //   dynamic segments and request-time capture.
     };
 
     DispatchKind dispatch_kind() const { return dispatch_kind_; }
@@ -282,7 +282,8 @@ struct RouteConfig {
         if (route_count >= kMaxRoutes) return false;
         if (upstream_id >= upstream_count) return false;
         if (!is_routable_path(path)) return false;
-        if (!has_no_param_segment(path)) return false;
+        if (!dispatch_accepts_path_shape(path)) return false;
+        if (!param_count_fits(path)) return false;
         const u8 method_key = route_method_key_from_legacy_char(method);
         if (route_method_slot(method_key) == kMethodSlotInvalid) return false;
         auto& r = routes[route_count];
@@ -298,6 +299,7 @@ struct RouteConfig {
         r.upstream_id = upstream_id;
         r.status_code = 0;
         r.fn = nullptr;
+        r.needs_req_body = false;
         if (!populate_dispatch_state(r)) {
             return false;  // active dispatch at capacity — fail loud
         }
@@ -310,7 +312,8 @@ struct RouteConfig {
     bool add_static(const char* path, u8 method, u16 status) {
         if (route_count >= kMaxRoutes) return false;
         if (!is_routable_path(path)) return false;
-        if (!has_no_param_segment(path)) return false;
+        if (!dispatch_accepts_path_shape(path)) return false;
+        if (!param_count_fits(path)) return false;
         const u8 method_key = route_method_key_from_legacy_char(method);
         if (route_method_slot(method_key) == kMethodSlotInvalid) return false;
         auto& r = routes[route_count];
@@ -326,6 +329,7 @@ struct RouteConfig {
         r.upstream_id = 0;
         r.status_code = status;
         r.fn = nullptr;
+        r.needs_req_body = false;
         if (!populate_dispatch_state(r)) {
             return false;
         }
@@ -336,11 +340,15 @@ struct RouteConfig {
     // Add a JIT-handler route. Handler is invoked on match; its HandlerResult
     // tells the runtime what to do next (return status, forward, or yield).
     // Same failure modes as add_proxy() plus null-fn check.
-    bool add_jit_handler(const char* path, u8 method, jit::HandlerFn fn) {
+    bool add_jit_handler(const char* path,
+                         u8 method,
+                         jit::HandlerFn fn,
+                         bool needs_req_body = false) {
         if (route_count >= kMaxRoutes) return false;
         if (fn == nullptr) return false;
         if (!is_routable_path(path)) return false;
-        if (!has_no_param_segment(path)) return false;
+        if (!dispatch_accepts_path_shape(path)) return false;
+        if (!param_count_fits(path)) return false;
         const u8 method_key = route_method_key_from_legacy_char(method);
         if (route_method_slot(method_key) == kMethodSlotInvalid) return false;
         auto& r = routes[route_count];
@@ -356,6 +364,7 @@ struct RouteConfig {
         r.upstream_id = 0;
         r.status_code = 0;
         r.fn = fn;
+        r.needs_req_body = needs_req_body;
         if (!populate_dispatch_state(r)) {
             return false;
         }
@@ -525,6 +534,15 @@ struct RouteConfig {
     // `method` must be a canonical route method key. Compatibility
     // callers with legacy first-char bytes should use match().
     const RouteEntry* match_canonical(Str canon, u8 method) const {
+        return match_canonical(canon, method, nullptr, nullptr, 0);
+    }
+
+    const RouteEntry* match_canonical(Str canon,
+                                      u8 method,
+                                      RouteParam* out_params,
+                                      u32* out_param_count,
+                                      u32 out_param_cap) const {
+        if (out_param_count) *out_param_count = 0;
         if (canon.ptr == nullptr) return nullptr;
         u16 idx;
         switch (dispatch_kind_) {
@@ -533,7 +551,7 @@ struct RouteConfig {
                                   : art_state.match_canonical_key(canon, method);
                 break;
             case DispatchKind::SegmentTrie:
-                idx = trie.match_key(canon, method);
+                idx = trie.match_key(canon, method, out_params, out_param_count, out_param_cap);
                 break;
             default:
                 __builtin_unreachable();
@@ -543,20 +561,31 @@ struct RouteConfig {
     }
 
 private:
-    // Returns true iff `path` contains no `:param`-style segment (a
-    // segment starting with ':'). Used by add_* to gate registration:
-    // if the path has a param segment the call returns false (the
-    // misconfiguration is surfaced loudly at startup rather than
-    // producing silent route misses at request time, because neither
-    // current dispatcher implements runtime parameter capture —
-    // registered "/users/:id" would store ":id" literally and
-    // "/users/42" would silently miss. Runtime parameter capture is
-    // a future feature; route_select.h's path_has_param_segment
-    // helper detects the shape).
-    bool has_no_param_segment(const char* path) const {
+    // ART is byte-prefix based and cannot interpret `:param` segments, so
+    // reject dynamic routes there. SegmentTrie supports dynamic segments
+    // and request-time capture.
+    bool dispatch_accepts_path_shape(const char* path) const {
         u32 plen = 0;
         while (path[plen]) plen++;
-        return !path_has_param_segment(Str{path, plen});
+        if (!path_has_param_segment(Str{path, plen})) return true;
+        return dispatch_kind_ == DispatchKind::SegmentTrie;
+    }
+
+    bool param_count_fits(const char* path) const {
+        u32 count = 0;
+        bool at_start = true;
+        for (u32 i = 0; path[i]; i++) {
+            if (path[i] == '/') {
+                at_start = true;
+                continue;
+            }
+            if (at_start && path[i] == ':') {
+                count++;
+                if (count > kMaxRouteParams) return false;
+            }
+            at_start = false;
+        }
+        return true;
     }
 
     // Tagged-union discriminator. Default is ArtJit since most

--- a/include/rut/runtime/route_trie.h
+++ b/include/rut/runtime/route_trie.h
@@ -2,6 +2,7 @@
 
 #include "rut/common/types.h"
 #include "rut/runtime/route_method.h"
+#include "rut/runtime/route_params.h"
 
 namespace rut {
 
@@ -29,6 +30,8 @@ namespace rut {
 //   - Path is split on '/' into segments.
 //   - Empty segments are dropped (so "/api//v1" == "/api/v1", "/api/" == "/api").
 //   - Matching is case-sensitive (per RFC 3986).
+//   - Route segments beginning with ':' match one request segment.
+//     Callers may request captured (name, value) views for the matched route.
 //   - A route attached at the root ("/") acts as a catch-all for any request.
 //   - If multiple routes share a path, the first-inserted wins (build-order
 //     determinism for duplicate keys; the trie is built incrementally via
@@ -171,6 +174,15 @@ public:
     // legacy first-char normalization stays out of request dispatch.
     u16 match_key(Str path, u8 method_key) const;
 
+    // Same as match_key(), but also materializes route params from the
+    // winning dynamic route into caller-owned storage. `out_param_count`
+    // is set to 0 on miss and to the number copied on hit.
+    u16 match_key(Str path,
+                  u8 method_key,
+                  RouteParam* out_params,
+                  u32* out_param_count,
+                  u32 out_param_cap) const;
+
     // Introspection helpers (for tests / bench).
     u32 node_count() const { return nodes.len; }
 
@@ -209,6 +221,8 @@ private:
     // index on top — at our segment-length distribution it's a net
     // cost, not a savings.
     u16 find_child(u16 parent, Str segment) const;
+
+    static bool is_param_segment(Str segment);
 };
 
 }  // namespace rut

--- a/include/rut/sim/simulate_engine.h
+++ b/include/rut/sim/simulate_engine.h
@@ -110,6 +110,7 @@ struct Engine {
         char pattern[128]{};
         u32 pattern_len = 0;
         jit::HandlerFn fn = nullptr;
+        bool needs_req_body = false;
     };
 
     CompiledRoute routes[kMaxRoutes];

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -151,7 +151,8 @@ static FrontendResult<u32> intern_hir_type_shape(HirModule* mod,
     shape.array_elem_shape_index =
         type == HirTypeKind::Array ? array_elem_shape_index : 0xffffffffu;
     shape.is_concrete = type == HirTypeKind::Bool || type == HirTypeKind::I32 ||
-                        type == HirTypeKind::Str || type == HirTypeKind::Method;
+                        type == HirTypeKind::Str || type == HirTypeKind::Method ||
+                        type == HirTypeKind::ByteSize || type == HirTypeKind::IP;
     if (type == HirTypeKind::Variant) shape.is_concrete = variant_index != 0xffffffffu;
     if (type == HirTypeKind::Struct) shape.is_concrete = struct_index != 0xffffffffu;
     if (type == HirTypeKind::Array) {
@@ -363,6 +364,8 @@ static bool hir_type_shape_satisfies_eq_constraint(const HirModule& mod,
         case HirTypeKind::I32:
         case HirTypeKind::Str:
         case HirTypeKind::Method:
+        case HirTypeKind::ByteSize:
+        case HirTypeKind::IP:
             return true;
         case HirTypeKind::Tuple:
             for (u32 i = 0; i < tuple_len; i++) {
@@ -1271,6 +1274,30 @@ static Str import_namespace_name(Str path, bool has_alias, Str alias) {
 static bool import_namespace_matches(Str path, bool has_alias, Str alias, Str ns) {
     const auto name = import_namespace_name(path, has_alias, alias);
     return name.eq(ns);
+}
+
+static bool is_route_param_name_byte(char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
+}
+
+static bool route_path_has_param(Str path, Str name) {
+    u32 segment_start = 0;
+    while (segment_start < path.len) {
+        while (segment_start < path.len && path.ptr[segment_start] == '/') segment_start++;
+        u32 segment_end = segment_start;
+        while (segment_end < path.len && path.ptr[segment_end] != '/') segment_end++;
+        if (segment_end > segment_start && path.ptr[segment_start] == ':') {
+            const u32 name_start = segment_start + 1;
+            u32 name_end = name_start;
+            while (name_end < segment_end && is_route_param_name_byte(path.ptr[name_end]))
+                name_end++;
+            if (name_end == segment_end && name_end > name_start &&
+                Str{path.ptr + name_start, name_end - name_start}.eq(name))
+                return true;
+        }
+        segment_start = segment_end + 1;
+    }
+    return false;
 }
 
 static bool has_import_namespace(const HirModule& mod, Str ns) {
@@ -3113,6 +3140,33 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
                                                  u32 local_count,
                                                  const MatchPayloadBinding* binding,
                                                  const HirExpr* pipe_lhs);
+static bool user_bound_req_name(const HirModule& mod,
+                                const HirLocal* locals,
+                                u32 local_count,
+                                const MatchPayloadBinding* binding) {
+    if (binding && binding->subject && binding->name.eq({"req", 3})) return true;
+    for (u32 i = 0; i < local_count; i++) {
+        if (locals[i].name.eq({"req", 3})) return true;
+    }
+    for (u32 i = 0; i < mod.variants.len; i++) {
+        if (mod.variants[i].name.eq({"req", 3})) return true;
+    }
+    if (find_function_index(mod, {"req", 3}) < mod.functions.len) return true;
+    if (find_struct_index(mod, {"req", 3}) < mod.structs.len) return true;
+    if (find_protocol_index(mod, {"req", 3}) < mod.protocols.len) return true;
+    if (find_type_alias(mod, {"req", 3}) != nullptr) return true;
+    return has_import_namespace(mod, {"req", 3});
+}
+
+static bool magic_req_receiver(const AstExpr& lhs,
+                               const HirModule& mod,
+                               const HirLocal* locals,
+                               u32 local_count,
+                               const MatchPayloadBinding* binding) {
+    return lhs.kind == AstExprKind::Ident && lhs.name.eq({"req", 3}) &&
+           !user_bound_req_name(mod, locals, local_count, binding);
+}
+
 static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
                                                         HirRoute* route,
                                                         const HirModule& mod,
@@ -3164,6 +3218,31 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         auto variant = analyze_expr(variant_expr, route, mod, locals, local_count, binding);
         if (variant) return variant;
+    }
+    if (magic_req_receiver(*expr.lhs, mod, locals, local_count, binding) &&
+        (expr.name.eq({"header", 6}) || expr.name.eq({"param", 5}) || expr.name.eq({"cookie", 6}) ||
+         expr.name.eq({"query", 5}))) {
+        if (expr.args.len != 1 || expr.args[0] == nullptr ||
+            expr.args[0]->kind != AstExprKind::StrLit) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
+        }
+        HirExpr out{};
+        out.span = expr.span;
+        out.type = HirTypeKind::Str;
+        out.str_value = expr.args[0]->str_value;
+        if (expr.name.eq({"param", 5})) {
+            out.kind = HirExprKind::ReqParam;
+        } else if (expr.name.eq({"cookie", 6})) {
+            out.kind = HirExprKind::ReqCookie;
+            out.may_nil = true;
+        } else if (expr.name.eq({"query", 5})) {
+            out.kind = HirExprKind::ReqQuery;
+            out.may_nil = true;
+        } else {
+            out.kind = HirExprKind::ReqHeader;
+            out.may_nil = true;
+        }
+        return out;
     }
 
     auto build_cmp = [&](HirExprKind kind,
@@ -5190,40 +5269,9 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
     if (expr.kind == AstExprKind::MethodCall) {
         return analyze_method_call_expr(expr, route, mod, locals, local_count, binding);
     }
-    // `req.X` is magic only when the name `req` doesn't already
-    // resolve to something the user declared: a local binding, a
-    // variant name, or an import namespace alias. Any of those wins
-    // and we fall through to the generic Field handler below, which
-    // knows how to route variant construction / namespace members /
-    // local field access. Only when `req` resolves to nothing does
-    // the magic request-object path take over.
     if (expr.kind == AstExprKind::Field && expr.lhs != nullptr &&
         expr.lhs->kind == AstExprKind::Ident && expr.lhs->name.eq({"req", 3})) {
-        bool user_bound = false;
-        if (binding && binding->subject && binding->name.eq({"req", 3})) user_bound = true;
-        for (u32 i = 0; i < local_count; i++) {
-            if (locals[i].name.eq({"req", 3})) {
-                user_bound = true;
-                break;
-            }
-        }
-        if (!user_bound) {
-            for (u32 i = 0; i < mod.variants.len; i++) {
-                if (mod.variants[i].name.eq({"req", 3})) {
-                    user_bound = true;
-                    break;
-                }
-            }
-        }
-        if (!user_bound) {
-            Str ignored_qualified{};
-            if (resolve_import_namespace_member(mod, expr, ignored_qualified)) user_bound = true;
-        }
-        if (!user_bound) {
-            // Known fields: method (HttpMethod), path (str). `header` isn't reached via this
-            // path — the parser captures `req.header("...")` as the
-            // dedicated ReqHeader special form before generic Field
-            // parsing runs.
+        if (magic_req_receiver(*expr.lhs, mod, locals, local_count, binding)) {
             if (expr.name.eq({"method", 6})) {
                 out.kind = HirExprKind::ReqMethod;
                 out.type = HirTypeKind::Method;
@@ -5232,6 +5280,62 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             if (expr.name.eq({"path", 4})) {
                 out.kind = HirExprKind::ReqPath;
                 out.type = HirTypeKind::Str;
+                return out;
+            }
+            if (expr.name.eq({"pathOnly", 8})) {
+                out.kind = HirExprKind::ReqPathOnly;
+                out.type = HirTypeKind::Str;
+                return out;
+            }
+            if (expr.name.eq({"body", 4})) {
+                out.kind = HirExprKind::ReqBody;
+                out.type = HirTypeKind::Str;
+                return out;
+            }
+            if (expr.name.eq({"keepAlive", 9})) {
+                out.kind = HirExprKind::ReqKeepAlive;
+                out.type = HirTypeKind::Bool;
+                return out;
+            }
+            if (expr.name.eq({"chunked", 7})) {
+                out.kind = HirExprKind::ReqChunked;
+                out.type = HirTypeKind::Bool;
+                return out;
+            }
+            if (expr.name.eq({"hasContentLength", 16})) {
+                out.kind = HirExprKind::ReqHasContentLength;
+                out.type = HirTypeKind::Bool;
+                return out;
+            }
+            if (expr.name.eq({"http10", 6})) {
+                out.kind = HirExprKind::ReqHttp10;
+                out.type = HirTypeKind::Bool;
+                return out;
+            }
+            if (expr.name.eq({"http11", 6})) {
+                out.kind = HirExprKind::ReqHttp11;
+                out.type = HirTypeKind::Bool;
+                return out;
+            }
+            if (expr.name.eq({"httpVersion", 11})) {
+                out.kind = HirExprKind::ReqHttpVersion;
+                out.type = HirTypeKind::Str;
+                return out;
+            }
+            if (expr.name.eq({"contentLength", 13})) {
+                out.kind = HirExprKind::ReqContentLength;
+                out.type = HirTypeKind::ByteSize;
+                return out;
+            }
+            if (expr.name.eq({"remoteAddr", 10})) {
+                out.kind = HirExprKind::ReqRemoteAddr;
+                out.type = HirTypeKind::IP;
+                return out;
+            }
+            if (expr.name.eq({"queryString", 11})) {
+                out.kind = HirExprKind::ReqQueryString;
+                out.type = HirTypeKind::Str;
+                out.may_nil = true;
                 return out;
             }
             struct ReqHeaderAlias {
@@ -5262,6 +5366,12 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                 out.type = HirTypeKind::Str;
                 out.may_nil = true;
                 out.str_value = alias.header;
+                return out;
+            }
+            if (route != nullptr && route_path_has_param(route->path, expr.name)) {
+                out.kind = HirExprKind::ReqParam;
+                out.type = HirTypeKind::Str;
+                out.str_value = expr.name;
                 return out;
             }
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
@@ -5691,6 +5801,32 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         out.type = HirTypeKind::Str;
         out.may_nil = true;
         out.str_value = expr.str_value;
+        return out;
+    }
+    if (expr.kind == AstExprKind::ReqParam) {
+        out.kind = HirExprKind::ReqParam;
+        out.type = HirTypeKind::Str;
+        out.str_value = expr.str_value;
+        return out;
+    }
+    if (expr.kind == AstExprKind::ReqCookie) {
+        out.kind = HirExprKind::ReqCookie;
+        out.type = HirTypeKind::Str;
+        out.may_nil = true;
+        out.str_value = expr.str_value;
+        return out;
+    }
+    if (expr.kind == AstExprKind::ReqQuery) {
+        out.kind = HirExprKind::ReqQuery;
+        out.type = HirTypeKind::Str;
+        out.may_nil = true;
+        out.str_value = expr.str_value;
+        return out;
+    }
+    if (expr.kind == AstExprKind::ReqQueryString) {
+        out.kind = HirExprKind::ReqQueryString;
+        out.type = HirTypeKind::Str;
+        out.may_nil = true;
         return out;
     }
     if (expr.kind == AstExprKind::LitMethod) {

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -539,6 +539,16 @@ static FrontendResult<const rir::Type*> rir_type_for_shape(
         if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
         return ty.value();
     }
+    if (type == MirTypeKind::ByteSize) {
+        auto ty = b.make_type(rir::TypeKind::ByteSize);
+        if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+        return ty.value();
+    }
+    if (type == MirTypeKind::IP) {
+        auto ty = b.make_type(rir::TypeKind::IP);
+        if (!ty) return frontend_error(FrontendError::OutOfMemory, span);
+        return ty.value();
+    }
     if (type == MirTypeKind::Variant && variant_index != 0xffffffffu &&
         variant_infos[variant_index].struct_type != nullptr)
         return variant_infos[variant_index].struct_type;
@@ -683,7 +693,7 @@ static FrontendResult<rir::ValueId> emit_eq_for_shape(MirTypeKind type,
                                                       rir::Builder& b,
                                                       Span span) {
     if (type == MirTypeKind::Bool || type == MirTypeKind::I32 || type == MirTypeKind::Str ||
-        type == MirTypeKind::Method) {
+        type == MirTypeKind::Method || type == MirTypeKind::ByteSize || type == MirTypeKind::IP) {
         auto cmp = b.emit_cmp(rir::Opcode::CmpEq, lhs, rhs, {span.line, span.col});
         if (!cmp) return frontend_error(FrontendError::OutOfMemory, span);
         return cmp.value();
@@ -1411,8 +1421,78 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
         if (!v) return frontend_error(FrontendError::OutOfMemory, span);
         return v.value();
     }
+    if (value.kind == MirValueKind::ReqParam) {
+        auto v = b.emit_req_param(value.str_value, {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqCookie) {
+        auto v = b.emit_req_cookie(value.str_value, {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqQuery) {
+        auto v = b.emit_req_query(value.str_value, {span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqQueryString) {
+        auto v = b.emit_req_query_string({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
     if (value.kind == MirValueKind::ReqPath) {
         auto v = b.emit_req_path({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqPathOnly) {
+        auto v = b.emit_req_path_only({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqBody) {
+        auto v = b.emit_req_body({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqKeepAlive) {
+        auto v = b.emit_req_keep_alive({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqChunked) {
+        auto v = b.emit_req_chunked({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqHasContentLength) {
+        auto v = b.emit_req_has_content_length({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqHttp10) {
+        auto v = b.emit_req_http10({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqHttp11) {
+        auto v = b.emit_req_http11({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqHttpVersion) {
+        auto v = b.emit_req_http_version({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqContentLength) {
+        auto v = b.emit_req_content_length({span.line, span.col});
+        if (!v) return frontend_error(FrontendError::OutOfMemory, span);
+        return v.value();
+    }
+    if (value.kind == MirValueKind::ReqRemoteAddr) {
+        auto v = b.emit_req_remote_addr({span.line, span.col});
         if (!v) return frontend_error(FrontendError::OutOfMemory, span);
         return v.value();
     }

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -37,14 +37,16 @@ static Str match_default_label() {
 }
 
 static MirTypeKind mir_type_kind(HirTypeKind kind) {
-    return kind == HirTypeKind::Bool      ? MirTypeKind::Bool
-           : kind == HirTypeKind::I32     ? MirTypeKind::I32
-           : kind == HirTypeKind::Str     ? MirTypeKind::Str
-           : kind == HirTypeKind::Method  ? MirTypeKind::Method
-           : kind == HirTypeKind::Variant ? MirTypeKind::Variant
-           : kind == HirTypeKind::Tuple   ? MirTypeKind::Tuple
-           : kind == HirTypeKind::Struct  ? MirTypeKind::Struct
-                                          : MirTypeKind::Unknown;
+    return kind == HirTypeKind::Bool       ? MirTypeKind::Bool
+           : kind == HirTypeKind::I32      ? MirTypeKind::I32
+           : kind == HirTypeKind::Str      ? MirTypeKind::Str
+           : kind == HirTypeKind::Method   ? MirTypeKind::Method
+           : kind == HirTypeKind::ByteSize ? MirTypeKind::ByteSize
+           : kind == HirTypeKind::IP       ? MirTypeKind::IP
+           : kind == HirTypeKind::Variant  ? MirTypeKind::Variant
+           : kind == HirTypeKind::Tuple    ? MirTypeKind::Tuple
+           : kind == HirTypeKind::Struct   ? MirTypeKind::Struct
+                                           : MirTypeKind::Unknown;
 }
 
 static bool expand_hir_flat_shape(const HirModule& module,
@@ -365,9 +367,85 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.str_value = expr.str_value;
         return v;
     }
+    if (expr.kind == HirExprKind::ReqParam) {
+        v.kind = MirValueKind::ReqParam;
+        v.type = MirTypeKind::Str;
+        v.str_value = expr.str_value;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqCookie) {
+        v.kind = MirValueKind::ReqCookie;
+        v.type = MirTypeKind::Str;
+        v.may_nil = true;
+        v.str_value = expr.str_value;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqQuery) {
+        v.kind = MirValueKind::ReqQuery;
+        v.type = MirTypeKind::Str;
+        v.may_nil = true;
+        v.str_value = expr.str_value;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqQueryString) {
+        v.kind = MirValueKind::ReqQueryString;
+        v.type = MirTypeKind::Str;
+        v.may_nil = true;
+        return v;
+    }
     if (expr.kind == HirExprKind::ReqPath) {
         v.kind = MirValueKind::ReqPath;
         v.type = MirTypeKind::Str;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqPathOnly) {
+        v.kind = MirValueKind::ReqPathOnly;
+        v.type = MirTypeKind::Str;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqBody) {
+        v.kind = MirValueKind::ReqBody;
+        v.type = MirTypeKind::Str;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqKeepAlive) {
+        v.kind = MirValueKind::ReqKeepAlive;
+        v.type = MirTypeKind::Bool;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqChunked) {
+        v.kind = MirValueKind::ReqChunked;
+        v.type = MirTypeKind::Bool;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqHasContentLength) {
+        v.kind = MirValueKind::ReqHasContentLength;
+        v.type = MirTypeKind::Bool;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqHttp10) {
+        v.kind = MirValueKind::ReqHttp10;
+        v.type = MirTypeKind::Bool;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqHttp11) {
+        v.kind = MirValueKind::ReqHttp11;
+        v.type = MirTypeKind::Bool;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqHttpVersion) {
+        v.kind = MirValueKind::ReqHttpVersion;
+        v.type = MirTypeKind::Str;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqContentLength) {
+        v.kind = MirValueKind::ReqContentLength;
+        v.type = MirTypeKind::ByteSize;
+        return v;
+    }
+    if (expr.kind == HirExprKind::ReqRemoteAddr) {
+        v.kind = MirValueKind::ReqRemoteAddr;
+        v.type = MirTypeKind::IP;
         return v;
     }
     if (expr.kind == HirExprKind::ConstMethod) {

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -396,22 +396,6 @@ struct Parser {
             expr.span = span_from(tok);
             return expr;
         }
-        if (cur().type == TokenType::Ident && cur().text.eq({"req", 3}) &&
-            peek().type == TokenType::Dot && peek(2).type == TokenType::Ident &&
-            peek(2).text.eq({"header", 6})) {
-            const Token start_tok = cur();
-            pos += 3;  // req . header
-            auto lparen = expect(TokenType::LParen);
-            if (!lparen) return core::make_unexpected(lparen.error());
-            auto name = expect(TokenType::StringLit);
-            if (!name) return core::make_unexpected(name.error());
-            auto rparen = expect(TokenType::RParen);
-            if (!rparen) return core::make_unexpected(rparen.error());
-            expr.kind = AstExprKind::ReqHeader;
-            expr.str_value = name.value()->text;
-            expr.span = Span{start_tok.start, rparen.value()->end, start_tok.line, start_tok.col};
-            return expr;
-        }
         // HTTP method literals as expressions (POST, GET, …). The
         // lexer already tokenizes these as KwGet/KwPost/etc.; until
         // now they were only consumed in route declarations. Map

--- a/src/compiler/rir_printer.cc
+++ b/src/compiler/rir_printer.cc
@@ -145,11 +145,41 @@ void print_opcode(PrintBuf& buf, Opcode op) {
         case Opcode::ReqParam:
             buf.put_cstr("req.param");
             break;
+        case Opcode::ReqQuery:
+            buf.put_cstr("req.query");
+            break;
+        case Opcode::ReqQueryString:
+            buf.put_cstr("req.queryString");
+            break;
         case Opcode::ReqMethod:
             buf.put_cstr("req.method");
             break;
         case Opcode::ReqPath:
             buf.put_cstr("req.path");
+            break;
+        case Opcode::ReqPathOnly:
+            buf.put_cstr("req.pathOnly");
+            break;
+        case Opcode::ReqBody:
+            buf.put_cstr("req.body");
+            break;
+        case Opcode::ReqKeepAlive:
+            buf.put_cstr("req.keepAlive");
+            break;
+        case Opcode::ReqChunked:
+            buf.put_cstr("req.chunked");
+            break;
+        case Opcode::ReqHasContentLength:
+            buf.put_cstr("req.hasContentLength");
+            break;
+        case Opcode::ReqHttp10:
+            buf.put_cstr("req.http10");
+            break;
+        case Opcode::ReqHttp11:
+            buf.put_cstr("req.http11");
+            break;
+        case Opcode::ReqHttpVersion:
+            buf.put_cstr("req.httpVersion");
             break;
         case Opcode::ResumeEventKind:
             buf.put_cstr("resume.event_kind");
@@ -476,12 +506,17 @@ void print_instruction(PrintBuf& buf, const Instruction& inst, const Function& f
             break;
         case Opcode::ReqHeader:
         case Opcode::ReqParam:
+        case Opcode::ReqQuery:
         case Opcode::ReqCookie:
             buf.put(' ');
             print_quoted_str(buf, inst.imm.str_val);
             break;
         case Opcode::ReqMethod:
         case Opcode::ReqPath:
+        case Opcode::ReqPathOnly:
+        case Opcode::ReqBody:
+        case Opcode::ReqQueryString:
+        case Opcode::ReqHttpVersion:
         case Opcode::ResumeEventKind:
         case Opcode::ResumeEventResult:
             break;

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -83,9 +83,18 @@ struct Ctx {
 
     // Lazily declared runtime helpers
     LLVMValueRef fn_req_path;
+    LLVMValueRef fn_req_path_only;
+    LLVMValueRef fn_req_body;
+    LLVMValueRef fn_req_http_version;
+    LLVMValueRef fn_req_flag;
     LLVMValueRef fn_req_method;
     LLVMValueRef fn_req_header;
+    LLVMValueRef fn_req_cookie;
+    LLVMValueRef fn_req_query;
+    LLVMValueRef fn_req_query_string;
+    LLVMValueRef fn_req_param;
     LLVMValueRef fn_req_remote_addr;
+    LLVMValueRef fn_req_content_length;
     LLVMValueRef fn_str_has_prefix;
     LLVMValueRef fn_str_eq;
     LLVMValueRef fn_str_cmp;
@@ -162,6 +171,46 @@ struct Ctx {
         return fn_req_path;
     }
 
+    // void rut_helper_req_path_only(ptr, i32, ptr, ptr)
+    LLVMValueRef get_req_path_only() {
+        if (!fn_req_path_only) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(void_ty, params, 4, 0);
+            fn_req_path_only = LLVMAddFunction(llvm_mod, "rut_helper_req_path_only", ft);
+        }
+        return fn_req_path_only;
+    }
+
+    // void rut_helper_req_body(ptr, i32, ptr, ptr)
+    LLVMValueRef get_req_body() {
+        if (!fn_req_body) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(void_ty, params, 4, 0);
+            fn_req_body = LLVMAddFunction(llvm_mod, "rut_helper_req_body", ft);
+        }
+        return fn_req_body;
+    }
+
+    // void rut_helper_req_http_version(ptr, i32, ptr, ptr)
+    LLVMValueRef get_req_http_version() {
+        if (!fn_req_http_version) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(void_ty, params, 4, 0);
+            fn_req_http_version = LLVMAddFunction(llvm_mod, "rut_helper_req_http_version", ft);
+        }
+        return fn_req_http_version;
+    }
+
+    // u8 rut_helper_req_flag(ptr, i32, i8)
+    LLVMValueRef get_req_flag() {
+        if (!fn_req_flag) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, i8_ty};
+            LLVMTypeRef ft = LLVMFunctionType(i8_ty, params, 3, 0);
+            fn_req_flag = LLVMAddFunction(llvm_mod, "rut_helper_req_flag", ft);
+        }
+        return fn_req_flag;
+    }
+
     // u8 rut_helper_req_method(ptr, i32)
     LLVMValueRef get_req_method() {
         if (!fn_req_method) {
@@ -182,6 +231,46 @@ struct Ctx {
         return fn_req_header;
     }
 
+    // void rut_helper_req_cookie(ptr, i32, ptr, i32, ptr, ptr, ptr)
+    LLVMValueRef get_req_cookie() {
+        if (!fn_req_cookie) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty, ptr_ty, ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(void_ty, params, 7, 0);
+            fn_req_cookie = LLVMAddFunction(llvm_mod, "rut_helper_req_cookie", ft);
+        }
+        return fn_req_cookie;
+    }
+
+    // void rut_helper_req_query(ptr, i32, ptr, i32, ptr, ptr, ptr)
+    LLVMValueRef get_req_query() {
+        if (!fn_req_query) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, i32_ty, ptr_ty, ptr_ty, ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(void_ty, params, 7, 0);
+            fn_req_query = LLVMAddFunction(llvm_mod, "rut_helper_req_query", ft);
+        }
+        return fn_req_query;
+    }
+
+    // void rut_helper_req_query_string(ptr, i32, ptr, ptr, ptr)
+    LLVMValueRef get_req_query_string() {
+        if (!fn_req_query_string) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty, ptr_ty, ptr_ty, ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(void_ty, params, 5, 0);
+            fn_req_query_string = LLVMAddFunction(llvm_mod, "rut_helper_req_query_string", ft);
+        }
+        return fn_req_query_string;
+    }
+
+    // void rut_helper_req_param(ptr, ptr, i32, ptr, ptr)
+    LLVMValueRef get_req_param() {
+        if (!fn_req_param) {
+            LLVMTypeRef params[] = {ptr_ty, ptr_ty, i32_ty, ptr_ty, ptr_ty};
+            LLVMTypeRef ft = LLVMFunctionType(void_ty, params, 5, 0);
+            fn_req_param = LLVMAddFunction(llvm_mod, "rut_helper_req_param", ft);
+        }
+        return fn_req_param;
+    }
+
     // u32 rut_helper_req_remote_addr(ptr)
     LLVMValueRef get_req_remote_addr() {
         if (!fn_req_remote_addr) {
@@ -190,6 +279,16 @@ struct Ctx {
             fn_req_remote_addr = LLVMAddFunction(llvm_mod, "rut_helper_req_remote_addr", ft);
         }
         return fn_req_remote_addr;
+    }
+
+    // u64 rut_helper_req_content_length(ptr, i32)
+    LLVMValueRef get_req_content_length() {
+        if (!fn_req_content_length) {
+            LLVMTypeRef params[] = {ptr_ty, i32_ty};
+            LLVMTypeRef ft = LLVMFunctionType(i64_ty, params, 2, 0);
+            fn_req_content_length = LLVMAddFunction(llvm_mod, "rut_helper_req_content_length", ft);
+        }
+        return fn_req_content_length;
     }
 
     // u8 rut_helper_str_has_prefix(ptr, i32, ptr, i32)
@@ -507,6 +606,83 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             c.set_value(inst.result, strval);
             break;
         }
+        case rir::Opcode::ReqPathOnly: {
+            LLVMValueRef out_ptr = LLVMBuildAlloca(c.builder, c.ptr_ty, "path_only.ptr");
+            LLVMValueRef out_len = LLVMBuildAlloca(c.builder, c.i32_ty, "path_only.len");
+            LLVMValueRef args[] = {c.param_req_data, c.param_req_len, out_ptr, out_len};
+            LLVMBuildCall2(c.builder,
+                           LLVMGlobalGetValueType(c.get_req_path_only()),
+                           c.get_req_path_only(),
+                           args,
+                           4,
+                           "");
+            LLVMValueRef p = LLVMBuildLoad2(c.builder, c.ptr_ty, out_ptr, "path_only.p");
+            LLVMValueRef l = LLVMBuildLoad2(c.builder, c.i32_ty, out_len, "path_only.l");
+            LLVMValueRef strval = LLVMGetUndef(c.str_ty);
+            strval = LLVMBuildInsertValue(c.builder, strval, p, 0, "path_only.s.ptr");
+            strval = LLVMBuildInsertValue(c.builder, strval, l, 1, "path_only.s.len");
+            c.set_value(inst.result, strval);
+            break;
+        }
+        case rir::Opcode::ReqBody: {
+            LLVMValueRef out_ptr = LLVMBuildAlloca(c.builder, c.ptr_ty, "body.ptr");
+            LLVMValueRef out_len = LLVMBuildAlloca(c.builder, c.i32_ty, "body.len");
+            LLVMValueRef args[] = {c.param_req_data, c.param_req_len, out_ptr, out_len};
+            LLVMBuildCall2(
+                c.builder, LLVMGlobalGetValueType(c.get_req_body()), c.get_req_body(), args, 4, "");
+            LLVMValueRef p = LLVMBuildLoad2(c.builder, c.ptr_ty, out_ptr, "body.p");
+            LLVMValueRef l = LLVMBuildLoad2(c.builder, c.i32_ty, out_len, "body.l");
+            LLVMValueRef strval = LLVMGetUndef(c.str_ty);
+            strval = LLVMBuildInsertValue(c.builder, strval, p, 0, "body.s.ptr");
+            strval = LLVMBuildInsertValue(c.builder, strval, l, 1, "body.s.len");
+            c.set_value(inst.result, strval);
+            break;
+        }
+        case rir::Opcode::ReqHttpVersion: {
+            LLVMValueRef out_ptr = LLVMBuildAlloca(c.builder, c.ptr_ty, "http_version.ptr");
+            LLVMValueRef out_len = LLVMBuildAlloca(c.builder, c.i32_ty, "http_version.len");
+            LLVMValueRef args[] = {c.param_req_data, c.param_req_len, out_ptr, out_len};
+            LLVMBuildCall2(c.builder,
+                           LLVMGlobalGetValueType(c.get_req_http_version()),
+                           c.get_req_http_version(),
+                           args,
+                           4,
+                           "");
+            LLVMValueRef p = LLVMBuildLoad2(c.builder, c.ptr_ty, out_ptr, "http_version.p");
+            LLVMValueRef l = LLVMBuildLoad2(c.builder, c.i32_ty, out_len, "http_version.l");
+            LLVMValueRef strval = LLVMGetUndef(c.str_ty);
+            strval = LLVMBuildInsertValue(c.builder, strval, p, 0, "http_version.s.ptr");
+            strval = LLVMBuildInsertValue(c.builder, strval, l, 1, "http_version.s.len");
+            c.set_value(inst.result, strval);
+            break;
+        }
+        case rir::Opcode::ReqKeepAlive:
+        case rir::Opcode::ReqChunked:
+        case rir::Opcode::ReqHasContentLength:
+        case rir::Opcode::ReqHttp10:
+        case rir::Opcode::ReqHttp11: {
+            const u8 flag = inst.op == rir::Opcode::ReqKeepAlive          ? 0
+                            : inst.op == rir::Opcode::ReqChunked          ? 1
+                            : inst.op == rir::Opcode::ReqHasContentLength ? 2
+                            : inst.op == rir::Opcode::ReqHttp10           ? 3
+                                                                          : 4;
+            LLVMValueRef args[] = {
+                c.param_req_data, c.param_req_len, LLVMConstInt(c.i8_ty, flag, 0)};
+            LLVMValueRef v = LLVMBuildCall2(c.builder,
+                                            LLVMGlobalGetValueType(c.get_req_flag()),
+                                            c.get_req_flag(),
+                                            args,
+                                            3,
+                                            flag == 0   ? "keep_alive"
+                                            : flag == 1 ? "chunked"
+                                            : flag == 2 ? "has_content_length"
+                                            : flag == 3 ? "http10"
+                                                        : "http11");
+            LLVMValueRef b =
+                LLVMBuildICmp(c.builder, LLVMIntNE, v, LLVMConstInt(c.i8_ty, 0, 0), "req.flag");
+            c.set_value(inst.result, b);
+            break;
+        }
         case rir::Opcode::ReqMethod: {
             LLVMValueRef args[] = {c.param_req_data, c.param_req_len};
             LLVMValueRef v = LLVMBuildCall2(c.builder,
@@ -608,6 +784,98 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             c.set_value(inst.result, opt);
             break;
         }
+        case rir::Opcode::ReqParam: {
+            Str name = inst.imm.str_val;
+            LLVMValueRef name_ptr = c.make_global_str(name, "param.name");
+            LLVMValueRef name_len = LLVMConstInt(c.i32_ty, name.len, 0);
+            LLVMValueRef out_ptr = LLVMBuildAlloca(c.builder, c.ptr_ty, "param.ptr");
+            LLVMValueRef out_len = LLVMBuildAlloca(c.builder, c.i32_ty, "param.len");
+            LLVMValueRef args[] = {c.param_ctx, name_ptr, name_len, out_ptr, out_len};
+            LLVMBuildCall2(c.builder,
+                           LLVMGlobalGetValueType(c.get_req_param()),
+                           c.get_req_param(),
+                           args,
+                           5,
+                           "");
+            LLVMValueRef p = LLVMBuildLoad2(c.builder, c.ptr_ty, out_ptr, "p");
+            LLVMValueRef l = LLVMBuildLoad2(c.builder, c.i32_ty, out_len, "l");
+            LLVMValueRef strval = LLVMGetUndef(c.str_ty);
+            strval = LLVMBuildInsertValue(c.builder, strval, p, 0, "param.s.ptr");
+            strval = LLVMBuildInsertValue(c.builder, strval, l, 1, "param.s.len");
+            c.set_value(inst.result, strval);
+            break;
+        }
+        case rir::Opcode::ReqCookie: {
+            Str name = inst.imm.str_val;
+            LLVMValueRef name_ptr = c.make_global_str(name, "cookie.name");
+            LLVMValueRef name_len = LLVMConstInt(c.i32_ty, name.len, 0);
+            LLVMValueRef out_has = LLVMBuildAlloca(c.builder, c.i8_ty, "cookie.has");
+            LLVMValueRef out_ptr = LLVMBuildAlloca(c.builder, c.ptr_ty, "cookie.ptr");
+            LLVMValueRef out_len = LLVMBuildAlloca(c.builder, c.i32_ty, "cookie.len");
+            LLVMValueRef args[] = {
+                c.param_req_data, c.param_req_len, name_ptr, name_len, out_has, out_ptr, out_len};
+            LLVMBuildCall2(c.builder,
+                           LLVMGlobalGetValueType(c.get_req_cookie()),
+                           c.get_req_cookie(),
+                           args,
+                           7,
+                           "");
+            LLVMValueRef h = LLVMBuildLoad2(c.builder, c.i8_ty, out_has, "cookie.h");
+            LLVMValueRef p = LLVMBuildLoad2(c.builder, c.ptr_ty, out_ptr, "cookie.p");
+            LLVMValueRef l = LLVMBuildLoad2(c.builder, c.i32_ty, out_len, "cookie.l");
+            LLVMValueRef opt = LLVMGetUndef(c.opt_str_ty);
+            opt = LLVMBuildInsertValue(c.builder, opt, h, 0, "cookie.opt.has");
+            opt = LLVMBuildInsertValue(c.builder, opt, p, 1, "cookie.opt.ptr");
+            opt = LLVMBuildInsertValue(c.builder, opt, l, 2, "cookie.opt.len");
+            c.set_value(inst.result, opt);
+            break;
+        }
+        case rir::Opcode::ReqQuery: {
+            Str name = inst.imm.str_val;
+            LLVMValueRef name_ptr = c.make_global_str(name, "query.name");
+            LLVMValueRef name_len = LLVMConstInt(c.i32_ty, name.len, 0);
+            LLVMValueRef out_has = LLVMBuildAlloca(c.builder, c.i8_ty, "query.has");
+            LLVMValueRef out_ptr = LLVMBuildAlloca(c.builder, c.ptr_ty, "query.ptr");
+            LLVMValueRef out_len = LLVMBuildAlloca(c.builder, c.i32_ty, "query.len");
+            LLVMValueRef args[] = {
+                c.param_req_data, c.param_req_len, name_ptr, name_len, out_has, out_ptr, out_len};
+            LLVMBuildCall2(c.builder,
+                           LLVMGlobalGetValueType(c.get_req_query()),
+                           c.get_req_query(),
+                           args,
+                           7,
+                           "");
+            LLVMValueRef h = LLVMBuildLoad2(c.builder, c.i8_ty, out_has, "query.h");
+            LLVMValueRef p = LLVMBuildLoad2(c.builder, c.ptr_ty, out_ptr, "query.p");
+            LLVMValueRef l = LLVMBuildLoad2(c.builder, c.i32_ty, out_len, "query.l");
+            LLVMValueRef opt = LLVMGetUndef(c.opt_str_ty);
+            opt = LLVMBuildInsertValue(c.builder, opt, h, 0, "query.opt.has");
+            opt = LLVMBuildInsertValue(c.builder, opt, p, 1, "query.opt.ptr");
+            opt = LLVMBuildInsertValue(c.builder, opt, l, 2, "query.opt.len");
+            c.set_value(inst.result, opt);
+            break;
+        }
+        case rir::Opcode::ReqQueryString: {
+            LLVMValueRef out_has = LLVMBuildAlloca(c.builder, c.i8_ty, "query_string.has");
+            LLVMValueRef out_ptr = LLVMBuildAlloca(c.builder, c.ptr_ty, "query_string.ptr");
+            LLVMValueRef out_len = LLVMBuildAlloca(c.builder, c.i32_ty, "query_string.len");
+            LLVMValueRef args[] = {c.param_req_data, c.param_req_len, out_has, out_ptr, out_len};
+            LLVMBuildCall2(c.builder,
+                           LLVMGlobalGetValueType(c.get_req_query_string()),
+                           c.get_req_query_string(),
+                           args,
+                           5,
+                           "");
+            LLVMValueRef h = LLVMBuildLoad2(c.builder, c.i8_ty, out_has, "query_string.h");
+            LLVMValueRef p = LLVMBuildLoad2(c.builder, c.ptr_ty, out_ptr, "query_string.p");
+            LLVMValueRef l = LLVMBuildLoad2(c.builder, c.i32_ty, out_len, "query_string.l");
+            LLVMValueRef opt = LLVMGetUndef(c.opt_str_ty);
+            opt = LLVMBuildInsertValue(c.builder, opt, h, 0, "query_string.opt.has");
+            opt = LLVMBuildInsertValue(c.builder, opt, p, 1, "query_string.opt.ptr");
+            opt = LLVMBuildInsertValue(c.builder, opt, l, 2, "query_string.opt.len");
+            c.set_value(inst.result, opt);
+            break;
+        }
         case rir::Opcode::ReqRemoteAddr: {
             LLVMValueRef args[] = {c.param_conn};
             LLVMValueRef v = LLVMBuildCall2(c.builder,
@@ -616,6 +884,17 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
                                             args,
                                             1,
                                             "addr");
+            c.set_value(inst.result, v);
+            break;
+        }
+        case rir::Opcode::ReqContentLength: {
+            LLVMValueRef args[] = {c.param_req_data, c.param_req_len};
+            LLVMValueRef v = LLVMBuildCall2(c.builder,
+                                            LLVMGlobalGetValueType(c.get_req_content_length()),
+                                            c.get_req_content_length(),
+                                            args,
+                                            2,
+                                            "content_length");
             c.set_value(inst.result, v);
             break;
         }
@@ -1172,9 +1451,18 @@ CodegenResult codegen(const rir::Module& rir_mod) {
 
     // Zero out lazy helper pointers
     c.fn_req_path = nullptr;
+    c.fn_req_path_only = nullptr;
+    c.fn_req_body = nullptr;
+    c.fn_req_http_version = nullptr;
+    c.fn_req_flag = nullptr;
     c.fn_req_method = nullptr;
     c.fn_req_header = nullptr;
+    c.fn_req_cookie = nullptr;
+    c.fn_req_query = nullptr;
+    c.fn_req_query_string = nullptr;
+    c.fn_req_param = nullptr;
     c.fn_req_remote_addr = nullptr;
+    c.fn_req_content_length = nullptr;
     c.fn_str_has_prefix = nullptr;
     c.fn_str_eq = nullptr;
     c.fn_str_cmp = nullptr;

--- a/src/jit/jit_engine.cc
+++ b/src/jit/jit_engine.cc
@@ -43,9 +43,18 @@ struct HelperEntry {
 // Null-terminated table of runtime helper symbols.
 static const HelperEntry kHelpers[] = {
     {"rut_helper_req_path", reinterpret_cast<void*>(&rut_helper_req_path)},
+    {"rut_helper_req_path_only", reinterpret_cast<void*>(&rut_helper_req_path_only)},
+    {"rut_helper_req_body", reinterpret_cast<void*>(&rut_helper_req_body)},
+    {"rut_helper_req_http_version", reinterpret_cast<void*>(&rut_helper_req_http_version)},
+    {"rut_helper_req_flag", reinterpret_cast<void*>(&rut_helper_req_flag)},
     {"rut_helper_req_method", reinterpret_cast<void*>(&rut_helper_req_method)},
     {"rut_helper_req_header", reinterpret_cast<void*>(&rut_helper_req_header)},
+    {"rut_helper_req_cookie", reinterpret_cast<void*>(&rut_helper_req_cookie)},
+    {"rut_helper_req_query", reinterpret_cast<void*>(&rut_helper_req_query)},
+    {"rut_helper_req_query_string", reinterpret_cast<void*>(&rut_helper_req_query_string)},
+    {"rut_helper_req_param", reinterpret_cast<void*>(&rut_helper_req_param)},
     {"rut_helper_req_remote_addr", reinterpret_cast<void*>(&rut_helper_req_remote_addr)},
+    {"rut_helper_req_content_length", reinterpret_cast<void*>(&rut_helper_req_content_length)},
     {"rut_helper_str_has_prefix", reinterpret_cast<void*>(&rut_helper_str_has_prefix)},
     {"rut_helper_str_eq", reinterpret_cast<void*>(&rut_helper_str_eq)},
     {"rut_helper_str_cmp", reinterpret_cast<void*>(&rut_helper_str_cmp)},
@@ -82,7 +91,7 @@ bool JitEngine::init() {
     // If kHelpers ever grows past kMaxHelpers, fail loudly instead of
     // silently skipping helpers (which would produce opaque JIT link
     // failures at runtime).
-    static constexpr u32 kMaxHelpers = 16;
+    static constexpr u32 kMaxHelpers = 24;
     u32 count = 0;
     for (const auto* h = kHelpers; h->name; h++) count++;
     if (count > kMaxHelpers) {

--- a/src/jit/runtime_helpers.cc
+++ b/src/jit/runtime_helpers.cc
@@ -43,6 +43,72 @@ void rut_helper_req_path(const u8* req_data, u32 req_len, const char** out_ptr, 
     *out_len = i - path_start;
 }
 
+void rut_helper_req_path_only(const u8* req_data, u32 req_len, const char** out_ptr, u32* out_len) {
+    rut_helper_req_path(req_data, req_len, out_ptr, out_len);
+    if (!out_ptr || !out_len || !*out_ptr) return;
+    const char* path = *out_ptr;
+    const u32 path_len = *out_len;
+    for (u32 i = 0; i < path_len; i++) {
+        if (path[i] == '?' || path[i] == '#') {
+            *out_len = i;
+            return;
+        }
+    }
+}
+
+void rut_helper_req_body(const u8* req_data, u32 req_len, const char** out_ptr, u32* out_len) {
+    *out_ptr = "";
+    *out_len = 0;
+
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    if (parser.parse(req_data, req_len, &req) != ParseStatus::Complete) return;
+    if (!req.has_content_length || parser.header_end >= req_len || req.content_length == 0) return;
+
+    const u32 available = req_len - parser.header_end;
+    if (available < req.content_length) return;
+    *out_ptr = reinterpret_cast<const char*>(req_data + parser.header_end);
+    *out_len = req.content_length;
+}
+
+void rut_helper_req_http_version(const u8* req_data,
+                                 u32 req_len,
+                                 const char** out_ptr,
+                                 u32* out_len) {
+    *out_ptr = "";
+    *out_len = 0;
+
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    if (parser.parse(req_data, req_len, &req) != ParseStatus::Complete) return;
+
+    if (req.version == HttpVersion::Http10) {
+        *out_ptr = "HTTP/1.0";
+        *out_len = 8;
+        return;
+    }
+    if (req.version == HttpVersion::Http11) {
+        *out_ptr = "HTTP/1.1";
+        *out_len = 8;
+        return;
+    }
+}
+
+u8 rut_helper_req_flag(const u8* req_data, u32 req_len, u8 flag) {
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    if (parser.parse(req_data, req_len, &req) != ParseStatus::Complete) return 0;
+    if (flag == 0) return req.keep_alive ? 1 : 0;
+    if (flag == 1) return req.chunked ? 1 : 0;
+    if (flag == 2) return req.has_content_length ? 1 : 0;
+    if (flag == 3) return req.version == HttpVersion::Http10 ? 1 : 0;
+    if (flag == 4) return req.version == HttpVersion::Http11 ? 1 : 0;
+    return 0;
+}
+
 u8 rut_helper_req_method(const u8* req_data, u32 req_len) {
     HttpParser parser;
     ParsedRequest req;
@@ -96,9 +162,196 @@ void rut_helper_req_header(const u8* req_data,
     }
 }
 
+static bool ascii_header_name_eq(Str h, const char* name, u32 name_len) {
+    if (h.len != name_len) return false;
+    for (u32 j = 0; j < name_len; j++) {
+        u8 a = static_cast<u8>(h.ptr[j]);
+        u8 b = static_cast<u8>(name[j]);
+        if (a >= 'A' && a <= 'Z') a += 'a' - 'A';
+        if (b >= 'A' && b <= 'Z') b += 'a' - 'A';
+        if (a != b) return false;
+    }
+    return true;
+}
+
+void rut_helper_req_cookie(const u8* req_data,
+                           u32 req_len,
+                           const char* name,
+                           u32 name_len,
+                           u8* out_has_value,
+                           const char** out_ptr,
+                           u32* out_len) {
+    *out_has_value = 0;
+    *out_ptr = nullptr;
+    *out_len = 0;
+    if (!name || name_len == 0) return;
+
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    if (parser.parse(req_data, req_len, &req) != ParseStatus::Complete) return;
+
+    for (u32 i = 0; i < req.header_count; i++) {
+        const auto& h = req.headers[i];
+        if (!ascii_header_name_eq(h.name, "Cookie", 6)) continue;
+        const char* p = h.value.ptr;
+        const u32 n = h.value.len;
+        u32 pos = 0;
+        while (pos < n) {
+            while (pos < n && (p[pos] == ' ' || p[pos] == '\t' || p[pos] == ';')) pos++;
+            const u32 key_start = pos;
+            while (pos < n && p[pos] != '=' && p[pos] != ';') pos++;
+            u32 key_end = pos;
+            while (key_end > key_start && (p[key_end - 1] == ' ' || p[key_end - 1] == '\t'))
+                key_end--;
+            if (pos >= n || p[pos] != '=') {
+                while (pos < n && p[pos] != ';') pos++;
+                continue;
+            }
+            pos++;
+            const u32 value_start = pos;
+            while (pos < n && p[pos] != ';') pos++;
+            u32 value_end = pos;
+            while (value_end > value_start && (p[value_end - 1] == ' ' || p[value_end - 1] == '\t'))
+                value_end--;
+            const u32 key_len = key_end - key_start;
+            if (key_len == name_len && memcmp(p + key_start, name, name_len) == 0) {
+                *out_has_value = 1;
+                *out_ptr = p + value_start;
+                *out_len = value_end - value_start;
+                return;
+            }
+        }
+    }
+}
+
+void rut_helper_req_query(const u8* req_data,
+                          u32 req_len,
+                          const char* name,
+                          u32 name_len,
+                          u8* out_has_value,
+                          const char** out_ptr,
+                          u32* out_len) {
+    *out_has_value = 0;
+    *out_ptr = nullptr;
+    *out_len = 0;
+    if (!name || name_len == 0) return;
+
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    if (parser.parse(req_data, req_len, &req) != ParseStatus::Complete) return;
+    if (req.path.len == 0) return;
+
+    const char* path = req.path.ptr;
+    u32 path_len = req.path.len;
+    u32 path_pos = 0;
+    while (path_pos < path_len && path[path_pos] != '?' && path[path_pos] != '#') {
+        path_pos++;
+    }
+    if (path_pos >= path_len || path[path_pos] != '?') return;
+    if (path_pos + 1 >= path_len) return;
+
+    const char* query = path + path_pos + 1;
+    u32 query_len = path_len - path_pos - 1;
+    for (u32 i = 0; i < query_len; i++) {
+        if (query[i] == '#') {
+            query_len = i;
+            break;
+        }
+    }
+    u32 pos = 0;
+    while (pos < query_len) {
+        while (pos < query_len && query[pos] == '&') pos++;
+        const u32 key_start = pos;
+        while (pos < query_len && query[pos] != '&' && query[pos] != '=') pos++;
+        const u32 key_end = pos;
+        u32 val_start = key_end;
+        u32 val_end = key_end;
+        if (pos < query_len && query[pos] == '=') {
+            pos++;
+            val_start = pos;
+            while (pos < query_len && query[pos] != '&') pos++;
+            val_end = pos;
+        }
+        const u32 key_len = key_end - key_start;
+        if (key_len == name_len && memcmp(query + key_start, name, name_len) == 0) {
+            *out_has_value = 1;
+            *out_ptr = query + val_start;
+            *out_len = val_end - val_start;
+            return;
+        }
+    }
+}
+
+void rut_helper_req_query_string(
+    const u8* req_data, u32 req_len, u8* out_has_value, const char** out_ptr, u32* out_len) {
+    *out_has_value = 0;
+    *out_ptr = nullptr;
+    *out_len = 0;
+
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    if (parser.parse(req_data, req_len, &req) != ParseStatus::Complete) return;
+    if (req.path.len == 0) return;
+
+    const char* path = req.path.ptr;
+    const u32 path_len = req.path.len;
+    u32 pos = 0;
+    while (pos < path_len && path[pos] != '?' && path[pos] != '#') pos++;
+    if (pos >= path_len || path[pos] != '?') return;
+
+    const char* query = path + pos + 1;
+    u32 query_len = path_len - pos - 1;
+    for (u32 i = 0; i < query_len; i++) {
+        if (query[i] == '#') {
+            query_len = i;
+            break;
+        }
+    }
+
+    *out_has_value = 1;
+    *out_ptr = query;
+    *out_len = query_len;
+}
+
+void rut_helper_req_param(
+    void* ctx, const char* name, u32 name_len, const char** out_ptr, u32* out_len) {
+    *out_ptr = "";
+    *out_len = 0;
+    if (!ctx || !name) return;
+    auto* hctx = static_cast<jit::HandlerCtx*>(ctx);
+    const u32 n =
+        hctx->route_param_count < kMaxRouteParams ? hctx->route_param_count : kMaxRouteParams;
+    for (u32 i = 0; i < n; i++) {
+        const RouteParam& p = hctx->route_params[i];
+        if (p.name_len != name_len) continue;
+        bool match = true;
+        for (u32 j = 0; j < name_len; j++) {
+            if (p.name[j] != name[j]) {
+                match = false;
+                break;
+            }
+        }
+        if (!match) continue;
+        *out_ptr = p.value ? p.value : "";
+        *out_len = p.value ? p.value_len : 0;
+        return;
+    }
+}
+
 u32 rut_helper_req_remote_addr(void* conn) {
     auto* c = static_cast<Connection*>(conn);
     return c->peer_addr;
+}
+
+u64 rut_helper_req_content_length(const u8* req_data, u32 req_len) {
+    HttpParser parser;
+    ParsedRequest req;
+    parser.reset();
+    if (parser.parse(req_data, req_len, &req) != ParseStatus::Complete) return 0;
+    return req.has_content_length ? req.content_length : 0;
 }
 
 // ── String Operations ──────────────────────────────────────────────

--- a/src/runtime/callbacks.cc
+++ b/src/runtime/callbacks.cc
@@ -712,6 +712,7 @@ template void on_request_body_sent<EpollEventLoop>(void*, Connection&, IoEvent);
 template void on_early_upstream_recvd<EpollEventLoop>(void*, Connection&, IoEvent);
 template void on_early_upstream_recvd_send_inflight<EpollEventLoop>(void*, Connection&, IoEvent);
 template void on_request_body_recvd<EpollEventLoop>(void*, Connection&, IoEvent);
+template void on_jit_request_body_recvd<EpollEventLoop>(void*, Connection&, IoEvent);
 template void resume_jit_handler<EpollEventLoop>(EpollEventLoop*, Connection&);
 
 template void on_request_complete<IoUringEventLoop>(IoUringEventLoop*, Connection&, u16, u32);
@@ -734,6 +735,7 @@ template void on_request_body_sent<IoUringEventLoop>(void*, Connection&, IoEvent
 template void on_early_upstream_recvd<IoUringEventLoop>(void*, Connection&, IoEvent);
 template void on_early_upstream_recvd_send_inflight<IoUringEventLoop>(void*, Connection&, IoEvent);
 template void on_request_body_recvd<IoUringEventLoop>(void*, Connection&, IoEvent);
+template void on_jit_request_body_recvd<IoUringEventLoop>(void*, Connection&, IoEvent);
 template void resume_jit_handler<IoUringEventLoop>(IoUringEventLoop*, Connection&);
 
 }  // namespace rut

--- a/src/runtime/route_trie.cc
+++ b/src/runtime/route_trie.cc
@@ -71,6 +71,10 @@ u16 RouteTrie::find_child(u16 parent, Str segment) const {
     return TrieNode::kInvalidNodeIdx;
 }
 
+bool RouteTrie::is_param_segment(Str segment) {
+    return segment.len > 0 && segment.ptr[0] == ':';
+}
+
 bool RouteTrie::insert(Str path, u8 method_char, u16 route_idx) {
     // Reject unsupported method bytes up-front. An earlier revision
     // fell back to slot 0 ("any") for unknown chars, which would
@@ -159,6 +163,15 @@ u16 RouteTrie::match(Str path, u8 method_char) const {
 }
 
 u16 RouteTrie::match_key(Str path, u8 method_key) const {
+    return match_key(path, method_key, nullptr, nullptr, 0);
+}
+
+u16 RouteTrie::match_key(Str path,
+                         u8 method_key,
+                         RouteParam* out_params,
+                         u32* out_param_count,
+                         u32 out_param_cap) const {
+    if (out_param_count) *out_param_count = 0;
     const u32 want_slot = method_key_slot(method_key);
     if (want_slot == kMethodSlotInvalid) return TrieNode::kInvalidRoute;
 
@@ -175,28 +188,105 @@ u16 RouteTrie::match_key(Str path, u8 method_key) const {
     // prefix route — insert() already rejects too-deep route configs,
     // so the trie never contains a terminal we'd miss.
     (void)tokenize_segments(path, segs);
-    u16 cur = 0;
-    // Track the deepest terminal we've seen that's compatible with the
-    // requested method. Initialize from the root so a route inserted at
-    // "/" acts as a catch-all even when the request has deeper segments
-    // not in the trie.
-    auto pick_terminal = [](const TrieNode& node, u32 slot) -> u16 {
+    struct Candidate {
+        u16 route_idx = TrieNode::kInvalidRoute;
+        u32 depth = 0;
+        u32 static_segments = 0;
+        u64 static_mask = 0;
+        bool method_specific = false;
+        FixedVec<RouteParam, kMaxRouteParams> params{};
+    };
+    Candidate best{};
+
+    struct Terminal {
+        u16 route_idx;
+        bool method_specific;
+    };
+    auto pick_terminal = [](const TrieNode& node, u32 slot) -> Terminal {
         // Prefer a method-specific slot; fall back to slot 0 ("any").
         if (slot != 0 && node.route_idx_by_method[slot] != TrieNode::kInvalidRoute) {
-            return node.route_idx_by_method[slot];
+            return {node.route_idx_by_method[slot], true};
         }
-        return node.route_idx_by_method[0];
+        return {node.route_idx_by_method[0], false};
     };
-    u16 best = pick_terminal(nodes[0], want_slot);
 
-    for (u32 i = 0; i < segs.len; i++) {
-        const u16 child = find_child(cur, segs[i]);
-        if (child == TrieNode::kInvalidNodeIdx) break;
-        cur = child;
-        const u16 candidate = pick_terminal(nodes[cur], want_slot);
-        if (candidate != TrieNode::kInvalidRoute) best = candidate;
+    auto consider = [&](Terminal terminal,
+                        u32 depth,
+                        u32 static_segments,
+                        u64 static_mask,
+                        const FixedVec<RouteParam, kMaxRouteParams>& params) {
+        if (terminal.route_idx == TrieNode::kInvalidRoute) return;
+        if (best.route_idx == TrieNode::kInvalidRoute || depth > best.depth ||
+            (depth == best.depth && static_segments > best.static_segments) ||
+            (depth == best.depth && static_segments == best.static_segments &&
+             static_mask > best.static_mask) ||
+            (depth == best.depth && static_segments == best.static_segments &&
+             static_mask == best.static_mask && terminal.method_specific &&
+             !best.method_specific)) {
+            best.route_idx = terminal.route_idx;
+            best.depth = depth;
+            best.static_segments = static_segments;
+            best.static_mask = static_mask;
+            best.method_specific = terminal.method_specific;
+            best.params = params;
+        }
+    };
+
+    struct Frame {
+        u16 node;
+        u32 seg_i;
+        u32 depth;
+        u32 static_segments;
+        u64 static_mask;
+        FixedVec<RouteParam, kMaxRouteParams> params;
+    };
+    FixedVec<Frame, kMaxNodes> stack{};
+    [[maybe_unused]] bool pushed = stack.push(Frame{});
+
+    while (stack.len > 0) {
+        const Frame frame = stack[stack.len - 1];
+        stack.len--;
+        consider(pick_terminal(nodes[frame.node], want_slot),
+                 frame.depth,
+                 frame.static_segments,
+                 frame.static_mask,
+                 frame.params);
+        if (frame.seg_i >= segs.len) continue;
+
+        const auto& node = nodes[frame.node];
+        for (u32 child_i = node.children.len; child_i > 0; child_i--) {
+            const u16 param_child = node.children[child_i - 1];
+            const Str name = nodes[param_child].segment;
+            if (!is_param_segment(name)) continue;
+            Frame next = frame;
+            next.node = param_child;
+            next.seg_i = frame.seg_i + 1;
+            next.depth = frame.depth + 1;
+            if (next.params.len < kMaxRouteParams) {
+                [[maybe_unused]] bool ok = next.params.push(RouteParam{
+                    name.ptr + 1, name.len - 1, segs[frame.seg_i].ptr, segs[frame.seg_i].len});
+            }
+            [[maybe_unused]] bool ok = stack.push(next);
+        }
+
+        const u16 literal_child = find_child(frame.node, segs[frame.seg_i]);
+        if (literal_child != TrieNode::kInvalidNodeIdx &&
+            !is_param_segment(nodes[literal_child].segment)) {
+            Frame next = frame;
+            next.node = literal_child;
+            next.seg_i = frame.seg_i + 1;
+            next.depth = frame.depth + 1;
+            next.static_segments = frame.static_segments + 1;
+            if (next.depth < 64) next.static_mask |= 1ull << (63 - next.depth);
+            [[maybe_unused]] bool ok = stack.push(next);
+        }
     }
-    return best;
+    if (out_params && out_param_count) {
+        const u32 n = best.params.len < out_param_cap ? best.params.len : out_param_cap;
+        for (u32 i = 0; i < n; i++) out_params[i] = best.params[i];
+        *out_param_count = n;
+    }
+    return best.route_idx;
 }
 
 }  // namespace rut

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -147,6 +147,18 @@ static bool validate_manifest(const Manifest& manifest) {
     return true;
 }
 
+static bool rir_function_needs_req_body(const rir::Function& fn) {
+    if (fn.blocks == nullptr) return false;
+    for (u32 bi = 0; bi < fn.block_count; bi++) {
+        const auto& block = fn.blocks[bi];
+        if (block.insts == nullptr) continue;
+        for (u32 ii = 0; ii < block.inst_count; ii++) {
+            if (block.insts[ii].op == rir::Opcode::ReqBody) return true;
+        }
+    }
+    return false;
+}
+
 static bool copy_str_into_arena(MmapArena& arena, const char* src, u32 len, Str* out) {
     char* mem = arena.alloc_array<char>(len + 1);
     if (!mem) return false;
@@ -157,44 +169,122 @@ static bool copy_str_into_arena(MmapArena& arena, const char* src, u32 len, Str*
     return true;
 }
 
-static bool route_matches(const Engine::CompiledRoute& route, const char* path, u32 path_len) {
+static bool route_matches(const Engine::CompiledRoute& route,
+                          const char* path,
+                          u32 path_len,
+                          RouteParam* out_params = nullptr,
+                          u32* out_param_count = nullptr,
+                          u32 out_param_cap = 0,
+                          u32* out_depth = nullptr,
+                          u32* out_static_segments = nullptr,
+                          u64* out_static_mask = nullptr) {
     u32 pi = 0;
     u32 ri = 0;
+    u32 param_count = 0;
+    u32 stored_param_count = 0;
+    u32 depth = 0;
+    u32 static_segments = 0;
+    u64 static_mask = 0;
     while (ri < route.pattern_len) {
         const bool kParamSegment =
             route.pattern[ri] == ':' && (ri == 0 || route.pattern[ri - 1] == '/');
         if (kParamSegment) {
-            ri++;
+            depth++;
+            const u32 name_start = ri + 1;
+            ri = name_start;
             while (ri < route.pattern_len && route.pattern[ri] != '/') ri++;
+            const u32 name_len = ri - name_start;
             const u32 param_start = pi;
-            while (pi < path_len && path[pi] != '/' && path[pi] != '?') pi++;
+            while (pi < path_len && path[pi] != '/' && path[pi] != '?' && path[pi] != '#') pi++;
             if (pi == param_start) return false;
+            if (out_params && stored_param_count < out_param_cap) {
+                out_params[stored_param_count++] = {
+                    route.pattern + name_start, name_len, path + param_start, pi - param_start};
+            }
+            param_count++;
             continue;
         }
         if (pi >= path_len) return false;
-        if (path[pi] == '?') return false;
+        if (path[pi] == '?' || path[pi] == '#') return false;
         if (route.pattern[ri] != path[pi]) return false;
+        if ((ri == 0 || route.pattern[ri - 1] == '/') && route.pattern[ri] != '/') {
+            depth++;
+            static_segments++;
+            if (depth < 64) static_mask |= 1ull << (63 - depth);
+        }
         ri++;
         pi++;
     }
+    if (out_param_count) *out_param_count = out_params ? stored_param_count : param_count;
+    if (out_depth) *out_depth = depth;
+    if (out_static_segments) *out_static_segments = static_segments;
+    if (out_static_mask) *out_static_mask = static_mask;
     return true;
 }
 
 static const Engine::CompiledRoute* select_route(const Engine& engine,
                                                  u8 method_key,
                                                  const char* path,
-                                                 u32 path_len) {
+                                                 u32 path_len,
+                                                 RouteParam* out_params = nullptr,
+                                                 u32* out_param_count = nullptr,
+                                                 u32 out_param_cap = 0) {
+    const Engine::CompiledRoute* best = nullptr;
+    u32 best_depth = 0;
+    u32 best_static_segments = 0;
+    u64 best_static_mask = 0;
+    bool best_method_specific = false;
+    RouteParam best_params[kMaxRouteParams]{};
+    u32 best_param_count = 0;
+
     for (u32 i = 0; i < engine.route_count; i++) {
         const auto& route = engine.routes[i];
         if (route.method != 0 && route.method != method_key) continue;
-        if (route_matches(route, path, path_len)) return &route;
+        const bool method_specific = route.method != 0;
+        RouteParam candidate_params[kMaxRouteParams]{};
+        u32 param_count = 0;
+        u32 depth = 0;
+        u32 static_segments = 0;
+        u64 static_mask = 0;
+        if (route_matches(route,
+                          path,
+                          path_len,
+                          candidate_params,
+                          &param_count,
+                          kMaxRouteParams,
+                          &depth,
+                          &static_segments,
+                          &static_mask)) {
+            if (best == nullptr || depth > best_depth ||
+                (depth == best_depth && static_segments > best_static_segments) ||
+                (depth == best_depth && static_segments == best_static_segments &&
+                 static_mask > best_static_mask) ||
+                (depth == best_depth && static_segments == best_static_segments &&
+                 static_mask == best_static_mask && method_specific && !best_method_specific)) {
+                best = &route;
+                best_depth = depth;
+                best_static_segments = static_segments;
+                best_static_mask = static_mask;
+                best_method_specific = method_specific;
+                best_param_count = param_count < out_param_cap ? param_count : out_param_cap;
+                for (u32 j = 0; j < best_param_count; j++) best_params[j] = candidate_params[j];
+            }
+        }
     }
+    if (best) {
+        if (out_params) {
+            for (u32 i = 0; i < best_param_count; i++) out_params[i] = best_params[i];
+        }
+        if (out_param_count) *out_param_count = best_param_count;
+        return best;
+    }
+    if (out_param_count) *out_param_count = 0;
     return nullptr;
 }
 
 static u32 visible_path_len(Str path) {
     u32 n = 0;
-    while (n < path.len && path.ptr[n] != '?') n++;
+    while (n < path.len && path.ptr[n] != '?' && path.ptr[n] != '#') n++;
     return n;
 }
 
@@ -788,6 +878,7 @@ bool Engine::init(const rir::Module& module,
         for (u32 j = 0; j < route.pattern_len; j++) route.pattern[j] = fn.route_pattern.ptr[j];
         route.pattern[route.pattern_len] = '\0';
         route.fn = reinterpret_cast<jit::HandlerFn>(addr);
+        route.needs_req_body = rir_function_needs_req_body(fn);
     }
 
     for (u32 i = 0; i < next_route_count; i++) routes[i] = next_routes[i];
@@ -824,8 +915,15 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
     for (u32 i = 0; i < copy_len; i++) result.path[i] = req.path.ptr[i];
     result.path[copy_len] = '\0';
 
-    const auto* route =
-        select_route(engine, http_route_method_key(req.method), req.path.ptr, kPathLen);
+    RouteParam route_params[kMaxRouteParams]{};
+    u32 route_param_count = 0;
+    const auto* route = select_route(engine,
+                                     http_route_method_key(req.method),
+                                     req.path.ptr,
+                                     kPathLen,
+                                     route_params,
+                                     &route_param_count,
+                                     kMaxRouteParams);
     if (!route) {
         result.action = jit::HandlerAction::ReturnStatus;
         result.actual_status = 200;
@@ -834,11 +932,17 @@ SimulateResult simulate_one(Engine& engine, const CaptureEntry& entry) {
                              : Verdict::Mismatch;
         return result;
     }
+    if (route->needs_req_body) {
+        result.verdict = Verdict::Unsupported;
+        return result;
+    }
 
     Connection conn;
     conn.reset();
     SimHandlerFrame frame;
     init_sim_handler_frame(frame);
+    frame.ctx.route_param_count = route_param_count;
+    for (u32 i = 0; i < route_param_count; i++) frame.ctx.route_params[i] = route_params[i];
 
     // Drive the handler's state machine to completion. Yields are the
     // handler's signal "I need I/O, resume me with state=next_state".

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -911,6 +911,38 @@ route GET "/users" {
     // surface as an "unknown req field" analyze error.
 }
 
+TEST(frontend, parse_user_local_req_shadows_magic_method_accessors) {
+    const char* src = R"rut(
+protocol Accessors {
+    func header(name: str) -> i32
+    func param(name: str) -> i32
+    func cookie(name: str) -> i32
+    func query(name: str) -> i32
+}
+struct Box { value: i32 }
+Box impl Accessors {
+    func header(self: Box, name: str) -> i32 => self.value
+    func param(self: Box, name: str) -> i32 => self.value
+    func cookie(self: Box, name: str) -> i32 => self.value
+    func query(self: Box, name: str) -> i32 => self.value
+}
+route GET "/users/:id" {
+    let req = Box(value: 42)
+    guard req.header("Host") == 42 else { return 500 }
+    guard req.param("id") == 42 else { return 500 }
+    guard req.cookie("sid") == 42 else { return 500 }
+    guard req.query("q") == 42 else { return 500 }
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
 TEST(frontend, parse_user_variant_named_req_shadows_magic_path) {
     // A variant literally named `req` must take precedence so
     // `req.case` resolves as variant construction (VariantCase),
@@ -952,6 +984,28 @@ route GET "/users" { if req.ping() == 200 { return 200 } else { return 500 } }
     REQUIRE(ast);
     auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
     REQUIRE(hir);
+}
+
+TEST(frontend, parse_selective_import_alias_req_shadows_magic_method_accessors) {
+    const std::string dir = "/tmp/rut_selective_import_req_shadow_frontend";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func imported() -> i32 => 200\n";
+    }
+    const auto src = R"rut(
+import { imported as req } from "auth.rut"
+route GET "/users/:id" {
+    let value = req.param("id")
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(!hir);
 }
 
 TEST(frontend, parse_match_payload_named_req_shadows_magic_path) {
@@ -8294,7 +8348,7 @@ TEST(frontend, req_header_flows_as_optional_str) {
     REQUIRE(ast);
     REQUIRE_EQ(ast->items[0].route.statements.len, 3u);
     CHECK_EQ(static_cast<u8>(ast->items[0].route.statements[0].expr.kind),
-             static_cast<u8>(AstExprKind::ReqHeader));
+             static_cast<u8>(AstExprKind::MethodCall));
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
@@ -8451,6 +8505,441 @@ TEST(frontend, req_standard_header_alias_flows_as_optional_str) {
     CHECK(fn.blocks[0].insts[10].imm.str_val.eq({"X-Real-IP", 9}));
     CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[11].op), static_cast<u8>(rir::Opcode::ReqHeader));
     CHECK(fn.blocks[0].insts[11].imm.str_val.eq({"X-Request-ID", 12}));
+    rir.destroy();
+}
+
+TEST(frontend, req_param_flows_as_str) {
+    const char* src =
+        "route GET \"/users/:id\" { let id = req.param(\"id\") if id == \"42\" { return 200 } "
+        "else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 2u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].route.statements[0].expr.kind),
+             static_cast<u8>(AstExprKind::MethodCall));
+
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqParam));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqParam));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ReqParam));
+    rir.destroy();
+}
+
+TEST(frontend, req_route_param_field_flows_as_str) {
+    const char* src =
+        "route GET \"/users/:id\" { let id = req.id if id == \"42\" { return 200 } else { "
+        "return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqParam));
+    CHECK(hir->routes[0].locals[0].init.str_value.eq({"id", 2}));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqParam));
+    CHECK(mir->functions[0].locals[0].init.str_value.eq({"id", 2}));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ReqParam));
+    CHECK(fn.blocks[0].insts[0].imm.str_val.eq({"id", 2}));
+    rir.destroy();
+}
+
+TEST(frontend, req_route_param_field_requires_full_param_segment) {
+    const char* sources[] = {
+        "route GET \"/foo:bar\" { let value = req.bar return 200 }\n",
+        "route GET \"/:id-v2\" { let value = req.id return 200 }\n",
+    };
+    for (const char* src : sources) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE_FALSE(hir.has_value());
+        CHECK_EQ(static_cast<u8>(hir.error().code),
+                 static_cast<u8>(FrontendError::UnsupportedSyntax));
+    }
+}
+
+TEST(frontend, req_query_flows_as_optional_str) {
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = or(q, \"\") if value == "
+        "\"rut\" { return 200 } else { "
+        "return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 3u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].route.statements[0].expr.kind),
+             static_cast<u8>(AstExprKind::MethodCall));
+
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqQuery));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqQuery));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ReqQuery));
+    rir.destroy();
+}
+
+TEST(frontend, req_query_string_flows_as_optional_str) {
+    const char* src =
+        "route GET \"/search\" { let raw = req.queryString let value = or(raw, \"\") if value == "
+        "\"q=rut\" { return 200 } else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqQueryString));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqQueryString));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op),
+             static_cast<u8>(rir::Opcode::ReqQueryString));
+    rir.destroy();
+}
+
+TEST(frontend, req_path_only_flows_as_str) {
+    const char* src =
+        "route GET \"/search\" { let path = req.pathOnly if path == \"/search\" { return 200 } "
+        "else { return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqPathOnly));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].type), static_cast<u8>(MirTypeKind::Str));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqPathOnly));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ReqPathOnly));
+    rir.destroy();
+}
+
+TEST(frontend, req_body_flows_as_str) {
+    const char* src =
+        "route POST \"/upload\" { let body = req.body if body == \"ok\" { return 204 } else { "
+        "return 400 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqBody));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].type), static_cast<u8>(MirTypeKind::Str));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqBody));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ReqBody));
+    rir.destroy();
+}
+
+TEST(frontend, req_request_flags_flow_as_bool) {
+    const char* src =
+        "route POST \"/upload\" { let ka = req.keepAlive let ch = req.chunked let has = "
+        "req.hasContentLength let h10 = req.http10 let h11 = req.http11 if ka { return 200 } "
+        "else { return 400 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 5u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqKeepAlive));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].type), static_cast<u8>(HirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::ReqChunked));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[2].type), static_cast<u8>(HirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[2].init.kind),
+             static_cast<u8>(HirExprKind::ReqHasContentLength));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[3].type), static_cast<u8>(HirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[3].init.kind),
+             static_cast<u8>(HirExprKind::ReqHttp10));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[4].type), static_cast<u8>(HirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[4].init.kind),
+             static_cast<u8>(HirExprKind::ReqHttp11));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 5u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].type), static_cast<u8>(MirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqKeepAlive));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[1].type), static_cast<u8>(MirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[1].init.kind),
+             static_cast<u8>(MirValueKind::ReqChunked));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[2].type), static_cast<u8>(MirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[2].init.kind),
+             static_cast<u8>(MirValueKind::ReqHasContentLength));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[3].type), static_cast<u8>(MirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[3].init.kind),
+             static_cast<u8>(MirValueKind::ReqHttp10));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[4].type), static_cast<u8>(MirTypeKind::Bool));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[4].init.kind),
+             static_cast<u8>(MirValueKind::ReqHttp11));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ReqKeepAlive));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[1].op), static_cast<u8>(rir::Opcode::ReqChunked));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[2].op),
+             static_cast<u8>(rir::Opcode::ReqHasContentLength));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[3].op), static_cast<u8>(rir::Opcode::ReqHttp10));
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[4].op), static_cast<u8>(rir::Opcode::ReqHttp11));
+    rir.destroy();
+}
+
+TEST(frontend, req_http_version_flows_as_str) {
+    const char* src =
+        "route GET \"/version\" { let version = req.httpVersion if version == \"HTTP/1.1\" { "
+        "return 200 } else { return 400 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqHttpVersion));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].type), static_cast<u8>(MirTypeKind::Str));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqHttpVersion));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op),
+             static_cast<u8>(rir::Opcode::ReqHttpVersion));
+    rir.destroy();
+}
+
+TEST(frontend, req_content_length_flows_as_bytesize) {
+    const char* src = "route POST \"/upload\" { let len = req.contentLength return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type),
+             static_cast<u8>(HirTypeKind::ByteSize));
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqContentLength));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].type),
+             static_cast<u8>(MirTypeKind::ByteSize));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqContentLength));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op),
+             static_cast<u8>(rir::Opcode::ReqContentLength));
+    rir.destroy();
+}
+
+TEST(frontend, req_remote_addr_flows_as_ip) {
+    const char* src = "route GET \"/addr\" { let addr = req.remoteAddr return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::IP));
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqRemoteAddr));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].type), static_cast<u8>(MirTypeKind::IP));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqRemoteAddr));
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op),
+             static_cast<u8>(rir::Opcode::ReqRemoteAddr));
+    rir.destroy();
+}
+
+TEST(frontend, req_content_length_and_remote_addr_equality_lower_to_rir) {
+    const char* sources[] = {
+        "route POST \"/upload\" { if req.contentLength == req.contentLength { return 200 } else "
+        "{ return 500 } }\n",
+        "route GET \"/addr\" { if req.remoteAddr == req.remoteAddr { return 200 } else { return "
+        "500 } }\n",
+    };
+    for (const char* src : sources) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(hir);
+        auto mir = build_mir_heap(hir.value());
+        REQUIRE(mir);
+        FrontendRirModule rir{};
+        auto lowered = lower_to_rir(mir.value(), rir);
+        REQUIRE(lowered);
+        rir.destroy();
+    }
+}
+
+TEST(frontend, req_cookie_flows_as_optional_str) {
+    const char* src =
+        "route GET \"/users\" { let sid = req.cookie(\"sid\") let value = or(sid, \"fallback\") "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items[0].route.statements.len, 3u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].route.statements[0].expr.kind),
+             static_cast<u8>(AstExprKind::MethodCall));
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Str));
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::ReqCookie));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[0].init.kind),
+             static_cast<u8>(MirValueKind::ReqCookie));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    const auto& fn = rir.module.functions[0];
+    CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[0].op), static_cast<u8>(rir::Opcode::ReqCookie));
     rir.destroy();
 }
 

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -3983,6 +3983,397 @@ TEST(route, populate_route_config_rejects_pre_bound_over_long_name) {
 }
 
 #if RUT_ENABLE_JIT_TESTS
+TEST(route, register_jit_routes_selects_segment_trie_and_adds_param_route) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/users/:id\" { if req.param(\"id\") == \"42\" { return 201 } else { return "
+        "404 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    CHECK_EQ(cfg.dispatch_kind(), RouteConfig::DispatchKind::SegmentTrie);
+    REQUIRE_EQ(cfg.route_count, 1u);
+    CHECK_EQ(cfg.routes[0].action, RouteAction::JitHandler);
+    CHECK_FALSE(cfg.routes[0].needs_req_body);
+
+    RouteParam params[kMaxRouteParams]{};
+    u32 param_count = 0;
+    const auto* matched = cfg.match_canonical(
+        Str{"users/42", 8}, kRouteMethodGet, params, &param_count, kMaxRouteParams);
+    REQUIRE(matched != nullptr);
+    CHECK_EQ(matched, &cfg.routes[0]);
+    REQUIRE_EQ(param_count, 1u);
+    CHECK((Str{params[0].name, params[0].name_len}.eq(Str{"id", 2})));
+    CHECK((Str{params[0].value, params[0].value_len}.eq(Str{"42", 2})));
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, register_jit_routes_marks_req_body_dependency) {
+    using namespace rut;
+    const char* src =
+        "route POST \"/upload\" { if req.body == \"payload\" { return 204 } else { return 400 } "
+        "}\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    REQUIRE_EQ(cfg.route_count, 1u);
+    CHECK(cfg.routes[0].needs_req_body);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_param_jit_handler_real_socket) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/users/:id\" { if req.param(\"id\") == \"42\" { return 201 } else { return "
+        "404 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] = "GET /users/42 HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "201");
+    const char kMissReq[] = "GET /users/41 HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMissReq, sizeof(kMissReq) - 1, "404");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_header_jit_handler_real_socket) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/auth\" { let token = or(req.header(\"Authorization\"), \"\") if token == "
+        "\"Bearer ok\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] = "GET /auth HTTP/1.1\r\nHost: x\r\nAuthorization: Bearer ok\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "204");
+    const char kBadReq[] = "GET /auth HTTP/1.1\r\nHost: x\r\nAuthorization: Bearer nope\r\n\r\n";
+    check_status(kBadReq, sizeof(kBadReq) - 1, "401");
+    const char kMissingReq[] = "GET /auth HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "401");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_cookie_jit_handler_real_socket) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/session\" { let sid = or(req.cookie(\"sid\"), \"\") if sid == \"ok\" { "
+        "return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] =
+        "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "204");
+    const char kBadReq[] =
+        "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark; sid=nope\r\n\r\n";
+    check_status(kBadReq, sizeof(kBadReq) - 1, "401");
+    const char kMissingReq[] = "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "401");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_query_jit_handler_real_socket) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = or(q, \"\") if value == "
+        "\"rut\" { return 204 } else { "
+        "return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] = "GET /search?q=rut HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "204");
+    const char kMissReq[] = "GET /search?q=cpp HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMissReq, sizeof(kMissReq) - 1, "401");
+    const char kMissingReq[] = "GET /search HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "401");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+#endif
+
+#if RUT_ENABLE_JIT_TESTS
 // End-to-end: compile DSL with an address-carrying `upstream` decl and
 // let populate_route_config bind the RouteConfig. Since no real backend
 // is listening on the compiled port, the forward will ECONNREFUSED and

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -196,6 +196,28 @@ TEST(jit, helpers_sanity) {
     CHECK(out_ptr != nullptr);
     CHECK(out_len == 14);
     CHECK(__builtin_memcmp(out_ptr, "/api/users?x=1", 14) == 0);
+
+    static const char fragment_req[] =
+        "GET /api/users?x=1#section HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "\r\n";
+    rut_helper_req_path_only(
+        reinterpret_cast<const u8*>(fragment_req), sizeof(fragment_req) - 1, &out_ptr, &out_len);
+    CHECK(out_ptr != nullptr);
+    CHECK(out_len == 10);
+    CHECK(__builtin_memcmp(out_ptr, "/api/users", 10) == 0);
+
+    static const char body_req[] =
+        "POST /api/users HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Content-Length: 7\r\n"
+        "\r\n"
+        "payload";
+    rut_helper_req_body(
+        reinterpret_cast<const u8*>(body_req), sizeof(body_req) - 1, &out_ptr, &out_len);
+    CHECK(out_ptr != nullptr);
+    CHECK(out_len == 7);
+    CHECK(__builtin_memcmp(out_ptr, "payload", 7) == 0);
 }
 
 // Test: Simple handler that always returns 200.
@@ -274,6 +296,540 @@ TEST(jit, frontend_req_header_or_fallback) {
                                            nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_standard_header_alias_or_fallback) {
+    const char* src =
+        "route GET \"/users\" { let auth = or(req.authorization, \"\") let request = "
+        "or(req.xRequestId, \"\") if auth == \"Bearer root\" { if request == \"req-1\" { "
+        "return 204 } else { return 401 } } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit[] =
+        "GET /users HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer root\r\n"
+        "X-Request-ID: req-1\r\n\r\n";
+    auto r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit), sizeof(hit) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 204);
+
+    auto miss = HandlerResult::unpack(handler(nullptr,
+                                              nullptr,
+                                              reinterpret_cast<const u8*>(kGetApiRequest),
+                                              sizeof(kGetApiRequest) - 1,
+                                              nullptr));
+    CHECK(miss.action == HandlerAction::ReturnStatus);
+    CHECK(miss.status_code == 401);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_remote_addr_read) {
+    const char* src = "route GET \"/addr\" { let addr = req.remoteAddr return 204 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    Connection conn;
+    conn.reset();
+    conn.peer_addr = 0x0100007F;
+    auto r = HandlerResult::unpack(handler(&conn,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetApiRequest),
+                                           sizeof(kGetApiRequest) - 1,
+                                           nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 204);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_route_param_field_guard) {
+    const char* src =
+        "route GET \"/users/:id\" { if req.id == \"42\" { return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    TestHandlerCtxFrame frame{};
+    static const char id_name[] = "id";
+    static const char id_hit[] = "42";
+    frame.ctx.route_param_count = 1;
+    frame.ctx.route_params[0] = {id_name, 2, id_hit, 2};
+
+    auto hit = HandlerResult::unpack(handler(nullptr,
+                                             &frame.ctx,
+                                             reinterpret_cast<const u8*>(kGetApiRequest),
+                                             sizeof(kGetApiRequest) - 1,
+                                             nullptr));
+    CHECK(hit.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(hit.status_code, 204u);
+
+    frame.ctx.route_params[0].value = "41";
+    auto miss = HandlerResult::unpack(handler(nullptr,
+                                              &frame.ctx,
+                                              reinterpret_cast<const u8*>(kGetApiRequest),
+                                              sizeof(kGetApiRequest) - 1,
+                                              nullptr));
+    CHECK(miss.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss.status_code, 401u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_query_string_or_fallback) {
+    const char* src =
+        "route GET \"/search\" { let raw = or(req.queryString, \"\") if raw == "
+        "\"q=rut&empty=\" { return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit[] = "GET /search?q=rut&empty=#frag HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit), sizeof(hit) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 204);
+
+    static const char miss[] = "GET /search HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(miss), sizeof(miss) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 401);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_path_only_ignores_query_and_fragment) {
+    const char* src =
+        "route GET \"/search\" { let path = req.pathOnly if path == \"/search\" { return 204 } "
+        "else { return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit[] = "GET /search?q=rut#frag HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit), sizeof(hit) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 204);
+
+    static const char miss[] = "GET /other?q=rut#frag HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto miss_r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(miss), sizeof(miss) - 1, nullptr));
+    CHECK(miss_r.action == HandlerAction::ReturnStatus);
+    CHECK(miss_r.status_code == 404);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_body_matches_content_length_bounded_bytes) {
+    const char* src =
+        "route POST \"/upload\" { let body = req.body if body == \"payload\" { return 204 } "
+        "else { return 400 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit[] =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 7\r\n\r\npayloadextra";
+    auto r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit), sizeof(hit) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 204);
+
+    static const char miss[] =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 4\r\n\r\npayload";
+    auto miss_r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(miss), sizeof(miss) - 1, nullptr));
+    CHECK(miss_r.action == HandlerAction::ReturnStatus);
+    CHECK(miss_r.status_code == 400);
+
+    static const char partial[] =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 10\r\n\r\npayload";
+    auto partial_r = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(partial), sizeof(partial) - 1, nullptr));
+    CHECK(partial_r.action == HandlerAction::ReturnStatus);
+    CHECK(partial_r.status_code == 400);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_request_flags_reflect_parsed_headers) {
+    const char* src =
+        "route POST \"/upload\" { if req.keepAlive { if req.chunked { return 204 } else { "
+        "return 400 } } else { return 408 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit[] =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nTransfer-Encoding: chunked\r\n\r\n";
+    auto r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit), sizeof(hit) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 204);
+
+    static const char not_chunked[] = "POST /upload HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto not_chunked_r = HandlerResult::unpack(handler(nullptr,
+                                                       nullptr,
+                                                       reinterpret_cast<const u8*>(not_chunked),
+                                                       sizeof(not_chunked) - 1,
+                                                       nullptr));
+    CHECK(not_chunked_r.action == HandlerAction::ReturnStatus);
+    CHECK(not_chunked_r.status_code == 400);
+
+    static const char close_req[] =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n"
+        "Transfer-Encoding: chunked\r\n\r\n";
+    auto close_r = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(close_req), sizeof(close_req) - 1, nullptr));
+    CHECK(close_r.action == HandlerAction::ReturnStatus);
+    CHECK(close_r.status_code == 408);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_has_content_length_distinguishes_zero_from_absent) {
+    const char* src =
+        "route POST \"/upload\" { if req.hasContentLength { return 204 } else { return 411 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char zero_len[] =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n";
+    auto r = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(zero_len), sizeof(zero_len) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 204);
+
+    static const char absent[] = "POST /upload HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    r = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(absent), sizeof(absent) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 411);
+
+    static const char nonzero[] =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1\r\n\r\nx";
+    r = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(nonzero), sizeof(nonzero) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 204);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_http_version_flags_reflect_request_line) {
+    const char* src =
+        "route GET \"/version\" { if req.http10 { return 210 } else { if req.http11 { return 211 "
+        "} else { return 400 } } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char http10[] = "GET /version HTTP/1.0\r\nHost: localhost\r\n\r\n";
+    auto r = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(http10), sizeof(http10) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 210);
+
+    static const char http11[] = "GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    r = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(http11), sizeof(http11) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 211);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_http_version_string_reflects_request_line) {
+    const char* src =
+        "route GET \"/version\" { let version = req.httpVersion if version == \"HTTP/1.0\" { "
+        "return 210 } else { if version == \"HTTP/1.1\" { return 211 } else { return 400 } } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char http10[] = "GET /version HTTP/1.0\r\nHost: localhost\r\n\r\n";
+    auto r = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(http10), sizeof(http10) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 210);
+
+    static const char http11[] = "GET /version HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    r = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(http11), sizeof(http11) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 211);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_cookie_or_fallback) {
+    const char* src =
+        "route GET \"/session\" { let sid = or(req.cookie(\"sid\"), \"\") if sid == \"ok\" { "
+        "return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit[] =
+        "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
+    auto r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit), sizeof(hit) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 204);
+
+    static const char miss[] =
+        "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=nope\r\n\r\n";
+    r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(miss), sizeof(miss) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 401);
+
+    r = HandlerResult::unpack(handler(nullptr,
+                                      nullptr,
+                                      reinterpret_cast<const u8*>(kGetApiRequest),
+                                      sizeof(kGetApiRequest) - 1,
+                                      nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 401);
 
     engine.shutdown();
     rir.destroy();
@@ -4784,6 +5340,46 @@ TEST(helpers, req_method) {
     CHECK(m == 1);  // HttpMethod::POST = 1
 }
 
+TEST(helpers, req_flags_keep_alive_and_chunked) {
+    static const char chunked[] =
+        "POST / HTTP/1.1\r\n"
+        "Host: h\r\n"
+        "Transfer-Encoding: chunked\r\n"
+        "\r\n";
+    CHECK(rut_helper_req_flag(reinterpret_cast<const u8*>(chunked), sizeof(chunked) - 1, 0) == 1);
+    CHECK(rut_helper_req_flag(reinterpret_cast<const u8*>(chunked), sizeof(chunked) - 1, 1) == 1);
+    CHECK(rut_helper_req_flag(reinterpret_cast<const u8*>(chunked), sizeof(chunked) - 1, 2) == 0);
+    CHECK(rut_helper_req_flag(reinterpret_cast<const u8*>(chunked), sizeof(chunked) - 1, 3) == 0);
+    CHECK(rut_helper_req_flag(reinterpret_cast<const u8*>(chunked), sizeof(chunked) - 1, 4) == 1);
+
+    static const char close_req[] =
+        "POST / HTTP/1.1\r\n"
+        "Host: h\r\n"
+        "Connection: close\r\n"
+        "\r\n";
+    CHECK(rut_helper_req_flag(reinterpret_cast<const u8*>(close_req), sizeof(close_req) - 1, 0) ==
+          0);
+    CHECK(rut_helper_req_flag(reinterpret_cast<const u8*>(close_req), sizeof(close_req) - 1, 1) ==
+          0);
+
+    static const char zero_len_req[] =
+        "POST / HTTP/1.1\r\n"
+        "Host: h\r\n"
+        "Content-Length: 0\r\n"
+        "\r\n";
+    CHECK(rut_helper_req_flag(
+              reinterpret_cast<const u8*>(zero_len_req), sizeof(zero_len_req) - 1, 2) == 1);
+
+    static const char http10_req[] =
+        "POST / HTTP/1.0\r\n"
+        "Host: h\r\n"
+        "\r\n";
+    CHECK(rut_helper_req_flag(reinterpret_cast<const u8*>(http10_req), sizeof(http10_req) - 1, 3) ==
+          1);
+    CHECK(rut_helper_req_flag(reinterpret_cast<const u8*>(http10_req), sizeof(http10_req) - 1, 4) ==
+          0);
+}
+
 TEST(helpers, req_header_case_insensitive) {
     static const char req[] =
         "GET / HTTP/1.1\r\n"
@@ -4813,6 +5409,379 @@ TEST(helpers, req_header_case_insensitive) {
     rut_helper_req_header(
         reinterpret_cast<const u8*>(req), sizeof(req) - 1, "X-Missing", 9, &has, &ptr, &len);
     CHECK(has == 0);
+}
+
+TEST(helpers, req_param_from_handler_ctx) {
+    TestHandlerCtxFrame frame{};
+    static const char id_name[] = "id";
+    static const char id_value[] = "42";
+    static const char book_name[] = "book";
+    static const char book_value[] = "rut";
+    frame.ctx.route_param_count = 2;
+    frame.ctx.route_params[0] = {id_name, 2, id_value, 2};
+    frame.ctx.route_params[1] = {book_name, 4, book_value, 3};
+
+    const char* ptr = nullptr;
+    u32 len = 0;
+    rut_helper_req_param(&frame.ctx, "book", 4, &ptr, &len);
+    REQUIRE(ptr != nullptr);
+    CHECK_EQ(len, 3u);
+    CHECK((Str{ptr, len}.eq(Str{"rut", 3})));
+
+    ptr = reinterpret_cast<const char*>(0x1);
+    len = 99;
+    rut_helper_req_param(&frame.ctx, "missing", 7, &ptr, &len);
+    CHECK(ptr != nullptr);
+    CHECK_EQ(len, 0u);
+}
+
+TEST(helpers, req_cookie_from_request_bytes) {
+    static const char req[] =
+        "GET / HTTP/1.1\r\n"
+        "Host: h\r\n"
+        "Cookie: theme=dark; sid=ok; empty=; spaced=value \t; malformed; lang=en\r\n"
+        "Cookie: other=second\r\n"
+        "\r\n";
+    u8 has = 0;
+    const char* ptr = nullptr;
+    u32 len = 0;
+
+    rut_helper_req_cookie(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "sid", 3, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK_EQ(len, 2u);
+    CHECK((Str{ptr, len}.eq(Str{"ok", 2})));
+
+    has = 0;
+    ptr = nullptr;
+    len = 0;
+    rut_helper_req_cookie(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "empty", 5, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK_EQ(len, 0u);
+    CHECK(ptr != nullptr);
+
+    has = 0;
+    ptr = nullptr;
+    len = 0;
+    rut_helper_req_cookie(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "spaced", 6, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK_EQ(len, 5u);
+    CHECK((Str{ptr, len}.eq(Str{"value", 5})));
+
+    has = 0;
+    ptr = nullptr;
+    len = 0;
+    rut_helper_req_cookie(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "other", 5, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK_EQ(len, 6u);
+    CHECK((Str{ptr, len}.eq(Str{"second", 6})));
+
+    has = 1;
+    ptr = reinterpret_cast<const char*>(0x1);
+    len = 99;
+    rut_helper_req_cookie(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "missing", 7, &has, &ptr, &len);
+    CHECK(has == 0);
+    CHECK(ptr == nullptr);
+    CHECK_EQ(len, 0u);
+}
+
+TEST(helpers, req_query_from_request_bytes) {
+    static const char req[] =
+        "GET /search?q=rut&book=cpp&empty= HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "\r\n";
+    u8 has = 0;
+    const char* ptr = nullptr;
+    u32 len = 0;
+
+    rut_helper_req_query(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "q", 1, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK(len == 3);
+    CHECK((Str{ptr, len}.eq(Str{"rut", 3})));
+
+    has = 0;
+    ptr = nullptr;
+    len = 0;
+    rut_helper_req_query(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "empty", 5, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK(len == 0u);
+    CHECK(ptr != nullptr);
+
+    has = 1;
+    ptr = reinterpret_cast<const char*>(0x1);
+    len = 99;
+    rut_helper_req_query(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "missing", 7, &has, &ptr, &len);
+    CHECK(has == 0);
+    CHECK(len == 0u);
+}
+
+TEST(helpers, req_query_ignores_fragment_suffix) {
+    static const char req[] =
+        "GET /search?q=rut&empty=#section HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "\r\n";
+    u8 has = 0;
+    const char* ptr = nullptr;
+    u32 len = 0;
+
+    rut_helper_req_query(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "q", 1, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK(len == 3u);
+    CHECK((Str{ptr, len}.eq(Str{"rut", 3})));
+
+    has = 0;
+    ptr = nullptr;
+    len = 99;
+    rut_helper_req_query(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "empty", 5, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK(len == 0u);
+}
+
+TEST(helpers, req_query_ignores_question_mark_inside_fragment) {
+    static const char req[] =
+        "GET /search#frag?q=rut HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "\r\n";
+    u8 has = 1;
+    const char* ptr = reinterpret_cast<const char*>(0x1);
+    u32 len = 99;
+
+    rut_helper_req_query(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, "q", 1, &has, &ptr, &len);
+    CHECK(has == 0);
+    CHECK(ptr == nullptr);
+    CHECK_EQ(len, 0u);
+}
+
+TEST(helpers, req_query_string_from_request_bytes) {
+    static const char req[] =
+        "GET /search?q=rut&empty=#section HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "\r\n";
+    u8 has = 0;
+    const char* ptr = nullptr;
+    u32 len = 0;
+
+    rut_helper_req_query_string(
+        reinterpret_cast<const u8*>(req), sizeof(req) - 1, &has, &ptr, &len);
+    CHECK(has == 1);
+    CHECK(len == 12u);
+    CHECK((Str{ptr, len}.eq(Str{"q=rut&empty=", 12})));
+
+    static const char no_query[] = "GET /search#section HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    has = 1;
+    ptr = reinterpret_cast<const char*>(0x1);
+    len = 99;
+    rut_helper_req_query_string(
+        reinterpret_cast<const u8*>(no_query), sizeof(no_query) - 1, &has, &ptr, &len);
+    CHECK(has == 0);
+    CHECK(ptr == nullptr);
+    CHECK(len == 0u);
+}
+
+TEST(helpers, req_content_length_from_request_bytes) {
+    static const char req[] =
+        "POST /upload HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Content-Length: 123\r\n"
+        "\r\n";
+    CHECK_EQ(rut_helper_req_content_length(reinterpret_cast<const u8*>(req), sizeof(req) - 1),
+             123u);
+
+    static const char no_len[] = "POST /upload HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    CHECK_EQ(rut_helper_req_content_length(reinterpret_cast<const u8*>(no_len), sizeof(no_len) - 1),
+             0u);
+}
+
+TEST(jit, req_param_guard) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("param_guard"), lit("/users/:id"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto reject = V(b.create_block(fn, lit("reject")));
+
+    b.set_insert_point(fn, entry);
+    auto id = V(b.emit_req_param(lit("id")));
+    auto want = V(b.emit_const_str(lit("42")));
+    auto matches = V(b.emit_cmp(Opcode::CmpEq, id, want));
+    VOK(b.emit_br(matches, ok, reject));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, reject);
+    VOK(b.emit_ret_status(404));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_param_guard"));
+    REQUIRE(handler != nullptr);
+
+    TestHandlerCtxFrame frame{};
+    static const char id_name[] = "id";
+    static const char id_value[] = "42";
+    frame.ctx.route_param_count = 1;
+    frame.ctx.route_params[0] = {id_name, 2, id_value, 2};
+
+    auto hit = HandlerResult::unpack(handler(nullptr,
+                                             &frame.ctx,
+                                             reinterpret_cast<const u8*>(kGetApiRequest),
+                                             sizeof(kGetApiRequest) - 1,
+                                             nullptr));
+    CHECK(hit.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(hit.status_code, 200u);
+
+    frame.ctx.route_params[0].value = "41";
+    auto miss = HandlerResult::unpack(handler(nullptr,
+                                              &frame.ctx,
+                                              reinterpret_cast<const u8*>(kGetApiRequest),
+                                              sizeof(kGetApiRequest) - 1,
+                                              nullptr));
+    CHECK(miss.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss.status_code, 404u);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+TEST(jit, req_content_length_guard) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("content_length_guard"), lit("/upload"), 'P'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto reject = V(b.create_block(fn, lit("reject")));
+
+    b.set_insert_point(fn, entry);
+    auto len = V(b.emit_req_content_length());
+    auto want = V(b.emit_const_bytesize(123));
+    auto matches = V(b.emit_cmp(Opcode::CmpEq, len, want));
+    VOK(b.emit_br(matches, ok, reject));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, reject);
+    VOK(b.emit_ret_status(413));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_content_length_guard"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit_req[] =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 123\r\n\r\n";
+    auto hit = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(hit_req), sizeof(hit_req) - 1, nullptr));
+    CHECK(hit.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(hit.status_code, 200u);
+
+    static const char miss_req[] =
+        "POST /upload HTTP/1.1\r\nHost: localhost\r\nContent-Length: 124\r\n\r\n";
+    auto miss = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(miss_req), sizeof(miss_req) - 1, nullptr));
+    CHECK(miss.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss.status_code, 413u);
+
+    engine.shutdown();
+    tc.destroy();
+}
+
+TEST(jit, req_query_guard) {
+    TestContext tc;
+    REQUIRE(tc.init());
+
+    Builder b;
+    b.init(&tc.mod);
+
+    auto* fn = V(b.create_function(lit("query_guard"), lit("/search"), 'G'));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto reject = V(b.create_block(fn, lit("reject")));
+    auto missing = V(b.create_block(fn, lit("missing")));
+    auto found = V(b.create_block(fn, lit("found")));
+
+    b.set_insert_point(fn, entry);
+    auto q = V(b.emit_req_query(lit("q")));
+    auto is_nil = V(b.emit_opt_is_nil(q));
+    VOK(b.emit_br(is_nil, missing, found));
+
+    b.set_insert_point(fn, missing);
+    VOK(b.emit_ret_status(404));
+
+    // Get the inner Str type for unwrap
+    auto str_ty = V(b.make_type(TypeKind::Str));
+
+    b.set_insert_point(fn, found);
+    auto val = V(b.emit_opt_unwrap(q, str_ty));
+    auto want = V(b.emit_const_str(lit("rut")));
+    auto matches = V(b.emit_cmp(Opcode::CmpEq, val, want));
+    VOK(b.emit_br(matches, ok, reject));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(200));
+
+    b.set_insert_point(fn, reject);
+    VOK(b.emit_ret_status(404));
+
+    auto cg = codegen(tc.mod);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_query_guard"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit_req[] =
+        "GET /search?q=rut HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "\r\n";
+    auto hit = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(hit_req), sizeof(hit_req) - 1, nullptr));
+    CHECK(hit.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(hit.status_code, 200u);
+
+    static const char miss_req[] =
+        "GET /search?q=cpp HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "\r\n";
+    auto miss = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(miss_req), sizeof(miss_req) - 1, nullptr));
+    CHECK(miss.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss.status_code, 404u);
+
+    engine.shutdown();
+    tc.destroy();
 }
 
 TEST(helpers, req_remote_addr) {

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -1,6 +1,7 @@
 // Mock tests — no real sockets. Ported from libuv/libevent scenarios.
 #include "fault_injection.h"
 #include "rut/runtime/arena.h"
+#include "rut/runtime/compile_to_config.h"
 #include "rut/runtime/error.h"
 #include "rut/runtime/io_uring_backend.h"
 #include "rut/runtime/route_table.h"
@@ -9,6 +10,7 @@
 #include "rut/runtime/upstream_pool.h"
 #include "test.h"
 #include "test_helpers.h"
+#include <memory>
 
 #include <errno.h>
 #include <sys/socket.h>
@@ -480,7 +482,7 @@ TEST(copilot, has_buf_distinguishes_no_buffer) {
     CHECK_EQ(no_buf.buf_id, 0u);
 
     // Event with buffer id 0 (valid)
-    IoEvent with_buf = {0, 100, 0, 1, IoEventType::Recv};
+    IoEvent with_buf = {0, 100, 0, 1, IoEventType::Recv, 0};
     CHECK_EQ(with_buf.has_buf, 1u);
     CHECK_EQ(with_buf.buf_id, 0u);
 
@@ -1338,14 +1340,14 @@ TEST(uring_buf, recv_without_has_buf) {
 // Verify that provided buffer events with has_buf=1 still include buf_id
 // (This tests the IoEvent structure itself)
 TEST(uring_buf, event_preserves_buf_id) {
-    IoEvent ev = {5, 100, 42, 1, IoEventType::Recv};
+    IoEvent ev = {5, 100, 42, 1, IoEventType::Recv, 0};
     CHECK_EQ(ev.conn_id, 5u);
     CHECK_EQ(ev.result, 100);
     CHECK_EQ(ev.buf_id, 42u);
     CHECK_EQ(ev.has_buf, 1u);
 
     // After io_uring wait() processes it: has_buf=0, buf_id=0 (buffer returned)
-    IoEvent processed = {5, 100, 0, 0, IoEventType::Recv};
+    IoEvent processed = {5, 100, 0, 0, IoEventType::Recv, 0};
     CHECK_EQ(processed.has_buf, 0u);
     CHECK_EQ(processed.buf_id, 0u);
 }
@@ -2270,25 +2272,75 @@ TEST(route, use_segment_trie_swaps_dispatch_pre_add) {
     CHECK_EQ(cfg.dispatch_kind(), RouteConfig::DispatchKind::ArtJit);
 }
 
-TEST(route, add_refuses_param_path) {
-    // Neither ArtJit (byte-prefix) nor SegmentTrie (literal-segment)
-    // currently implements runtime ":param" capture — a registered
-    // "/users/:id" would be stored under the literal ":id" segment
-    // in either dispatcher and "/users/42" would silently miss.
-    // add_*() refuses param paths so the misconfiguration surfaces
-    // at startup instead of at request time.
+TEST(route, add_refuses_param_path_under_art_dispatch) {
+    // ArtJit is byte-prefix based and cannot interpret ":param" segments.
+    // Dynamic route paths must use SegmentTrie so request segments are
+    // compared one segment at a time.
     RouteConfig cfg;
     CHECK(!cfg.add_static("/users/:id", 0, 200));
-    // Refusal is consistent under explicit SegmentTrie too — it
-    // stores ":v" literally, so "/api/v1/users" still wouldn't
-    // match.
-    RouteConfig cfg2;
-    REQUIRE(cfg2.use_segment_trie());
-    CHECK(!cfg2.add_static("/api/:v/users", 0, 200));
-    // Routes without ":param" segments are unaffected.
-    RouteConfig cfg3;
-    CHECK(cfg3.add_static("/users/me", 0, 200));
-    CHECK(cfg3.add_static("/api/v1/users", 0, 200));
+    CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, configure_route_dispatch_selects_segment_trie_for_param_route) {
+    rir::Function funcs[1]{};
+    funcs[0].route_pattern = Str{"/users/:id", 10};
+    rir::Module mod{};
+    mod.functions = funcs;
+    mod.func_count = 1;
+
+    RouteConfig cfg;
+    CHECK(configure_route_dispatch(cfg, mod));
+    CHECK_EQ(cfg.dispatch_kind(), RouteConfig::DispatchKind::SegmentTrie);
+    CHECK(cfg.add_static("/users/:id", 0, 200));
+}
+
+TEST(route, configure_route_dispatch_selects_segment_trie_for_boundary_overlap) {
+    rir::Function funcs[2]{};
+    funcs[0].route_pattern = Str{"/api", 4};
+    funcs[1].route_pattern = Str{"/apix", 5};
+    rir::Module mod{};
+    mod.functions = funcs;
+    mod.func_count = 2;
+
+    RouteConfig cfg;
+    CHECK(configure_route_dispatch(cfg, mod));
+    CHECK_EQ(cfg.dispatch_kind(), RouteConfig::DispatchKind::SegmentTrie);
+}
+
+TEST(route, configure_route_dispatch_refuses_after_route_add) {
+    rir::Function funcs[1]{};
+    funcs[0].route_pattern = Str{"/users/:id", 10};
+    rir::Module mod{};
+    mod.functions = funcs;
+    mod.func_count = 1;
+
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    CHECK(!configure_route_dispatch(cfg, mod));
+    CHECK_EQ(cfg.dispatch_kind(), RouteConfig::DispatchKind::ArtJit);
+}
+
+TEST(route, segment_trie_matches_param_path) {
+    RouteConfig cfg;
+    REQUIRE(cfg.use_segment_trie());
+    CHECK(cfg.add_static("/users/:id", 0, 201));
+    CHECK(cfg.add_static("/users/me", 0, 202));
+    auto* dynamic = cfg.match(reinterpret_cast<const u8*>("/users/42"), 9, 0);
+    REQUIRE(dynamic != nullptr);
+    CHECK_EQ(dynamic->status_code, 201u);
+    auto* literal = cfg.match(reinterpret_cast<const u8*>("/users/me"), 9, 0);
+    REQUIRE(literal != nullptr);
+    CHECK_EQ(literal->status_code, 202u);
+
+    RouteParam params[kMaxRouteParams]{};
+    u32 param_count = 0;
+    auto* captured =
+        cfg.match_canonical(Str{"users/42", 8}, 0, params, &param_count, kMaxRouteParams);
+    REQUIRE(captured != nullptr);
+    CHECK_EQ(captured->status_code, 201u);
+    REQUIRE_EQ(param_count, 1u);
+    CHECK((Str{params[0].name, params[0].name_len}.eq(Str{"id", 2})));
+    CHECK((Str{params[0].value, params[0].value_len}.eq(Str{"42", 2})));
 }
 
 TEST(route, use_dispatch_refuses_after_first_add) {
@@ -5078,11 +5130,13 @@ TEST(streaming, request_body_cl_multi_chunk_send_recv) {
     u32 hdr_end = 57;    // offset past \r\n\r\n
     u32 body_in_buf = 12;
     u32 req_len = hdr_end + body_in_buf;
+    u32 available = static_cast<u32>(sizeof(req) - 1);
+    u32 copy_len = req_len < available ? req_len : available;
 
     c->recv_buf.reset();
     u8* dst = c->recv_buf.write_ptr();
-    for (u32 j = 0; j < req_len; j++) dst[j] = static_cast<u8>(req[j]);
-    c->recv_buf.commit(req_len);
+    for (u32 j = 0; j < copy_len; j++) dst[j] = static_cast<u8>(req[j]);
+    c->recv_buf.commit(copy_len);
 
     IoEvent recv_ev = make_ev(c->id, IoEventType::Recv, static_cast<i32>(req_len));
     loop.backend.inject(recv_ev);
@@ -7899,70 +7953,70 @@ static u64 state_invariant_wait_recv_then_status(
     void*, jit::HandlerCtx* ctx, const u8*, u32, void*);
 
 TEST(legacy_loop, alloc_upstream_buf) {
-    EventLoop<MockBackend> loop;
-    auto initialized = loop.init(0, -1);
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    auto initialized = loop->init(0, -1);
     REQUIRE(initialized);
-    auto* c = loop.alloc_conn();
+    auto* c = loop->alloc_conn();
     REQUIRE(c != nullptr);
 
-    CHECK(loop.alloc_upstream_buf(*c));
+    CHECK(loop->alloc_upstream_buf(*c));
     CHECK(c->upstream_recv_slice != nullptr);
-    CHECK(loop.alloc_upstream_buf(*c));
+    CHECK(loop->alloc_upstream_buf(*c));
 
-    loop.free_conn(*c);
-    loop.shutdown();
+    loop->free_conn(*c);
+    loop->shutdown();
 }
 
 TEST(legacy_loop, sync_submit_and_close_paths) {
-    EventLoop<MockBackend> loop;
-    auto initialized = loop.init(0, -1);
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    auto initialized = loop->init(0, -1);
     REQUIRE(initialized);
     ShardMetrics metrics;
     metrics.init();
     metrics.connections_active = 1;
     metrics.requests_active = 1;
-    loop.metrics = &metrics;
+    loop->metrics = &metrics;
     ShardEpoch epoch;
     epoch.epoch.store(0, std::memory_order_relaxed);
-    loop.epoch = &epoch;
+    loop->epoch = &epoch;
 
-    auto* c = loop.alloc_conn();
+    auto* c = loop->alloc_conn();
     REQUIRE(c != nullptr);
     c->fd = dup(2);
     REQUIRE(c->fd >= 0);
     c->upstream_fd = dup(2);
     REQUIRE(c->upstream_fd >= 0);
     c->req_start_us = 1;
-    CHECK(loop.alloc_upstream_buf(*c));
+    CHECK(loop->alloc_upstream_buf(*c));
 
     static const u8 kBody[] = {'o', 'k'};
     sockaddr_in addr{};
-    CHECK(loop.submit_recv(*c));
-    loop.submit_send(*c, kBody, sizeof(kBody));
-    CHECK(loop.submit_connect(*c, &addr, sizeof(addr)));
-    CHECK(loop.submit_send_upstream(*c, kBody, sizeof(kBody)));
-    CHECK(loop.submit_recv_upstream(*c));
+    CHECK(loop->submit_recv(*c));
+    loop->submit_send(*c, kBody, sizeof(kBody));
+    CHECK(loop->submit_connect(*c, &addr, sizeof(addr)));
+    CHECK(loop->submit_send_upstream(*c, kBody, sizeof(kBody)));
+    CHECK(loop->submit_recv_upstream(*c));
 
-    loop.backend.fail_connect = true;
-    CHECK(!loop.submit_connect(*c, &addr, sizeof(addr)));
-    loop.backend.fail_upstream_send = true;
-    CHECK(!loop.submit_send_upstream(*c, kBody, sizeof(kBody)));
-    loop.backend.fail_upstream_recv = true;
-    CHECK(!loop.submit_recv_upstream(*c));
+    loop->backend.fail_connect = true;
+    CHECK(!loop->submit_connect(*c, &addr, sizeof(addr)));
+    loop->backend.fail_upstream_send = true;
+    CHECK(!loop->submit_send_upstream(*c, kBody, sizeof(kBody)));
+    loop->backend.fail_upstream_recv = true;
+    CHECK(!loop->submit_recv_upstream(*c));
 
-    loop.close_conn(*c);
+    loop->close_conn(*c);
     CHECK_EQ(metrics.connections_closed, 1u);
     CHECK_EQ(metrics.connections_active, 0u);
     CHECK_EQ(metrics.requests_active, 0u);
     CHECK_EQ(epoch.epoch.load(std::memory_order_relaxed), 1u);
-    loop.shutdown();
+    loop->shutdown();
 }
 
 TEST(legacy_loop, async_submit_and_close_paths) {
-    EventLoop<AsyncMockBackend> loop;
-    auto initialized = loop.init(0, -1);
+    auto loop = std::make_unique<EventLoop<AsyncMockBackend>>();
+    auto initialized = loop->init(0, -1);
     REQUIRE(initialized);
-    auto* c = loop.alloc_conn();
+    auto* c = loop->alloc_conn();
     REQUIRE(c != nullptr);
     c->fd = dup(2);
     REQUIRE(c->fd >= 0);
@@ -7971,50 +8025,50 @@ TEST(legacy_loop, async_submit_and_close_paths) {
 
     static const u8 kBody[] = {'o', 'k'};
     sockaddr_in addr{};
-    CHECK(loop.submit_recv(*c));
-    CHECK(loop.submit_recv(*c));
-    loop.submit_send(*c, kBody, sizeof(kBody));
-    CHECK(loop.submit_connect(*c, &addr, sizeof(addr)));
-    CHECK(loop.submit_send_upstream(*c, kBody, sizeof(kBody)));
-    CHECK(loop.submit_recv_upstream(*c));
-    CHECK(loop.submit_recv_upstream(*c));
+    CHECK(loop->submit_recv(*c));
+    CHECK(loop->submit_recv(*c));
+    loop->submit_send(*c, kBody, sizeof(kBody));
+    CHECK(loop->submit_connect(*c, &addr, sizeof(addr)));
+    CHECK(loop->submit_send_upstream(*c, kBody, sizeof(kBody)));
+    CHECK(loop->submit_recv_upstream(*c));
+    CHECK(loop->submit_recv_upstream(*c));
     CHECK(c->pending_ops > 0);
     CHECK(c->recv_armed);
     CHECK(c->send_armed);
     CHECK(c->upstream_recv_armed);
     CHECK(c->upstream_send_armed);
 
-    loop.close_conn(*c);
-    CHECK_EQ(loop.pending_free_count, 1u);
-    CHECK_EQ(loop.backend.count_ops(MockOp::Cancel), 1u);
-    loop.shutdown();
+    loop->close_conn(*c);
+    CHECK_EQ(loop->pending_free_count, 1u);
+    CHECK_EQ(loop->backend.count_ops(MockOp::Cancel), 1u);
+    loop->shutdown();
 }
 
 TEST(legacy_loop, event_yield_fails_fast) {
-    EventLoop<MockBackend> loop;
-    auto initialized = loop.init(0, -1);
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    auto initialized = loop->init(0, -1);
     REQUIRE(initialized);
-    auto* c = loop.alloc_conn();
+    auto* c = loop->alloc_conn();
     REQUIRE(c != nullptr);
     c->fd = 42;
-    loop.timer.add(c, loop.keepalive_timeout);
+    loop->timer.add(c, loop->keepalive_timeout);
 
     JitDispatchOutcome outcome{};
     outcome.kind = JitDispatchOutcome::Kind::EventYield;
     outcome.next_state = 7;
     outcome.yield_kind = jit::YieldKind::Recv;
-    loop.backend.clear_ops();
+    loop->backend.clear_ops();
     handle_jit_outcome<EventLoop<MockBackend>>(
-        &loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+        loop.get(), *c, outcome, &state_invariant_wait_recv_then_status, true);
 
     CHECK_EQ(c->pending_handler_fn, nullptr);
     CHECK_EQ(c->state, ConnState::Sending);
     CHECK_EQ(c->resp_status, 500);
     CHECK_EQ(c->on_send, &on_response_sent<EventLoop<MockBackend>>);
-    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+    CHECK_EQ(loop->backend.count_ops(MockOp::Send), 1u);
 
-    loop.free_conn(*c);
-    loop.shutdown();
+    loop->free_conn(*c);
+    loop->shutdown();
 }
 
 // === Slot state machine tests: on_body_send_with_early_response ===
@@ -8866,6 +8920,111 @@ static jit::HandlerResult g_state_invariant_jit_result = jit::HandlerResult::mak
 
 static u64 state_invariant_configured_jit_result(void*, jit::HandlerCtx*, const u8*, u32, void*) {
     return g_state_invariant_jit_result.pack();
+}
+
+static u64 state_invariant_req_body_payload(
+    void*, jit::HandlerCtx*, const u8* req, u32 len, void*) {
+    const u8 needle[] = {'\r', '\n', '\r', '\n'};
+    u32 body_start = len;
+    for (u32 i = 0; i + sizeof(needle) <= len; i++) {
+        if (__builtin_memcmp(req + i, needle, sizeof(needle)) == 0) {
+            body_start = i + sizeof(needle);
+            break;
+        }
+    }
+    const bool match =
+        body_start + 7 <= len && __builtin_memcmp(req + body_start, "payload", 7) == 0;
+    return jit::HandlerResult::make_status(match ? 204 : 400).pack();
+}
+
+TEST(state_invariant, jit_content_length_body_waits_until_full_buffer) {
+    SmallLoop loop;
+    loop.setup();
+    RouteConfig cfg;
+    REQUIRE(cfg.add_jit_handler("/upload", 'P', &state_invariant_req_body_payload, true));
+    const RouteConfig* active = &cfg;
+    loop.config_ptr = &active;
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    auto append_and_dispatch = [&](const char* data, u32 len) {
+        u8* dst = c->recv_buf.write_ptr();
+        for (u32 i = 0; i < len; i++) dst[i] = static_cast<u8>(data[i]);
+        c->recv_buf.commit(len);
+        loop.backend.inject(make_ev(c->id, IoEventType::Recv, static_cast<i32>(len)));
+        IoEvent events[8];
+        u32 n = loop.backend.wait(events, 8);
+        for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
+    };
+
+    static const char kHeadAndPartial[] =
+        "POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: 7\r\n\r\npay";
+    append_and_dispatch(kHeadAndPartial, sizeof(kHeadAndPartial) - 1);
+
+    CHECK_EQ(c->state, ConnState::ReadingBody);
+    CHECK_EQ(c->on_recv, &on_jit_request_body_recvd<SmallLoop>);
+    CHECK_EQ(c->on_send, nullptr);
+    CHECK_EQ(c->req_body_remaining, 4u);
+
+    append_and_dispatch("load", 4);
+
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->resp_status, 204u);
+    CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
+}
+
+TEST(state_invariant, jit_content_length_without_body_dependency_runs_immediately) {
+    SmallLoop loop;
+    loop.setup();
+    RouteConfig cfg;
+    REQUIRE(cfg.add_jit_handler("/upload", 'P', &state_invariant_configured_jit_result));
+    const RouteConfig* active = &cfg;
+    loop.config_ptr = &active;
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    static const char kHeadAndPartial[] =
+        "POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: 7\r\n\r\npay";
+    u8* dst = c->recv_buf.write_ptr();
+    for (u32 i = 0; i < sizeof(kHeadAndPartial) - 1; i++)
+        dst[i] = static_cast<u8>(kHeadAndPartial[i]);
+    c->recv_buf.commit(sizeof(kHeadAndPartial) - 1);
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, sizeof(kHeadAndPartial) - 1));
+
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->resp_status, 204u);
+    CHECK_EQ(c->on_recv, nullptr);
+    CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
+}
+
+TEST(state_invariant, jit_req_body_chunked_request_is_rejected) {
+    SmallLoop loop;
+    loop.setup();
+    RouteConfig cfg;
+    REQUIRE(cfg.add_jit_handler("/upload", 'P', &state_invariant_req_body_payload, true));
+    const RouteConfig* active = &cfg;
+    loop.config_ptr = &active;
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    static const char kChunkedHead[] =
+        "POST /upload HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n";
+    u8* dst = c->recv_buf.write_ptr();
+    for (u32 i = 0; i < sizeof(kChunkedHead) - 1; i++) dst[i] = static_cast<u8>(kChunkedHead[i]);
+    c->recv_buf.commit(sizeof(kChunkedHead) - 1);
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, sizeof(kChunkedHead) - 1));
+
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->resp_status, 400u);
+    CHECK_EQ(c->keep_alive, false);
+    CHECK_EQ(c->on_recv, nullptr);
+    CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
 }
 
 TEST(state_invariant, static_dispatch_keeps_slots_consistent) {

--- a/tests/test_route_trie.cc
+++ b/tests/test_route_trie.cc
@@ -104,6 +104,114 @@ TEST(route_trie, catchall_root_matches_unrouted_paths) {
     CHECK_EQ(canon_match(t, S("/"), 0), 99u);         // root path hits catchall
 }
 
+TEST(route_trie, param_segment_matches_one_request_segment) {
+    RouteTrie t;
+    const Insert items[] = {{"/users/:id", 0, 11}};
+    REQUIRE(build_ok(t, items, 1));
+    CHECK_EQ(canon_match(t, S("/users/42"), 0), 11u);
+    CHECK_EQ(canon_match(t, S("/users/alice"), 0), 11u);
+    CHECK_EQ(canon_match(t, S("/users"), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_trie, literal_segment_wins_over_param_at_same_depth) {
+    RouteTrie t;
+    const Insert items[] = {{"/users/:id", 0, 11}, {"/users/me", 0, 12}};
+    REQUIRE(build_ok(t, items, 2));
+    CHECK_EQ(canon_match(t, S("/users/me"), 0), 12u);
+    CHECK_EQ(canon_match(t, S("/users/42"), 0), 11u);
+}
+
+TEST(route_trie, param_branch_can_win_when_literal_branch_dead_ends) {
+    RouteTrie t;
+    const Insert items[] = {{"/users/me", 0, 12}, {"/users/:id/settings", 0, 13}};
+    REQUIRE(build_ok(t, items, 2));
+    CHECK_EQ(canon_match(t, S("/users/me/settings"), 0), 13u);
+}
+
+TEST(route_trie, distinct_param_names_keep_distinct_dynamic_children) {
+    RouteTrie t;
+    const Insert items[] = {{"/users/:id/settings", 0, 21}, {"/users/:name/profile", 0, 22}};
+    REQUIRE(build_ok(t, items, 2));
+    CHECK_EQ(canon_match(t, S("/users/42/settings"), 0), 21u);
+    CHECK_EQ(canon_match(t, S("/users/alice/profile"), 0), 22u);
+
+    RouteParam params[kMaxRouteParams]{};
+    u32 param_count = 0;
+    CHECK_EQ(
+        t.match_key(canonicalize_request(S("/users/alice/profile")), 0, params, &param_count, 16),
+        22u);
+    REQUIRE_EQ(param_count, 1u);
+    CHECK((Str{params[0].name, params[0].name_len}.eq(S("name"))));
+    CHECK((Str{params[0].value, params[0].value_len}.eq(S("alice"))));
+}
+
+TEST(route_trie, earlier_param_sibling_wins_equal_precedence_tie) {
+    RouteTrie t;
+    const Insert items[] = {{"/users/:id", 0, 41}, {"/users/:name", 0, 42}};
+    REQUIRE(build_ok(t, items, 2));
+
+    RouteParam params[kMaxRouteParams]{};
+    u32 param_count = 0;
+    CHECK_EQ(t.match_key(canonicalize_request(S("/users/alice")), 0, params, &param_count, 16),
+             41u);
+    REQUIRE_EQ(param_count, 1u);
+    CHECK((Str{params[0].name, params[0].name_len}.eq(S("id"))));
+    CHECK((Str{params[0].value, params[0].value_len}.eq(S("alice"))));
+}
+
+TEST(route_trie, earlier_literal_position_wins_same_depth_static_count_tie) {
+    RouteTrie t;
+    const Insert items[] = {{"/:a/:x/z", 0, 51}, {"/:b/x/:z", 0, 52}};
+    REQUIRE(build_ok(t, items, 2));
+
+    RouteParam params[kMaxRouteParams]{};
+    u32 param_count = 0;
+    CHECK_EQ(t.match_key(canonicalize_request(S("/foo/x/z")), 0, params, &param_count, 16), 52u);
+    REQUIRE_EQ(param_count, 2u);
+    CHECK((Str{params[0].name, params[0].name_len}.eq(S("b"))));
+    CHECK((Str{params[0].value, params[0].value_len}.eq(S("foo"))));
+    CHECK((Str{params[1].name, params[1].name_len}.eq(S("z"))));
+    CHECK((Str{params[1].value, params[1].value_len}.eq(S("z"))));
+}
+
+TEST(route_trie, param_child_is_not_reused_as_literal_match_for_colon_segment) {
+    RouteTrie t;
+    const Insert items[] = {{"/:id/:x", 0, 61}, {"/:name/y", 0, 62}};
+    REQUIRE(build_ok(t, items, 2));
+
+    RouteParam params[kMaxRouteParams]{};
+    u32 param_count = 0;
+    CHECK_EQ(t.match_key(canonicalize_request(S("/:id/y")), 0, params, &param_count, 16), 62u);
+    REQUIRE_EQ(param_count, 1u);
+    CHECK((Str{params[0].name, params[0].name_len}.eq(S("name"))));
+    CHECK((Str{params[0].value, params[0].value_len}.eq(S(":id"))));
+}
+
+TEST(route_trie, param_capture_reports_names_and_values_for_winning_route) {
+    RouteTrie t;
+    const Insert items[] = {{"/users/:id/books/:book", 0, 31}, {"/users/me/books/:book", 0, 32}};
+    REQUIRE(build_ok(t, items, 2));
+
+    RouteParam params[kMaxRouteParams]{};
+    u32 param_count = 99;
+    const u16 route =
+        t.match_key(canonicalize_request(S("/users/42/books/rust")), 0, params, &param_count, 16);
+    CHECK_EQ(route, 31u);
+    REQUIRE_EQ(param_count, 2u);
+    CHECK((Str{params[0].name, params[0].name_len}.eq(S("id"))));
+    CHECK((Str{params[0].value, params[0].value_len}.eq(S("42"))));
+    CHECK((Str{params[1].name, params[1].name_len}.eq(S("book"))));
+    CHECK((Str{params[1].value, params[1].value_len}.eq(S("rust"))));
+
+    param_count = 99;
+    const u16 literal =
+        t.match_key(canonicalize_request(S("/users/me/books/rut")), 0, params, &param_count, 16);
+    CHECK_EQ(literal, 32u);
+    REQUIRE_EQ(param_count, 1u);
+    CHECK((Str{params[0].name, params[0].name_len}.eq(S("book"))));
+    CHECK((Str{params[0].value, params[0].value_len}.eq(S("rut"))));
+}
+
 TEST(route_trie, longest_match_wins_regardless_of_insert_order) {
     // Two orderings of the same routes must produce the same match — the
     // whole point of moving off the linear first-match-wins scan.

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -405,6 +405,27 @@ TEST(simulate_engine, wait_handler_drives_state_machine_to_terminal_status) {
     rir.destroy();
 }
 
+TEST(simulate_engine, req_body_route_is_unsupported_for_header_only_capture) {
+    const char* src =
+        "route POST \"/upload\" { if req.body == \"payload\" { return 204 } else { return 400 } "
+        "}\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+    REQUIRE_EQ(engine.route_count, 1u);
+    CHECK(engine.routes[0].needs_req_body);
+
+    const auto result = simulate_one(
+        engine, make_entry("POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: 7\r\n\r\n", 204));
+    CHECK_EQ(result.verdict, Verdict::Unsupported);
+    CHECK_EQ(result.actual_status, 0u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(simulate_engine, let_before_wait_drives_to_terminal) {
     // Slice 1 acceptance: a let before a wait runs when the terminal
     // state reaches the entry block, and the yield chain still drives
@@ -893,6 +914,181 @@ TEST(simulate_engine, param_prefix_route_matches) {
     const auto result =
         simulate_one(engine, make_entry("GET /users/123/profile HTTP/1.1\r\nHost: x\r\n\r\n", 201));
     CHECK_EQ(result.verdict, Verdict::Match);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, route_param_capture_feeds_jit_handler_ctx) {
+    ModuleContext ctx;
+    REQUIRE(ctx.init(1));
+
+    rir::Builder b;
+    b.init(&ctx.module);
+
+    auto fn_res = b.create_function(Str{"param_guard", 11}, Str{"/users/:id", 10}, kRouteMethodGet);
+    REQUIRE(fn_res);
+    auto* fn = fn_res.value();
+    auto entry_res = b.create_block(fn, Str{"entry", 5});
+    auto ok_res = b.create_block(fn, Str{"ok", 2});
+    auto reject_res = b.create_block(fn, Str{"reject", 6});
+    REQUIRE(entry_res);
+    REQUIRE(ok_res);
+    REQUIRE(reject_res);
+
+    auto entry = entry_res.value();
+    auto ok = ok_res.value();
+    auto reject = reject_res.value();
+
+    b.set_insert_point(fn, entry);
+    auto id = b.emit_req_param(Str{"id", 2});
+    REQUIRE(id);
+    auto want = b.emit_const_str(Str{"42", 2});
+    REQUIRE(want);
+    auto matches = b.emit_cmp(rir::Opcode::CmpEq, id.value(), want.value());
+    REQUIRE(matches);
+    REQUIRE(b.emit_br(matches.value(), ok, reject));
+
+    b.set_insert_point(fn, ok);
+    REQUIRE(b.emit_ret_status(201));
+
+    b.set_insert_point(fn, reject);
+    REQUIRE(b.emit_ret_status(404));
+
+    Engine engine;
+    REQUIRE(engine.init(ctx.module, nullptr, 0));
+
+    const auto hit =
+        simulate_one(engine, make_entry("GET /users/42 HTTP/1.1\r\nHost: x\r\n\r\n", 201));
+    CHECK_EQ(hit.verdict, Verdict::Match);
+    CHECK_EQ(hit.actual_status, 201u);
+
+    const auto miss =
+        simulate_one(engine, make_entry("GET /users/41 HTTP/1.1\r\nHost: x\r\n\r\n", 404));
+    CHECK_EQ(miss.verdict, Verdict::Match);
+    CHECK_EQ(miss.actual_status, 404u);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, frontend_req_param_guard_matches_capture) {
+    const char* src =
+        "route GET \"/users/:id\" { if req.param(\"id\") == \"42\" { return 201 } else { return "
+        "404 } }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto hit =
+        simulate_one(engine, make_entry("GET /users/42 HTTP/1.1\r\nHost: x\r\n\r\n", 201));
+    CHECK_EQ(hit.verdict, Verdict::Match);
+    CHECK_EQ(hit.actual_status, 201u);
+
+    const auto miss =
+        simulate_one(engine, make_entry("GET /users/41 HTTP/1.1\r\nHost: x\r\n\r\n", 404));
+    CHECK_EQ(miss.verdict, Verdict::Match);
+    CHECK_EQ(miss.actual_status, 404u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(simulate_engine, literal_route_takes_precedence_over_earlier_param_route) {
+    Manifest manifest{};
+    manifest.route_count = 2;
+    manifest.routes[0].method = kRouteMethodGet;
+    strcpy(manifest.routes[0].pattern, "/users/:id");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 201;
+    manifest.routes[1].method = kRouteMethodGet;
+    strcpy(manifest.routes[1].pattern, "/users/me");
+    manifest.routes[1].action = ManifestAction::ReturnStatus;
+    manifest.routes[1].status_code = 202;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    const auto literal =
+        simulate_one(engine, make_entry("GET /users/me HTTP/1.1\r\nHost: x\r\n\r\n", 202));
+    CHECK_EQ(literal.verdict, Verdict::Match);
+    CHECK_EQ(literal.actual_status, 202u);
+
+    const auto param =
+        simulate_one(engine, make_entry("GET /users/42 HTTP/1.1\r\nHost: x\r\n\r\n", 201));
+    CHECK_EQ(param.verdict, Verdict::Match);
+    CHECK_EQ(param.actual_status, 201u);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, earlier_literal_segment_takes_precedence_over_later_literal_segment) {
+    Manifest manifest{};
+    manifest.route_count = 2;
+    manifest.routes[0].method = kRouteMethodGet;
+    strcpy(manifest.routes[0].pattern, "/:a/x");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 201;
+    manifest.routes[1].method = kRouteMethodGet;
+    strcpy(manifest.routes[1].pattern, "/b/:y");
+    manifest.routes[1].action = ManifestAction::ReturnStatus;
+    manifest.routes[1].status_code = 202;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    const auto result =
+        simulate_one(engine, make_entry("GET /b/x HTTP/1.1\r\nHost: x\r\n\r\n", 202));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 202u);
+
+    engine.shutdown();
+    ctx.destroy();
+}
+
+TEST(simulate_engine, param_capture_stops_at_fragment_delimiter) {
+    const char* src =
+        "route GET \"/users/:id\" { if req.param(\"id\") == \"42\" { return 201 } else { return "
+        "404 } }\n";
+    FrontendRirModule rir{};
+    REQUIRE(compile_to_rir(src, rir));
+
+    Engine engine;
+    REQUIRE(engine.init(rir.module, nullptr, 0));
+
+    const auto hit =
+        simulate_one(engine, make_entry("GET /users/42#frag HTTP/1.1\r\nHost: x\r\n\r\n", 201));
+    CHECK_EQ(hit.verdict, Verdict::Match);
+    CHECK_EQ(hit.actual_status, 201u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(simulate_engine, deep_param_route_matches_when_capture_buffer_fills) {
+    Manifest manifest{};
+    manifest.route_count = 1;
+    manifest.routes[0].method = kRouteMethodGet;
+    strcpy(manifest.routes[0].pattern, "/:a/:b/:c/:d/:e/:f/:g/:h/:i/:j/:k/:l/:m/:n/:o/:p/:q");
+    manifest.routes[0].action = ManifestAction::ReturnStatus;
+    manifest.routes[0].status_code = 201;
+
+    ModuleContext ctx;
+    Engine engine;
+    REQUIRE(init_engine(manifest, ctx, engine));
+
+    const auto result =
+        simulate_one(engine,
+                     make_entry("GET /1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17 HTTP/1.1\r\nHost: "
+                                "x\r\n\r\n",
+                                201));
+    CHECK_EQ(result.verdict, Verdict::Match);
+    CHECK_EQ(result.actual_status, 201u);
 
     engine.shutdown();
     ctx.destroy();


### PR DESCRIPTION
## Summary
- add request-facing DSL/compiler accessors for route params, query strings, cookies, body, HTTP metadata, and remote address
- wire request accessor opcodes through RIR/JIT runtime helpers and handler context
- add segment-trie route param capture, preserving distinct dynamic parameter names across sibling branches
- cover the network/request behavior in frontend, JIT, simulation, network, integration, and route trie tests

## Validation
- `cmake --build build --target test_route_trie test_frontend test_jit test_integration test_network test_simulate_engine`
- `build/tests/test_route_trie`
- `build/tests/test_frontend`
- `build/tests/test_simulate_engine`
- `build/tests/test_network`
- `build/tests/test_jit`
- `build/tests/test_integration`