### PR TITLE
Add static for loop lowering

### DIFF
--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -29,19 +29,22 @@ enum class AstStmtKind : u8 {
     Block,
     Wait,  // `wait(N)` / `wait(2s)` — suspend handler for a timer duration.
     WaitAny,
-    // `for <name> in <expr> { <body> }`. Fields reused from AstStatement:
+    // `for <name> in <expr> { <body> }` and
+    // `inline for <name> in <expr> { <body> }`. Fields reused from
+    // AstStatement:
     //   - name        = loop variable identifier (e.g., "item" in `for item in xs`)
     //   - expr        = iteration source expression (must type-check as Array<T>)
     //   - then_stmt   = body block (via parse_braced_stmt_body; may be a single
     //                   stmt if the block contained exactly one stmt)
+    //   - is_inline   = source used the compatibility `inline for` spelling.
     // No break / continue / else / labels (spec §3.3.9: every iteration runs
     // to completion). Analyze (Phase 3b) enforces the iteration source is
-    // array-typed and compile-time-sized and builds a HirForLoop. MIR build
-    // unrolls for-loops in the Scope A pattern (one for-loop, body-guards
-    // only, Direct route control, no sibling route guards) — see
-    // mir_build.cc. Out-of-scope shapes (body terminator, if/match route
-    // control, interleaving with route guards, multiple for-loops) remain
-    // rejected here and are the target of Phase 4c/d.
+    // array-typed and compile-time-sized and builds a HirForLoop. `inline`
+    // is retained in the AST for source fidelity; the compiler, not this
+    // marker, decides whether the loop can use the static unroll path. MIR
+    // build unrolls supported static for-loops into a source-ordered route
+    // step chain for Direct, if, and match route control — see mir_build.cc.
+    // Runtime iterables remain later work.
     For,
 };
 
@@ -154,6 +157,7 @@ struct AstStatement {
     Str name{};
     bool bind_value = false;
     bool is_const = false;
+    bool is_inline = false;
     bool has_type = false;
     AstTypeRef type{};
     AstExpr expr{};

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -78,9 +78,9 @@ enum class HirExprKind : u8 {
     RegexMatch,
     Tuple,
     // Array literal: elements stored in `args`. analyze rejects heterogeneous
-    // arrays and empty `[]` (Rutlang has no push/append so size + element
-    // type must be compile-time known; contextual inference from annotations
-    // is deferred — empty literals currently error even with an annotation).
+    // arrays and bare empty `[]`; typed empty route locals are currently
+    // accepted only when their `let xs: [T] = []` binding is used solely as a
+    // static for-loop iterator.
     // Element count is a value property on `HirExpr.array_len`, not a type
     // property; the result's HirTypeShape carries only `array_elem_shape_index`.
     ArrayLit,
@@ -678,7 +678,9 @@ struct HirGuardBody {
         If,
     };
 
+    static constexpr u32 kMaxLocals = 4;
     BodyKind body_kind = BodyKind::Direct;
+    FixedVec<HirLocal, kMaxLocals> locals;
     HirExpr cond{};
     HirTerminator then_term{};
     HirTerminator else_term{};
@@ -756,20 +758,90 @@ struct HirControl {
     HirTerminator direct_term{};
 };
 
-// Body of a `for ... in` loop. Phase 3b MVP: body is `guard*` plus an
-// optional terminator (return / forward). Lets, nested for-loops, and
-// arbitrary if/match are deferred to later phases. The body's guards carry
-// inline HirExpr cond subtrees whose lhs/rhs/args* point into the parent
+struct HirForLoopIf {
+    Span span{};
+    HirExpr cond{};
+    HirTerminator then_term{};
+    HirTerminator else_term{};
+};
+
+struct HirForLoopMatchArm {
+    enum class BodyKind : u8 {
+        Direct,
+        If,
+    };
+
+    Span span{};
+    bool is_wildcard = false;
+    HirExpr pattern{};
+    bool bind_payload = false;
+    Str bind_name{};
+    HirTypeKind bind_type = HirTypeKind::Unknown;
+    u32 bind_variant_index = 0xffffffffu;
+    u32 bind_struct_index = 0xffffffffu;
+    u32 bind_tuple_len = 0;
+    HirTypeKind bind_tuple_types[kMaxTupleSlots]{};
+    u32 bind_tuple_variant_indices[kMaxTupleSlots]{};
+    u32 bind_tuple_struct_indices[kMaxTupleSlots]{};
+    bool has_arm_guard = false;
+    HirExpr arm_guard{};
+    BodyKind body_kind = BodyKind::Direct;
+    static constexpr u32 kMaxLocals = 4;
+    static constexpr u32 kMaxPreludeGuards = 2;
+    FixedVec<HirLocal, kMaxLocals> locals;
+    FixedVec<HirGuard, kMaxPreludeGuards> guards;
+    HirExpr cond{};
+    HirTerminator then_term{};
+    HirTerminator else_term{};
+    HirTerminator direct_term{};
+};
+
+struct HirForLoopMatch {
+    Span span{};
+    static constexpr u32 kMaxMatchArms = 8;
+    HirExpr match_expr{};
+    FixedVec<HirForLoopMatchArm, kMaxMatchArms> arms;
+};
+
+// Body of a `for ... in` loop. The current compile-time unroll path supports
+// body-local lets, body guards, and an optional terminating control (return /
+// forward / if with terminal branches / simple match with terminal arms).
+// Nested for-loops and richer match forms are represented in the HIR body.
+// The body's guards, local inits, if conds, and match exprs/patterns carry
+// inline HirExpr subtrees whose lhs/rhs/args* point into the parent
 // HirRoute::exprs pool; HirRoute::rebase_from must walk them. HirTerminator
 // has no HirExpr pointers (only status_code / upstream_index / response
 // strings), so it doesn't participate in rebase.
 struct HirForLoopBody {
+    struct Step {
+        enum class Kind : u8 {
+            Let,
+            Guard,
+            If,
+            Match,
+            For,
+            Term,
+        };
+        Kind kind = Kind::Let;
+        u32 index = 0;
+        Span span{};
+    };
+    // Body-local lets are compile-time-expanded with each iteration. Keep
+    // this small: each HirLocal carries an inline HirExpr init.
+    static constexpr u32 kMaxLocals = 4;
     // 2 guards cover the canonical DESIGN.md examples (1 guard short-circuits
     // the request, rarely 2 for compound checks). Each HirGuard is ~4.5 KB
     // inline, so raising this directly grows HirRoute on the stack — see
     // HirExpr::kMaxArgs comment for the recursive-analyze stack budget.
     static constexpr u32 kMaxGuards = 2;
+    static constexpr u32 kMaxIfs = 1;
+    static constexpr u32 kMaxMatches = 1;
+    static constexpr u32 kMaxSteps = kMaxLocals + kMaxGuards + kMaxIfs + kMaxMatches + 2;
+    FixedVec<Step, kMaxSteps> steps;
+    FixedVec<HirLocal, kMaxLocals> locals;
     FixedVec<HirGuard, kMaxGuards> guards;
+    FixedVec<HirForLoopIf, kMaxIfs> ifs;
+    FixedVec<HirForLoopMatch, kMaxMatches> matches;
     HirTerminator term{};
     bool has_term = false;
 };
@@ -922,22 +994,47 @@ private:
         }
     }
 
+    void rebase_guard(HirGuard& guard, const HirRoute& other) {
+        rebase_expr(guard.cond, other);
+        rebase_expr(guard.fail_match_expr, other);
+        for (u32 li = 0; li < guard.fail_body.locals.len; li++) {
+            rebase_expr(guard.fail_body.locals[li].init, other);
+        }
+        rebase_expr(guard.fail_body.cond, other);
+    }
+
     void rebase_from(const HirRoute& other) {
         for (u32 i = 0; i < exprs.len; i++) rebase_expr(exprs[i], other);
         for (u32 i = 0; i < locals.len; i++) rebase_expr(locals[i].init, other);
         for (u32 i = 0; i < guards.len; i++) {
-            rebase_expr(guards[i].cond, other);
-            rebase_expr(guards[i].fail_match_expr, other);
-            rebase_expr(guards[i].fail_body.cond, other);
+            rebase_guard(guards[i], other);
         }
         // For-loops: iter_expr and the body's guard conds all point into
         // `exprs`, so rebase them the same way as top-level guards.
         for (u32 i = 0; i < for_loops.len; i++) {
             rebase_expr(for_loops[i].iter_expr, other);
+            for (u32 li = 0; li < for_loops[i].body.locals.len; li++) {
+                rebase_expr(for_loops[i].body.locals[li].init, other);
+            }
             for (u32 gi = 0; gi < for_loops[i].body.guards.len; gi++) {
-                rebase_expr(for_loops[i].body.guards[gi].cond, other);
-                rebase_expr(for_loops[i].body.guards[gi].fail_match_expr, other);
-                rebase_expr(for_loops[i].body.guards[gi].fail_body.cond, other);
+                rebase_guard(for_loops[i].body.guards[gi], other);
+            }
+            for (u32 ii = 0; ii < for_loops[i].body.ifs.len; ii++) {
+                rebase_expr(for_loops[i].body.ifs[ii].cond, other);
+            }
+            for (u32 mi = 0; mi < for_loops[i].body.matches.len; mi++) {
+                rebase_expr(for_loops[i].body.matches[mi].match_expr, other);
+                for (u32 ai = 0; ai < for_loops[i].body.matches[mi].arms.len; ai++) {
+                    rebase_expr(for_loops[i].body.matches[mi].arms[ai].pattern, other);
+                    rebase_expr(for_loops[i].body.matches[mi].arms[ai].arm_guard, other);
+                    for (u32 li = 0; li < for_loops[i].body.matches[mi].arms[ai].locals.len; li++) {
+                        rebase_expr(for_loops[i].body.matches[mi].arms[ai].locals[li].init, other);
+                    }
+                    for (u32 gi = 0; gi < for_loops[i].body.matches[mi].arms[ai].guards.len; gi++) {
+                        rebase_guard(for_loops[i].body.matches[mi].arms[ai].guards[gi], other);
+                    }
+                    rebase_expr(for_loops[i].body.matches[mi].arms[ai].cond, other);
+                }
             }
         }
         rebase_expr(control.cond, other);
@@ -946,7 +1043,7 @@ private:
             rebase_expr(control.match_arms[i].pattern, other);
             rebase_expr(control.match_arms[i].arm_guard, other);
             for (u32 gi = 0; gi < control.match_arms[i].guards.len; gi++) {
-                rebase_expr(control.match_arms[i].guards[gi].cond, other);
+                rebase_guard(control.match_arms[i].guards[gi], other);
             }
             rebase_expr(control.match_arms[i].cond, other);
         }

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3057,6 +3057,55 @@ static FrontendResult<void> apply_declared_type_to_expr(HirExpr* expr,
     return {};
 }
 
+static FrontendResult<HirExpr> analyze_empty_array_lit_with_declared_type(const AstStatement& stmt,
+                                                                          HirModule& mod) {
+    if (!stmt.has_type || stmt.expr.kind != AstExprKind::ArrayLit || stmt.expr.args.len != 0)
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+
+    u32 variant_index = 0xffffffffu;
+    u32 struct_index = 0xffffffffu;
+    u32 tuple_len = 0;
+    HirTypeKind tuple_types[kMaxTupleSlots]{};
+    u32 tuple_variant_indices[kMaxTupleSlots]{};
+    u32 tuple_struct_indices[kMaxTupleSlots]{};
+    u32 array_elem_shape_index = 0xffffffffu;
+    auto declared = resolve_func_type_ref(mod,
+                                          stmt.type,
+                                          nullptr,
+                                          nullptr,
+                                          variant_index,
+                                          struct_index,
+                                          tuple_len,
+                                          tuple_types,
+                                          tuple_variant_indices,
+                                          tuple_struct_indices,
+                                          stmt.span,
+                                          &array_elem_shape_index);
+    if (!declared) return core::make_unexpected(declared.error());
+    if (declared.value() != HirTypeKind::Array || array_elem_shape_index >= mod.type_shapes.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+    auto declared_shape = intern_hir_type_shape(&mod,
+                                                declared.value(),
+                                                0xffffffffu,
+                                                variant_index,
+                                                struct_index,
+                                                tuple_len,
+                                                tuple_types,
+                                                tuple_variant_indices,
+                                                tuple_struct_indices,
+                                                stmt.span,
+                                                array_elem_shape_index);
+    if (!declared_shape) return core::make_unexpected(declared_shape.error());
+
+    HirExpr out{};
+    out.kind = HirExprKind::ArrayLit;
+    out.type = HirTypeKind::Array;
+    out.shape_index = declared_shape.value();
+    out.array_len = 0;
+    out.span = stmt.expr.span;
+    return out;
+}
+
 static KnownValueState known_value_state(const HirExpr& expr,
                                          const HirLocal* locals,
                                          u32 local_count,
@@ -3081,6 +3130,10 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                             const HirLocal* locals,
                                             u32 local_count,
                                             const MatchPayloadBinding* binding);
+static bool is_static_for_iter_expr(const HirExpr& expr,
+                                    const HirLocal* locals,
+                                    u32 local_count,
+                                    u32 depth = 0);
 static FrontendResult<HirExpr> analyze_array_iter_expr(const AstExpr& expr,
                                                        HirRoute* route,
                                                        const HirModule& mod,
@@ -3131,7 +3184,8 @@ static FrontendResult<HirExpr> analyze_guard_cond(const AstExpr& expr,
                                                   HirRoute* route,
                                                   const HirModule& mod,
                                                   const HirLocal* locals,
-                                                  u32 local_count);
+                                                  u32 local_count,
+                                                  const MatchPayloadBinding* binding);
 static bool is_standard_error_field(Str field_name);
 static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
                                                  HirRoute* route,
@@ -4781,8 +4835,8 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
                 auto bound =
                     analyze_expr(inner.expr, scratch, mod, cur_locals, cur_local_count, nullptr);
                 if (!bound) return core::make_unexpected(bound.error());
-                auto cond =
-                    analyze_guard_cond(inner.expr, scratch, mod, cur_locals, cur_local_count);
+                auto cond = analyze_guard_cond(
+                    inner.expr, scratch, mod, cur_locals, cur_local_count, nullptr);
                 if (!cond) return core::make_unexpected(cond.error());
 
                 HirLocal succ_locals[HirRoute::kMaxLocals]{};
@@ -5707,12 +5761,11 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         for (u32 i = 0; i < expr.args.len; i++) {
             auto elem = analyze_expr(*expr.args[i], route, mod, locals, local_count, binding);
             if (!elem) return core::make_unexpected(elem.error());
-            // Reject element kinds we don't support inside arrays for Phase 3a.
-            // Nested tuples and heterogeneous nil/error unions get a cleaner
-            // answer once contextual inference + smart widening land; for now
-            // the MVP is strict.
-            if (elem->type == HirTypeKind::Unknown || elem->may_error ||
-                elem->type == HirTypeKind::Tuple || elem->may_nil)
+            // Reject element kinds that need contextual inference or union
+            // widening. Tuple elements are allowed: their shape_index carries
+            // slot metadata and same_hir_type_shape enforces homogeneous
+            // tuple layout across the array.
+            if (elem->type == HirTypeKind::Unknown || elem->may_error || elem->may_nil)
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.args[i]->span);
             // First element defines the array's element type; subsequent
             // elements must match its shape exactly.
@@ -6076,6 +6129,8 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                 tuple.span = expr.span;
                 return tuple;
             }
+            if (locals[i].type == HirTypeKind::Array && !allow_array_lit)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
             out.kind = HirExprKind::LocalRef;
             out.type = locals[i].type;
             out.is_wait_result = locals[i].is_wait_result;
@@ -6145,6 +6200,35 @@ static FrontendResult<HirExpr> analyze_expr(const AstExpr& expr,
                                             u32 local_count,
                                             const MatchPayloadBinding* binding) {
     return analyze_expr_impl(expr, route, mod, locals, local_count, binding, false);
+}
+
+static bool is_static_for_iter_expr(const HirExpr& expr,
+                                    const HirLocal* locals,
+                                    u32 local_count,
+                                    u32 depth) {
+    if (depth > local_count + HirRoute::kMaxLocals) return false;
+    if (expr.kind == HirExprKind::ArrayLit) return true;
+    if (expr.kind != HirExprKind::LocalRef) return false;
+    for (u32 i = 0; i < local_count; i++) {
+        if (locals[i].ref_index == expr.local_index)
+            return is_static_for_iter_expr(locals[i].init, locals, local_count, depth + 1);
+    }
+    return false;
+}
+
+static bool static_for_iter_len(
+    const HirExpr& expr, const HirLocal* locals, u32 local_count, u32 depth, u32* len) {
+    if (depth > local_count + HirRoute::kMaxLocals) return false;
+    if (expr.kind == HirExprKind::ArrayLit) {
+        *len = expr.args.len;
+        return true;
+    }
+    if (expr.kind != HirExprKind::LocalRef) return false;
+    for (u32 i = 0; i < local_count; i++) {
+        if (locals[i].ref_index == expr.local_index)
+            return static_for_iter_len(locals[i].init, locals, local_count, depth + 1, len);
+    }
+    return false;
 }
 
 static FrontendResult<HirExpr> analyze_array_iter_expr(const AstExpr& expr,
@@ -6963,6 +7047,29 @@ static FrontendResult<void> analyze_guard_match_arms(
     return {};
 }
 
+static FrontendResult<void> record_seen_literal_match_case(
+    const HirExpr& pattern,
+    FixedVec<i32, AstStatement::kMaxMatchArms>& seen_int_cases,
+    FixedVec<Str, AstStatement::kMaxMatchArms>& seen_str_cases,
+    Span span) {
+    if (pattern.kind == HirExprKind::IntLit) {
+        for (u32 i = 0; i < seen_int_cases.len; i++) {
+            if (seen_int_cases[i] == pattern.int_value)
+                return frontend_error(FrontendError::UnsupportedSyntax, span);
+        }
+        if (!seen_int_cases.push(pattern.int_value))
+            return frontend_error(FrontendError::TooManyItems, span);
+    } else if (pattern.kind == HirExprKind::StrLit) {
+        for (u32 i = 0; i < seen_str_cases.len; i++) {
+            if (seen_str_cases[i].eq(pattern.str_value))
+                return frontend_error(FrontendError::UnsupportedSyntax, span);
+        }
+        if (!seen_str_cases.push(pattern.str_value))
+            return frontend_error(FrontendError::TooManyItems, span);
+    }
+    return {};
+}
+
 static KnownValueState known_value_state(const HirExpr& expr,
                                          const HirLocal* locals,
                                          u32 local_count,
@@ -7102,8 +7209,9 @@ static FrontendResult<HirExpr> analyze_guard_cond(const AstExpr& expr,
                                                   HirRoute* route,
                                                   const HirModule& mod,
                                                   const HirLocal* locals,
-                                                  u32 local_count) {
-    auto analyzed = analyze_expr(expr, route, mod, locals, local_count, nullptr);
+                                                  u32 local_count,
+                                                  const MatchPayloadBinding* binding) {
+    auto analyzed = analyze_expr(expr, route, mod, locals, local_count, binding);
     if (!analyzed) return core::make_unexpected(analyzed.error());
 
     HirExpr cond{};
@@ -7276,22 +7384,11 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
                     inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
                 if (!bound) return core::make_unexpected(bound.error());
                 auto cond = analyze_guard_cond(
-                    inner.expr, route, mod, scoped_locals.data, scoped_locals.len);
+                    inner.expr, route, mod, scoped_locals.data, scoped_locals.len, binding);
                 if (!cond) return core::make_unexpected(cond.error());
                 guard.cond = cond.value();
                 if (inner.match_arms.len != 0) {
-                    if (!bound->may_error) {
-                        u32 fallback_arm = 0;
-                        for (u32 ai = 0; ai < inner.match_arms.len; ai++) {
-                            if (inner.match_arms[ai].is_wildcard) {
-                                fallback_arm = ai;
-                                break;
-                            }
-                        }
-                        auto fail_term = analyze_term(*inner.match_arms[fallback_arm].stmt, mod);
-                        if (!fail_term) return core::make_unexpected(fail_term.error());
-                        guard.fail_term = fail_term.value();
-                    } else {
+                    if (bound->may_error) {
                         guard.fail_kind = HirGuard::FailKind::Match;
                         guard.fail_match_expr = bound.value();
                         auto* guard_match_arms =
@@ -7306,6 +7403,8 @@ static FrontendResult<void> analyze_match_arm_body(const AstStatement& stmt,
                                                                    guard_match_arms,
                                                                    &guard);
                         if (!fail_match) return core::make_unexpected(fail_match.error());
+                    } else {
+                        return frontend_error(FrontendError::UnsupportedSyntax, inner.expr.span);
                     }
                 } else {
                     if (inner.else_stmt->kind == AstStmtKind::ReturnStatus ||
@@ -7456,7 +7555,11 @@ static FrontendResult<void> analyze_guard_fail_body(const AstStatement& stmt,
                 local.error_variant_index = init->error_variant_index;
                 local.shape_index = init->shape_index;
                 local.init = init.value();
-                if (!route->locals.push(local))
+                if (!body->locals.push(local))
+                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                HirLocal hidden_local = local;
+                hidden_local.name = {};
+                if (!route->locals.push(hidden_local))
                     return frontend_error(FrontendError::TooManyItems, inner.span);
                 if (local.ref_index >= HirRoute::kMaxLocals)
                     return frontend_error(FrontendError::TooManyItems, inner.span);
@@ -7840,6 +7943,8 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                 bool inner_seen_wildcard = false;
                 bool inner_seen_bool_true = false;
                 bool inner_seen_bool_false = false;
+                FixedVec<i32, AstStatement::kMaxMatchArms> inner_seen_int_cases;
+                FixedVec<Str, AstStatement::kMaxMatchArms> inner_seen_str_cases;
                 bool inner_seen_variant_cases[HirVariant::kMaxCases]{};
                 u32 inner_seen_variant_case_count = 0;
                 for (u32 iai = 0; iai < nested_match_stmt->match_arms.len; iai++) {
@@ -7878,6 +7983,13 @@ static FrontendResult<void> analyze_control_stmt(const AstStatement& stmt,
                             else
                                 inner_seen_bool_false = true;
                         }
+                        auto recorded_literal =
+                            record_seen_literal_match_case(inner_pattern.value(),
+                                                           inner_seen_int_cases,
+                                                           inner_seen_str_cases,
+                                                           inner_arm.span);
+                        if (!recorded_literal)
+                            return core::make_unexpected(recorded_literal.error());
                         if (inner_pattern->kind == HirExprKind::VariantCase) {
                             if (inner_pattern->variant_index != inner_subject->variant_index)
                                 return frontend_error(FrontendError::UnsupportedSyntax,
@@ -9312,6 +9424,1151 @@ static FrontendResult<void> analyze_wait_any_stmt_control(const AstStatement& st
     route.control.then_term = then_term.value();
     route.control.else_term = else_term.value();
     return {};
+}
+
+static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
+                                            HirRoute* route,
+                                            HirModule& mod) {
+    auto iter =
+        analyze_array_iter_expr(stmt.expr, route, mod, route->locals.data, route->locals.len);
+    if (!iter) return core::make_unexpected(iter.error());
+    if (iter->type != HirTypeKind::Array || iter->shape_index >= mod.type_shapes.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+    if (!is_static_for_iter_expr(iter.value(), route->locals.data, route->locals.len, 0))
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+
+    const auto& iter_shape = mod.type_shapes[iter->shape_index];
+    if (iter_shape.array_elem_shape_index >= mod.type_shapes.len)
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+    const auto& elem_shape = mod.type_shapes[iter_shape.array_elem_shape_index];
+
+    for (u32 li = 0; li < route->locals.len; li++) {
+        if (route->locals[li].name.len != 0 && route->locals[li].name.eq(stmt.name))
+            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+    }
+
+    const u32 locals_saved = route->locals.len;
+
+    HirForLoop fl{};
+    fl.span = stmt.span;
+    fl.iter_expr = iter.value();
+    fl.loop_var_name = stmt.name;
+    fl.loop_var_type = elem_shape.type;
+    fl.loop_var_variant_index = elem_shape.variant_index;
+    fl.loop_var_struct_index = elem_shape.struct_index;
+    fl.loop_var_shape_index = iter_shape.array_elem_shape_index;
+
+    HirLocal loop_var{};
+    loop_var.span = stmt.span;
+    loop_var.name = stmt.name;
+    loop_var.ref_index = next_local_ref_index(route, route->locals.data, route->locals.len);
+    fl.loop_var_ref_index = loop_var.ref_index;
+    loop_var.type = fl.loop_var_type;
+    loop_var.variant_index = fl.loop_var_variant_index;
+    loop_var.struct_index = fl.loop_var_struct_index;
+    loop_var.shape_index = fl.loop_var_shape_index;
+    if (elem_shape.type == HirTypeKind::Tuple) {
+        loop_var.tuple_len = elem_shape.tuple_len;
+        for (u32 ti = 0; ti < elem_shape.tuple_len; ti++) {
+            const u32 slot_shape_index = elem_shape.tuple_elem_shape_indices[ti];
+            if (slot_shape_index >= mod.type_shapes.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+            const auto& slot_shape = mod.type_shapes[slot_shape_index];
+            loop_var.tuple_types[ti] = slot_shape.type;
+            loop_var.tuple_variant_indices[ti] =
+                slot_shape.type == HirTypeKind::Variant ? slot_shape.variant_index : 0xffffffffu;
+            loop_var.tuple_struct_indices[ti] =
+                slot_shape.type == HirTypeKind::Struct
+                    ? slot_shape.struct_index
+                    : (slot_shape.type == HirTypeKind::Generic ? slot_shape.generic_index
+                                                               : 0xffffffffu);
+        }
+    }
+    loop_var.init.kind = HirExprKind::LocalRef;
+    loop_var.init.local_index = loop_var.ref_index;
+    loop_var.init.type = fl.loop_var_type;
+    loop_var.init.variant_index = fl.loop_var_variant_index;
+    loop_var.init.struct_index = fl.loop_var_struct_index;
+    loop_var.init.shape_index = fl.loop_var_shape_index;
+    loop_var.init.tuple_len = loop_var.tuple_len;
+    for (u32 ti = 0; ti < loop_var.tuple_len; ti++) {
+        loop_var.init.tuple_types[ti] = loop_var.tuple_types[ti];
+        loop_var.init.tuple_variant_indices[ti] = loop_var.tuple_variant_indices[ti];
+        loop_var.init.tuple_struct_indices[ti] = loop_var.tuple_struct_indices[ti];
+    }
+    loop_var.init.span = stmt.span;
+    if (!route->locals.push(loop_var))
+        return frontend_error(FrontendError::TooManyItems, stmt.span);
+
+    const u32 for_index = route->for_loops.len;
+    if (!route->for_loops.push(fl)) return frontend_error(FrontendError::TooManyItems, stmt.span);
+    HirForLoop& loop = route->for_loops[for_index];
+
+    const AstStatement* body = stmt.then_stmt;
+    const u32 body_item_count = body->kind == AstStmtKind::Block ? body->block_stmts.len : 1u;
+    for (u32 bi = 0; bi < body_item_count; bi++) {
+        const AstStatement& bstmt =
+            (body->kind == AstStmtKind::Block) ? *body->block_stmts[bi] : *body;
+        if (bstmt.kind == AstStmtKind::Let) {
+            if (loop.body.has_term)
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+            if (bstmt.expr.kind == AstExprKind::Wait || bstmt.expr.kind == AstExprKind::ArrayLit)
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.expr.span);
+            for (u32 li = 0; li < route->locals.len; li++) {
+                if (route->locals[li].name.len != 0 && route->locals[li].name.eq(bstmt.name))
+                    return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+            }
+            HirLocal local{};
+            local.span = bstmt.span;
+            local.name = bstmt.name;
+            local.ref_index = next_local_ref_index(route, route->locals.data, route->locals.len);
+            auto init = analyze_expr(
+                bstmt.expr, route, mod, route->locals.data, route->locals.len, nullptr);
+            if (!init) return core::make_unexpected(init.error());
+            auto typed = apply_declared_type_to_expr(&init.value(), mod, bstmt);
+            if (!typed) return core::make_unexpected(typed.error());
+            local.type = init->type;
+            local.is_wait_result = init->is_wait_result;
+            local.wait_event_kind = init->wait_event_kind;
+            local.wait_payload = init->wait_payload;
+            local.wait_index = init->wait_index;
+            local.generic_index = init->generic_index;
+            local.generic_has_error_constraint = init->generic_has_error_constraint;
+            local.generic_has_eq_constraint = init->generic_has_eq_constraint;
+            local.generic_has_ord_constraint = init->generic_has_ord_constraint;
+            local.generic_protocol_index = init->generic_protocol_index;
+            local.generic_protocol_count = init->generic_protocol_count;
+            for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                local.generic_protocol_indices[cpi] = init->generic_protocol_indices[cpi];
+            local.may_nil = init->may_nil;
+            local.may_error = init->may_error;
+            local.variant_index = init->variant_index;
+            local.struct_index = init->struct_index;
+            local.tuple_len = init->tuple_len;
+            for (u32 ti = 0; ti < init->tuple_len; ti++) {
+                local.tuple_types[ti] = init->tuple_types[ti];
+                local.tuple_variant_indices[ti] = init->tuple_variant_indices[ti];
+                local.tuple_struct_indices[ti] = init->tuple_struct_indices[ti];
+            }
+            local.error_struct_index = init->error_struct_index;
+            local.error_variant_index = init->error_variant_index;
+            local.shape_index = init->shape_index;
+            local.init = init.value();
+            const u32 local_index = loop.body.locals.len;
+            if (!route->locals.push(local))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            if (!loop.body.locals.push(local))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            HirForLoopBody::Step step{};
+            step.kind = HirForLoopBody::Step::Kind::Let;
+            step.index = local_index;
+            step.span = bstmt.span;
+            if (!loop.body.steps.push(step))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            continue;
+        }
+        if (bstmt.kind == AstStmtKind::Guard) {
+            if (loop.body.has_term)
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+            if (bstmt.match_arms.len == 0 && bstmt.else_stmt == nullptr)
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+            HirGuard guard{};
+            guard.span = bstmt.span;
+            auto bound = analyze_expr(
+                bstmt.expr, route, mod, route->locals.data, route->locals.len, nullptr);
+            if (!bound) return core::make_unexpected(bound.error());
+            auto cond = analyze_guard_cond(
+                bstmt.expr, route, mod, route->locals.data, route->locals.len, nullptr);
+            if (!cond) return core::make_unexpected(cond.error());
+            guard.cond = cond.value();
+            if (bstmt.match_arms.len != 0) {
+                if (bound->may_error) {
+                    guard.fail_kind = HirGuard::FailKind::Match;
+                    guard.fail_match_expr = bound.value();
+                    auto fail_match = analyze_guard_match_arms(bstmt.match_arms,
+                                                               bound.value(),
+                                                               route,
+                                                               mod,
+                                                               route->locals.data,
+                                                               route->locals.len,
+                                                               &mod.guard_match_arms,
+                                                               &guard);
+                    if (!fail_match) return core::make_unexpected(fail_match.error());
+                } else {
+                    return frontend_error(FrontendError::UnsupportedSyntax, bstmt.expr.span);
+                }
+            } else if (bstmt.else_stmt->kind == AstStmtKind::ReturnStatus ||
+                       bstmt.else_stmt->kind == AstStmtKind::ForwardUpstream) {
+                auto fail = analyze_term(*bstmt.else_stmt, mod);
+                if (!fail) return core::make_unexpected(fail.error());
+                guard.fail_term = fail.value();
+            } else {
+                guard.fail_kind = HirGuard::FailKind::Body;
+                auto fail_body = analyze_guard_fail_body(*bstmt.else_stmt,
+                                                         &guard.fail_body,
+                                                         route,
+                                                         mod,
+                                                         route->locals.data,
+                                                         route->locals.len,
+                                                         nullptr);
+                if (!fail_body) return core::make_unexpected(fail_body.error());
+            }
+            const u32 guard_index = loop.body.guards.len;
+            if (!loop.body.guards.push(guard))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            HirForLoopBody::Step guard_step{};
+            guard_step.kind = HirForLoopBody::Step::Kind::Guard;
+            guard_step.index = guard_index;
+            guard_step.span = bstmt.span;
+            if (!loop.body.steps.push(guard_step))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            if (bstmt.bind_value) {
+                if (known_value_state(bound.value(), route->locals.data, route->locals.len, 0) ==
+                    KnownValueState::Error)
+                    return frontend_error(FrontendError::UnsupportedSyntax, bstmt.expr.span);
+                for (u32 li = 0; li < route->locals.len; li++) {
+                    if (route->locals[li].name.len != 0 && route->locals[li].name.eq(bstmt.name))
+                        return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                }
+                HirLocal local{};
+                local.span = bstmt.span;
+                local.name = bstmt.name;
+                local.ref_index =
+                    next_local_ref_index(route, route->locals.data, route->locals.len);
+                local.type = bound->type;
+                local.generic_index = bound->generic_index;
+                local.generic_has_error_constraint = bound->generic_has_error_constraint;
+                local.generic_has_eq_constraint = bound->generic_has_eq_constraint;
+                local.generic_has_ord_constraint = bound->generic_has_ord_constraint;
+                local.generic_protocol_index = bound->generic_protocol_index;
+                local.generic_protocol_count = bound->generic_protocol_count;
+                for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                    local.generic_protocol_indices[cpi] = bound->generic_protocol_indices[cpi];
+                local.may_nil = bound->may_nil;
+                local.may_error = false;
+                local.variant_index = bound->variant_index;
+                local.struct_index = bound->struct_index;
+                local.tuple_len = bound->tuple_len;
+                for (u32 ti = 0; ti < bound->tuple_len; ti++) {
+                    local.tuple_types[ti] = bound->tuple_types[ti];
+                    local.tuple_variant_indices[ti] = bound->tuple_variant_indices[ti];
+                    local.tuple_struct_indices[ti] = bound->tuple_struct_indices[ti];
+                }
+                local.error_struct_index = bound->error_struct_index;
+                local.error_variant_index = 0xffffffffu;
+                local.shape_index = bound->shape_index;
+                auto init = make_guard_bound_init(route, bound.value(), bstmt.span);
+                if (!init) return core::make_unexpected(init.error());
+                local.init = init.value();
+                const u32 local_index = loop.body.locals.len;
+                if (!route->locals.push(local))
+                    return frontend_error(FrontendError::TooManyItems, bstmt.span);
+                if (!loop.body.locals.push(local))
+                    return frontend_error(FrontendError::TooManyItems, bstmt.span);
+                HirForLoopBody::Step local_step{};
+                local_step.kind = HirForLoopBody::Step::Kind::Let;
+                local_step.index = local_index;
+                local_step.span = bstmt.span;
+                if (!loop.body.steps.push(local_step))
+                    return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            }
+            continue;
+        }
+        if (bstmt.kind == AstStmtKind::ReturnStatus || bstmt.kind == AstStmtKind::ForwardUpstream) {
+            if (loop.body.has_term)
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+            auto t = analyze_term(bstmt, mod);
+            if (!t) return core::make_unexpected(t.error());
+            loop.body.term = t.value();
+            loop.body.has_term = true;
+            HirForLoopBody::Step step{};
+            step.kind = HirForLoopBody::Step::Kind::Term;
+            step.span = bstmt.span;
+            if (!loop.body.steps.push(step))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            continue;
+        }
+        if (bstmt.kind == AstStmtKind::If) {
+            if (loop.body.has_term)
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+            const auto simple_branch = [](const AstStatement& branch) {
+                return branch.kind == AstStmtKind::ReturnStatus ||
+                       branch.kind == AstStmtKind::ForwardUpstream;
+            };
+            if (bstmt.then_stmt == nullptr || bstmt.else_stmt == nullptr ||
+                !simple_branch(*bstmt.then_stmt) || !simple_branch(*bstmt.else_stmt))
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+            HirForLoopIf body_if{};
+            body_if.span = bstmt.span;
+            auto cond = analyze_expr(
+                bstmt.expr, route, mod, route->locals.data, route->locals.len, nullptr);
+            if (!cond) return core::make_unexpected(cond.error());
+            if (cond->type != HirTypeKind::Bool || cond->may_nil || cond->may_error)
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.expr.span);
+            body_if.cond = cond.value();
+            auto then_term = analyze_term(*bstmt.then_stmt, mod);
+            if (!then_term) return core::make_unexpected(then_term.error());
+            auto else_term = analyze_term(*bstmt.else_stmt, mod);
+            if (!else_term) return core::make_unexpected(else_term.error());
+            body_if.then_term = then_term.value();
+            body_if.else_term = else_term.value();
+            const u32 if_index = loop.body.ifs.len;
+            if (!loop.body.ifs.push(body_if))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            loop.body.has_term = true;
+            HirForLoopBody::Step step{};
+            step.kind = HirForLoopBody::Step::Kind::If;
+            step.index = if_index;
+            step.span = bstmt.span;
+            if (!loop.body.steps.push(step))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            continue;
+        }
+        if (bstmt.kind == AstStmtKind::Match) {
+            if (loop.body.has_term)
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+            HirForLoopMatch body_match{};
+            body_match.span = bstmt.span;
+            auto subject = analyze_expr(
+                bstmt.expr, route, mod, route->locals.data, route->locals.len, nullptr);
+            if (!subject) return core::make_unexpected(subject.error());
+            if (subject->may_nil || subject->may_error)
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.expr.span);
+            body_match.match_expr = subject.value();
+            if (!route->exprs.push(subject.value()))
+                return frontend_error(FrontendError::TooManyItems, bstmt.expr.span);
+            const HirExpr* subject_ptr = &route->exprs[route->exprs.len - 1];
+            bool seen_wildcard = false;
+            bool has_wildcard = false;
+            bool seen_bool_true = false;
+            bool seen_bool_false = false;
+            bool seen_unguarded_bool_true = false;
+            bool seen_unguarded_bool_false = false;
+            bool seen_variant_cases[HirVariant::kMaxCases]{};
+            bool seen_unguarded_variant_cases[HirVariant::kMaxCases]{};
+            for (u32 ai = 0; ai < bstmt.match_arms.len; ai++) {
+                const auto& ast_arm = bstmt.match_arms[ai];
+                const AstStatement* nested_match_stmt = nullptr;
+                const bool can_expand_nested_match =
+                    !ast_arm.is_wildcard && !ast_arm.has_guard && ast_arm.pattern.lhs == nullptr;
+                if (can_expand_nested_match && ast_arm.stmt != nullptr &&
+                    ast_arm.stmt->kind == AstStmtKind::Match && !ast_arm.stmt->is_const) {
+                    nested_match_stmt = ast_arm.stmt;
+                } else if (can_expand_nested_match && ast_arm.stmt != nullptr &&
+                           ast_arm.stmt->kind == AstStmtKind::Block &&
+                           ast_arm.stmt->block_stmts.len != 0) {
+                    if (ast_arm.stmt->block_stmts.len == 1) {
+                        const auto* only = ast_arm.stmt->block_stmts[0];
+                        if (only->kind == AstStmtKind::Match && !only->is_const)
+                            nested_match_stmt = only;
+                    } else {
+                        const auto* last =
+                            ast_arm.stmt->block_stmts[ast_arm.stmt->block_stmts.len - 1];
+                        if (last->kind == AstStmtKind::Match && !last->is_const &&
+                            ast_arm.stmt->block_stmts[0]->kind != AstStmtKind::Let &&
+                            ast_arm.stmt->block_stmts[0]->kind != AstStmtKind::Guard)
+                            return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                    }
+                }
+                if (ast_arm.is_wildcard && ast_arm.has_guard)
+                    return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                if (seen_wildcard)
+                    return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                if (ast_arm.stmt == nullptr)
+                    return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                if (nested_match_stmt != nullptr) {
+                    auto outer_pattern = analyze_match_pattern(ast_arm.pattern,
+                                                               subject.value(),
+                                                               route,
+                                                               mod,
+                                                               route->locals.data,
+                                                               route->locals.len);
+                    if (!outer_pattern) return core::make_unexpected(outer_pattern.error());
+                    if (outer_pattern->kind != HirExprKind::BoolLit &&
+                        outer_pattern->kind != HirExprKind::IntLit &&
+                        outer_pattern->kind != HirExprKind::StrLit &&
+                        outer_pattern->kind != HirExprKind::VariantCase)
+                        return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                    if (outer_pattern->type != subject->type)
+                        return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                    if (outer_pattern->kind == HirExprKind::BoolLit) {
+                        bool& seen = outer_pattern->bool_value ? seen_bool_true : seen_bool_false;
+                        bool& seen_unguarded = outer_pattern->bool_value
+                                                   ? seen_unguarded_bool_true
+                                                   : seen_unguarded_bool_false;
+                        if (seen_unguarded)
+                            return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                        if (!seen) seen = true;
+                        seen_unguarded = true;
+                    }
+                    if (outer_pattern->kind == HirExprKind::IntLit ||
+                        outer_pattern->kind == HirExprKind::StrLit) {
+                        for (u32 pi = 0; pi < body_match.arms.len; pi++) {
+                            const auto& prior = body_match.arms[pi];
+                            if (prior.has_arm_guard || prior.pattern.kind != outer_pattern->kind)
+                                continue;
+                            if (outer_pattern->kind == HirExprKind::IntLit &&
+                                prior.pattern.int_value == outer_pattern->int_value)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      ast_arm.span);
+                            if (outer_pattern->kind == HirExprKind::StrLit &&
+                                prior.pattern.str_value.eq(outer_pattern->str_value))
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      ast_arm.span);
+                        }
+                    }
+                    if (outer_pattern->kind == HirExprKind::VariantCase) {
+                        if (outer_pattern->variant_index != subject->variant_index)
+                            return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                        const u32 case_index = static_cast<u32>(outer_pattern->int_value);
+                        if (case_index >= HirVariant::kMaxCases ||
+                            seen_unguarded_variant_cases[case_index])
+                            return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                        if (!seen_variant_cases[case_index]) seen_variant_cases[case_index] = true;
+                        seen_unguarded_variant_cases[case_index] = true;
+                    }
+
+                    auto inner_subject = analyze_expr(nested_match_stmt->expr,
+                                                      route,
+                                                      mod,
+                                                      route->locals.data,
+                                                      route->locals.len,
+                                                      nullptr);
+                    if (!inner_subject) return core::make_unexpected(inner_subject.error());
+                    if (inner_subject->may_nil || inner_subject->may_error)
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              nested_match_stmt->expr.span);
+                    if (!route->exprs.push(inner_subject.value()))
+                        return frontend_error(FrontendError::TooManyItems,
+                                              nested_match_stmt->expr.span);
+                    HirExpr* inner_subject_ptr = &route->exprs[route->exprs.len - 1];
+                    bool inner_seen_wildcard = false;
+                    bool inner_seen_bool_true = false;
+                    bool inner_seen_bool_false = false;
+                    FixedVec<i32, AstStatement::kMaxMatchArms> inner_seen_int_cases;
+                    FixedVec<Str, AstStatement::kMaxMatchArms> inner_seen_str_cases;
+                    bool inner_seen_variant_cases[HirVariant::kMaxCases]{};
+                    for (u32 iai = 0; iai < nested_match_stmt->match_arms.len; iai++) {
+                        const auto& inner_arm = nested_match_stmt->match_arms[iai];
+                        if (inner_arm.has_guard || inner_arm.pattern.lhs != nullptr)
+                            return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
+                        if (inner_seen_wildcard)
+                            return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
+                        if (inner_arm.stmt == nullptr)
+                            return frontend_error(FrontendError::UnsupportedSyntax, inner_arm.span);
+                        HirForLoopMatchArm arm{};
+                        arm.span = inner_arm.span;
+                        arm.pattern = outer_pattern.value();
+                        if (!inner_arm.is_wildcard) {
+                            auto inner_pattern = analyze_match_pattern(inner_arm.pattern,
+                                                                       inner_subject.value(),
+                                                                       route,
+                                                                       mod,
+                                                                       route->locals.data,
+                                                                       route->locals.len);
+                            if (!inner_pattern) return core::make_unexpected(inner_pattern.error());
+                            if (inner_pattern->kind != HirExprKind::BoolLit &&
+                                inner_pattern->kind != HirExprKind::IntLit &&
+                                inner_pattern->kind != HirExprKind::StrLit &&
+                                inner_pattern->kind != HirExprKind::VariantCase)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_arm.span);
+                            if (inner_pattern->type != inner_subject->type)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_arm.span);
+                            if (inner_pattern->kind == HirExprKind::BoolLit) {
+                                bool& seen_inner = inner_pattern->bool_value
+                                                       ? inner_seen_bool_true
+                                                       : inner_seen_bool_false;
+                                if (seen_inner)
+                                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                                          inner_arm.span);
+                                seen_inner = true;
+                            }
+                            auto recorded_literal =
+                                record_seen_literal_match_case(inner_pattern.value(),
+                                                               inner_seen_int_cases,
+                                                               inner_seen_str_cases,
+                                                               inner_arm.span);
+                            if (!recorded_literal)
+                                return core::make_unexpected(recorded_literal.error());
+                            if (inner_pattern->kind == HirExprKind::VariantCase) {
+                                if (inner_pattern->variant_index != inner_subject->variant_index)
+                                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                                          inner_arm.span);
+                                const u32 inner_case_index =
+                                    static_cast<u32>(inner_pattern->int_value);
+                                if (inner_case_index >= HirVariant::kMaxCases ||
+                                    inner_seen_variant_cases[inner_case_index])
+                                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                                          inner_arm.span);
+                                inner_seen_variant_cases[inner_case_index] = true;
+                            }
+                            HirExpr cond{};
+                            cond.kind = HirExprKind::Eq;
+                            cond.type = HirTypeKind::Bool;
+                            cond.span = inner_arm.span;
+                            if (inner_pattern->kind == HirExprKind::VariantCase) {
+                                HirExpr tag{};
+                                tag.kind = HirExprKind::VariantTag;
+                                tag.type = HirTypeKind::I32;
+                                tag.span = inner_arm.span;
+                                tag.variant_index = inner_pattern->variant_index;
+                                tag.lhs = inner_subject_ptr;
+
+                                HirExpr case_index{};
+                                case_index.kind = HirExprKind::IntLit;
+                                case_index.type = HirTypeKind::I32;
+                                case_index.span = inner_arm.span;
+                                case_index.int_value = inner_pattern->int_value;
+                                if (!route->exprs.push(tag))
+                                    return frontend_error(FrontendError::TooManyItems,
+                                                          inner_arm.span);
+                                cond.lhs = &route->exprs[route->exprs.len - 1];
+                                if (!route->exprs.push(case_index))
+                                    return frontend_error(FrontendError::TooManyItems,
+                                                          inner_arm.span);
+                                cond.rhs = &route->exprs[route->exprs.len - 1];
+                            } else {
+                                cond.lhs = inner_subject_ptr;
+                                if (!route->exprs.push(inner_pattern.value()))
+                                    return frontend_error(FrontendError::TooManyItems,
+                                                          inner_arm.span);
+                                cond.rhs = &route->exprs[route->exprs.len - 1];
+                            }
+                            arm.has_arm_guard = true;
+                            arm.arm_guard = cond;
+                        } else {
+                            inner_seen_wildcard = true;
+                        }
+                        if (inner_arm.stmt->kind == AstStmtKind::If) {
+                            const auto simple_branch = [](const AstStatement& branch) {
+                                return branch.kind == AstStmtKind::ReturnStatus ||
+                                       branch.kind == AstStmtKind::ForwardUpstream;
+                            };
+                            if (inner_arm.stmt->then_stmt == nullptr ||
+                                inner_arm.stmt->else_stmt == nullptr ||
+                                !simple_branch(*inner_arm.stmt->then_stmt) ||
+                                !simple_branch(*inner_arm.stmt->else_stmt))
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_arm.stmt->span);
+                            auto cond_expr = analyze_expr(inner_arm.stmt->expr,
+                                                          route,
+                                                          mod,
+                                                          route->locals.data,
+                                                          route->locals.len,
+                                                          nullptr);
+                            if (!cond_expr) return core::make_unexpected(cond_expr.error());
+                            if (cond_expr->type != HirTypeKind::Bool || cond_expr->may_nil ||
+                                cond_expr->may_error)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_arm.stmt->expr.span);
+                            auto then_term = analyze_term(*inner_arm.stmt->then_stmt, mod);
+                            if (!then_term) return core::make_unexpected(then_term.error());
+                            auto else_term = analyze_term(*inner_arm.stmt->else_stmt, mod);
+                            if (!else_term) return core::make_unexpected(else_term.error());
+                            arm.body_kind = HirForLoopMatchArm::BodyKind::If;
+                            arm.cond = cond_expr.value();
+                            arm.then_term = then_term.value();
+                            arm.else_term = else_term.value();
+                        } else if (inner_arm.stmt->kind == AstStmtKind::ReturnStatus ||
+                                   inner_arm.stmt->kind == AstStmtKind::ForwardUpstream) {
+                            auto term = analyze_term(*inner_arm.stmt, mod);
+                            if (!term) return core::make_unexpected(term.error());
+                            arm.direct_term = term.value();
+                        } else {
+                            return frontend_error(FrontendError::UnsupportedSyntax,
+                                                  inner_arm.stmt->span);
+                        }
+                        if (!body_match.arms.push(arm))
+                            return frontend_error(FrontendError::TooManyItems, inner_arm.span);
+                    }
+                    if (!inner_seen_wildcard)
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              nested_match_stmt->span);
+                    continue;
+                }
+                HirForLoopMatchArm arm{};
+                arm.span = ast_arm.span;
+                arm.is_wildcard = ast_arm.is_wildcard;
+                MatchPayloadBinding arm_binding{};
+                const MatchPayloadBinding* arm_binding_ptr = nullptr;
+                if (!ast_arm.is_wildcard) {
+                    auto pattern = analyze_match_pattern(ast_arm.pattern,
+                                                         subject.value(),
+                                                         route,
+                                                         mod,
+                                                         route->locals.data,
+                                                         route->locals.len);
+                    if (!pattern) return core::make_unexpected(pattern.error());
+                    if (pattern->kind != HirExprKind::BoolLit &&
+                        pattern->kind != HirExprKind::IntLit &&
+                        pattern->kind != HirExprKind::StrLit &&
+                        pattern->kind != HirExprKind::VariantCase)
+                        return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                    if (pattern->type != subject->type)
+                        return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                    if (pattern->kind == HirExprKind::BoolLit) {
+                        bool& seen = pattern->bool_value ? seen_bool_true : seen_bool_false;
+                        bool& seen_unguarded = pattern->bool_value ? seen_unguarded_bool_true
+                                                                   : seen_unguarded_bool_false;
+                        if (seen_unguarded)
+                            return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                        if (!seen) seen = true;
+                        if (!ast_arm.has_guard) seen_unguarded = true;
+                    }
+                    if (pattern->kind == HirExprKind::IntLit ||
+                        pattern->kind == HirExprKind::StrLit) {
+                        for (u32 pi = 0; pi < body_match.arms.len; pi++) {
+                            const auto& prior = body_match.arms[pi];
+                            if (prior.has_arm_guard || prior.pattern.kind != pattern->kind)
+                                continue;
+                            if (pattern->kind == HirExprKind::IntLit &&
+                                prior.pattern.int_value == pattern->int_value)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      ast_arm.span);
+                            if (pattern->kind == HirExprKind::StrLit &&
+                                prior.pattern.str_value.eq(pattern->str_value))
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      ast_arm.span);
+                        }
+                    }
+                    if (pattern->kind == HirExprKind::VariantCase) {
+                        if (pattern->variant_index != subject->variant_index)
+                            return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                        const u32 case_index = static_cast<u32>(pattern->int_value);
+                        if (case_index >= HirVariant::kMaxCases ||
+                            seen_unguarded_variant_cases[case_index])
+                            return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                        if (!seen_variant_cases[case_index]) seen_variant_cases[case_index] = true;
+                        if (!ast_arm.has_guard) seen_unguarded_variant_cases[case_index] = true;
+                        const auto& case_decl =
+                            mod.variants[pattern->variant_index].cases[case_index];
+                        if (ast_arm.pattern.lhs != nullptr) {
+                            if (!case_decl.has_payload)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      ast_arm.pattern.lhs->span);
+                            arm.bind_payload = true;
+                            arm.bind_name = ast_arm.pattern.lhs->name;
+                            arm.bind_type = case_decl.payload_type;
+                            arm.bind_variant_index = case_decl.payload_variant_index;
+                            arm.bind_struct_index = case_decl.payload_struct_index;
+                            arm.bind_tuple_len = case_decl.payload_tuple_len;
+                            for (u32 ti = 0; ti < case_decl.payload_tuple_len; ti++) {
+                                arm.bind_tuple_types[ti] = case_decl.payload_tuple_types[ti];
+                                arm.bind_tuple_variant_indices[ti] =
+                                    case_decl.payload_tuple_variant_indices[ti];
+                                arm.bind_tuple_struct_indices[ti] =
+                                    case_decl.payload_tuple_struct_indices[ti];
+                            }
+                            bind_match_payload(
+                                &arm_binding, arm.bind_name, case_decl, case_index, subject_ptr);
+                            arm_binding_ptr = &arm_binding;
+                        }
+                    } else if (ast_arm.pattern.lhs != nullptr) {
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              ast_arm.pattern.lhs->span);
+                    }
+                    arm.pattern = pattern.value();
+                    if (ast_arm.has_guard) {
+                        if (ast_arm.guard == nullptr)
+                            return frontend_error(FrontendError::UnsupportedSyntax, ast_arm.span);
+                        auto guard = analyze_expr(*ast_arm.guard,
+                                                  route,
+                                                  mod,
+                                                  route->locals.data,
+                                                  route->locals.len,
+                                                  arm_binding_ptr);
+                        if (!guard) return core::make_unexpected(guard.error());
+                        if (guard->type != HirTypeKind::Bool || guard->may_nil || guard->may_error)
+                            return frontend_error(FrontendError::UnsupportedSyntax,
+                                                  ast_arm.guard->span);
+                        arm.has_arm_guard = true;
+                        arm.arm_guard = guard.value();
+                    }
+                } else {
+                    seen_wildcard = true;
+                    has_wildcard = true;
+                }
+                const AstStatement* arm_stmt = ast_arm.stmt;
+                FixedVec<HirLocal, HirRoute::kMaxLocals> arm_scoped_locals;
+                const HirLocal* arm_locals = route->locals.data;
+                u32 arm_local_count = route->locals.len;
+                if (arm_stmt->kind == AstStmtKind::Block) {
+                    for (u32 li = 0; li < route->locals.len; li++) {
+                        if (!arm_scoped_locals.push(route->locals[li]))
+                            return frontend_error(FrontendError::TooManyItems, arm_stmt->span);
+                    }
+                    if (arm_stmt->block_stmts.len == 0)
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm_stmt->span);
+                    for (u32 si = 0; si < arm_stmt->block_stmts.len; si++) {
+                        const auto& inner = *arm_stmt->block_stmts[si];
+                        const bool is_last = si + 1 == arm_stmt->block_stmts.len;
+                        if (inner.kind == AstStmtKind::Let) {
+                            if (is_last)
+                                return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                            if (inner.expr.kind == AstExprKind::Wait ||
+                                inner.expr.kind == AstExprKind::ArrayLit)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner.expr.span);
+                            for (u32 li = 0; li < arm_scoped_locals.len; li++) {
+                                if (arm_scoped_locals[li].name.len != 0 &&
+                                    arm_scoped_locals[li].name.eq(inner.name))
+                                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                                          inner.span);
+                            }
+                            HirLocal local{};
+                            local.span = inner.span;
+                            local.name = inner.name;
+                            local.ref_index = next_local_ref_index(
+                                route, arm_scoped_locals.data, arm_scoped_locals.len);
+                            auto init = analyze_expr(inner.expr,
+                                                     route,
+                                                     mod,
+                                                     arm_scoped_locals.data,
+                                                     arm_scoped_locals.len,
+                                                     arm_binding_ptr);
+                            if (!init) return core::make_unexpected(init.error());
+                            auto typed = apply_declared_type_to_expr(&init.value(), mod, inner);
+                            if (!typed) return core::make_unexpected(typed.error());
+                            local.type = init->type;
+                            local.is_wait_result = init->is_wait_result;
+                            local.wait_event_kind = init->wait_event_kind;
+                            local.wait_payload = init->wait_payload;
+                            local.wait_index = init->wait_index;
+                            local.generic_index = init->generic_index;
+                            local.generic_has_error_constraint = init->generic_has_error_constraint;
+                            local.generic_has_eq_constraint = init->generic_has_eq_constraint;
+                            local.generic_has_ord_constraint = init->generic_has_ord_constraint;
+                            local.generic_protocol_index = init->generic_protocol_index;
+                            local.generic_protocol_count = init->generic_protocol_count;
+                            for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++) {
+                                local.generic_protocol_indices[cpi] =
+                                    init->generic_protocol_indices[cpi];
+                            }
+                            local.may_nil = init->may_nil;
+                            local.may_error = init->may_error;
+                            local.variant_index = init->variant_index;
+                            local.struct_index = init->struct_index;
+                            local.tuple_len = init->tuple_len;
+                            for (u32 ti = 0; ti < init->tuple_len; ti++) {
+                                local.tuple_types[ti] = init->tuple_types[ti];
+                                local.tuple_variant_indices[ti] = init->tuple_variant_indices[ti];
+                                local.tuple_struct_indices[ti] = init->tuple_struct_indices[ti];
+                            }
+                            local.error_struct_index = init->error_struct_index;
+                            local.error_variant_index = init->error_variant_index;
+                            local.shape_index = init->shape_index;
+                            local.init = init.value();
+                            if (!arm.locals.push(local))
+                                return frontend_error(FrontendError::TooManyItems, inner.span);
+                            auto inserted = insert_scoped_local(arm_scoped_locals.data,
+                                                                arm_scoped_locals.len,
+                                                                HirRoute::kMaxLocals,
+                                                                local,
+                                                                inner.span);
+                            if (!inserted) return core::make_unexpected(inserted.error());
+                            continue;
+                        }
+                        if (inner.kind == AstStmtKind::Guard) {
+                            if (is_last ||
+                                (inner.match_arms.len == 0 && inner.else_stmt == nullptr))
+                                return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                            HirGuard guard{};
+                            guard.span = inner.span;
+                            auto bound = analyze_expr(inner.expr,
+                                                      route,
+                                                      mod,
+                                                      arm_scoped_locals.data,
+                                                      arm_scoped_locals.len,
+                                                      arm_binding_ptr);
+                            if (!bound) return core::make_unexpected(bound.error());
+                            auto cond = analyze_guard_cond(inner.expr,
+                                                           route,
+                                                           mod,
+                                                           arm_scoped_locals.data,
+                                                           arm_scoped_locals.len,
+                                                           arm_binding_ptr);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            guard.cond = cond.value();
+                            if (inner.match_arms.len != 0) {
+                                if (bound->may_error) {
+                                    guard.fail_kind = HirGuard::FailKind::Match;
+                                    guard.fail_match_expr = bound.value();
+                                    auto fail_match =
+                                        analyze_guard_match_arms(inner.match_arms,
+                                                                 bound.value(),
+                                                                 route,
+                                                                 mod,
+                                                                 arm_scoped_locals.data,
+                                                                 arm_scoped_locals.len,
+                                                                 &mod.guard_match_arms,
+                                                                 &guard);
+                                    if (!fail_match)
+                                        return core::make_unexpected(fail_match.error());
+                                } else {
+                                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                                          inner.expr.span);
+                                }
+                            } else {
+                                if (inner.else_stmt->kind == AstStmtKind::ReturnStatus ||
+                                    inner.else_stmt->kind == AstStmtKind::ForwardUpstream) {
+                                    auto fail = analyze_term(*inner.else_stmt, mod);
+                                    if (!fail) return core::make_unexpected(fail.error());
+                                    guard.fail_term = fail.value();
+                                } else {
+                                    guard.fail_kind = HirGuard::FailKind::Body;
+                                    auto fail_body = analyze_guard_fail_body(*inner.else_stmt,
+                                                                             &guard.fail_body,
+                                                                             route,
+                                                                             mod,
+                                                                             arm_scoped_locals.data,
+                                                                             arm_scoped_locals.len,
+                                                                             arm_binding_ptr);
+                                    if (!fail_body) return core::make_unexpected(fail_body.error());
+                                }
+                            }
+                            if (!arm.guards.push(guard))
+                                return frontend_error(FrontendError::TooManyItems, inner.span);
+                            if (inner.bind_value) {
+                                if (known_value_state(bound.value(),
+                                                      arm_scoped_locals.data,
+                                                      arm_scoped_locals.len,
+                                                      0) == KnownValueState::Error)
+                                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                                          inner.expr.span);
+                                for (u32 li = 0; li < arm_scoped_locals.len; li++) {
+                                    if (arm_scoped_locals[li].name.len != 0 &&
+                                        arm_scoped_locals[li].name.eq(inner.name))
+                                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                                              inner.span);
+                                }
+                                HirLocal local{};
+                                local.span = inner.span;
+                                local.name = inner.name;
+                                local.ref_index = next_local_ref_index(
+                                    route, arm_scoped_locals.data, arm_scoped_locals.len);
+                                local.type = bound->type;
+                                local.generic_index = bound->generic_index;
+                                local.generic_has_error_constraint =
+                                    bound->generic_has_error_constraint;
+                                local.generic_has_eq_constraint = bound->generic_has_eq_constraint;
+                                local.generic_has_ord_constraint =
+                                    bound->generic_has_ord_constraint;
+                                local.generic_protocol_index = bound->generic_protocol_index;
+                                local.generic_protocol_count = bound->generic_protocol_count;
+                                for (u32 cpi = 0; cpi < local.generic_protocol_count; cpi++)
+                                    local.generic_protocol_indices[cpi] =
+                                        bound->generic_protocol_indices[cpi];
+                                local.may_nil = bound->may_nil;
+                                local.may_error = false;
+                                local.variant_index = bound->variant_index;
+                                local.struct_index = bound->struct_index;
+                                local.tuple_len = bound->tuple_len;
+                                for (u32 ti = 0; ti < bound->tuple_len; ti++) {
+                                    local.tuple_types[ti] = bound->tuple_types[ti];
+                                    local.tuple_variant_indices[ti] =
+                                        bound->tuple_variant_indices[ti];
+                                    local.tuple_struct_indices[ti] =
+                                        bound->tuple_struct_indices[ti];
+                                }
+                                local.error_struct_index = bound->error_struct_index;
+                                local.error_variant_index = 0xffffffffu;
+                                local.shape_index = bound->shape_index;
+                                auto init = make_guard_bound_init(route, bound.value(), inner.span);
+                                if (!init) return core::make_unexpected(init.error());
+                                local.init = init.value();
+                                if (!arm.locals.push(local))
+                                    return frontend_error(FrontendError::TooManyItems, inner.span);
+                                auto inserted = insert_scoped_local(arm_scoped_locals.data,
+                                                                    arm_scoped_locals.len,
+                                                                    HirRoute::kMaxLocals,
+                                                                    local,
+                                                                    inner.span);
+                                if (!inserted) return core::make_unexpected(inserted.error());
+                            }
+                            continue;
+                        }
+                        if (!is_last)
+                            return frontend_error(FrontendError::UnsupportedSyntax, inner.span);
+                        arm_stmt = &inner;
+                    }
+                    arm_locals = arm_scoped_locals.data;
+                    arm_local_count = arm_scoped_locals.len;
+                }
+                if (arm_stmt->kind == AstStmtKind::Match && !arm_stmt->is_const) {
+                    auto inner_subject = analyze_expr(
+                        arm_stmt->expr, route, mod, arm_locals, arm_local_count, arm_binding_ptr);
+                    if (!inner_subject) return core::make_unexpected(inner_subject.error());
+                    if (inner_subject->may_nil || inner_subject->may_error)
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              arm_stmt->expr.span);
+                    if (!route->exprs.push(inner_subject.value()))
+                        return frontend_error(FrontendError::TooManyItems, arm_stmt->expr.span);
+                    HirExpr* inner_subject_ptr = &route->exprs[route->exprs.len - 1];
+                    bool inner_seen_wildcard = false;
+                    bool inner_seen_bool_true = false;
+                    bool inner_seen_bool_false = false;
+                    FixedVec<i32, AstStatement::kMaxMatchArms> inner_seen_int_cases;
+                    FixedVec<Str, AstStatement::kMaxMatchArms> inner_seen_str_cases;
+                    bool inner_seen_variant_cases[HirVariant::kMaxCases]{};
+                    for (u32 iai = 0; iai < arm_stmt->match_arms.len; iai++) {
+                        const auto& inner_ast_arm = arm_stmt->match_arms[iai];
+                        if (inner_ast_arm.has_guard || inner_ast_arm.pattern.lhs != nullptr)
+                            return frontend_error(FrontendError::UnsupportedSyntax,
+                                                  inner_ast_arm.span);
+                        if (inner_seen_wildcard)
+                            return frontend_error(FrontendError::UnsupportedSyntax,
+                                                  inner_ast_arm.span);
+                        if (inner_ast_arm.stmt == nullptr)
+                            return frontend_error(FrontendError::UnsupportedSyntax,
+                                                  inner_ast_arm.span);
+                        HirForLoopMatchArm expanded = arm;
+                        expanded.span = inner_ast_arm.span;
+                        auto assign_flattened_arm_guard =
+                            [&](HirForLoopMatchArm* target,
+                                const HirExpr& inner_cond) -> FrontendResult<void> {
+                            if (!arm.has_arm_guard) {
+                                target->has_arm_guard = true;
+                                target->arm_guard = inner_cond;
+                                return {};
+                            }
+
+                            HirExpr combined{};
+                            combined.kind = HirExprKind::IfElse;
+                            combined.type = HirTypeKind::Bool;
+                            combined.span = inner_ast_arm.span;
+
+                            HirExpr fallback{};
+                            fallback.kind = HirExprKind::BoolLit;
+                            fallback.type = HirTypeKind::Bool;
+                            fallback.span = inner_ast_arm.span;
+                            fallback.bool_value = false;
+
+                            if (!route->exprs.push(arm.arm_guard))
+                                return frontend_error(FrontendError::TooManyItems,
+                                                      inner_ast_arm.span);
+                            combined.lhs = &route->exprs[route->exprs.len - 1];
+                            if (!route->exprs.push(inner_cond))
+                                return frontend_error(FrontendError::TooManyItems,
+                                                      inner_ast_arm.span);
+                            combined.rhs = &route->exprs[route->exprs.len - 1];
+                            if (!route->exprs.push(fallback))
+                                return frontend_error(FrontendError::TooManyItems,
+                                                      inner_ast_arm.span);
+                            if (!combined.args.push(&route->exprs[route->exprs.len - 1]))
+                                return frontend_error(FrontendError::TooManyItems,
+                                                      inner_ast_arm.span);
+
+                            target->has_arm_guard = true;
+                            target->arm_guard = combined;
+                            return {};
+                        };
+                        if (!inner_ast_arm.is_wildcard) {
+                            auto inner_pattern = analyze_match_pattern(inner_ast_arm.pattern,
+                                                                       inner_subject.value(),
+                                                                       route,
+                                                                       mod,
+                                                                       arm_locals,
+                                                                       arm_local_count);
+                            if (!inner_pattern) return core::make_unexpected(inner_pattern.error());
+                            if (inner_pattern->kind != HirExprKind::BoolLit &&
+                                inner_pattern->kind != HirExprKind::IntLit &&
+                                inner_pattern->kind != HirExprKind::StrLit &&
+                                inner_pattern->kind != HirExprKind::VariantCase)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_ast_arm.span);
+                            if (inner_pattern->type != inner_subject->type)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_ast_arm.span);
+                            if (inner_pattern->kind == HirExprKind::BoolLit) {
+                                bool& seen_inner = inner_pattern->bool_value
+                                                       ? inner_seen_bool_true
+                                                       : inner_seen_bool_false;
+                                if (seen_inner)
+                                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                                          inner_ast_arm.span);
+                                seen_inner = true;
+                            }
+                            auto recorded_literal =
+                                record_seen_literal_match_case(inner_pattern.value(),
+                                                               inner_seen_int_cases,
+                                                               inner_seen_str_cases,
+                                                               inner_ast_arm.span);
+                            if (!recorded_literal)
+                                return core::make_unexpected(recorded_literal.error());
+                            if (inner_pattern->kind == HirExprKind::VariantCase) {
+                                if (inner_pattern->variant_index != inner_subject->variant_index)
+                                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                                          inner_ast_arm.span);
+                                const u32 inner_case_index =
+                                    static_cast<u32>(inner_pattern->int_value);
+                                if (inner_case_index >= HirVariant::kMaxCases ||
+                                    inner_seen_variant_cases[inner_case_index])
+                                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                                          inner_ast_arm.span);
+                                inner_seen_variant_cases[inner_case_index] = true;
+                            }
+                            HirExpr cond{};
+                            cond.kind = HirExprKind::Eq;
+                            cond.type = HirTypeKind::Bool;
+                            cond.span = inner_ast_arm.span;
+                            if (inner_pattern->kind == HirExprKind::VariantCase) {
+                                HirExpr tag{};
+                                tag.kind = HirExprKind::VariantTag;
+                                tag.type = HirTypeKind::I32;
+                                tag.span = inner_ast_arm.span;
+                                tag.variant_index = inner_pattern->variant_index;
+                                tag.lhs = inner_subject_ptr;
+                                HirExpr case_index{};
+                                case_index.kind = HirExprKind::IntLit;
+                                case_index.type = HirTypeKind::I32;
+                                case_index.span = inner_ast_arm.span;
+                                case_index.int_value = inner_pattern->int_value;
+                                if (!route->exprs.push(tag))
+                                    return frontend_error(FrontendError::TooManyItems,
+                                                          inner_ast_arm.span);
+                                cond.lhs = &route->exprs[route->exprs.len - 1];
+                                if (!route->exprs.push(case_index))
+                                    return frontend_error(FrontendError::TooManyItems,
+                                                          inner_ast_arm.span);
+                                cond.rhs = &route->exprs[route->exprs.len - 1];
+                            } else {
+                                cond.lhs = inner_subject_ptr;
+                                if (!route->exprs.push(inner_pattern.value()))
+                                    return frontend_error(FrontendError::TooManyItems,
+                                                          inner_ast_arm.span);
+                                cond.rhs = &route->exprs[route->exprs.len - 1];
+                            }
+                            auto assigned_guard = assign_flattened_arm_guard(&expanded, cond);
+                            if (!assigned_guard)
+                                return core::make_unexpected(assigned_guard.error());
+                        } else {
+                            inner_seen_wildcard = true;
+                        }
+                        if (inner_ast_arm.stmt->kind == AstStmtKind::If) {
+                            const auto simple_branch = [](const AstStatement& branch) {
+                                return branch.kind == AstStmtKind::ReturnStatus ||
+                                       branch.kind == AstStmtKind::ForwardUpstream;
+                            };
+                            if (inner_ast_arm.stmt->then_stmt == nullptr ||
+                                inner_ast_arm.stmt->else_stmt == nullptr ||
+                                !simple_branch(*inner_ast_arm.stmt->then_stmt) ||
+                                !simple_branch(*inner_ast_arm.stmt->else_stmt))
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_ast_arm.stmt->span);
+                            auto cond = analyze_expr(inner_ast_arm.stmt->expr,
+                                                     route,
+                                                     mod,
+                                                     arm_locals,
+                                                     arm_local_count,
+                                                     arm_binding_ptr);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            if (cond->type != HirTypeKind::Bool || cond->may_nil || cond->may_error)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      inner_ast_arm.stmt->expr.span);
+                            auto then_term = analyze_term(*inner_ast_arm.stmt->then_stmt, mod);
+                            if (!then_term) return core::make_unexpected(then_term.error());
+                            auto else_term = analyze_term(*inner_ast_arm.stmt->else_stmt, mod);
+                            if (!else_term) return core::make_unexpected(else_term.error());
+                            expanded.body_kind = HirForLoopMatchArm::BodyKind::If;
+                            expanded.cond = cond.value();
+                            expanded.then_term = then_term.value();
+                            expanded.else_term = else_term.value();
+                        } else if (inner_ast_arm.stmt->kind == AstStmtKind::ReturnStatus ||
+                                   inner_ast_arm.stmt->kind == AstStmtKind::ForwardUpstream) {
+                            auto term = analyze_term(*inner_ast_arm.stmt, mod);
+                            if (!term) return core::make_unexpected(term.error());
+                            expanded.body_kind = HirForLoopMatchArm::BodyKind::Direct;
+                            expanded.direct_term = term.value();
+                        } else {
+                            return frontend_error(FrontendError::UnsupportedSyntax,
+                                                  inner_ast_arm.stmt->span);
+                        }
+                        if (!body_match.arms.push(expanded))
+                            return frontend_error(FrontendError::TooManyItems, inner_ast_arm.span);
+                    }
+                    if (!inner_seen_wildcard)
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm_stmt->span);
+                    continue;
+                }
+                if (arm_stmt->kind == AstStmtKind::If) {
+                    const auto simple_branch = [](const AstStatement& branch) {
+                        return branch.kind == AstStmtKind::ReturnStatus ||
+                               branch.kind == AstStmtKind::ForwardUpstream;
+                    };
+                    if (arm_stmt->then_stmt == nullptr || arm_stmt->else_stmt == nullptr ||
+                        !simple_branch(*arm_stmt->then_stmt) ||
+                        !simple_branch(*arm_stmt->else_stmt))
+                        return frontend_error(FrontendError::UnsupportedSyntax, arm_stmt->span);
+                    auto cond = analyze_expr(
+                        arm_stmt->expr, route, mod, arm_locals, arm_local_count, arm_binding_ptr);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    if (cond->type != HirTypeKind::Bool || cond->may_nil || cond->may_error)
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              arm_stmt->expr.span);
+                    auto then_term = analyze_term(*arm_stmt->then_stmt, mod);
+                    if (!then_term) return core::make_unexpected(then_term.error());
+                    auto else_term = analyze_term(*arm_stmt->else_stmt, mod);
+                    if (!else_term) return core::make_unexpected(else_term.error());
+                    arm.body_kind = HirForLoopMatchArm::BodyKind::If;
+                    arm.cond = cond.value();
+                    arm.then_term = then_term.value();
+                    arm.else_term = else_term.value();
+                } else if (arm_stmt->kind == AstStmtKind::ReturnStatus ||
+                           arm_stmt->kind == AstStmtKind::ForwardUpstream) {
+                    auto term = analyze_term(*arm_stmt, mod);
+                    if (!term) return core::make_unexpected(term.error());
+                    arm.direct_term = term.value();
+                } else {
+                    return frontend_error(FrontendError::UnsupportedSyntax, arm_stmt->span);
+                }
+                if (!body_match.arms.push(arm))
+                    return frontend_error(FrontendError::TooManyItems, ast_arm.span);
+            }
+            if (!has_wildcard) return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+            const u32 match_index = loop.body.matches.len;
+            if (!loop.body.matches.push(body_match))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            loop.body.has_term = true;
+            HirForLoopBody::Step step{};
+            step.kind = HirForLoopBody::Step::Kind::Match;
+            step.index = match_index;
+            step.span = bstmt.span;
+            if (!loop.body.steps.push(step))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            continue;
+        }
+        if (bstmt.kind == AstStmtKind::For) {
+            if (loop.body.has_term)
+                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+            auto nested = analyze_for_stmt(bstmt, route, mod);
+            if (!nested) return core::make_unexpected(nested.error());
+            HirForLoopBody::Step step{};
+            step.kind = HirForLoopBody::Step::Kind::For;
+            step.index = nested.value();
+            step.span = bstmt.span;
+            if (!loop.body.steps.push(step))
+                return frontend_error(FrontendError::TooManyItems, bstmt.span);
+            const HirForLoop& nested_loop = route->for_loops[nested.value()];
+            u32 nested_iter_len = 0;
+            if (nested_loop.body.has_term &&
+                static_for_iter_len(nested_loop.iter_expr,
+                                    route->locals.data,
+                                    route->locals.len,
+                                    0,
+                                    &nested_iter_len) &&
+                nested_iter_len != 0)
+                loop.body.has_term = true;
+            continue;
+        }
+        return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+    }
+
+    if (route->locals.len < locals_saved + 1)
+        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+    for (u32 li = locals_saved; li < route->locals.len; li++) route->locals[li].name = {};
+    return for_index;
 }
 
 static FrontendResult<HirModule*> analyze_file_internal(
@@ -12494,26 +13751,77 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
             }
             if (stmt.kind == AstStmtKind::Let) {
+                auto stmt_uses_iter = [&](const auto& self,
+                                          const AstStatement& future,
+                                          const Str& target_name) -> bool {
+                    if (future.kind == AstStmtKind::For && future.expr.kind == AstExprKind::Ident &&
+                        future.expr.name.eq(target_name))
+                        return true;
+                    if (future.then_stmt != nullptr && self(self, *future.then_stmt, target_name))
+                        return true;
+                    if (future.else_stmt != nullptr && self(self, *future.else_stmt, target_name))
+                        return true;
+                    for (u32 bi = 0; bi < future.block_stmts.len; bi++) {
+                        if (future.block_stmts[bi] != nullptr &&
+                            self(self, *future.block_stmts[bi], target_name))
+                            return true;
+                    }
+                    for (u32 mi = 0; mi < future.match_arms.len; mi++) {
+                        if (future.match_arms[mi].stmt != nullptr &&
+                            self(self, *future.match_arms[mi].stmt, target_name))
+                            return true;
+                    }
+                    return false;
+                };
+                auto can_be_used_for_iter =
+                    [&](const auto& self, const Str& target_name, u32 start_idx) -> bool {
+                    for (u32 fi = start_idx; fi < item.route.statements.len; fi++) {
+                        const auto& future = item.route.statements[fi];
+                        if (stmt_uses_iter(stmt_uses_iter, future, target_name)) return true;
+                        if (future.kind == AstStmtKind::Let &&
+                            future.expr.kind == AstExprKind::Ident &&
+                            future.expr.name.eq(target_name))
+                            if (self(self, future.name, fi + 1)) {
+                                return true;
+                            }
+                    }
+                    return false;
+                };
+
                 HirLocal local{};
                 local.span = stmt.span;
                 local.name = stmt.name;
                 local.ref_index = next_local_ref_index(&route, route.locals.data, route.locals.len);
+                const bool used_for_iter =
+                    can_be_used_for_iter(can_be_used_for_iter, stmt.name, si + 1);
                 auto init =
                     stmt.expr.kind == AstExprKind::Wait
                         ? analyze_wait_result_expr(stmt.expr, mod)
-                        : analyze_expr(
-                              stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
+                        : (stmt.expr.kind == AstExprKind::ArrayLit
+                               ? (stmt.expr.args.len == 0 && stmt.has_type
+                                      ? analyze_empty_array_lit_with_declared_type(stmt, mod)
+                                      : analyze_array_iter_expr(stmt.expr,
+                                                                &route,
+                                                                mod,
+                                                                route.locals.data,
+                                                                route.locals.len))
+                               : (used_for_iter ? analyze_array_iter_expr(stmt.expr,
+                                                                          &route,
+                                                                          mod,
+                                                                          route.locals.data,
+                                                                          route.locals.len)
+                                                : analyze_expr(stmt.expr,
+                                                               &route,
+                                                               mod,
+                                                               route.locals.data,
+                                                               route.locals.len,
+                                                               nullptr)));
                 if (!init) return core::make_unexpected(init.error());
-                // ArrayLit at let RHS fails at MIR because MIR has no
-                // ArrayLit → MirValue lowering. Reject at analyze so users
-                // get a clean diagnostic at the declaration site instead of
-                // a later MIR error. Arrays only exist transiently as
-                // for-loop iterables today (MIR unroll lowers elements
-                // directly and never materializes the array as a MirValue);
-                // let-RHS arrays need a separate array-constant lowering
-                // pass before they can be supported.
-                if (init->kind == HirExprKind::ArrayLit)
-                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                if (init.value().type == HirTypeKind::Array) {
+                    if (!used_for_iter || !is_static_for_iter_expr(
+                                              init.value(), route.locals.data, route.locals.len, 0))
+                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                }
                 if (init->kind == HirExprKind::WaitResult) {
                     if (seen_for)
                         return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
@@ -12567,23 +13875,12 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 auto bound = analyze_expr(
                     stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!bound) return core::make_unexpected(bound.error());
-                auto cond =
-                    analyze_guard_cond(stmt.expr, &route, mod, route.locals.data, route.locals.len);
+                auto cond = analyze_guard_cond(
+                    stmt.expr, &route, mod, route.locals.data, route.locals.len, nullptr);
                 if (!cond) return core::make_unexpected(cond.error());
                 guard.cond = cond.value();
                 if (stmt.match_arms.len != 0) {
-                    if (!bound->may_error) {
-                        u32 fallback_arm = 0;
-                        for (u32 ai = 0; ai < stmt.match_arms.len; ai++) {
-                            if (stmt.match_arms[ai].is_wildcard) {
-                                fallback_arm = ai;
-                                break;
-                            }
-                        }
-                        auto fail_term = analyze_term(*stmt.match_arms[fallback_arm].stmt, mod);
-                        if (!fail_term) return core::make_unexpected(fail_term.error());
-                        guard.fail_term = fail_term.value();
-                    } else {
+                    if (bound->may_error) {
                         guard.fail_kind = HirGuard::FailKind::Match;
                         guard.fail_match_expr = bound.value();
                         auto fail_match = analyze_guard_match_arms(stmt.match_arms,
@@ -12595,6 +13892,8 @@ static FrontendResult<HirModule*> analyze_file_internal(
                                                                    &mod.guard_match_arms,
                                                                    &guard);
                         if (!fail_match) return core::make_unexpected(fail_match.error());
+                    } else {
+                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
                     }
                 } else {
                     if (stmt.else_stmt->kind == AstStmtKind::ReturnStatus ||
@@ -12666,152 +13965,10 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 break;
             }
             if (stmt.kind == AstStmtKind::For) {
+                if (seen_wait) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 seen_for = true;
-                // Phase 3b: analyze `for <var> in <iter> { <body> }` into a
-                // HirForLoop node. Body is restricted to `guard*` + optional
-                // terminator (return/forward) per Phase 3b MVP. The loop
-                // variable is pushed into route.locals so body LocalRefs
-                // get a stable ref_index, then has its *name* cleared once
-                // the body is analyzed (the block below) — so it stays
-                // out of later Ident resolution without freeing the slot.
-                auto iter = analyze_array_iter_expr(
-                    stmt.expr, &route, mod, route.locals.data, route.locals.len);
-                if (!iter) return core::make_unexpected(iter.error());
-                if (iter->type != HirTypeKind::Array || iter->shape_index >= mod.type_shapes.len)
-                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
-                const auto& iter_shape = mod.type_shapes[iter->shape_index];
-                if (iter_shape.array_elem_shape_index >= mod.type_shapes.len)
-                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
-                const auto& elem_shape = mod.type_shapes[iter_shape.array_elem_shape_index];
-
-                HirForLoop fl{};
-                fl.span = stmt.span;
-                fl.iter_expr = iter.value();
-                fl.loop_var_name = stmt.name;
-                fl.loop_var_type = elem_shape.type;
-                fl.loop_var_variant_index = elem_shape.variant_index;
-                fl.loop_var_struct_index = elem_shape.struct_index;
-                fl.loop_var_shape_index = iter_shape.array_elem_shape_index;
-
-                // Reject shadowing of an outer local by the loop variable.
-                // Ident resolution scans locals by name from index 0 upward,
-                // so an earlier local with the same name would win over the
-                // per-iteration loop var (`let item = 1; for item in [2] { ... }`
-                // would bind `item` inside the body to the outer `1`).
-                // Making the collision a compile error is simpler than
-                // rewriting name lookup to prefer most-recent.
-                for (u32 li = 0; li < route.locals.len; li++) {
-                    if (route.locals[li].name.len != 0 && route.locals[li].name.eq(stmt.name))
-                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
-                }
-
-                const u32 locals_saved = route.locals.len;
-                HirLocal loop_var{};
-                loop_var.span = stmt.span;
-                loop_var.name = stmt.name;
-                loop_var.ref_index =
-                    next_local_ref_index(&route, route.locals.data, route.locals.len);
-                fl.loop_var_ref_index = loop_var.ref_index;
-                loop_var.type = fl.loop_var_type;
-                loop_var.variant_index = fl.loop_var_variant_index;
-                loop_var.struct_index = fl.loop_var_struct_index;
-                loop_var.shape_index = fl.loop_var_shape_index;
-                // Synthetic init — MIR unroll substitutes the per-iteration
-                // element value when reaching a LocalRef to this slot (via
-                // ForLoopCtx in mir_build.cc), so init is never read at
-                // runtime. We still
-                // need a consistent HirExpr for downstream passes that
-                // inspect local.init.kind (const-fold, diagnostics) — use
-                // a self-referential LocalRef so the node reads as "look
-                // up my own slot", obviously synthetic. Leaving kind at
-                // the HirExpr default BoolLit would claim a false bool
-                // value while type says i32/str.
-                loop_var.init.kind = HirExprKind::LocalRef;
-                loop_var.init.local_index = loop_var.ref_index;
-                loop_var.init.type = fl.loop_var_type;
-                loop_var.init.variant_index = fl.loop_var_variant_index;
-                loop_var.init.struct_index = fl.loop_var_struct_index;
-                loop_var.init.shape_index = fl.loop_var_shape_index;
-                loop_var.init.span = stmt.span;
-                if (!route.locals.push(loop_var))
-                    return frontend_error(FrontendError::TooManyItems, stmt.span);
-
-                // Walk the body. parse_braced_stmt_body collapses single-stmt
-                // blocks, so body is either a Block (n>=2) or a single stmt.
-                const AstStatement* body = stmt.then_stmt;
-                const u32 body_item_count =
-                    body->kind == AstStmtKind::Block ? body->block_stmts.len : 1u;
-                for (u32 bi = 0; bi < body_item_count; bi++) {
-                    const AstStatement& bstmt =
-                        (body->kind == AstStmtKind::Block) ? *body->block_stmts[bi] : *body;
-                    if (bstmt.kind == AstStmtKind::Guard) {
-                        // Phase 3b MVP: only `guard cond else { return N }` or
-                        // `guard cond else { return forward(...) }`. No
-                        // bind_value, no match arms, no non-terminator fail
-                        // body.
-                        //
-                        // HirForLoopBody stores guards and the terminator in
-                        // separate fields rather than a single ordered stmt
-                        // list. If we accepted a guard after `has_term` was
-                        // already set, MIR unroll would silently reorder the
-                        // guard before the (already-fired) terminator —
-                        // miscompile. Reject so source order is preserved.
-                        if (fl.body.has_term)
-                            return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
-                        if (bstmt.bind_value || bstmt.match_arms.len != 0)
-                            return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
-                        if (bstmt.else_stmt == nullptr ||
-                            (bstmt.else_stmt->kind != AstStmtKind::ReturnStatus &&
-                             bstmt.else_stmt->kind != AstStmtKind::ForwardUpstream))
-                            return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
-                        HirGuard guard{};
-                        guard.span = bstmt.span;
-                        // Use analyze_guard_cond (matches the top-level
-                        // guard dispatch at route scope): it enforces the
-                        // boolean predicate shape and rejects may_error /
-                        // may_nil conditions, unlike plain analyze_expr.
-                        auto cond = analyze_guard_cond(
-                            bstmt.expr, &route, mod, route.locals.data, route.locals.len);
-                        if (!cond) return core::make_unexpected(cond.error());
-                        guard.cond = cond.value();
-                        auto fail = analyze_term(*bstmt.else_stmt, mod);
-                        if (!fail) return core::make_unexpected(fail.error());
-                        guard.fail_term = fail.value();
-                        if (!fl.body.guards.push(guard))
-                            return frontend_error(FrontendError::TooManyItems, bstmt.span);
-                        continue;
-                    }
-                    if (bstmt.kind == AstStmtKind::ReturnStatus ||
-                        bstmt.kind == AstStmtKind::ForwardUpstream) {
-                        if (fl.body.has_term)
-                            return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
-                        auto t = analyze_term(bstmt, mod);
-                        if (!t) return core::make_unexpected(t.error());
-                        fl.body.term = t.value();
-                        fl.body.has_term = true;
-                        continue;
-                    }
-                    // Reject let / nested for / if / match in Phase 3b MVP.
-                    return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
-                }
-
-                // Keep loop_var *in* route.locals so its ref_index stays
-                // stable for body HirExpr LocalRefs (MIR unroll will read
-                // those). Hide the *name* by clearing it — Ident resolution
-                // scans locals by name, so post-loop code that references
-                // the loop variable won't find it (scope semantics) while
-                // the ref_index itself is never reused by
-                // next_local_ref_index. Naive truncation would let later
-                // lets reuse the slot and collide with the body's LocalRefs.
-                //
-                // Note: `locals_saved` is retained in the debugger view via
-                // the assert below to catch accidental double-push of the
-                // loop_var (which would break the name-clearing trick).
-                if (route.locals.len != locals_saved + 1)
-                    return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
-                route.locals[locals_saved].name = {};
-                if (!route.for_loops.push(fl))
-                    return frontend_error(FrontendError::TooManyItems, stmt.span);
+                auto loop = analyze_for_stmt(stmt, &route, mod);
+                if (!loop) return core::make_unexpected(loop.error());
                 continue;
             }
             auto control = analyze_control_stmt(stmt, &route, mod, nullptr);
@@ -12837,11 +13994,98 @@ static FrontendResult<HirModule*> analyze_file_internal(
             collected =
                 collect_named_error_cases(route.guards[gi].fail_match_expr, named_error_cases);
             if (!collected) return core::make_unexpected(collected.error());
+            for (u32 li = 0; li < route.guards[gi].fail_body.locals.len; li++) {
+                collected = collect_named_error_cases(route.guards[gi].fail_body.locals[li].init,
+                                                      named_error_cases);
+                if (!collected) return core::make_unexpected(collected.error());
+            }
             for (u32 ai = 0; ai < route.guards[gi].fail_match_count; ai++) {
                 collected = collect_named_error_cases(
                     mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern,
                     named_error_cases);
                 if (!collected) return core::make_unexpected(collected.error());
+            }
+        }
+        for (u32 fi = 0; fi < route.for_loops.len; fi++) {
+            auto collected =
+                collect_named_error_cases(route.for_loops[fi].iter_expr, named_error_cases);
+            if (!collected) return core::make_unexpected(collected.error());
+            for (u32 li = 0; li < route.for_loops[fi].body.locals.len; li++) {
+                collected = collect_named_error_cases(route.for_loops[fi].body.locals[li].init,
+                                                      named_error_cases);
+                if (!collected) return core::make_unexpected(collected.error());
+            }
+            for (u32 gi = 0; gi < route.for_loops[fi].body.guards.len; gi++) {
+                HirGuard& guard = route.for_loops[fi].body.guards[gi];
+                collected = collect_named_error_cases(guard.cond, named_error_cases);
+                if (!collected) return core::make_unexpected(collected.error());
+                collected = collect_named_error_cases(guard.fail_match_expr, named_error_cases);
+                if (!collected) return core::make_unexpected(collected.error());
+                for (u32 li = 0; li < guard.fail_body.locals.len; li++) {
+                    collected = collect_named_error_cases(guard.fail_body.locals[li].init,
+                                                          named_error_cases);
+                    if (!collected) return core::make_unexpected(collected.error());
+                }
+                if (guard.fail_kind == HirGuard::FailKind::Body &&
+                    guard.fail_body.body_kind == HirGuardBody::BodyKind::If) {
+                    collected = collect_named_error_cases(guard.fail_body.cond, named_error_cases);
+                    if (!collected) return core::make_unexpected(collected.error());
+                }
+                for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
+                    collected = collect_named_error_cases(
+                        mod.guard_match_arms[guard.fail_match_start + ai].pattern,
+                        named_error_cases);
+                    if (!collected) return core::make_unexpected(collected.error());
+                }
+            }
+            for (u32 ii = 0; ii < route.for_loops[fi].body.ifs.len; ii++) {
+                collected = collect_named_error_cases(route.for_loops[fi].body.ifs[ii].cond,
+                                                      named_error_cases);
+                if (!collected) return core::make_unexpected(collected.error());
+            }
+            for (u32 mi = 0; mi < route.for_loops[fi].body.matches.len; mi++) {
+                collected = collect_named_error_cases(
+                    route.for_loops[fi].body.matches[mi].match_expr, named_error_cases);
+                if (!collected) return core::make_unexpected(collected.error());
+                for (u32 ai = 0; ai < route.for_loops[fi].body.matches[mi].arms.len; ai++) {
+                    HirForLoopMatchArm& arm = route.for_loops[fi].body.matches[mi].arms[ai];
+                    collected = collect_named_error_cases(arm.pattern, named_error_cases);
+                    if (!collected) return core::make_unexpected(collected.error());
+                    collected = collect_named_error_cases(arm.arm_guard, named_error_cases);
+                    if (!collected) return core::make_unexpected(collected.error());
+                    for (u32 li = 0; li < arm.locals.len; li++) {
+                        collected =
+                            collect_named_error_cases(arm.locals[li].init, named_error_cases);
+                        if (!collected) return core::make_unexpected(collected.error());
+                    }
+                    for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                        HirGuard& guard = arm.guards[gi];
+                        collected = collect_named_error_cases(guard.cond, named_error_cases);
+                        if (!collected) return core::make_unexpected(collected.error());
+                        collected =
+                            collect_named_error_cases(guard.fail_match_expr, named_error_cases);
+                        if (!collected) return core::make_unexpected(collected.error());
+                        for (u32 li = 0; li < guard.fail_body.locals.len; li++) {
+                            collected = collect_named_error_cases(guard.fail_body.locals[li].init,
+                                                                  named_error_cases);
+                            if (!collected) return core::make_unexpected(collected.error());
+                        }
+                        if (guard.fail_kind == HirGuard::FailKind::Body &&
+                            guard.fail_body.body_kind == HirGuardBody::BodyKind::If) {
+                            collected =
+                                collect_named_error_cases(guard.fail_body.cond, named_error_cases);
+                            if (!collected) return core::make_unexpected(collected.error());
+                        }
+                        for (u32 fai = 0; fai < guard.fail_match_count; fai++) {
+                            collected = collect_named_error_cases(
+                                mod.guard_match_arms[guard.fail_match_start + fai].pattern,
+                                named_error_cases);
+                            if (!collected) return core::make_unexpected(collected.error());
+                        }
+                    }
+                    collected = collect_named_error_cases(arm.cond, named_error_cases);
+                    if (!collected) return core::make_unexpected(collected.error());
+                }
             }
         }
         if (route.control.kind == HirControlKind::If) {
@@ -12866,6 +14110,14 @@ static FrontendResult<HirModule*> analyze_file_internal(
                     collected = collect_named_error_cases(
                         route.control.match_arms[ai].guards[gi].fail_match_expr, named_error_cases);
                     if (!collected) return core::make_unexpected(collected.error());
+                    for (u32 li = 0;
+                         li < route.control.match_arms[ai].guards[gi].fail_body.locals.len;
+                         li++) {
+                        collected = collect_named_error_cases(
+                            route.control.match_arms[ai].guards[gi].fail_body.locals[li].init,
+                            named_error_cases);
+                        if (!collected) return core::make_unexpected(collected.error());
+                    }
                     for (u32 fai = 0;
                          fai < route.control.match_arms[ai].guards[gi].fail_match_count;
                          fai++) {
@@ -12912,6 +14164,14 @@ static FrontendResult<HirModule*> analyze_file_internal(
                                           named_error_cases);
                 patch_error_variant_refs(&route.guards[gi].fail_match_expr,
                                          route.error_variant_index);
+                for (u32 li = 0; li < route.guards[gi].fail_body.locals.len; li++) {
+                    HirLocal& local = route.guards[gi].fail_body.locals[li];
+                    patch_named_error_variant(
+                        &local.init, route.error_variant_index, named_error_cases);
+                    patch_error_variant_refs(&local.init, route.error_variant_index);
+                    if (local.may_error && local.error_variant_index == 0xffffffffu)
+                        local.error_variant_index = route.error_variant_index;
+                }
                 for (u32 ai = 0; ai < route.guards[gi].fail_match_count; ai++) {
                     patch_named_error_variant(
                         &mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern,
@@ -12920,6 +14180,121 @@ static FrontendResult<HirModule*> analyze_file_internal(
                     patch_error_variant_refs(
                         &mod.guard_match_arms[route.guards[gi].fail_match_start + ai].pattern,
                         route.error_variant_index);
+                }
+            }
+            for (u32 fi = 0; fi < route.for_loops.len; fi++) {
+                patch_named_error_variant(
+                    &route.for_loops[fi].iter_expr, route.error_variant_index, named_error_cases);
+                patch_error_variant_refs(&route.for_loops[fi].iter_expr, route.error_variant_index);
+                for (u32 li = 0; li < route.for_loops[fi].body.locals.len; li++) {
+                    HirLocal& local = route.for_loops[fi].body.locals[li];
+                    patch_named_error_variant(
+                        &local.init, route.error_variant_index, named_error_cases);
+                    patch_error_variant_refs(&local.init, route.error_variant_index);
+                    if (local.may_error && local.error_variant_index == 0xffffffffu)
+                        local.error_variant_index = route.error_variant_index;
+                }
+                for (u32 gi = 0; gi < route.for_loops[fi].body.guards.len; gi++) {
+                    HirGuard& guard = route.for_loops[fi].body.guards[gi];
+                    patch_named_error_variant(
+                        &guard.cond, route.error_variant_index, named_error_cases);
+                    patch_error_variant_refs(&guard.cond, route.error_variant_index);
+                    patch_named_error_variant(
+                        &guard.fail_match_expr, route.error_variant_index, named_error_cases);
+                    patch_error_variant_refs(&guard.fail_match_expr, route.error_variant_index);
+                    for (u32 li = 0; li < guard.fail_body.locals.len; li++) {
+                        HirLocal& local = guard.fail_body.locals[li];
+                        patch_named_error_variant(
+                            &local.init, route.error_variant_index, named_error_cases);
+                        patch_error_variant_refs(&local.init, route.error_variant_index);
+                        if (local.may_error && local.error_variant_index == 0xffffffffu)
+                            local.error_variant_index = route.error_variant_index;
+                    }
+                    if (guard.fail_kind == HirGuard::FailKind::Body &&
+                        guard.fail_body.body_kind == HirGuardBody::BodyKind::If) {
+                        patch_named_error_variant(
+                            &guard.fail_body.cond, route.error_variant_index, named_error_cases);
+                        patch_error_variant_refs(&guard.fail_body.cond, route.error_variant_index);
+                    }
+                    for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
+                        patch_named_error_variant(
+                            &mod.guard_match_arms[guard.fail_match_start + ai].pattern,
+                            route.error_variant_index,
+                            named_error_cases);
+                        patch_error_variant_refs(
+                            &mod.guard_match_arms[guard.fail_match_start + ai].pattern,
+                            route.error_variant_index);
+                    }
+                }
+                for (u32 ii = 0; ii < route.for_loops[fi].body.ifs.len; ii++) {
+                    patch_named_error_variant(&route.for_loops[fi].body.ifs[ii].cond,
+                                              route.error_variant_index,
+                                              named_error_cases);
+                    patch_error_variant_refs(&route.for_loops[fi].body.ifs[ii].cond,
+                                             route.error_variant_index);
+                }
+                for (u32 mi = 0; mi < route.for_loops[fi].body.matches.len; mi++) {
+                    patch_named_error_variant(&route.for_loops[fi].body.matches[mi].match_expr,
+                                              route.error_variant_index,
+                                              named_error_cases);
+                    patch_error_variant_refs(&route.for_loops[fi].body.matches[mi].match_expr,
+                                             route.error_variant_index);
+                    for (u32 ai = 0; ai < route.for_loops[fi].body.matches[mi].arms.len; ai++) {
+                        HirForLoopMatchArm& arm = route.for_loops[fi].body.matches[mi].arms[ai];
+                        patch_named_error_variant(
+                            &arm.pattern, route.error_variant_index, named_error_cases);
+                        patch_error_variant_refs(&arm.pattern, route.error_variant_index);
+                        patch_named_error_variant(
+                            &arm.arm_guard, route.error_variant_index, named_error_cases);
+                        patch_error_variant_refs(&arm.arm_guard, route.error_variant_index);
+                        for (u32 li = 0; li < arm.locals.len; li++) {
+                            HirLocal& local = arm.locals[li];
+                            patch_named_error_variant(
+                                &local.init, route.error_variant_index, named_error_cases);
+                            patch_error_variant_refs(&local.init, route.error_variant_index);
+                            if (local.may_error && local.error_variant_index == 0xffffffffu)
+                                local.error_variant_index = route.error_variant_index;
+                        }
+                        for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                            HirGuard& guard = arm.guards[gi];
+                            patch_named_error_variant(
+                                &guard.cond, route.error_variant_index, named_error_cases);
+                            patch_error_variant_refs(&guard.cond, route.error_variant_index);
+                            patch_named_error_variant(&guard.fail_match_expr,
+                                                      route.error_variant_index,
+                                                      named_error_cases);
+                            patch_error_variant_refs(&guard.fail_match_expr,
+                                                     route.error_variant_index);
+                            for (u32 li = 0; li < guard.fail_body.locals.len; li++) {
+                                HirLocal& local = guard.fail_body.locals[li];
+                                patch_named_error_variant(
+                                    &local.init, route.error_variant_index, named_error_cases);
+                                patch_error_variant_refs(&local.init, route.error_variant_index);
+                                if (local.may_error && local.error_variant_index == 0xffffffffu)
+                                    local.error_variant_index = route.error_variant_index;
+                            }
+                            if (guard.fail_kind == HirGuard::FailKind::Body &&
+                                guard.fail_body.body_kind == HirGuardBody::BodyKind::If) {
+                                patch_named_error_variant(&guard.fail_body.cond,
+                                                          route.error_variant_index,
+                                                          named_error_cases);
+                                patch_error_variant_refs(&guard.fail_body.cond,
+                                                         route.error_variant_index);
+                            }
+                            for (u32 fai = 0; fai < guard.fail_match_count; fai++) {
+                                patch_named_error_variant(
+                                    &mod.guard_match_arms[guard.fail_match_start + fai].pattern,
+                                    route.error_variant_index,
+                                    named_error_cases);
+                                patch_error_variant_refs(
+                                    &mod.guard_match_arms[guard.fail_match_start + fai].pattern,
+                                    route.error_variant_index);
+                            }
+                        }
+                        patch_named_error_variant(
+                            &arm.cond, route.error_variant_index, named_error_cases);
+                        patch_error_variant_refs(&arm.cond, route.error_variant_index);
+                    }
                 }
             }
             if (route.control.kind == HirControlKind::If) {
@@ -12956,6 +14331,17 @@ static FrontendResult<HirModule*> analyze_file_internal(
                         patch_error_variant_refs(
                             &route.control.match_arms[ai].guards[gi].fail_match_expr,
                             route.error_variant_index);
+                        for (u32 li = 0;
+                             li < route.control.match_arms[ai].guards[gi].fail_body.locals.len;
+                             li++) {
+                            HirLocal& local =
+                                route.control.match_arms[ai].guards[gi].fail_body.locals[li];
+                            patch_named_error_variant(
+                                &local.init, route.error_variant_index, named_error_cases);
+                            patch_error_variant_refs(&local.init, route.error_variant_index);
+                            if (local.may_error && local.error_variant_index == 0xffffffffu)
+                                local.error_variant_index = route.error_variant_index;
+                        }
                         for (u32 fai = 0;
                              fai < route.control.match_arms[ai].guards[gi].fail_match_count;
                              fai++) {

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2525,7 +2525,26 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
                                          local_count,
                                          term.span);
             if (!rhs) return core::make_unexpected(rhs.error());
-            if (term.lhs.may_error && term.lhs.error_variant_index != 0xffffffffu) {
+            if (term.lhs.kind == MirValueKind::Error &&
+                term.lhs.error_variant_index != 0xffffffffu) {
+                auto i32_ty_result = b.make_type(rir::TypeKind::I32);
+                if (!i32_ty_result) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto* i32_ty = i32_ty_result.value();
+                rir::ValueId rhs_tag = rhs.value();
+                if (rhs_shape.type == MirTypeKind::Variant &&
+                    rhs_shape.variant_index < mir.variants.len &&
+                    variant_infos[rhs_shape.variant_index].struct_type != nullptr) {
+                    auto rhs_tag_field = b.emit_struct_field(
+                        rhs.value(), lit("tag"), i32_ty, {term.span.line, term.span.col});
+                    if (!rhs_tag_field)
+                        return frontend_error(FrontendError::OutOfMemory, term.span);
+                    rhs_tag = rhs_tag_field.value();
+                }
+                auto cmp = b.emit_cmp(
+                    rir::Opcode::CmpEq, lhs.value(), rhs_tag, {term.span.line, term.span.col});
+                if (!cmp) return frontend_error(FrontendError::OutOfMemory, term.span);
+                cond_id = cmp.value();
+            } else if (term.lhs.may_error && term.lhs.error_variant_index != 0xffffffffu) {
                 auto& err_info = error_info_for(lhs_shape,
                                                 term.lhs.error_struct_index,
                                                 error_scalar_infos,

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -1,5 +1,7 @@
 #include "rut/compiler/mir_build.h"
 
+#include <vector>
+
 namespace rut {
 
 namespace {
@@ -211,16 +213,17 @@ static bool variant_payload_carrier_ready(const MirModule& mir,
     return false;
 }
 
-// Context for MIR for-loop unrolling (Phase 4b). When lowering the body of
-// a HirForLoop iteration, the caller passes a non-null ctx so that any
-// LocalRef to the loop variable's ref_index is replaced with the current
-// iteration's element MirValue. External callers (route-level guards /
-// terminator / let init) pass nullptr: route-level code cannot reference
-// the loop variable because analyze clears its name after the body (see
-// analyze.cc:10123-10137), so substitution is never needed there.
+// Context for MIR for-loop unrolling. When lowering the body of a HirForLoop
+// iteration, the caller passes a non-null ctx so LocalRefs to the loop variable
+// or body-local bindings are replaced with the current iteration's MirValues.
+// External callers pass nullptr: route-level code cannot reference those
+// bindings because analyze clears their names after the body.
 struct ForLoopCtx {
-    u32 loop_var_ref_index;    // matches HirExpr::local_index on LocalRef to loop var
-    MirValue current_element;  // value to substitute at that LocalRef
+    struct LocalBinding {
+        u32 ref_index = 0xffffffffu;
+        const MirValue* value = nullptr;
+    };
+    FixedVec<LocalBinding, HirRoute::kMaxLocals> locals;
 };
 
 static FrontendResult<MirValue> mir_value(const HirExpr& expr,
@@ -640,23 +643,12 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         return v;
     }
     if (expr.kind == HirExprKind::LocalRef) {
-        // For-loop unroll (Phase 4b): when lowering a body expression for
-        // iteration j, ctx carries the loop var's ref_index and the element
-        // MirValue for that iteration. A LocalRef whose local_index matches
-        // the loop var is replaced with the element directly; the element
-        // already carries its own shape / may_nil / may_error from having
-        // been lowered via mir_value() on the ArrayLit element expr, so no
-        // metadata merge is needed.
-        //
-        // LocalRefs to other locals (outer `let` bindings referenced from
-        // inside the loop body, e.g. `guard n > threshold`) fall through
-        // to the normal LocalRef lowering below — that path is exercised
-        // whenever ctx is null (route-level lowering) or the local_index
-        // doesn't match. The loop-var ref_index sentinel is validated once
-        // in the unroll driver, not here, to keep this hot path branchless
-        // for non-loop-var refs.
-        if (ctx != nullptr && expr.local_index == ctx->loop_var_ref_index) {
-            return ctx->current_element;
+        if (ctx != nullptr) {
+            for (u32 li = 0; li < ctx->locals.len; li++) {
+                if (expr.local_index == ctx->locals[li].ref_index &&
+                    ctx->locals[li].value != nullptr)
+                    return *ctx->locals[li].value;
+            }
         }
         v.kind = MirValueKind::LocalRef;
         v.type = mir_type_kind(expr.type);
@@ -867,6 +859,10 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
 
         for (u32 li = 0; li < module.routes[i].locals.len; li++) {
             if (module.routes[i].locals[li].type == HirTypeKind::Tuple) continue;
+            // Array locals are compile-time constants for for-loop unroll
+            // only. They have no runtime MirValue carrier yet, so do not
+            // emit a MIR local for them.
+            if (module.routes[i].locals[li].type == HirTypeKind::Array) continue;
             // Skip synthetic name-cleared locals. Analyze keeps for-loop
             // loop variables in HirRoute::locals so body LocalRefs bind to
             // a stable ref_index, then blanks the name for scope-hiding
@@ -943,6 +939,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         };
         auto guard_fail_block_count = [&](const HirGuard& guard) -> u32 {
             if (guard.fail_kind == HirGuard::FailKind::Term) return 1;
+            if (guard.fail_kind == HirGuard::FailKind::Body)
+                return guard.fail_body.body_kind == HirGuardBody::BodyKind::If ? 3u : 1u;
             u32 non_wildcard = 0;
             for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
                 // one test block per non-wildcard arm, one case/default block per arm
@@ -952,7 +950,8 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             }
             return non_wildcard + guard.fail_match_count;
         };
-        auto emit_guard_fail = [&](const HirGuard& guard) -> FrontendResult<void> {
+        auto emit_guard_fail = [&](const HirGuard& guard,
+                                   const ForLoopCtx* ctx = nullptr) -> FrontendResult<void> {
             if (guard.fail_kind == HirGuard::FailKind::Term) {
                 MirBlock fail_block{};
                 fail_block.label = fail_label();
@@ -963,12 +962,30 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             }
 
             if (guard.fail_kind == HirGuard::FailKind::Body) {
+                ForLoopCtx scoped_ctx{};
+                const ForLoopCtx* body_ctx = ctx;
+                if (guard.fail_body.locals.len != 0) {
+                    if (ctx != nullptr) scoped_ctx = *ctx;
+                    body_ctx = &scoped_ctx;
+                    for (u32 li = 0; li < guard.fail_body.locals.len; li++) {
+                        const auto& local = guard.fail_body.locals[li];
+                        auto local_value = mir_value(local.init, module, &fn, body_ctx);
+                        if (!local_value) return core::make_unexpected(local_value.error());
+                        if (!fn.values.push(local_value.value()))
+                            return frontend_error(FrontendError::TooManyItems, local.span);
+                        ForLoopCtx::LocalBinding binding{};
+                        binding.ref_index = local.ref_index;
+                        binding.value = &fn.values[fn.values.len - 1];
+                        if (!scoped_ctx.locals.push(binding))
+                            return frontend_error(FrontendError::TooManyItems, local.span);
+                    }
+                }
                 MirBlock fail_block{};
                 fail_block.label = fail_label();
                 if (guard.fail_body.body_kind == HirGuardBody::BodyKind::If) {
                     fail_block.term.kind = MirTerminatorKind::Branch;
                     fail_block.term.span = guard.fail_body.cond.span;
-                    auto cond = mir_value(guard.fail_body.cond, module, &fn);
+                    auto cond = mir_value(guard.fail_body.cond, module, &fn, body_ctx);
                     if (!cond) return core::make_unexpected(cond.error());
                     fail_block.term.cond = cond.value();
                     const u32 then_index = fn.blocks.len + 1;
@@ -1011,14 +1028,14 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 if (arm.is_wildcard) default_index = case_index[ai];
             }
 
-            auto subject = mir_value(guard.fail_match_expr, module, &fn);
+            auto subject = mir_value(guard.fail_match_expr, module, &fn, ctx);
             if (!subject) return core::make_unexpected(subject.error());
             for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
                 const auto& arm = module.guard_match_arms[guard.fail_match_start + ai];
                 if (arm.is_wildcard) continue;
                 MirBlock test_block{};
                 test_block.label = match_test_label();
-                auto arm_pattern = mir_value(arm.pattern, module, &fn);
+                auto arm_pattern = mir_value(arm.pattern, module, &fn, ctx);
                 if (!arm_pattern) return core::make_unexpected(arm_pattern.error());
                 test_block.term.kind = MirTerminatorKind::Branch;
                 test_block.term.use_cmp = true;
@@ -1432,123 +1449,877 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             continue;
         }
 
-        // Phase 4b Scope A for-loop unroll. A for-loop compiles to a flat
-        // chain of N × M virtual guards (N = iter_expr.args.len, M =
-        // body.guards.len), each branching to the next on pass and to its
-        // own fail block on failure. Pass of the final virtual guard falls
-        // into the route's direct terminator. This pass handles only the
-        // canonical allowlist-shaped pattern; other shapes remain rejected
-        // here until Phase 4c/d generalize the emission.
+        // Phase 4b/4c for-loop unroll. A guard-only for-loop compiles to a
+        // flat chain of per-iteration virtual body steps. A loop body with a
+        // terminator lowers only the first iteration, since the terminator
+        // exits the route before any later iteration can run. Virtual loop
+        // steps sort at the source position of the containing for statement;
+        // within that expansion they keep loop iteration and body order.
         //
-        // Scope A preconditions (checked below): exactly one for-loop, no
-        // sibling route-level guards, route control is Direct, body has at
-        // least one guard and no body terminator. Rejected shapes (route
-        // guards mixed with for-loop, body terminator, if/match route
-        // control, multiple for-loops) get FrontendError::UnsupportedSyntax
-        // pointing at the for-loop span.
+        // Preconditions (checked below): route control is Direct, If, or
+        // Match and every for-loop body has at least one body step. Rejected
+        // shapes (runtime iterables, empty bodies) get
+        // FrontendError::UnsupportedSyntax pointing at the relevant span.
         if (module.routes[i].for_loops.len != 0) {
-            const auto& fl = module.routes[i].for_loops[0];
-            // Scope A also requires an inline array literal as the iter
-            // expression — the unroll reads elements from iter_expr.args
-            // which only ArrayLit populates. Today analyze only produces
-            // Array-typed HirExprs via the ArrayLit path (analyze.cc:4472
-            // is the sole producer), so this check is defensive against
-            // a future analyze change that admits other array-producing
-            // expressions (LocalRef/Field/call) — those would need a
-            // different MIR strategy since args.len would be 0 for them.
-            const bool scope_a =
-                module.routes[i].for_loops.len == 1 && module.routes[i].guards.len == 0 &&
-                module.routes[i].control.kind == HirControlKind::Direct && !fl.body.has_term &&
-                fl.body.guards.len != 0 && fl.iter_expr.kind == HirExprKind::ArrayLit &&
-                fl.iter_expr.args.len != 0;
-            if (!scope_a || fl.loop_var_ref_index == 0xffffffffu) {
-                return frontend_error(FrontendError::UnsupportedSyntax, fl.span);
-            }
-
-            // Block budget pre-check. The unroll produces 2T+1 blocks
-            // (T virtual guards + 1 body + T fail blocks, T = N × M).
-            // MirFunction caps at kMaxBlocks, so worst-case shapes like
-            // N=8,M=1 or N=4,M=2 would push past the cap mid-emission.
-            // Reject up-front with a deterministic error at the for-loop
-            // span instead of a TooManyItems buried inside a later push.
-            {
-                const u64 total_guards =
-                    static_cast<u64>(fl.iter_expr.args.len) * fl.body.guards.len;
-                if (2 * total_guards + 1 > MirFunction::kMaxBlocks) {
-                    return frontend_error(FrontendError::TooManyItems, fl.span);
-                }
-            }
-
-            // Unroll N × M virtual guards. Each entry pairs a body-guard
-            // pointer with the ForLoopCtx that mir_value uses to substitute
-            // the loop variable's LocalRef on the condition expression.
-            // Phase 3b body guards are restricted to fail_kind == Term, so
-            // emit_guard_fail pushes exactly one fail block per guard.
-            struct UnrolledGuard {
-                const HirGuard* guard;
-                ForLoopCtx ctx;
+            auto iter_array_for = [&](const HirForLoop& fl) -> const HirExpr* {
+                auto resolve_array =
+                    [&](auto&& self, const HirExpr& expr, u32 depth) -> const HirExpr* {
+                    if (depth > module.routes[i].locals.len + HirRoute::kMaxLocals) return nullptr;
+                    if (expr.kind == HirExprKind::ArrayLit) return &expr;
+                    if (expr.kind != HirExprKind::LocalRef) return nullptr;
+                    for (u32 li = 0; li < module.routes[i].locals.len; li++) {
+                        const auto& local = module.routes[i].locals[li];
+                        if (local.ref_index == expr.local_index)
+                            return self(self, local.init, depth + 1);
+                    }
+                    return nullptr;
+                };
+                return resolve_array(resolve_array, fl.iter_expr, 0);
             };
-            constexpr u32 kMaxUnrolled = HirExpr::kMaxArgs * HirForLoopBody::kMaxGuards;
-            FixedVec<UnrolledGuard, kMaxUnrolled> expanded{};
-            for (u32 ai = 0; ai < fl.iter_expr.args.len; ai++) {
-                auto elem = mir_value(*fl.iter_expr.args[ai], module, &fn);
-                if (!elem) return core::make_unexpected(elem.error());
-                for (u32 gi = 0; gi < fl.body.guards.len; gi++) {
-                    UnrolledGuard u{};
-                    u.guard = &fl.body.guards[gi];
-                    u.ctx.loop_var_ref_index = fl.loop_var_ref_index;
-                    u.ctx.current_element = elem.value();
-                    if (!expanded.push(u))
-                        return frontend_error(FrontendError::TooManyItems, fl.span);
+            struct RouteStep {
+                enum class Kind : u8 {
+                    Guard,
+                    If,
+                    Match,
+                    Term,
+                };
+                Kind kind = Kind::Guard;
+                const HirGuard* guard = nullptr;
+                const HirForLoopIf* body_if = nullptr;
+                const HirForLoopMatch* body_match = nullptr;
+                const HirTerminator* term = nullptr;
+                Span span{};
+                u32 order_start = 0;
+                u32 order_seq = 0;
+                bool has_ctx = false;
+                u32 ctx_index = 0xffffffffu;
+            };
+            constexpr u32 kMaxUnrolled = HirExpr::kMaxArgs * HirForLoopBody::kMaxSteps;
+            constexpr u32 kMaxForRouteSteps =
+                HirRoute::kMaxGuards + HirRoute::kMaxForLoops * kMaxUnrolled;
+            FixedVec<RouteStep, kMaxForRouteSteps> steps{};
+            std::vector<ForLoopCtx> step_contexts;
+            step_contexts.reserve(kMaxForRouteSteps);
+            u32 route_step_seq = 0;
+            auto set_step_ctx = [&](RouteStep* step,
+                                    const ForLoopCtx& ctx) -> FrontendResult<void> {
+                if (step_contexts.size() >= kMaxForRouteSteps)
+                    return frontend_error(FrontendError::TooManyItems, step->span);
+                step->has_ctx = true;
+                step->ctx_index = static_cast<u32>(step_contexts.size());
+                step_contexts.push_back(ctx);
+                return {};
+            };
+            auto route_step_ctx = [&](const RouteStep& step) -> const ForLoopCtx* {
+                if (!step.has_ctx) return nullptr;
+                if (step.ctx_index >= step_contexts.size()) return nullptr;
+                return &step_contexts[step.ctx_index];
+            };
+            auto push_ctx_binding = [&](ForLoopCtx* ctx,
+                                        u32 ref_index,
+                                        MirValue value,
+                                        Span span) -> FrontendResult<void> {
+                if (!fn.values.push(value))
+                    return frontend_error(FrontendError::TooManyItems, span);
+                ForLoopCtx::LocalBinding binding{};
+                binding.ref_index = ref_index;
+                binding.value = &fn.values[fn.values.len - 1];
+                if (!ctx->locals.push(binding))
+                    return frontend_error(FrontendError::TooManyItems, span);
+                return {};
+            };
+            bool for_loop_is_child[kMaxForRouteSteps]{};
+            for (u32 fi = 0; fi < module.routes[i].for_loops.len; fi++) {
+                const auto& fl = module.routes[i].for_loops[fi];
+                for (u32 si = 0; si < fl.body.steps.len; si++) {
+                    const auto& body_step = fl.body.steps[si];
+                    if (body_step.kind == HirForLoopBody::Step::Kind::For) {
+                        if (body_step.index >= module.routes[i].for_loops.len)
+                            return frontend_error(FrontendError::UnsupportedSyntax, body_step.span);
+                        for_loop_is_child[body_step.index] = true;
+                    }
+                }
+            }
+            auto emit_for_loop = [&](auto&& self,
+                                     u32 fi,
+                                     const ForLoopCtx* parent_ctx,
+                                     u32 order_start) -> FrontendResult<void> {
+                const auto& fl = module.routes[i].for_loops[fi];
+                const HirExpr* iter_array = iter_array_for(fl);
+                // This unroll requires a compile-time-known array literal,
+                // either inline in the for expression or through a
+                // route-local array constant. Other array-producing
+                // expressions need a runtime array carrier before they can
+                // be lowered.
+                const bool supported = fl.body.steps.len != 0 && iter_array != nullptr;
+                if (!supported || fl.loop_var_ref_index == 0xffffffffu) {
+                    return frontend_error(FrontendError::UnsupportedSyntax, fl.span);
+                }
+                const u32 iter_count =
+                    fl.body.has_term && iter_array->args.len != 0 ? 1u : iter_array->args.len;
+                for (u32 ai = 0; ai < iter_count; ai++) {
+                    auto elem = mir_value(*iter_array->args[ai], module, &fn, parent_ctx);
+                    if (!elem) return core::make_unexpected(elem.error());
+                    ForLoopCtx ctx = parent_ctx ? *parent_ctx : ForLoopCtx{};
+                    auto loop_binding =
+                        push_ctx_binding(&ctx, fl.loop_var_ref_index, elem.value(), fl.span);
+                    if (!loop_binding) return core::make_unexpected(loop_binding.error());
+                    for (u32 bi = 0; bi < fl.body.steps.len; bi++) {
+                        const auto& body_step = fl.body.steps[bi];
+                        if (body_step.kind == HirForLoopBody::Step::Kind::Let) {
+                            if (body_step.index >= fl.body.locals.len)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      body_step.span);
+                            const auto& local = fl.body.locals[body_step.index];
+                            auto local_value = mir_value(local.init, module, &fn, &ctx);
+                            if (!local_value) return core::make_unexpected(local_value.error());
+                            auto local_binding = push_ctx_binding(
+                                &ctx, local.ref_index, local_value.value(), local.span);
+                            if (!local_binding) return core::make_unexpected(local_binding.error());
+                            continue;
+                        }
+                        if (body_step.kind == HirForLoopBody::Step::Kind::Guard) {
+                            if (body_step.index >= fl.body.guards.len)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      body_step.span);
+                            RouteStep step{};
+                            step.kind = RouteStep::Kind::Guard;
+                            step.guard = &fl.body.guards[body_step.index];
+                            step.span = fl.body.guards[body_step.index].span;
+                            step.order_start = order_start;
+                            step.order_seq = route_step_seq++;
+                            auto ctx_set = set_step_ctx(&step, ctx);
+                            if (!ctx_set) return core::make_unexpected(ctx_set.error());
+                            if (!steps.push(step))
+                                return frontend_error(FrontendError::TooManyItems, fl.span);
+                            continue;
+                        }
+                        if (body_step.kind == HirForLoopBody::Step::Kind::If) {
+                            if (body_step.index >= fl.body.ifs.len)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      body_step.span);
+                            RouteStep step{};
+                            step.kind = RouteStep::Kind::If;
+                            step.body_if = &fl.body.ifs[body_step.index];
+                            step.span = fl.body.ifs[body_step.index].span;
+                            step.order_start = order_start;
+                            step.order_seq = route_step_seq++;
+                            auto ctx_set = set_step_ctx(&step, ctx);
+                            if (!ctx_set) return core::make_unexpected(ctx_set.error());
+                            if (!steps.push(step))
+                                return frontend_error(FrontendError::TooManyItems, fl.span);
+                            continue;
+                        }
+                        if (body_step.kind == HirForLoopBody::Step::Kind::Match) {
+                            if (body_step.index >= fl.body.matches.len)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      body_step.span);
+                            RouteStep step{};
+                            step.kind = RouteStep::Kind::Match;
+                            step.body_match = &fl.body.matches[body_step.index];
+                            step.span = fl.body.matches[body_step.index].span;
+                            step.order_start = order_start;
+                            step.order_seq = route_step_seq++;
+                            auto ctx_set = set_step_ctx(&step, ctx);
+                            if (!ctx_set) return core::make_unexpected(ctx_set.error());
+                            if (!steps.push(step))
+                                return frontend_error(FrontendError::TooManyItems, fl.span);
+                            continue;
+                        }
+                        if (body_step.kind == HirForLoopBody::Step::Kind::For) {
+                            if (body_step.index >= module.routes[i].for_loops.len)
+                                return frontend_error(FrontendError::UnsupportedSyntax,
+                                                      body_step.span);
+                            auto child = self(self, body_step.index, &ctx, order_start);
+                            if (!child) return core::make_unexpected(child.error());
+                            continue;
+                        }
+                        RouteStep step{};
+                        step.kind = RouteStep::Kind::Term;
+                        step.term = &fl.body.term;
+                        step.span = fl.body.term.span;
+                        step.order_start = order_start;
+                        step.order_seq = route_step_seq++;
+                        auto ctx_set = set_step_ctx(&step, ctx);
+                        if (!ctx_set) return core::make_unexpected(ctx_set.error());
+                        if (!steps.push(step))
+                            return frontend_error(FrontendError::TooManyItems, fl.span);
+                    }
+                }
+                return {};
+            };
+            for (u32 gi = 0; gi < module.routes[i].guards.len; gi++) {
+                RouteStep step{};
+                step.kind = RouteStep::Kind::Guard;
+                step.guard = &module.routes[i].guards[gi];
+                step.span = module.routes[i].guards[gi].span;
+                step.order_start = step.span.start;
+                step.order_seq = route_step_seq++;
+                if (!steps.push(step))
+                    return frontend_error(FrontendError::TooManyItems,
+                                          module.routes[i].guards[gi].span);
+            }
+            if (module.routes[i].control.kind != HirControlKind::Direct &&
+                module.routes[i].control.kind != HirControlKind::If &&
+                module.routes[i].control.kind != HirControlKind::Match) {
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      module.routes[i].for_loops[0].span);
+            }
+            for (u32 fi = 0; fi < module.routes[i].for_loops.len; fi++) {
+                if (for_loop_is_child[fi]) continue;
+                auto emitted = emit_for_loop(
+                    emit_for_loop, fi, nullptr, module.routes[i].for_loops[fi].span.start);
+                if (!emitted) return core::make_unexpected(emitted.error());
+            }
+            for (u32 si = 1; si < steps.len; si++) {
+                RouteStep cur = steps[si];
+                u32 pos = si;
+                while (pos > 0 && (cur.order_start < steps[pos - 1].order_start ||
+                                   (cur.order_start == steps[pos - 1].order_start &&
+                                    cur.order_seq < steps[pos - 1].order_seq))) {
+                    steps[pos] = steps[pos - 1];
+                    pos--;
+                }
+                steps[pos] = cur;
+            }
+
+            u32 step_count = steps.len;
+            bool has_terminating_step = false;
+            u32 terminating_step_index = 0xffffffffu;
+            for (u32 si = 0; si < steps.len; si++) {
+                if (steps[si].kind == RouteStep::Kind::Term ||
+                    steps[si].kind == RouteStep::Kind::If ||
+                    steps[si].kind == RouteStep::Kind::Match) {
+                    step_count = si + 1;
+                    has_terminating_step = true;
+                    terminating_step_index = si;
+                    break;
                 }
             }
 
-            const u32 total = expanded.len;
-            const u32 body_index = total;
-            u32 guard_fail_index[kMaxUnrolled]{};
-            u32 fail_cursor = body_index + 1;
-            for (u32 gi = 0; gi < total; gi++) {
-                guard_fail_index[gi] = fail_cursor++;
+            const u32 terminal_index = step_count;
+            const bool route_control_is_if =
+                module.routes[i].control.kind == HirControlKind::If && !has_terminating_step;
+            const u32 then_index = route_control_is_if ? terminal_index + 1 : 0;
+            const u32 else_index = route_control_is_if ? terminal_index + 2 : 0;
+            u32 match_arm_block_index[HirControl::kMaxMatchArms]{};
+            u32 match_arm_body_index[HirControl::kMaxMatchArms]{};
+            u32 match_arm_then_index[HirControl::kMaxMatchArms]{};
+            u32 match_arm_else_index[HirControl::kMaxMatchArms]{};
+            u32 match_arm_guard_index[HirControl::kMaxMatchArms][HirMatchArm::kMaxPreludeGuards]{};
+            u32 match_arm_guard_fail_index[HirControl::kMaxMatchArms]
+                                          [HirMatchArm::kMaxPreludeGuards]{};
+            u32 match_arm_count = 0;
+            u32 match_test_count = 0;
+            u32 match_end_index = 0;
+            u32 body_match_extra_test_index[HirForLoopMatch::kMaxMatchArms]{};
+            u32 body_match_test_ordinal[HirForLoopMatch::kMaxMatchArms]{};
+            u32 body_match_guard_index[HirForLoopMatch::kMaxMatchArms]{};
+            u32 body_match_prelude_guard_index[HirForLoopMatch::kMaxMatchArms]
+                                              [HirForLoopMatchArm::kMaxPreludeGuards]{};
+            u32 body_match_prelude_guard_fail_index[HirForLoopMatch::kMaxMatchArms]
+                                                   [HirForLoopMatchArm::kMaxPreludeGuards]{};
+            u32 body_match_case_index[HirForLoopMatch::kMaxMatchArms]{};
+            u32 body_match_then_index[HirForLoopMatch::kMaxMatchArms]{};
+            u32 body_match_else_index[HirForLoopMatch::kMaxMatchArms]{};
+            u32 body_match_non_wildcard_count = 0;
+            u32 body_match_end_index = 0;
+            bool block_budget_overflow = false;
+            Span block_budget_span = module.routes[i].span;
+            auto note_block_budget = [&](u32 next_index, Span span) {
+                if (!block_budget_overflow && next_index > MirFunction::kMaxBlocks) {
+                    block_budget_overflow = true;
+                    block_budget_span = span;
+                }
+            };
+            auto reserve_blocks = [&](u32* cursor, u32 count, Span span) -> u32 {
+                const u32 first = *cursor;
+                *cursor += count;
+                note_block_budget(*cursor, span);
+                return first;
+            };
+            if (module.routes[i].control.kind == HirControlKind::Match && !has_terminating_step) {
+                match_arm_count = module.routes[i].control.match_arms.len;
+                match_test_count = match_arm_count - 1;
+                u32 next_index = terminal_index + match_test_count;
+                note_block_budget(next_index, module.routes[i].span);
+                for (u32 ai = 0; ai < match_arm_count; ai++) {
+                    const auto& arm = module.routes[i].control.match_arms[ai];
+                    match_arm_block_index[ai] = reserve_blocks(&next_index, 1, arm.span);
+                    if (arm.guards.len != 0) {
+                        if (arm.has_arm_guard)
+                            match_arm_guard_index[ai][0] = reserve_blocks(&next_index, 1, arm.span);
+                        for (u32 gi = 1; gi < arm.guards.len; gi++)
+                            match_arm_guard_index[ai][gi] =
+                                reserve_blocks(&next_index, 1, arm.guards[gi].span);
+                        match_arm_body_index[ai] = reserve_blocks(&next_index, 1, arm.span);
+                        for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                            match_arm_guard_fail_index[ai][gi] = next_index;
+                            reserve_blocks(&next_index,
+                                           guard_fail_block_count(arm.guards[gi]),
+                                           arm.guards[gi].span);
+                        }
+                    } else if (arm.has_arm_guard) {
+                        match_arm_body_index[ai] = reserve_blocks(&next_index, 1, arm.span);
+                    } else {
+                        match_arm_body_index[ai] = match_arm_block_index[ai];
+                    }
+                    if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                        match_arm_then_index[ai] = reserve_blocks(&next_index, 1, arm.span);
+                        match_arm_else_index[ai] = reserve_blocks(&next_index, 1, arm.span);
+                    }
+                }
+                match_end_index = next_index;
             }
+            u32 guard_fail_index[kMaxForRouteSteps]{};
+            u32 fail_cursor = terminal_index;
+            if (has_terminating_step && steps[terminating_step_index].kind == RouteStep::Kind::If) {
+                fail_cursor = terminal_index + 2;
+            } else if (has_terminating_step &&
+                       steps[terminating_step_index].kind == RouteStep::Kind::Match) {
+                const auto& body_match = *steps[terminating_step_index].body_match;
+                for (u32 ai = 0; ai < body_match.arms.len; ai++) {
+                    if (!body_match.arms[ai].is_wildcard) {
+                        body_match_test_ordinal[ai] = body_match_non_wildcard_count++;
+                    }
+                }
+                u32 cursor = terminal_index;
+                note_block_budget(cursor, steps[terminating_step_index].span);
+                for (u32 ai = 1; ai < body_match_non_wildcard_count; ai++) {
+                    body_match_extra_test_index[ai] =
+                        reserve_blocks(&cursor, 1, steps[terminating_step_index].span);
+                }
+                for (u32 ai = 0; ai < body_match.arms.len; ai++) {
+                    if (body_match.arms[ai].has_arm_guard)
+                        body_match_guard_index[ai] =
+                            reserve_blocks(&cursor, 1, body_match.arms[ai].span);
+                }
+                for (u32 ai = 0; ai < body_match.arms.len; ai++) {
+                    for (u32 gi = 0; gi < body_match.arms[ai].guards.len; gi++) {
+                        body_match_prelude_guard_index[ai][gi] =
+                            reserve_blocks(&cursor, 1, body_match.arms[ai].guards[gi].span);
+                    }
+                }
+                for (u32 ai = 0; ai < body_match.arms.len; ai++) {
+                    body_match_case_index[ai] =
+                        reserve_blocks(&cursor, 1, body_match.arms[ai].span);
+                    if (body_match.arms[ai].body_kind == HirForLoopMatchArm::BodyKind::If) {
+                        body_match_then_index[ai] =
+                            reserve_blocks(&cursor, 1, body_match.arms[ai].span);
+                        body_match_else_index[ai] =
+                            reserve_blocks(&cursor, 1, body_match.arms[ai].span);
+                    }
+                }
+                for (u32 ai = 0; ai < body_match.arms.len; ai++) {
+                    for (u32 gi = 0; gi < body_match.arms[ai].guards.len; gi++) {
+                        body_match_prelude_guard_fail_index[ai][gi] = cursor;
+                        reserve_blocks(&cursor,
+                                       guard_fail_block_count(body_match.arms[ai].guards[gi]),
+                                       body_match.arms[ai].guards[gi].span);
+                    }
+                }
+                body_match_end_index = cursor;
+                fail_cursor = body_match_end_index;
+            }
+            if (!has_terminating_step) {
+                if (module.routes[i].control.kind == HirControlKind::Direct) {
+                    fail_cursor = terminal_index + 1;
+                    note_block_budget(fail_cursor, module.routes[i].span);
+                } else if (module.routes[i].control.kind == HirControlKind::If) {
+                    fail_cursor = terminal_index + 3;
+                    note_block_budget(fail_cursor, module.routes[i].span);
+                } else {
+                    fail_cursor = match_end_index;
+                }
+            }
+            for (u32 si = 0; si < step_count; si++) {
+                if (steps[si].kind != RouteStep::Kind::Guard) continue;
+                guard_fail_index[si] = fail_cursor;
+                reserve_blocks(
+                    &fail_cursor, guard_fail_block_count(*steps[si].guard), steps[si].span);
+            }
+            if (fail_cursor > MirFunction::kMaxBlocks)
+                return frontend_error(FrontendError::TooManyItems, block_budget_span);
 
-            // Entry block: test the first virtual guard's condition.
-            MirBlock entry_block{};
-            entry_block.label = entry_label();
-            entry_block.term.kind = MirTerminatorKind::Branch;
-            entry_block.term.span = expanded[0].guard->span;
-            auto cond0 = mir_value(expanded[0].guard->cond, module, &fn, &expanded[0].ctx);
-            if (!cond0) return core::make_unexpected(cond0.error());
-            entry_block.term.cond = cond0.value();
-            entry_block.term.then_block = total > 1 ? 1 : body_index;
-            entry_block.term.else_block = guard_fail_index[0];
-            if (!fn.blocks.push(entry_block))
-                return frontend_error(FrontendError::TooManyItems, fn.span);
+            auto extend_for_loop_match_arm_ctx =
+                [&](const HirForLoopMatchArm& arm,
+                    const ForLoopCtx* base_ctx,
+                    ForLoopCtx* scoped_ctx) -> FrontendResult<const ForLoopCtx*> {
+                if (arm.locals.len == 0) return base_ctx;
+                if (base_ctx != nullptr) *scoped_ctx = *base_ctx;
+                const ForLoopCtx* body_ctx = scoped_ctx;
+                for (u32 li = 0; li < arm.locals.len; li++) {
+                    const auto& local = arm.locals[li];
+                    auto local_value = mir_value(local.init, module, &fn, body_ctx);
+                    if (!local_value) return core::make_unexpected(local_value.error());
+                    auto local_binding = push_ctx_binding(
+                        scoped_ctx, local.ref_index, local_value.value(), local.span);
+                    if (!local_binding) return core::make_unexpected(local_binding.error());
+                }
+                return body_ctx;
+            };
+            auto body_match_arm_entry_index = [&](const HirForLoopMatchArm& arm,
+                                                  u32 arm_index) -> u32 {
+                if (arm.has_arm_guard) return body_match_guard_index[arm_index];
+                if (arm.guards.len != 0) return body_match_prelude_guard_index[arm_index][0];
+                return body_match_case_index[arm_index];
+            };
+            auto body_match_arm_body_index = [&](const HirForLoopMatchArm& arm,
+                                                 u32 arm_index) -> u32 {
+                if (arm.guards.len != 0) return body_match_prelude_guard_index[arm_index][0];
+                return body_match_case_index[arm_index];
+            };
+            auto emit_body_match_prelude_guards =
+                [&](const HirForLoopMatch& body_match,
+                    const ForLoopCtx* ctx) -> FrontendResult<void> {
+                for (u32 ai = 0; ai < body_match.arms.len; ai++) {
+                    const auto& arm = body_match.arms[ai];
+                    ForLoopCtx scoped_ctx{};
+                    auto body_ctx = extend_for_loop_match_arm_ctx(arm, ctx, &scoped_ctx);
+                    if (!body_ctx) return core::make_unexpected(body_ctx.error());
+                    for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                        MirBlock guard_block{};
+                        guard_block.label = cont_label();
+                        guard_block.term.kind = MirTerminatorKind::Branch;
+                        guard_block.term.span = arm.guards[gi].span;
+                        auto cond = mir_value(arm.guards[gi].cond, module, &fn, body_ctx.value());
+                        if (!cond) return core::make_unexpected(cond.error());
+                        guard_block.term.cond = cond.value();
+                        guard_block.term.then_block =
+                            gi + 1 < arm.guards.len ? body_match_prelude_guard_index[ai][gi + 1]
+                                                    : body_match_case_index[ai];
+                        guard_block.term.else_block = body_match_prelude_guard_fail_index[ai][gi];
+                        if (!fn.blocks.push(guard_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                    }
+                }
+                return {};
+            };
+            auto emit_body_match_prelude_guard_fails =
+                [&](const HirForLoopMatch& body_match,
+                    const ForLoopCtx* ctx) -> FrontendResult<void> {
+                for (u32 ai = 0; ai < body_match.arms.len; ai++) {
+                    const auto& arm = body_match.arms[ai];
+                    ForLoopCtx scoped_ctx{};
+                    auto body_ctx = extend_for_loop_match_arm_ctx(arm, ctx, &scoped_ctx);
+                    if (!body_ctx) return core::make_unexpected(body_ctx.error());
+                    for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                        auto emitted = emit_guard_fail(arm.guards[gi], body_ctx.value());
+                        if (!emitted) return core::make_unexpected(emitted.error());
+                    }
+                }
+                return {};
+            };
 
-            // Subsequent virtual-guard blocks.
-            for (u32 gi = 1; gi < total; gi++) {
-                MirBlock guard_block{};
-                guard_block.label = cont_label();
-                guard_block.term.kind = MirTerminatorKind::Branch;
-                guard_block.term.span = expanded[gi].guard->span;
-                auto cond = mir_value(expanded[gi].guard->cond, module, &fn, &expanded[gi].ctx);
+            for (u32 si = 0; si < step_count; si++) {
+                const ForLoopCtx* step_ctx = route_step_ctx(steps[si]);
+                MirBlock block{};
+                block.label = si == 0 ? entry_label() : cont_label();
+                if (steps[si].kind == RouteStep::Kind::Term) {
+                    set_term_from_hir(&block.term, *steps[si].term);
+                    if (!fn.blocks.push(block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                    continue;
+                }
+                if (steps[si].kind == RouteStep::Kind::If) {
+                    block.term.kind = MirTerminatorKind::Branch;
+                    block.term.span = steps[si].body_if->span;
+                    auto cond = mir_value(steps[si].body_if->cond, module, &fn, step_ctx);
+                    if (!cond) return core::make_unexpected(cond.error());
+                    block.term.cond = cond.value();
+                    block.term.then_block = terminal_index;
+                    block.term.else_block = terminal_index + 1;
+                    if (!fn.blocks.push(block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                    continue;
+                }
+                if (steps[si].kind == RouteStep::Kind::Match) {
+                    const auto& body_match = *steps[si].body_match;
+                    if (body_match.arms.len == 0)
+                        return frontend_error(FrontendError::UnsupportedSyntax, body_match.span);
+                    auto subject = mir_value(body_match.match_expr, module, &fn, step_ctx);
+                    if (!subject) return core::make_unexpected(subject.error());
+                    auto body_match_fallthrough_target = [&](u32 arm_index) -> u32 {
+                        for (u32 next = arm_index + 1; next < body_match.arms.len; next++) {
+                            if (body_match.arms[next].is_wildcard)
+                                return body_match_arm_entry_index(body_match.arms[next], next);
+                            const u32 ordinal = body_match_test_ordinal[next];
+                            return ordinal == 0 ? si : body_match_extra_test_index[ordinal];
+                        }
+                        return body_match_arm_entry_index(body_match.arms[body_match.arms.len - 1],
+                                                          body_match.arms.len - 1);
+                    };
+                    if (body_match_non_wildcard_count == 0) {
+                        block.term.kind = MirTerminatorKind::Branch;
+                        block.term.cond.kind = MirValueKind::BoolConst;
+                        block.term.cond.type = MirTypeKind::Bool;
+                        block.term.cond.bool_value = true;
+                        block.term.then_block = body_match_arm_entry_index(body_match.arms[0], 0);
+                        block.term.else_block = block.term.then_block;
+                    } else {
+                        auto arm_pattern =
+                            mir_value(body_match.arms[0].pattern, module, &fn, step_ctx);
+                        if (!arm_pattern) return core::make_unexpected(arm_pattern.error());
+                        block.term.kind = MirTerminatorKind::Branch;
+                        block.term.use_cmp = true;
+                        block.term.span = body_match.arms[0].span;
+                        block.term.lhs = subject.value();
+                        block.term.rhs = arm_pattern.value();
+                        block.term.then_block = body_match_arm_entry_index(body_match.arms[0], 0);
+                        block.term.else_block = body_match_non_wildcard_count > 1
+                                                    ? body_match_extra_test_index[1]
+                                                    : body_match_fallthrough_target(0);
+                    }
+                    if (!fn.blocks.push(block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                    continue;
+                }
+                block.term.kind = MirTerminatorKind::Branch;
+                block.term.span = steps[si].guard->span;
+                auto cond = mir_value(steps[si].guard->cond, module, &fn, step_ctx);
                 if (!cond) return core::make_unexpected(cond.error());
-                guard_block.term.cond = cond.value();
-                guard_block.term.then_block = gi + 1 < total ? gi + 1 : body_index;
-                guard_block.term.else_block = guard_fail_index[gi];
-                if (!fn.blocks.push(guard_block))
+                block.term.cond = cond.value();
+                block.term.then_block = si + 1 < step_count ? si + 1 : terminal_index;
+                block.term.else_block = guard_fail_index[si];
+                if (!fn.blocks.push(block))
                     return frontend_error(FrontendError::TooManyItems, fn.span);
             }
 
-            // Body block: the route's direct terminator.
-            MirBlock body_block{};
-            body_block.label = cont_label();
-            set_term_from_hir(&body_block.term, module.routes[i].control.direct_term);
-            if (!fn.blocks.push(body_block))
-                return frontend_error(FrontendError::TooManyItems, fn.span);
+            if (has_terminating_step && steps[terminating_step_index].kind == RouteStep::Kind::If) {
+                const auto& body_if = *steps[terminating_step_index].body_if;
+                MirBlock then_block{};
+                then_block.label = then_label();
+                set_term_from_hir(&then_block.term, body_if.then_term);
+                if (!fn.blocks.push(then_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
 
-            // Fail blocks, one per virtual guard.
-            for (u32 gi = 0; gi < total; gi++) {
-                auto emitted = emit_guard_fail(*expanded[gi].guard);
+                MirBlock else_block{};
+                else_block.label = else_label();
+                set_term_from_hir(&else_block.term, body_if.else_term);
+                if (!fn.blocks.push(else_block))
+                    return frontend_error(FrontendError::TooManyItems, fn.span);
+            } else if (has_terminating_step &&
+                       steps[terminating_step_index].kind == RouteStep::Kind::Match) {
+                const auto& body_match = *steps[terminating_step_index].body_match;
+                const ForLoopCtx* terminating_ctx = route_step_ctx(steps[terminating_step_index]);
+                auto subject = mir_value(body_match.match_expr, module, &fn, terminating_ctx);
+                if (!subject) return core::make_unexpected(subject.error());
+                auto body_match_fallthrough_target = [&](u32 arm_index) -> u32 {
+                    for (u32 next = arm_index + 1; next < body_match.arms.len; next++) {
+                        if (body_match.arms[next].is_wildcard)
+                            return body_match_arm_entry_index(body_match.arms[next], next);
+                        return body_match_extra_test_index[body_match_test_ordinal[next]];
+                    }
+                    return body_match_arm_entry_index(body_match.arms[body_match.arms.len - 1],
+                                                      body_match.arms.len - 1);
+                };
+                auto set_body_match_arm_term = [&](MirBlock* out,
+                                                   const HirForLoopMatchArm& arm,
+                                                   u32 arm_index) -> FrontendResult<void> {
+                    ForLoopCtx scoped_ctx{};
+                    auto body_ctx =
+                        extend_for_loop_match_arm_ctx(arm, terminating_ctx, &scoped_ctx);
+                    if (!body_ctx) return core::make_unexpected(body_ctx.error());
+                    if (arm.body_kind == HirForLoopMatchArm::BodyKind::If) {
+                        out->term.kind = MirTerminatorKind::Branch;
+                        out->term.span = arm.cond.span;
+                        auto cond = mir_value(arm.cond, module, &fn, body_ctx.value());
+                        if (!cond) return core::make_unexpected(cond.error());
+                        out->term.cond = cond.value();
+                        out->term.then_block = body_match_then_index[arm_index];
+                        out->term.else_block = body_match_else_index[arm_index];
+                    } else {
+                        set_term_from_hir(&out->term, arm.direct_term);
+                    }
+                    return {};
+                };
+                for (u32 ai = 1; ai < body_match_non_wildcard_count; ai++) {
+                    MirBlock test_block{};
+                    test_block.label = match_test_label();
+                    auto arm_pattern =
+                        mir_value(body_match.arms[ai].pattern, module, &fn, terminating_ctx);
+                    if (!arm_pattern) return core::make_unexpected(arm_pattern.error());
+                    test_block.term.kind = MirTerminatorKind::Branch;
+                    test_block.term.use_cmp = true;
+                    test_block.term.span = body_match.arms[ai].span;
+                    test_block.term.lhs = subject.value();
+                    test_block.term.rhs = arm_pattern.value();
+                    test_block.term.then_block =
+                        body_match_arm_entry_index(body_match.arms[ai], ai);
+                    test_block.term.else_block = ai + 1 < body_match_non_wildcard_count
+                                                     ? body_match_extra_test_index[ai + 1]
+                                                     : body_match_fallthrough_target(ai);
+                    if (!fn.blocks.push(test_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                }
+                for (u32 ai = 0; ai < body_match.arms.len; ai++) {
+                    const auto& arm = body_match.arms[ai];
+                    if (!arm.has_arm_guard) continue;
+                    ForLoopCtx scoped_ctx{};
+                    auto body_ctx =
+                        extend_for_loop_match_arm_ctx(arm, terminating_ctx, &scoped_ctx);
+                    if (!body_ctx) return core::make_unexpected(body_ctx.error());
+                    MirBlock guard_block{};
+                    guard_block.label = cont_label();
+                    guard_block.term.kind = MirTerminatorKind::Branch;
+                    guard_block.term.span = arm.arm_guard.span;
+                    auto guard = mir_value(arm.arm_guard, module, &fn, body_ctx.value());
+                    if (!guard) return core::make_unexpected(guard.error());
+                    guard_block.term.cond = guard.value();
+                    guard_block.term.then_block =
+                        body_match_arm_body_index(body_match.arms[ai], ai);
+                    guard_block.term.else_block = body_match_fallthrough_target(ai);
+                    if (!fn.blocks.push(guard_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                }
+                auto prelude_guards = emit_body_match_prelude_guards(body_match, terminating_ctx);
+                if (!prelude_guards) return core::make_unexpected(prelude_guards.error());
+                for (u32 ai = 0; ai < body_match.arms.len; ai++) {
+                    MirBlock case_block{};
+                    case_block.label = body_match.arms[ai].is_wildcard ? match_default_label()
+                                                                       : match_case_label();
+                    auto armed = set_body_match_arm_term(&case_block, body_match.arms[ai], ai);
+                    if (!armed) return core::make_unexpected(armed.error());
+                    if (!fn.blocks.push(case_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                    if (body_match.arms[ai].body_kind == HirForLoopMatchArm::BodyKind::If) {
+                        MirBlock then_block{};
+                        then_block.label = then_label();
+                        set_term_from_hir(&then_block.term, body_match.arms[ai].then_term);
+                        if (!fn.blocks.push(then_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                        MirBlock else_block{};
+                        else_block.label = else_label();
+                        set_term_from_hir(&else_block.term, body_match.arms[ai].else_term);
+                        if (!fn.blocks.push(else_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                    }
+                }
+                auto prelude_fails =
+                    emit_body_match_prelude_guard_fails(body_match, terminating_ctx);
+                if (!prelude_fails) return core::make_unexpected(prelude_fails.error());
+            }
+
+            if (!has_terminating_step) {
+                // Body block: the route's terminal control after every
+                // guard-only loop iteration has passed.
+                MirBlock body_block{};
+                body_block.label = cont_label();
+                if (module.routes[i].control.kind == HirControlKind::Direct) {
+                    set_term_from_hir(&body_block.term, module.routes[i].control.direct_term);
+                    if (!fn.blocks.push(body_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                } else if (module.routes[i].control.kind == HirControlKind::If) {
+                    body_block.term.kind = MirTerminatorKind::Branch;
+                    body_block.term.span = module.routes[i].control.cond.span;
+                    auto if_cond = mir_value(module.routes[i].control.cond, module, &fn);
+                    if (!if_cond) return core::make_unexpected(if_cond.error());
+                    body_block.term.cond = if_cond.value();
+                    body_block.term.then_block = then_index;
+                    body_block.term.else_block = else_index;
+                    if (!fn.blocks.push(body_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                    MirBlock then_block{};
+                    then_block.label = then_label();
+                    set_term_from_hir(&then_block.term, module.routes[i].control.then_term);
+                    if (!fn.blocks.push(then_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+
+                    MirBlock else_block{};
+                    else_block.label = else_label();
+                    set_term_from_hir(&else_block.term, module.routes[i].control.else_term);
+                    if (!fn.blocks.push(else_block))
+                        return frontend_error(FrontendError::TooManyItems, fn.span);
+                } else {
+                    auto subject = mir_value(module.routes[i].control.match_expr, module, &fn);
+                    if (!subject) return core::make_unexpected(subject.error());
+                    auto arm_fallthrough_target = [&](u32 ai) -> FrontendResult<u32> {
+                        if (ai + 1 < match_test_count) return terminal_index + ai + 1;
+                        if (ai + 1 < match_arm_count) return match_arm_block_index[ai + 1];
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              module.routes[i].control.match_arms[ai].span);
+                    };
+                    if (match_test_count == 0) {
+                        const auto& arm = module.routes[i].control.match_arms[0];
+                        body_block.label =
+                            arm.is_wildcard ? match_default_label() : match_case_label();
+                        if (arm.has_arm_guard) {
+                            auto guarded = set_match_arm_guard_branch(
+                                body_block,
+                                arm,
+                                match_arm_guard_index[0][0],
+                                match_arm_body_index[0],
+                                [&] { return arm_fallthrough_target(0); });
+                            if (!guarded) return core::make_unexpected(guarded.error());
+                        } else if (arm.guards.len != 0) {
+                            auto cond = mir_value(arm.guards[0].cond, module, &fn);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            body_block.term.kind = MirTerminatorKind::Branch;
+                            body_block.term.span = arm.guards[0].span;
+                            body_block.term.cond = cond.value();
+                            body_block.term.then_block = arm.guards.len > 1
+                                                             ? match_arm_guard_index[0][1]
+                                                             : match_arm_body_index[0];
+                            body_block.term.else_block = match_arm_guard_fail_index[0][0];
+                        } else if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                            body_block.term.kind = MirTerminatorKind::Branch;
+                            body_block.term.span = arm.cond.span;
+                            auto cond = mir_value(arm.cond, module, &fn);
+                            if (!cond) return core::make_unexpected(cond.error());
+                            body_block.term.cond = cond.value();
+                            body_block.term.then_block = match_arm_then_index[0];
+                            body_block.term.else_block = match_arm_else_index[0];
+                        } else {
+                            set_term_from_hir(&body_block.term, arm.direct_term);
+                        }
+                        if (!fn.blocks.push(body_block))
+                            return frontend_error(FrontendError::TooManyItems, fn.span);
+                        auto guard_blocks =
+                            emit_match_prelude_guard_blocks(arm,
+                                                            0,
+                                                            match_arm_guard_index,
+                                                            match_arm_guard_fail_index,
+                                                            match_arm_body_index);
+                        if (!guard_blocks) return core::make_unexpected(guard_blocks.error());
+                        if (arm.guards.len != 0 || arm.has_arm_guard) {
+                            MirBlock match_body_block{};
+                            match_body_block.label = cont_label();
+                            if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                                match_body_block.term.kind = MirTerminatorKind::Branch;
+                                match_body_block.term.span = arm.cond.span;
+                                auto cond = mir_value(arm.cond, module, &fn);
+                                if (!cond) return core::make_unexpected(cond.error());
+                                match_body_block.term.cond = cond.value();
+                                match_body_block.term.then_block = match_arm_then_index[0];
+                                match_body_block.term.else_block = match_arm_else_index[0];
+                            } else {
+                                set_term_from_hir(&match_body_block.term, arm.direct_term);
+                            }
+                            if (!fn.blocks.push(match_body_block))
+                                return frontend_error(FrontendError::TooManyItems, fn.span);
+                            for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                                auto emitted = emit_guard_fail(arm.guards[gi]);
+                                if (!emitted) return core::make_unexpected(emitted.error());
+                            }
+                        }
+                        if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                            MirBlock then_block{};
+                            then_block.label = then_label();
+                            set_term_from_hir(&then_block.term, arm.then_term);
+                            if (!fn.blocks.push(then_block))
+                                return frontend_error(FrontendError::TooManyItems, fn.span);
+                            MirBlock else_block{};
+                            else_block.label = else_label();
+                            set_term_from_hir(&else_block.term, arm.else_term);
+                            if (!fn.blocks.push(else_block))
+                                return frontend_error(FrontendError::TooManyItems, fn.span);
+                        }
+                    } else {
+                        for (u32 ai = 0; ai < match_test_count; ai++) {
+                            MirBlock test_block{};
+                            test_block.label = ai == 0 ? cont_label() : match_test_label();
+                            const auto& arm = module.routes[i].control.match_arms[ai];
+                            auto arm_pattern = mir_value(arm.pattern, module, &fn);
+                            if (!arm_pattern) return core::make_unexpected(arm_pattern.error());
+                            test_block.term.kind = MirTerminatorKind::Branch;
+                            test_block.term.use_cmp = true;
+                            test_block.term.span = arm.span;
+                            test_block.term.lhs = subject.value();
+                            test_block.term.rhs = arm_pattern.value();
+                            test_block.term.then_block = match_arm_block_index[ai];
+                            test_block.term.else_block =
+                                ai + 1 < match_test_count ? terminal_index + ai + 1
+                                                          : match_arm_block_index[match_test_count];
+                            if (!fn.blocks.push(test_block))
+                                return frontend_error(FrontendError::TooManyItems, fn.span);
+                        }
+                        for (u32 ai = 0; ai < match_arm_count; ai++) {
+                            MirBlock case_block{};
+                            const auto& arm = module.routes[i].control.match_arms[ai];
+                            case_block.label =
+                                arm.is_wildcard ? match_default_label() : match_case_label();
+                            if (arm.has_arm_guard) {
+                                auto guarded = set_match_arm_guard_branch(
+                                    case_block,
+                                    arm,
+                                    match_arm_guard_index[ai][0],
+                                    match_arm_body_index[ai],
+                                    [&] { return arm_fallthrough_target(ai); });
+                                if (!guarded) return core::make_unexpected(guarded.error());
+                            } else if (arm.guards.len != 0) {
+                                auto cond = mir_value(arm.guards[0].cond, module, &fn);
+                                if (!cond) return core::make_unexpected(cond.error());
+                                case_block.term.kind = MirTerminatorKind::Branch;
+                                case_block.term.span = arm.guards[0].span;
+                                case_block.term.cond = cond.value();
+                                case_block.term.then_block = arm.guards.len > 1
+                                                                 ? match_arm_guard_index[ai][1]
+                                                                 : match_arm_body_index[ai];
+                                case_block.term.else_block = match_arm_guard_fail_index[ai][0];
+                            } else if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                                case_block.term.kind = MirTerminatorKind::Branch;
+                                case_block.term.span = arm.cond.span;
+                                auto cond = mir_value(arm.cond, module, &fn);
+                                if (!cond) return core::make_unexpected(cond.error());
+                                case_block.term.cond = cond.value();
+                                case_block.term.then_block = match_arm_then_index[ai];
+                                case_block.term.else_block = match_arm_else_index[ai];
+                            } else {
+                                set_term_from_hir(&case_block.term, arm.direct_term);
+                            }
+                            if (!fn.blocks.push(case_block))
+                                return frontend_error(FrontendError::TooManyItems, fn.span);
+                            auto guard_blocks =
+                                emit_match_prelude_guard_blocks(arm,
+                                                                ai,
+                                                                match_arm_guard_index,
+                                                                match_arm_guard_fail_index,
+                                                                match_arm_body_index);
+                            if (!guard_blocks) return core::make_unexpected(guard_blocks.error());
+                            if (arm.guards.len != 0 || arm.has_arm_guard) {
+                                MirBlock match_body_block{};
+                                match_body_block.label = cont_label();
+                                if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                                    match_body_block.term.kind = MirTerminatorKind::Branch;
+                                    match_body_block.term.span = arm.cond.span;
+                                    auto cond = mir_value(arm.cond, module, &fn);
+                                    if (!cond) return core::make_unexpected(cond.error());
+                                    match_body_block.term.cond = cond.value();
+                                    match_body_block.term.then_block = match_arm_then_index[ai];
+                                    match_body_block.term.else_block = match_arm_else_index[ai];
+                                } else {
+                                    set_term_from_hir(&match_body_block.term, arm.direct_term);
+                                }
+                                if (!fn.blocks.push(match_body_block))
+                                    return frontend_error(FrontendError::TooManyItems, fn.span);
+                                for (u32 gi = 0; gi < arm.guards.len; gi++) {
+                                    auto emitted = emit_guard_fail(arm.guards[gi]);
+                                    if (!emitted) return core::make_unexpected(emitted.error());
+                                }
+                            }
+                            if (arm.body_kind == HirMatchArm::BodyKind::If) {
+                                MirBlock then_block{};
+                                then_block.label = then_label();
+                                set_term_from_hir(&then_block.term, arm.then_term);
+                                if (!fn.blocks.push(then_block))
+                                    return frontend_error(FrontendError::TooManyItems, fn.span);
+                                MirBlock else_block{};
+                                else_block.label = else_label();
+                                set_term_from_hir(&else_block.term, arm.else_term);
+                                if (!fn.blocks.push(else_block))
+                                    return frontend_error(FrontendError::TooManyItems, fn.span);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Fail blocks, one per route/virtual guard step.
+            for (u32 si = 0; si < step_count; si++) {
+                if (steps[si].kind != RouteStep::Kind::Guard) continue;
+                auto emitted = emit_guard_fail(*steps[si].guard, route_step_ctx(steps[si]));
                 if (!emitted) return core::make_unexpected(emitted.error());
             }
 

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -1143,7 +1143,13 @@ struct Parser {
             stmt.span = Span{start.start, else_stmt->span.end, start.line, start.col};
             return stmt;
         }
-        if (take(TokenType::KwFor)) {
+        const bool is_inline_for = cur().type == TokenType::Ident && cur().text.eq({"inline", 6}) &&
+                                   peek().type == TokenType::KwFor;
+        if (is_inline_for || cur().type == TokenType::KwFor) {
+            const bool is_inline = is_inline_for;
+            if (is_inline) pos++;
+            if (auto for_kw = expect(TokenType::KwFor); !for_kw)
+                return core::make_unexpected(for_kw.error());
             auto var_name = expect(TokenType::Ident);
             if (!var_name) return core::make_unexpected(var_name.error());
             auto in_kw = expect(TokenType::KwIn);
@@ -1158,6 +1164,9 @@ struct Parser {
             if (!body_ptr) return core::make_unexpected(body_ptr.error());
             AstStatement stmt{};
             stmt.kind = AstStmtKind::For;
+            // Keep the spelling for source fidelity; static unroll decisions
+            // are made later from the analyzed iterator/body shape.
+            stmt.is_inline = is_inline;
             stmt.name = var_name.value()->text;
             stmt.expr = iter_expr.value();
             stmt.then_stmt = body_ptr.value();

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -115,6 +115,16 @@ TEST(frontend, lex_emits_at_token_for_decorator_prefix) {
     CHECK(lexed->tokens[1].text.eq(lit("auth")));
 }
 
+TEST(frontend, lex_keeps_inline_contextual) {
+    const char* src = "inline for";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    REQUIRE_EQ(lexed->tokens.len, 3u);
+    CHECK_EQ(static_cast<u8>(lexed->tokens[0].type), static_cast<u8>(TokenType::Ident));
+    CHECK(lexed->tokens[0].text.eq(lit("inline")));
+    CHECK_EQ(static_cast<u8>(lexed->tokens[1].type), static_cast<u8>(TokenType::KwFor));
+}
+
 TEST(frontend, lex_recognizes_lowercase_http_methods) {
     const char* src = "get post put delete patch head options";
     auto lexed = lex(lit(src));
@@ -1995,10 +2005,35 @@ TEST(frontend, analyze_rejects_parameterized_wait_any_arms_until_rich_payloads) 
 
 TEST(frontend, analyze_rejects_wait_after_for_loop) {
     const char* sources[] = {
+        "route GET \"/x\" { inline for item in [1] { guard item > 0 else { return 400 } } "
+        "wait(50) return 204 }\n",
+        "route GET \"/x\" { inline for item in [1] { guard item > 0 else { return 400 } } "
+        "let ev = wait(downstream.recv()) return 204 }\n",
         "route GET \"/x\" { for item in [1] { guard item > 0 else { return 400 } } "
         "wait(50) return 204 }\n",
         "route GET \"/x\" { for item in [1] { guard item > 0 else { return 400 } } "
         "let ev = wait(downstream.recv()) return 204 }\n",
+    };
+    for (const char* src : sources) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE(!hir);
+    }
+}
+
+TEST(frontend, analyze_rejects_for_loop_after_wait) {
+    const char* sources[] = {
+        "route GET \"/x\" { wait(50) inline for item in [1] { guard item > 0 else { return 400 } "
+        "} return 204 }\n",
+        "route GET \"/x\" { let ev = wait(downstream.recv()) inline for item in [1] { guard item "
+        "> 0 else { return 400 } } return 204 }\n",
+        "route GET \"/x\" { wait(50) for item in [1] { guard item > 0 else { return 400 } "
+        "} return 204 }\n",
+        "route GET \"/x\" { let ev = wait(downstream.recv()) for item in [1] { guard item "
+        "> 0 else { return 400 } } return 204 }\n",
     };
     for (const char* src : sources) {
         auto lexed = lex(lit(src));
@@ -5401,6 +5436,27 @@ TEST(frontend, variant_payload_binding_flows_into_match_arm_block_with_guard) {
     REQUIRE(lowered);
     rir.destroy();
 }
+TEST(frontend, match_arm_block_guard_else_local_named_error_gets_hidden_variant) {
+    const char* src =
+        "variant Result { ok, err }\n"
+        "route GET \"/users\" { let state = Result.ok match state { case .ok: { guard false else "
+        "{ let failed = error(.timeout) if true { return 401 } else { return 402 } } return 200 } "
+        "case .err: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 2u);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    REQUIRE_EQ(hir->routes[0].control.match_arms[0].guards.len, 1u);
+    REQUIRE_EQ(hir->routes[0].control.match_arms[0].guards[0].fail_body.locals.len, 1u);
+    const auto& local = hir->routes[0].control.match_arms[0].guards[0].fail_body.locals[0];
+    CHECK_EQ(local.error_variant_index, hir->routes[0].error_variant_index);
+    CHECK_EQ(local.init.error_variant_index, hir->routes[0].error_variant_index);
+    CHECK_EQ(local.init.error_case_index, 0u);
+}
 TEST(frontend, variant_payload_binding_flows_into_match_arm_block_with_guard_match) {
     const char* src =
         "variant Result { ok(i32), err }\n"
@@ -8241,6 +8297,24 @@ TEST(frontend, guard_else_block_with_let_is_supported) {
     CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].fail_body.body_kind),
              static_cast<u8>(HirGuardBody::BodyKind::If));
 }
+TEST(frontend, guard_else_block_local_named_error_gets_hidden_variant) {
+    const char* src =
+        "route GET \"/users\" { guard false else { let failed = error(.timeout) if true { return "
+        "401 } else { return 500 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 1u);
+    REQUIRE_EQ(hir->routes[0].guards.len, 1u);
+    REQUIRE_EQ(hir->routes[0].guards[0].fail_body.locals.len, 1u);
+    const auto& local = hir->routes[0].guards[0].fail_body.locals[0];
+    CHECK_EQ(local.error_variant_index, 0u);
+    CHECK_EQ(local.init.error_variant_index, 0u);
+    CHECK_EQ(local.init.error_case_index, 0u);
+}
 TEST(frontend, guard_let_binds_success_value) {
     const char* src =
         "route GET \"/users\" { guard let code = 200 else { return 401 } if code == 200 { return "
@@ -9429,6 +9503,37 @@ TEST(frontend, analyze_rejects_route_nested_match_duplicate_bool_case) {
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
+
+TEST(frontend, analyze_rejects_route_nested_match_duplicate_int_case) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let code = 1 match auth { case .ok: match "
+        "code { case 1: return 200 case 1: return 201 case _: return 404 } case .denied: return "
+        "403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_rejects_route_nested_match_duplicate_string_case) {
+    const char* src =
+        "variant Auth { ok, denied }\n"
+        "route GET \"/users\" { let auth = Auth.ok let path = \"/users\" match auth { case .ok: "
+        "match path { case \"/users\": return 200 case \"/users\": return 201 case _: return "
+        "404 } case .denied: return 403 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
 TEST(frontend, analyze_rejects_route_nested_match_duplicate_outer_bool_case) {
     const char* src =
         "route GET \"/users\" { let ok = true let allowed = true match ok { case true: match "
@@ -9612,6 +9717,25 @@ TEST(frontend, guard_match_lowers_to_fail_side_match_arms) {
     REQUIRE(mir);
     CHECK(mir->functions[0].blocks.len >= 5u);
 }
+
+TEST(frontend, lower_to_rir_supports_guard_match_known_error_fail_side) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case "
+        ".timeout: return 503 case _: return 500 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
 TEST(frontend, parse_rejects_guard_match_arm_guard) {
     const char* src =
         "route GET \"/users\" { let failed = error(.timeout) guard match failed else { case "
@@ -9682,9 +9806,196 @@ TEST(frontend, analyze_rejects_match_arm_block_guard_match_on_non_error_value) {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE_FALSE(hir.has_value());
+    REQUIRE_FALSE(hir);
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
+
+TEST(frontend, analyze_rejects_route_guard_match_on_non_error_value) {
+    const char* src =
+        "route GET \"/users\" { let code = 200 guard match code else { case true: return 401 "
+        "case _: return 402 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_rejects_route_array_local_used_outside_for_iter) {
+    const char* src = "route GET \"/x\" { let nums = [1, 2, 3] let second = nums return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_rejects_typed_empty_array_local_used_outside_for_iter) {
+    const char* src = "route GET \"/x\" { let nums: [i32] = [] let second = nums return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_rejects_array_local_alias_chain_used_outside_for_iter) {
+    const char* src =
+        "route GET \"/x\" { let nums = [1, 2, 3] let second = nums let third = second return 200 "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_rejects_alias_chain_partially_used_outside_for_iter) {
+    const char* src =
+        "route GET \"/x\" { let nums = [1, 2, 3] let alias = nums inline for item in alias "
+        "{ return 200 } let leaked = nums return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_plain_for_rejects_alias_chain_partially_used_outside_for_iter) {
+    const char* src =
+        "route GET \"/x\" { let nums = [1, 2, 3] let alias = nums for item in alias "
+        "{ return 200 } let leaked = nums return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_for_rejects_alias_chain_partially_used_outside_for_iter) {
+    const char* src =
+        "route GET \"/x\" { let nums = [1, 2, 3] let alias = nums inline for item in alias "
+        "{ return 200 } let leaked = nums return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_rejects_typed_array_local_call_as_for_iter) {
+    const char* src =
+        "func make() -> [i32] => [1, 2, 3]\n"
+        "route GET \"/x\" { let xs: [i32] = make() inline for item in xs { return 200 } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_plain_for_rejects_typed_array_local_call_as_for_iter) {
+    const char* src =
+        "func make() -> [i32] => [1, 2, 3]\n"
+        "route GET \"/x\" { let xs: [i32] = make() for item in xs { return 200 } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_for_rejects_typed_array_local_call_as_for_iter) {
+    const char* src =
+        "func make() -> [i32] => [1, 2, 3]\n"
+        "route GET \"/x\" { let xs: [i32] = make() inline for item in xs { return 200 } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_accepts_typed_array_alias_chain_for_for_iter) {
+    const char* src =
+        "route GET \"/x\" { let xs: [i32] = [1, 2, 3] let ys = xs inline for item in ys { return "
+        "200 } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_plain_for_accepts_typed_array_alias_chain_for_for_iter) {
+    const char* src =
+        "route GET \"/x\" { let xs: [i32] = [1, 2, 3] let ys = xs for item in ys { return "
+        "200 } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_for_accepts_typed_array_alias_chain_for_for_iter) {
+    const char* src =
+        "route GET \"/x\" { let xs: [i32] = [1, 2, 3] let ys = xs inline for item in ys { return "
+        "200 } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
 TEST(frontend, analyze_rejects_match_without_wildcard) {
     const char* src =
         "route GET \"/users\" { let code = 200 match code { case 200: return 200 } }\n";
@@ -17616,11 +17927,12 @@ TEST(frontend, parse_array_lit_nested_type) {
 }
 
 TEST(frontend, parse_for_loop_basic) {
-    // `for item in xs { return 200 }` — loop variable stored in `name`,
+    // `inline for item in xs { return 200 }` — loop variable stored in `name`,
     // iteration source in `expr`, body block in `then_stmt`. Intentionally
     // parse-only: asserts AST shape independent of analyze (full-pipeline
     // coverage lives in analyze_for_loop_* tests below).
-    const char* src = "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 200 }\n";
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { return 200 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -17629,6 +17941,7 @@ TEST(frontend, parse_for_loop_basic) {
     REQUIRE_EQ(route.statements.len, 2u);
     const auto& for_stmt = route.statements[0];
     CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(for_stmt.is_inline);
     CHECK(for_stmt.name.eq(lit("item")));
     CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::ArrayLit));
     REQUIRE_EQ(for_stmt.expr.args.len, 3u);
@@ -17639,10 +17952,58 @@ TEST(frontend, parse_for_loop_basic) {
     CHECK_EQ(for_stmt.then_stmt->status_code, 200u);
 }
 
+TEST(frontend, parse_plain_for_loop_basic) {
+    // `for item in [1, 2, 3] { return 200 }` — same AST shape as inline, except
+    // the `is_inline` marker stays false.
+    const char* src = "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& route = ast->items[0].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    const auto& for_stmt = route.statements[0];
+    CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(!for_stmt.is_inline);
+    CHECK(for_stmt.name.eq(lit("item")));
+    CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::ArrayLit));
+    REQUIRE_EQ(for_stmt.expr.args.len, 3u);
+    REQUIRE(for_stmt.then_stmt != nullptr);
+    // Body is single-stmt `return 200` in parse representation.
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind), static_cast<u8>(AstStmtKind::ReturnStatus));
+    CHECK_EQ(for_stmt.then_stmt->status_code, 200u);
+}
+
+TEST(frontend, parse_inline_identifier_is_not_reserved) {
+    const char* src =
+        "route GET \"/x\" { let inline = 1 guard inline == 1 else { return 400 } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
 TEST(frontend, parse_for_loop_field_access_source) {
-    // `for server in up.servers` — iteration source is a field access expr,
+    // `inline for server in up.servers` — iteration source is a field access expr,
     // not a literal. Exercises parse_expr → parse_primary_expr → Field path
     // inside the for's iter-expr slot.
+    const char* src =
+        "route GET \"/x\" { inline for server in up.servers { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& for_stmt = ast->items[0].route.statements[0];
+    CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(for_stmt.is_inline);
+    CHECK(for_stmt.name.eq(lit("server")));
+    CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::Field));
+}
+
+TEST(frontend, parse_plain_for_field_access_source) {
     const char* src = "route GET \"/x\" { for server in up.servers { return 200 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -17650,6 +18011,34 @@ TEST(frontend, parse_for_loop_field_access_source) {
     REQUIRE(ast);
     const auto& for_stmt = ast->items[0].route.statements[0];
     CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(!for_stmt.is_inline);
+    CHECK(for_stmt.name.eq(lit("server")));
+    CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::Field));
+}
+
+TEST(frontend, parse_for_field_access_source) {
+    const char* src =
+        "route GET \"/x\" { inline for server in up.servers { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& for_stmt = ast->items[0].route.statements[0];
+    CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(for_stmt.is_inline);
+    CHECK(for_stmt.name.eq(lit("server")));
+    CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::Field));
+}
+
+TEST(frontend, parse_plain_for_loop_field_access_source) {
+    const char* src = "route GET \"/x\" { for server in up.servers { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& for_stmt = ast->items[0].route.statements[0];
+    CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(!for_stmt.is_inline);
     CHECK(for_stmt.name.eq(lit("server")));
     CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::Field));
 }
@@ -17658,13 +18047,15 @@ TEST(frontend, parse_for_loop_multi_stmt_body) {
     // Body with multiple statements — parse_braced_stmt_body returns a Block
     // wrapping them; then_stmt points to that Block.
     const char* src =
-        "route GET \"/x\" { for item in [1, 2] { let n = item guard n > 0 else { return 400 } } "
+        "route GET \"/x\" { inline for item in [1, 2] { let n = item guard n > 0 else { return 400 "
+        "} } "
         "return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     const auto& for_stmt = ast->items[0].route.statements[0];
+    CHECK(for_stmt.is_inline);
     REQUIRE(for_stmt.then_stmt != nullptr);
     CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind), static_cast<u8>(AstStmtKind::Block));
     REQUIRE_EQ(for_stmt.then_stmt->block_stmts.len, 2u);
@@ -17674,13 +18065,108 @@ TEST(frontend, parse_for_loop_multi_stmt_body) {
              static_cast<u8>(AstStmtKind::Guard));
 }
 
-TEST(frontend, analyze_array_lit_at_let_rhs_rejected) {
-    // ArrayLit at let RHS is rejected in analyze because MIR cannot yet
-    // lower array values as constants (no indexing, no const-folded array
-    // locals). Inline `for x in [1,2,3] { ... }` is allowed at analyze
-    // level, but Phase 4a's mir_build also rejects any route with
-    // `for_loops.len > 0` — so no for-loop-bearing program compiles end
-    // to end until Phase 4b implements MIR unroll.
+TEST(frontend, parse_plain_for_without_inline_marker) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2] { let n = item guard n > 0 else { return 400 } } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& for_stmt = ast->items[0].route.statements[0];
+    CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(!for_stmt.is_inline);
+    CHECK(for_stmt.name.eq(lit("item")));
+    CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::ArrayLit));
+    REQUIRE_EQ(for_stmt.expr.args.len, 2u);
+    REQUIRE(for_stmt.then_stmt != nullptr);
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind), static_cast<u8>(AstStmtKind::Block));
+    REQUIRE_EQ(for_stmt.then_stmt->block_stmts.len, 2u);
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->block_stmts[0]->kind),
+             static_cast<u8>(AstStmtKind::Let));
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->block_stmts[1]->kind),
+             static_cast<u8>(AstStmtKind::Guard));
+}
+
+TEST(frontend, parse_for_without_inline_marker) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2] { let n = item guard n > 0 else { return 400 "
+        "} } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& for_stmt = ast->items[0].route.statements[0];
+    CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(for_stmt.is_inline);
+    CHECK(for_stmt.name.eq(lit("item")));
+    CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::ArrayLit));
+    REQUIRE_EQ(for_stmt.expr.args.len, 2u);
+    REQUIRE(for_stmt.then_stmt != nullptr);
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind), static_cast<u8>(AstStmtKind::Block));
+    REQUIRE_EQ(for_stmt.then_stmt->block_stmts.len, 2u);
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->block_stmts[0]->kind),
+             static_cast<u8>(AstStmtKind::Let));
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->block_stmts[1]->kind),
+             static_cast<u8>(AstStmtKind::Guard));
+}
+
+TEST(frontend, parse_plain_for_single_stmt_body) {
+    const char* src = "route GET \"/x\" { for item in [1] { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& for_stmt = ast->items[0].route.statements[0];
+    CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(!for_stmt.is_inline);
+    CHECK(for_stmt.name.eq(lit("item")));
+    CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::ArrayLit));
+    REQUIRE(for_stmt.then_stmt != nullptr);
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind), static_cast<u8>(AstStmtKind::ReturnStatus));
+    CHECK_EQ(for_stmt.then_stmt->status_code, 200u);
+}
+
+TEST(frontend, parse_for_single_stmt_body) {
+    const char* src = "route GET \"/x\" { inline for item in [1] { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& for_stmt = ast->items[0].route.statements[0];
+    CHECK_EQ(static_cast<u8>(for_stmt.kind), static_cast<u8>(AstStmtKind::For));
+    CHECK(for_stmt.is_inline);
+    CHECK(for_stmt.name.eq(lit("item")));
+    CHECK_EQ(static_cast<u8>(for_stmt.expr.kind), static_cast<u8>(AstExprKind::ArrayLit));
+    REQUIRE(for_stmt.then_stmt != nullptr);
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind), static_cast<u8>(AstStmtKind::ReturnStatus));
+    CHECK_EQ(for_stmt.then_stmt->status_code, 200u);
+}
+
+TEST(frontend, parse_plain_for_loop_multi_stmt_body) {
+    // Plain `for` keeps multi-statement block behavior identical to inline.
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2] { let n = item guard n > 0 else { return 400 } } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    const auto& for_stmt = ast->items[0].route.statements[0];
+    CHECK(for_stmt.is_inline == false);
+    REQUIRE(for_stmt.then_stmt != nullptr);
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->kind), static_cast<u8>(AstStmtKind::Block));
+    REQUIRE_EQ(for_stmt.then_stmt->block_stmts.len, 2u);
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->block_stmts[0]->kind),
+             static_cast<u8>(AstStmtKind::Let));
+    CHECK_EQ(static_cast<u8>(for_stmt.then_stmt->block_stmts[1]->kind),
+             static_cast<u8>(AstStmtKind::Guard));
+}
+
+TEST(frontend, analyze_rejects_array_lit_at_route_let_rhs) {
+    // A route-level array `let` is only accepted when used as a later
+    // inlined `for` as static iterable source.
     const char* src = "route GET \"/x\" { let xs: [i32] = [1, 2, 3] return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -17703,8 +18189,19 @@ TEST(frontend, analyze_array_lit_heterogeneous_rejected) {
 }
 
 TEST(frontend, analyze_array_lit_empty_rejected) {
-    // `[]` leaves element type unresolvable with Rutlang's no-push rule.
-    // Contextual inference from annotation is future work; MVP rejects.
+    // Bare `[]` leaves element type unresolvable with Rutlang's no-push rule.
+    const char* src = "route GET \"/x\" { inline for item in [] { return 201 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_rejects_typed_empty_array_at_route_let_rhs) {
+    // Typed empty array `let` at route level is also rejected unless fed to
+    // `for` iteration.
     const char* src = "route GET \"/x\" { let xs: [i32] = [] return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -17714,20 +18211,22 @@ TEST(frontend, analyze_array_lit_empty_rejected) {
     CHECK(!hir);
 }
 
-// NOTE: a former `analyze_array_annotation_type_mismatch_rejected` test used
-// `let xs: [str] = [1, 2, 3]` to exercise `apply_declared_type_to_expr` /
-// `same_hir_type_shape` for Array. That path is unreachable in Phase 3a/3b
-// because any ArrayLit at a let RHS is rejected earlier (see
-// `analyze_array_lit_at_let_rhs_rejected`). The Array-shape comparison path
-// will regain test coverage once Phase 5 adds struct fields / function
-// params typed as `Array<T>`, which route `resolve_func_type_ref` through
-// positions where the ArrayLit-at-let gate doesn't fire first.
+TEST(frontend, analyze_array_annotation_type_mismatch_rejected) {
+    const char* src = "route GET \"/x\" { let xs: [str] = [1, 2, 3] return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
 
 TEST(frontend, analyze_for_loop_terminator_body) {
     // Phase 3b: body is a single `return` terminator. Analyze must produce a
     // HirForLoop on route.for_loops with iter_expr typed Array<I32>, loop_var
     // bound to I32, and body.term populated (has_term = true).
-    const char* src = "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 200 }\n";
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { return 200 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -17750,12 +18249,508 @@ TEST(frontend, analyze_for_loop_terminator_body) {
              static_cast<u8>(HirTerminatorKind::ReturnStatus));
 }
 
+TEST(frontend, analyze_plain_for_loop_terminator_body) {
+    const char* src = "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    const auto& route = hir->routes[0];
+    REQUIRE_EQ(route.for_loops.len, 1u);
+    const auto& fl = route.for_loops[0];
+    CHECK(fl.loop_var_name.eq(lit("item")));
+    CHECK_EQ(static_cast<u8>(fl.loop_var_type), static_cast<u8>(HirTypeKind::I32));
+    CHECK_EQ(static_cast<u8>(fl.iter_expr.type), static_cast<u8>(HirTypeKind::Array));
+    CHECK_EQ(fl.iter_expr.array_len, 3u);
+    CHECK(fl.body.has_term);
+    CHECK_EQ(static_cast<u8>(fl.body.term.kind), static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(fl.body.term.status_code, 200);
+    CHECK_EQ(static_cast<u8>(route.control.direct_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+}
+
+TEST(frontend, analyze_plain_for_static_array_uses_compiler_unroll_path) {
+    const char* src = "route GET \"/x\" { for item in [1, 2] { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK(hir->routes[0].for_loops[0].loop_var_name.eq(lit("item")));
+}
+
+TEST(frontend, analyze_for_static_array_uses_compiler_unroll_path) {
+    const char* src = "route GET \"/x\" { inline for item in [1, 2] { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK(hir->routes[0].for_loops[0].loop_var_name.eq(lit("item")));
+}
+
+TEST(frontend, mir_unrolls_plain_for_from_static_array_alias) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1, 2] let ys = xs for item in ys { guard item > 0 else { "
+        "return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const i32 expected[] = {1, 2};
+    for (u32 i = 0; i < 2; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_from_static_array_alias) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1, 2] let ys = xs inline for item in ys { guard item > 0 "
+        "else { "
+        "return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const i32 expected[] = {1, 2};
+    for (u32 i = 0; i < 2; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_skips_plain_for_from_typed_empty_array_alias) {
+    const char* src =
+        "route GET \"/x\" { let base: [i32] = [] let xs = base for item in xs { return 201 } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].iter_expr.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    if (mir->functions[0].blocks[0].term.status_code != 200u) {
+        const auto msg = std::string("mir status code ") +
+                         std::to_string(mir->functions[0].blocks[0].term.status_code);
+        FAIL(msg.c_str());
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_skips_for_from_typed_empty_array_alias) {
+    const char* src =
+        "route GET \"/x\" { let base: [i32] = [] let xs = base inline for item in xs { return 201 "
+        "} "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].iter_expr.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    if (mir->functions[0].blocks[0].term.status_code != 200u) {
+        const auto msg = std::string("mir status code ") +
+                         std::to_string(mir->functions[0].blocks[0].term.status_code);
+        FAIL(msg.c_str());
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_rejects_static_array_alias_outside_for_iter) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1] guard xs == xs else { return 400 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_guard_fail_body_local_scoped_to_fail_body) {
+    const char* src =
+        "route GET \"/x\" { guard false else { let hidden = 1 return 400 } "
+        "guard hidden == 1 else { return 401 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, mir_for_loop_wildcard_only_match_enters_prelude_guard) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case _: { guard false else { "
+        "return 400 } return 200 } } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 4u);
+    const auto& entry = mir->functions[0].blocks[0].term;
+    CHECK_EQ(static_cast<u8>(entry.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(entry.then_block, 1u);
+    const auto& guard = mir->functions[0].blocks[1].term;
+    CHECK_EQ(static_cast<u8>(guard.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(guard.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 400u);
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_wildcard_only_match_enters_prelude_guard) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case _: { guard false else { return 400 "
+        "} "
+        "return 200 } } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 4u);
+    const auto& entry = mir->functions[0].blocks[0].term;
+    CHECK_EQ(static_cast<u8>(entry.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(entry.then_block, 1u);
+    const auto& guard = mir->functions[0].blocks[1].term;
+    CHECK_EQ(static_cast<u8>(guard.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(guard.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 400u);
+}
+
+TEST(frontend, mir_unrolls_for_loop_wildcard_only_match_enters_prelude_guard) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case _: { guard false else { "
+        "return 400 } "
+        "return 200 } } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 4u);
+    const auto& entry = mir->functions[0].blocks[0].term;
+    CHECK_EQ(static_cast<u8>(entry.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(entry.then_block, 1u);
+    const auto& guard = mir->functions[0].blocks[1].term;
+    CHECK_EQ(static_cast<u8>(guard.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(guard.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 400u);
+}
+
+TEST(frontend, mir_for_loop_wildcard_fallthrough_enters_prelude_guard) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [2] { match item { case 1: return 201 case _: { "
+        "guard false else { return 400 } return 200 } } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const auto& entry = mir->functions[0].blocks[0].term;
+    CHECK_EQ(static_cast<u8>(entry.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(entry.else_block, 1u);
+    const auto& guard = mir->functions[0].blocks[1].term;
+    CHECK_EQ(static_cast<u8>(guard.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(guard.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 400u);
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_wildcard_fallthrough_enters_prelude_guard) {
+    const char* src =
+        "route GET \"/x\" { for item in [2] { match item { case 1: return 201 case _: { "
+        "guard false else { return 400 } return 200 } } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const auto& entry = mir->functions[0].blocks[0].term;
+    CHECK_EQ(static_cast<u8>(entry.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(entry.else_block, 1u);
+    const auto& guard = mir->functions[0].blocks[1].term;
+    CHECK_EQ(static_cast<u8>(guard.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(guard.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 400u);
+}
+
+TEST(frontend, mir_unrolls_for_loop_wildcard_fallthrough_enters_prelude_guard) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [2] { match item { case 1: return 201 case _: { "
+        "guard false else { return 400 } return 200 } } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const auto& entry = mir->functions[0].blocks[0].term;
+    CHECK_EQ(static_cast<u8>(entry.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(entry.else_block, 1u);
+    const auto& guard = mir->functions[0].blocks[1].term;
+    CHECK_EQ(static_cast<u8>(guard.kind), static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(guard.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 400u);
+}
+
+TEST(frontend, analyze_for_loop_body_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { let ok: bool = error(.timeout) inline for item in [1] { if ok { "
+        "return 200 } else { return 400 } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_body_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { let ok: bool = error(.timeout) for item in [1] { if ok { "
+        "return 200 } else { return 400 } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_body_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { let ok: bool = error(.timeout) for item in [1] { if ok { return 200 } "
+        "else { return 400 } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_body_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { let ok: bool = error(.timeout) inline for item in [1] { if ok { return "
+        "200 } "
+        "else { return 400 } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_match_arm_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { let ok: bool = error(.timeout) inline for item in [1] { match item { "
+        "case _: if ok { return 200 } else { return 400 } } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_match_arm_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { let ok: bool = error(.timeout) for item in [1] { match item { "
+        "case _: if ok { return 200 } else { return 400 } } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_match_arm_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { let ok: bool = error(.timeout) for item in [1] { match item { "
+        "case _: if ok { return 200 } else { return 400 } } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_match_arm_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { let ok: bool = error(.timeout) inline for item in [1] { match item { "
+        "case _: if ok { return 200 } else { return 400 } } } return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_nested_match_arm_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let ok: bool = error(.timeout) match item { "
+        "case 1: match item { case 1: if ok { return 200 } else { return 400 } case _: return 404 "
+        "} "
+        "case _: return 204 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_nested_match_arm_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let ok: bool = error(.timeout) match item { "
+        "case 1: match item { case 1: if ok { return 200 } else { return 400 } case _: return 404 "
+        "} "
+        "case _: return 204 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_nested_match_arm_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let ok: bool = error(.timeout) match item { "
+        "case 1: match item { case 1: if ok { return 200 } else { return 400 } case _: return 404 "
+        "} "
+        "case _: return 204 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_nested_match_arm_if_rejects_fallible_bool) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let ok: bool = error(.timeout) match item { "
+        "case 1: match item { case 1: if ok { return 200 } else { return 400 } case _: return 404 "
+        "} "
+        "case _: return 204 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
 TEST(frontend, analyze_for_loop_guard_body) {
     // Canonical Phase 3b use: iterate an allowlist-style array with a guard
     // that short-circuits the handler. The loop var (`n`) must be in scope
     // inside the guard's condition.
     const char* src =
-        "route GET \"/x\" { for n in [1, 2, 3] { guard n > 0 else { return 400 } } return 200 }\n";
+        "route GET \"/x\" { inline for n in [1, 2, 3] { guard n > 0 else { return 400 } } return "
+        "200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -17774,7 +18769,43 @@ TEST(frontend, analyze_for_loop_guard_body) {
     CHECK(!fl.body.has_term);
 }
 
+TEST(frontend, analyze_plain_for_loop_guard_body) {
+    // Same guard-only shape as inline form, but using plain `for`.
+    const char* src =
+        "route GET \"/x\" { for n in [1, 2, 3] { guard n > 0 else { return 400 } } return "
+        "200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    const auto& route = hir->routes[0];
+    REQUIRE_EQ(route.for_loops.len, 1u);
+    const auto& fl = route.for_loops[0];
+    CHECK(fl.loop_var_name.eq(lit("n")));
+    REQUIRE_EQ(fl.body.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(fl.body.guards[0].fail_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(fl.body.guards[0].fail_term.status_code, 400);
+    CHECK(!fl.body.has_term);
+}
+
 TEST(frontend, analyze_for_loop_var_scoped_to_body) {
+    // The loop variable must NOT leak to code after the for-loop. Writing
+    // `item` in a post-loop let should fail to resolve (Ident unknown).
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { return 200 } "
+        "let x = item return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_var_scoped_to_body) {
     // The loop variable must NOT leak to code after the for-loop. Writing
     // `item` in a post-loop let should fail to resolve (Ident unknown).
     const char* src =
@@ -17788,7 +18819,64 @@ TEST(frontend, analyze_for_loop_var_scoped_to_body) {
     CHECK(!hir);
 }
 
+TEST(frontend, analyze_plain_for_var_scoped_to_body) {
+    // `item` bound by plain `for` must remain inaccessible after the loop body.
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { return 200 } let x = item return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_var_scoped_to_body) {
+    // The loop variable must NOT leak to code after the for-loop. Writing
+    // `item` in a post-loop let should fail to resolve (Ident unknown).
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { return 200 } "
+        "let x = item return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_iter_not_array_rejected) {
+    const char* src = "route GET \"/x\" { for item in 42 { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_iter_not_array_rejected) {
+    const char* src = "route GET \"/x\" { inline for item in 42 { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
 TEST(frontend, analyze_for_loop_iter_not_array_rejected) {
+    // Iter source must be Array<T>; iterating a scalar is a type error.
+    const char* src = "route GET \"/x\" { inline for item in 42 { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_iter_not_array_rejected) {
     // Iter source must be Array<T>; iterating a scalar is a type error.
     const char* src = "route GET \"/x\" { for item in 42 { return 200 } return 200 }\n";
     auto lexed = lex(lit(src));
@@ -17797,6 +18885,122 @@ TEST(frontend, analyze_for_loop_iter_not_array_rejected) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     CHECK(!hir);
+}
+
+TEST(frontend, analyze_rejects_non_static_for_loop_iter) {
+    const char* src =
+        "func make() -> [i32] => [1, 2, 3]\n"
+        "route GET \"/x\" { inline for item in make() { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_plain_for_rejects_non_static_for_loop_iter) {
+    const char* src =
+        "func make() -> [i32] => [1, 2, 3]\n"
+        "route GET \"/x\" { for item in make() { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_for_rejects_non_static_for_loop_iter) {
+    const char* src =
+        "func make() -> [i32] => [1, 2, 3]\n"
+        "route GET \"/x\" { inline for item in make() { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_non_static_for_loop_iter_via_alias_chain) {
+    const char* src =
+        "func make() -> [i32] => [1, 2, 3]\n"
+        "route GET \"/x\" { let xs = make() let ys = xs inline for item in ys { return 200 } "
+        "return "
+        "200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_plain_for_rejects_non_static_for_loop_iter_via_alias_chain) {
+    const char* src =
+        "func make() -> [i32] => [1, 2, 3]\n"
+        "route GET \"/x\" { let xs = make() let ys = xs for item in ys { return 200 } return "
+        "200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_for_rejects_non_static_for_loop_iter_via_alias_chain) {
+    const char* src =
+        "func make() -> [i32] => [1, 2, 3]\n"
+        "route GET \"/x\" { let xs = make() let ys = xs inline for item in ys { return 200 } "
+        "return "
+        "200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_field_access_for_loop_iter) {
+    const char* src =
+        "struct Upstream { servers: [i32] }\n"
+        "route GET \"/x\" { let up = Upstream(servers: [1, 2, 3]) inline for server in up.servers "
+        "{ return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_plain_for_rejects_field_access_for_loop_iter) {
+    const char* src =
+        "struct Upstream { servers: [i32] }\n"
+        "route GET \"/x\" { let up = Upstream(servers: [1, 2, 3]) for server in up.servers "
+        "{ return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_for_rejects_field_access_for_loop_iter) {
+    const char* src =
+        "struct Upstream { servers: [i32] }\n"
+        "route GET \"/x\" { let up = Upstream(servers: [1, 2, 3]) inline for server in up.servers "
+        "{ return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
 }
 
 TEST(frontend, mir_unrolls_for_loop_scope_a_basic) {
@@ -17808,7 +19012,7 @@ TEST(frontend, mir_unrolls_for_loop_scope_a_basic) {
     //   block[4..6] = fail blocks (`return 400` from the body guard's else)
     // Total: 7 blocks.
     const char* src =
-        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else "
+        "route GET \"/x\" { inline for item in [1, 2, 3] { guard item > 0 else "
         "{ return 400 } } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -17822,15 +19026,86 @@ TEST(frontend, mir_unrolls_for_loop_scope_a_basic) {
     CHECK_EQ(mir->functions[0].blocks.len, 7u);
 }
 
+TEST(frontend, mir_unrolls_plain_for_loop_scope_a_basic) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else { return 400 } } return "
+        "200 "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].blocks.len, 7u);
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_into_route_if_control) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2] { guard item > 0 else { return 400 } } "
+        "if true { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.cond.kind),
+             static_cast<u8>(MirValueKind::BoolConst));
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 200u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 500u);
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_into_route_match_control) {
+    const char* src =
+        "route GET \"/x\" { let path = \"/x\" for item in [1, 2] { guard item > 0 else "
+        "{ return 400 } } match path { case \"/x\": return 200 case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK(mir->functions[0].blocks[2].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 200u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+}
+
 TEST(frontend, mir_unrolls_for_loop_substitutes_element_in_cond) {
     // The heart of the unroll: each iteration's virtual guard should test
     // the element value directly, not a LocalRef to the loop variable.
-    // For `for item in [1, 2, 3] { guard item > 0 ...}`, block[0].term.cond
+    // For `inline for item in [1, 2, 3] { guard item > 0 ...}`, block[0].term.cond
     // must be Gt with lhs = IntConst(1), block[1] lhs = IntConst(2),
     // block[2] lhs = IntConst(3). A regression that forgets to substitute
     // would leave lhs as a LocalRef to the loop var's synthetic init.
     const char* src =
-        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else "
+        "route GET \"/x\" { inline for item in [1, 2, 3] { guard item > 0 else "
         "{ return 400 } } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -17851,11 +19126,95 @@ TEST(frontend, mir_unrolls_for_loop_substitutes_element_in_cond) {
     }
 }
 
-TEST(frontend, mir_rejects_for_loop_with_body_terminator) {
-    // Scope A excludes body terminators (iteration 0 would short-circuit
-    // unconditionally, making later iterations dead). Analyze accepts this
-    // shape (Phase 3b), but MIR rejects until Scope B. Assertion: MIR fails
-    // cleanly instead of silently dropping the loop.
+TEST(frontend, mir_unrolls_for_substitutes_element_in_cond) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { guard item > 0 else { return 400 } } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_plain_for_substitutes_element_in_cond) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else { return 400 } } return "
+        "200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_substitutes_element_in_cond) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else { return 400 } } return "
+        "200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_for_loop_with_body_terminator) {
+    // A body terminator exits the route during the first iteration, so later
+    // iterations are unreachable under normal loop semantics.
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { return 200 } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_with_body_terminator) {
     const char* src = "route GET \"/x\" { for item in [1, 2, 3] { return 200 } return 500 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -17864,7 +19223,68 @@ TEST(frontend, mir_rejects_for_loop_with_body_terminator) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     auto mir = build_mir_heap(hir.value());
-    CHECK(!mir);
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+}
+
+TEST(frontend, mir_unrolls_for_loop_guard_before_body_terminator) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { guard item > 0 else "
+        "{ return 400 } return 200 } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    REQUIRE(mir->functions[0].blocks[0].term.cond.lhs != nullptr);
+    CHECK_EQ(mir->functions[0].blocks[0].term.cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    CHECK_EQ(mir->functions[0].blocks[1].term.status_code, 200u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 400u);
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_guard_before_body_terminator) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else { return 400 } return 200 "
+        "} "
+        "return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    REQUIRE(mir->functions[0].blocks[0].term.cond.lhs != nullptr);
+    CHECK_EQ(mir->functions[0].blocks[0].term.cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    CHECK_EQ(mir->functions[0].blocks[1].term.status_code, 200u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 400u);
 }
 
 TEST(frontend, mir_for_loop_lowers_through_rir_without_synthetic_local) {
@@ -17877,7 +19297,7 @@ TEST(frontend, mir_for_loop_lowers_through_rir_without_synthetic_local) {
     // zero locals (the only HIR local was the loop var, which must have
     // been skipped).
     const char* src =
-        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else "
+        "route GET \"/x\" { inline for item in [1, 2, 3] { guard item > 0 else "
         "{ return 400 } } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -17895,13 +19315,668 @@ TEST(frontend, mir_for_loop_lowers_through_rir_without_synthetic_local) {
     rir.destroy();
 }
 
+TEST(frontend, mir_unrolls_plain_for_loop_lowers_through_rir_without_synthetic_local) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { guard item > 0 else { return 400 } } return "
+        "200 "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_lowers_through_rir_without_synthetic_local) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { guard item > 0 else { return 400 } } "
+        "return 200 "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_from_array_local) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1, 2, 3] inline for item in xs { guard item > 0 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].name.eq(lit("xs")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Array));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_from_array_local) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1, 2, 3] for item in xs { guard item > 0 else { return 400 } "
+        "} return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].name.eq(lit("xs")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].type), static_cast<u8>(HirTypeKind::Array));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_from_array_local_alias) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1, 2, 3] let ys = xs inline for item in ys { guard item > "
+        "0 else { return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].name.eq(lit("ys")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_from_array_local_alias) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1, 2, 3] let ys = xs for item in ys { guard item > 0 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].name.eq(lit("ys")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_over_struct_array_field_access) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "route GET \"/x\" { let boxes = [Box(value: 1), Box(value: 2)] inline for box in boxes { "
+        "guard box.value > 0 else { return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(hir->routes[0].for_loops[0].loop_var_type, HirTypeKind::Struct);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    for (u32 i = 0; i < 2; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::Field));
+        REQUIRE(cond.lhs->lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->lhs->kind), static_cast<u8>(MirValueKind::StructInit));
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_over_struct_array_field_access) {
+    const char* src =
+        "struct Box { value: i32 }\n"
+        "route GET \"/x\" { let boxes = [Box(value: 1), Box(value: 2)] for box in boxes { "
+        "guard box.value > 0 else { return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(hir->routes[0].for_loops[0].loop_var_type, HirTypeKind::Struct);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    for (u32 i = 0; i < 2; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::Field));
+        REQUIRE(cond.lhs->lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->lhs->kind), static_cast<u8>(MirValueKind::StructInit));
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_over_variant_array_match) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for state in [Result.ok(1)] { match state { case .ok(code): "
+        "return 201 case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(hir->routes[0].for_loops[0].loop_var_type, HirTypeKind::Variant);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.lhs.kind),
+             static_cast<u8>(MirValueKind::VariantCase));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.rhs.kind),
+             static_cast<u8>(MirValueKind::VariantCase));
+    CHECK_EQ(mir->functions[0].blocks[1].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_over_variant_array_match) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for state in [Result.ok(1)] { match state { case .ok(code): "
+        "return 201 case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(hir->routes[0].for_loops[0].loop_var_type, HirTypeKind::Variant);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.lhs.kind),
+             static_cast<u8>(MirValueKind::VariantCase));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.rhs.kind),
+             static_cast<u8>(MirValueKind::VariantCase));
+    CHECK_EQ(mir->functions[0].blocks[1].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_over_tuple_array_pipe_slots) {
+    const char* src =
+        "func second(a: i32, b: i32) -> i32 => b\n"
+        "route GET \"/x\" { inline for pair in [(200, 1), (200, 2)] { let code = pair | "
+        "second(_2, _1) guard code == 200 else { return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(hir->routes[0].for_loops[0].loop_var_type, HirTypeKind::Tuple);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    for (u32 i = 0; i < 2; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Eq));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::TupleSlot));
+        REQUIRE(cond.lhs->lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->lhs->kind), static_cast<u8>(MirValueKind::Tuple));
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_over_tuple_array_pipe_slots) {
+    const char* src =
+        "func second(a: i32, b: i32) -> i32 => b\n"
+        "route GET \"/x\" { for pair in [(200, 1), (200, 2)] { let code = pair | "
+        "second(_2, _1) guard code == 200 else { return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(hir->routes[0].for_loops[0].loop_var_type, HirTypeKind::Tuple);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    for (u32 i = 0; i < 2; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Eq));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::TupleSlot));
+        REQUIRE(cond.lhs->lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->lhs->kind), static_cast<u8>(MirValueKind::Tuple));
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_skips_zero_iteration_for_loop_from_typed_empty_array) {
+    const char* src =
+        "route GET \"/x\" { let xs: [i32] = [] inline for item in xs { return 201 } return 200 "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(hir->routes[0].for_loops[0].iter_expr.array_len, 0u);
+    CHECK(hir->routes[0].for_loops[0].body.has_term);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    if (mir->functions[0].blocks[0].term.status_code != 200u) {
+        const auto msg = std::string("mir status code ") +
+                         std::to_string(mir->functions[0].blocks[0].term.status_code);
+        FAIL(msg.c_str());
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_skips_zero_iteration_plain_for_loop_from_typed_empty_array) {
+    const char* src =
+        "route GET \"/x\" { let xs: [i32] = [] for item in xs { return 201 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(hir->routes[0].for_loops[0].iter_expr.array_len, 0u);
+    CHECK(hir->routes[0].for_loops[0].body.has_term);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    if (mir->functions[0].blocks[0].term.status_code != 200u) {
+        const auto msg = std::string("mir status code ") +
+                         std::to_string(mir->functions[0].blocks[0].term.status_code);
+        FAIL(msg.c_str());
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_from_array_local_alias_chain) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1, 2, 3] let ys = xs let zs = ys inline for item in zs { "
+        "guard "
+        "item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(hir->routes[0].locals[2].name.eq(lit("zs")), true);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[2].init.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_from_array_local_alias_chain) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1, 2, 3] let ys = xs let zs = ys for item in zs { guard "
+        "item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(hir->routes[0].locals[2].name.eq(lit("zs")), true);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[2].init.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_skips_zero_iteration_plain_for_loop_from_typed_empty_array_alias) {
+    const char* src =
+        "route GET \"/x\" { let base: [i32] = [] let xs = base for item in xs { return 201 } "
+        "return "
+        "200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].iter_expr.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    CHECK_EQ(mir->functions[0].blocks[0].term.status_code, 200u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_skips_zero_iteration_for_loop_from_typed_empty_array_alias) {
+    const char* src =
+        "route GET \"/x\" { let base: [i32] = [] let xs = base inline for item in xs { return "
+        "201 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].iter_expr.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+    CHECK_EQ(mir->functions[0].blocks[0].term.status_code, 200u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_multiple_for_loops) {
+    const char* src =
+        "route GET \"/x\" { "
+        "inline for a in [1, 2] { guard a > 0 else { return 400 } } "
+        "inline for b in [3, 4] { guard b > 0 else { return 401 } } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 9u);
+    const i32 expected[] = {1, 2, 3, 4};
+    for (u32 i = 0; i < 4; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_multiple_for_loops) {
+    const char* src =
+        "route GET \"/x\" { "
+        "for a in [1, 2] { guard a > 0 else { return 400 } } "
+        "for b in [3, 4] { guard b > 0 else { return 401 } } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 9u);
+    const i32 expected[] = {1, 2, 3, 4};
+    for (u32 i = 0; i < 4; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_multiple_for_loops) {
+    const char* src =
+        "route GET \"/x\" { "
+        "inline for a in [1, 2] { guard a > 0 else { return 400 } } "
+        "inline for b in [3, 4] { guard b > 0 else { return 401 } } "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].locals.len, 0u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 9u);
+    const i32 expected[] = {1, 2, 3, 4};
+    for (u32 i = 0; i < 4; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
 TEST(frontend, mir_rejects_for_loop_exceeding_block_budget) {
     // A Scope-A-shape program (one for-loop, body guards only, Direct
     // control, no route guards) that unrolls to more than MirFunction::
-    // kMaxBlocks (16) blocks must reject cleanly at the for-loop span
+    // kMaxBlocks (16) blocks must reject cleanly at the overflowing step span
     // rather than fail mid-emission with a TooManyItems buried inside a
     // later `fn.blocks.push`. N=8, M=1 → 2T+1 = 17 > 16. Analyze accepts
     // this shape (kMaxArgs=8), so the reject must live in MIR's pre-check.
+    const char* src =
+        "route GET \"/x\" { inline for n in [1, 2, 3, 4, 5, 6, 7, 8] { "
+        "guard n > 0 else { return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(!mir);
+    CHECK_EQ(mir.error().code, FrontendError::TooManyItems);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 1u);
+    CHECK_EQ(mir.error().span.start, hir->routes[0].for_loops[0].body.guards[0].span.start);
+}
+
+TEST(frontend, mir_rejects_plain_for_loop_exceeding_block_budget) {
     const char* src =
         "route GET \"/x\" { for n in [1, 2, 3, 4, 5, 6, 7, 8] { "
         "guard n > 0 else { return 400 } } return 200 }\n";
@@ -17912,15 +19987,22 @@ TEST(frontend, mir_rejects_for_loop_exceeding_block_budget) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     auto mir = build_mir_heap(hir.value());
-    CHECK(!mir);
+    REQUIRE(!mir);
+    CHECK_EQ(mir.error().code, FrontendError::TooManyItems);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 1u);
+    CHECK_EQ(mir.error().span.start, hir->routes[0].for_loops[0].body.guards[0].span.start);
 }
 
-TEST(frontend, mir_rejects_for_loop_with_route_level_guard) {
-    // Scope A excludes routes that mix for-loops with sibling route-level
-    // guards (span-ordered interleaving is deferred to Scope C).
+TEST(frontend, mir_unrolls_for_loop_with_route_level_guard) {
+    // Route-level guards and for-loop guards are emitted as one
+    // source-ordered guard chain. For one route guard plus three virtual
+    // loop guards, lowering produces:
+    //   block[0..3] = guard chain
+    //   block[4]    = route terminal
+    //   block[5..8] = one fail block per guard
     const char* src =
         "route GET \"/x\" { guard true else { return 403 } "
-        "for item in [1, 2, 3] { guard item > 0 else { return 400 } } "
+        "inline for item in [1, 2, 3] { guard item > 0 else { return 400 } } "
         "return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -17929,7 +20011,245 @@ TEST(frontend, mir_rejects_for_loop_with_route_level_guard) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     auto mir = build_mir_heap(hir.value());
-    CHECK(!mir);
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].blocks.len, 9u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.cond.kind),
+             static_cast<u8>(MirValueKind::BoolConst));
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i + 1].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_with_route_level_guard) {
+    // Same guard-chain ordering as inline form, but with plain `for`.
+    const char* src =
+        "route GET \"/x\" { guard true else { return 403 } for item in [1, 2, 3] { guard item > "
+        "0 else { return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].blocks.len, 9u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.cond.kind),
+             static_cast<u8>(MirValueKind::BoolConst));
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i + 1].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_for_loop_before_later_route_level_guard) {
+    // The mixed chain is sorted by source span, so a route guard after the
+    // loop runs after every virtual loop guard.
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2] { guard item > 0 else { return 400 } } "
+        "guard true else { return 403 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.cond.kind),
+             static_cast<u8>(MirValueKind::BoolConst));
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_before_later_route_level_guard) {
+    // Guard ordering is sorted by source span even with plain `for`.
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2] { guard item > 0 else { return 400 } } "
+        "guard true else { return 403 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    CHECK_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.cond.kind),
+             static_cast<u8>(MirValueKind::BoolConst));
+}
+
+TEST(frontend, mir_unrolls_for_loop_into_route_if_control) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2] { guard item > 0 else { return 400 } } "
+        "if true { return 200 } else { return 500 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.cond.kind),
+             static_cast<u8>(MirValueKind::BoolConst));
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 200u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 500u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_into_route_match_control) {
+    const char* src =
+        "route GET \"/x\" { let path = \"/x\" inline for item in [1, 2] { guard item > 0 else "
+        "{ return 400 } } match path { case \"/x\": return 200 case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK(mir->functions[0].blocks[2].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 200u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_into_route_match_arm_guard) {
+    const char* src =
+        "route GET \"/x\" { let path = \"/x\" let allow = true inline for item in [1, 2] { guard "
+        "item > 0 else { return 400 } } match path { case \"/x\" if allow: return 200 case _: "
+        "return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_into_route_match_arm_guard) {
+    const char* src =
+        "route GET \"/x\" { let path = \"/x\" let allow = true for item in [1, 2] { guard "
+        "item > 0 else { return 400 } } match path { case \"/x\" if allow: return 200 case _: "
+        "return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK(hir->routes[0].control.match_arms[0].has_arm_guard);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_into_route_match_arm_if_body) {
+    const char* src =
+        "route GET \"/x\" { let path = \"/x\" let allow = true inline for item in [1, 2] { guard "
+        "item > 0 else { return 400 } } match path { case \"/x\": if allow { return 200 } else { "
+        "return 201 } case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].body_kind),
+             static_cast<u8>(HirMatchArm::BodyKind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_into_route_match_arm_if_body) {
+    const char* src =
+        "route GET \"/x\" { let path = \"/x\" let allow = true for item in [1, 2] { guard "
+        "item > 0 else { return 400 } } match path { case \"/x\": if allow { return 200 } else { "
+        "return 201 } case _: return 404 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].control.match_arms.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.match_arms[0].body_kind),
+             static_cast<u8>(HirMatchArm::BodyKind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
 }
 
 TEST(frontend, analyze_array_lit_at_nested_let_rhs_rejected) {
@@ -17967,7 +20287,48 @@ TEST(frontend, analyze_for_loop_rejects_guard_after_terminator) {
     // of the already-fired return. Analyze rejects to preserve source
     // semantics until lowering is order-aware.
     const char* src =
+        "route GET \"/x\" { inline for x in [1] { return 200 guard x > 0 else "
+        "{ return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_rejects_guard_after_terminator) {
+    // HirForLoopBody stores guards and terminator in separate fields (no
+    // source-ordered stmt list), so accepting a guard after a terminator
+    // would let MIR unroll silently reorder an unreachable guard in front
+    // of the already-fired return. Analyze rejects to preserve source
+    // semantics until lowering is order-aware.
+    const char* src =
         "route GET \"/x\" { for x in [1] { return 200 guard x > 0 else "
+        "{ return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_rejects_guard_after_terminator) {
+    const char* src =
+        "route GET \"/x\" { for x in [1] { return 200 guard x > 0 else "
+        "{ return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_rejects_guard_after_terminator) {
+    const char* src =
+        "route GET \"/x\" { inline for x in [1] { return 200 guard x > 0 else "
         "{ return 400 } } return 500 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -17983,6 +20344,22 @@ TEST(frontend, analyze_for_loop_rejects_shadowing_outer_local) {
     // binding win in the body — producing wrong guard behavior under MIR
     // unroll. Analyze rejects the collision outright.
     const char* src =
+        "route GET \"/x\" { let item = 1 inline for item in [2, 3] { guard item > 1 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_rejects_shadowing_outer_local) {
+    // Ident resolution scans route.locals by name from index 0 upward, so a
+    // loop var that shares its name with an outer local would let the outer
+    // binding win in the body — producing wrong guard behavior under MIR
+    // unroll. Analyze rejects the collision outright.
+    const char* src =
         "route GET \"/x\" { let item = 1 for item in [2, 3] { guard item > 1 else "
         "{ return 400 } } return 200 }\n";
     auto lexed = lex(lit(src));
@@ -17993,12 +20370,3990 @@ TEST(frontend, analyze_for_loop_rejects_shadowing_outer_local) {
     CHECK(!hir);
 }
 
-TEST(frontend, analyze_for_loop_rejects_let_in_body) {
-    // Phase 3b MVP: body allows `guard*` + optional terminator. A nested let
-    // inside the body is an explicit scope restriction — future phases may
-    // relax this, but for now we fail loudly.
+TEST(frontend, analyze_plain_for_rejects_shadowing_outer_local) {
     const char* src =
-        "route GET \"/x\" { for item in [1, 2, 3] { let y = 7 return 200 } return 200 }\n";
+        "route GET \"/x\" { let item = 1 for item in [2, 3] { guard item > 1 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_rejects_shadowing_outer_local) {
+    const char* src =
+        "route GET \"/x\" { let item = 1 inline for item in [2, 3] { guard item > 1 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_let) {
+    // Body-local lets are expanded per iteration and can feed later guards.
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { let n = item guard n > 0 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    CHECK(hir->routes[0].for_loops[0].body.locals[0].name.eq(lit("n")));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_let) {
+    // Body-local lets are expanded per iteration and can feed later guards.
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { let n = item guard n > 0 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    CHECK(hir->routes[0].for_loops[0].body.locals[0].name.eq(lit("n")));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_allows_for_loop_body_let_only_as_noop) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { let n = item } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.steps.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[0].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::Let));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+}
+
+TEST(frontend, mir_allows_plain_for_loop_body_let_only_as_noop) {
+    const char* src = "route GET \"/x\" { for item in [1, 2, 3] { let n = item } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.steps.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[0].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::Let));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::ReturnStatus));
+}
+
+TEST(frontend, analyze_for_loop_body_local_named_error_gets_hidden_variant) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let failed = error(.timeout) } return 200 "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 1u);
+    CHECK(hir->variants[0].name.eq(lit("__error_route")));
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    const auto& local = hir->routes[0].for_loops[0].body.locals[0];
+    CHECK_EQ(local.error_variant_index, 0u);
+    CHECK_EQ(local.init.error_variant_index, 0u);
+    CHECK_EQ(local.init.error_case_index, 0u);
+}
+
+TEST(frontend, analyze_plain_for_loop_body_local_named_error_gets_hidden_variant) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let failed = error(.timeout) } return 200 "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 1u);
+    CHECK(hir->variants[0].name.eq(lit("__error_route")));
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    const auto& local = hir->routes[0].for_loops[0].body.locals[0];
+    CHECK_EQ(local.error_variant_index, 0u);
+    CHECK_EQ(local.init.error_variant_index, 0u);
+    CHECK_EQ(local.init.error_case_index, 0u);
+}
+
+TEST(frontend, analyze_plain_for_body_local_named_error_gets_hidden_variant) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let failed = error(.timeout) } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 1u);
+    CHECK(hir->variants[0].name.eq(lit("__error_route")));
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    const auto& local = hir->routes[0].for_loops[0].body.locals[0];
+    CHECK_EQ(local.error_variant_index, 0u);
+}
+
+TEST(frontend, analyze_for_body_local_named_error_gets_hidden_variant) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let failed = error(.timeout) } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->variants.len, 1u);
+    CHECK(hir->variants[0].name.eq(lit("__error_route")));
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    const auto& local = hir->routes[0].for_loops[0].body.locals[0];
+    CHECK_EQ(local.error_variant_index, 0u);
+    CHECK_EQ(local.init.error_variant_index, 0u);
+    CHECK_EQ(local.init.error_case_index, 0u);
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_let_chain) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { let n = item let m = n guard m > 0 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_let_chain) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { let n = item let m = n guard m > 0 else "
+        "{ return 400 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+    }
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_guard_let) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2, 3] { guard let n = item else { return 400 } guard n "
+        "> 0 "
+        "else { return 401 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 2u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.steps.len, 3u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[0].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::Guard));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[1].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::Let));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[2].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::Guard));
+    CHECK(hir->routes[0].for_loops[0].body.locals[0].name.eq(lit("n")));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 13u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& bind_cond = mir->functions[0].blocks[i * 2].term.cond;
+        CHECK_EQ(static_cast<u8>(bind_cond.kind), static_cast<u8>(MirValueKind::BoolConst));
+        CHECK(bind_cond.bool_value);
+
+        const auto& guard_cond = mir->functions[0].blocks[i * 2 + 1].term.cond;
+        CHECK_EQ(static_cast<u8>(guard_cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(guard_cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(guard_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(guard_cond.lhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_if_with_body_local_cond) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2] { let n = item if n > 0 { return 201 } else { "
+        "return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.ifs.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.steps.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[1].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    const auto& cond = mir->functions[0].blocks[0].term.cond;
+    CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 402u);
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_with_body_local_subject) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2] { let n = item match n { case 1: return 201 case _: "
+        "return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.steps.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[1].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.lhs.kind),
+             static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(mir->functions[0].blocks[0].term.lhs.int_value, 1);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.rhs.kind),
+             static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(mir->functions[0].blocks[0].term.rhs.int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_guard_let) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2, 3] { guard let n = item else "
+        "{ return 400 } guard n > 0 else { return 401 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 2u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.steps.len, 3u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[0].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::Guard));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[1].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::Let));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[2].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::Guard));
+    CHECK(hir->routes[0].for_loops[0].body.locals[0].name.eq(lit("n")));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 13u);
+    const i32 expected[] = {1, 2, 3};
+    for (u32 i = 0; i < 3; i++) {
+        const auto& bind_cond = mir->functions[0].blocks[i * 2].term.cond;
+        CHECK_EQ(static_cast<u8>(bind_cond.kind), static_cast<u8>(MirValueKind::BoolConst));
+        CHECK(bind_cond.bool_value);
+
+        const auto& guard_cond = mir->functions[0].blocks[i * 2 + 1].term.cond;
+        CHECK_EQ(static_cast<u8>(guard_cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(guard_cond.lhs != nullptr);
+        CHECK_EQ(static_cast<u8>(guard_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(guard_cond.lhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_guard_fail_if_with_loop_var) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { guard item < 0 else { if item > 0 "
+        "{ return 401 } else { return 402 } } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.guards[0].fail_kind),
+             static_cast<u8>(HirGuard::FailKind::Body));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    const auto& fail_cond = mir->functions[0].blocks[2].term.cond;
+    CHECK_EQ(static_cast<u8>(fail_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(fail_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(fail_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(fail_cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 401u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_guard_fail_if_with_loop_var) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { guard item < 0 else { if item > 0 "
+        "{ return 401 } else { return 402 } } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.guards[0].fail_kind),
+             static_cast<u8>(HirGuard::FailKind::Body));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    const auto& fail_cond = mir->functions[0].blocks[2].term.cond;
+    CHECK_EQ(static_cast<u8>(fail_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(fail_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(fail_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(fail_cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 401u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_guard_fail_block_let) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { guard item < 0 else { let code = item if code "
+        "> 0 { return 401 } else { return 402 } } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards[0].fail_body.locals.len, 1u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    const auto& fail_cond = mir->functions[0].blocks[2].term.cond;
+    CHECK_EQ(static_cast<u8>(fail_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(fail_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(fail_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(fail_cond.lhs->int_value, 1);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_guard_fail_block_let) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { guard item < 0 else { let code = item if code "
+        "> 0 { return 401 } else { return 402 } } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards[0].fail_body.locals.len, 1u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    const auto& fail_cond = mir->functions[0].blocks[2].term.cond;
+    CHECK_EQ(static_cast<u8>(fail_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(fail_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(fail_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(fail_cond.lhs->int_value, 1);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_if_with_body_local_cond) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2] { let n = item if n > 0 { return 201 } else "
+        "{ return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.ifs.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.steps.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[1].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    const auto& cond = mir->functions[0].blocks[0].term.cond;
+    CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 402u);
+}
+
+TEST(frontend, analyze_for_loop_rejects_statement_after_body_if) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { if item > 0 { return 201 } else { return 402 "
+        "} guard item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_rejects_statement_after_body_if) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { if item > 0 { return 201 } else { return 402 "
+        "} guard item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_rejects_statement_after_body_if) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { if item > 0 { return 201 } else { return 402 "
+        "} guard item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_rejects_statement_after_body_if) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { if item > 0 { return 201 } else { return 402 "
+        "} guard item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_with_body_local_subject) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2] { let n = item match n { case 1: return 201 "
+        "case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.steps.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.steps[1].kind),
+             static_cast<u8>(HirForLoopBody::Step::Kind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 3u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.lhs.kind),
+             static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(mir->functions[0].blocks[0].term.lhs.int_value, 1);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.rhs.kind),
+             static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(mir->functions[0].blocks[0].term.rhs.int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_for_loop_rejects_statement_after_body_match) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case 1: return 201 case _: "
+        "return 402 } guard item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_rejects_statement_after_body_match) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: return 201 case _: "
+        "return 402 } guard item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_rejects_statement_after_body_match) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case 1: return 201 case _: "
+        "return 402 } guard item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_rejects_statement_after_body_match) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: return 201 case _: "
+        "return 402 } guard item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_rejects_statement_after_terminating_nested_for) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { inline for inner in [2] { return 200 } "
+        "return 201 } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_rejects_statement_after_terminating_nested_for) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { for inner in [2] { return 200 } return 201 } "
+        "return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_allows_statement_after_empty_terminating_nested_for) {
+    const char* src =
+        "route GET \"/x\" { let xs: [i32] = [] inline for item in [1] { inline for inner in xs { "
+        "return 200 } guard item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+}
+
+TEST(frontend, analyze_plain_for_loop_allows_statement_after_empty_terminating_nested_for) {
+    const char* src =
+        "route GET \"/x\" { let xs: [i32] = [] for item in [1] { for inner in xs { return 200 } "
+        "guard item > 0 else { return 400 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+}
+
+TEST(frontend, mir_unrolls_nested_for_loop_uses_outer_and_inner_vars) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2] { inline for inner in [3, 4] { "
+        "guard inner > item else { return 400 } } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 9u);
+    const i32 expected_lhs[] = {3, 4, 3, 4};
+    const i32 expected_rhs[] = {1, 1, 2, 2};
+    for (u32 i = 0; i < 4; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        REQUIRE(cond.rhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(static_cast<u8>(cond.rhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected_lhs[i]);
+        CHECK_EQ(cond.rhs->int_value, expected_rhs[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_plain_nested_for_loop_uses_outer_and_inner_vars) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2] { for inner in [3, 4] { "
+        "guard inner > item else { return 400 } } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 9u);
+    const i32 expected_lhs[] = {3, 4, 3, 4};
+    const i32 expected_rhs[] = {1, 1, 2, 2};
+    for (u32 i = 0; i < 4; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Gt));
+        REQUIRE(cond.lhs != nullptr);
+        REQUIRE(cond.rhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(static_cast<u8>(cond.rhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected_lhs[i]);
+        CHECK_EQ(cond.rhs->int_value, expected_rhs[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_nested_for_iter_with_outer_loop_var) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2] { inline for inner in [item] { "
+        "guard inner == item else { return 400 } } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const i32 expected[] = {1, 2};
+    for (u32 i = 0; i < 2; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Eq));
+        REQUIRE(cond.lhs != nullptr);
+        REQUIRE(cond.rhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(static_cast<u8>(cond.rhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+        CHECK_EQ(cond.rhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, mir_unrolls_plain_nested_for_iter_with_outer_loop_var) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2] { for inner in [item] { guard inner == item else "
+        "{ return 400 } } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const i32 expected[] = {1, 2};
+    for (u32 i = 0; i < 2; i++) {
+        const auto& cond = mir->functions[0].blocks[i].term.cond;
+        CHECK_EQ(static_cast<u8>(cond.kind), static_cast<u8>(MirValueKind::Eq));
+        REQUIRE(cond.lhs != nullptr);
+        REQUIRE(cond.rhs != nullptr);
+        CHECK_EQ(static_cast<u8>(cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(static_cast<u8>(cond.rhs->kind), static_cast<u8>(MirValueKind::IntConst));
+        CHECK_EQ(cond.lhs->int_value, expected[i]);
+        CHECK_EQ(cond.rhs->int_value, expected[i]);
+    }
+}
+
+TEST(frontend, analyze_accepts_array_local_used_by_nested_for_iter) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1, 2] inline for outer in [0] { inline for item in xs { "
+        "guard "
+        "item > outer else { return 400 } } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+}
+
+TEST(frontend, analyze_plain_for_accepts_array_local_used_by_nested_for_iter) {
+    const char* src =
+        "route GET \"/x\" { let xs = [1, 2] for outer in [0] { for item in xs { guard item > outer "
+        "else { return 400 } } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 2u);
+}
+
+TEST(frontend, mir_preserves_nested_for_before_later_parent_guard) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { inline for inner in [1] { guard inner == 2 "
+        "else { return 401 } } guard item == 2 else { return 402 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_GE(mir->functions[0].blocks.len, 2u);
+    u32 first_child_fail = 0xffffffffu;
+    u32 first_parent_fail = 0xffffffffu;
+    for (u32 bi = 0; bi < mir->functions[0].blocks.len; bi++) {
+        const u32 status = mir->functions[0].blocks[bi].term.status_code;
+        if (status == 401u && first_child_fail == 0xffffffffu) first_child_fail = bi;
+        if (status == 402u && first_parent_fail == 0xffffffffu) first_parent_fail = bi;
+    }
+    REQUIRE_NE(first_child_fail, 0xffffffffu);
+    REQUIRE_NE(first_parent_fail, 0xffffffffu);
+    CHECK_LT(first_child_fail, first_parent_fail);
+}
+
+TEST(frontend, mir_plain_for_preserves_nested_for_before_later_parent_guard) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { for inner in [1] { guard inner == 2 else { return "
+        "401 } } guard item == 2 else { return 402 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_GE(mir->functions[0].blocks.len, 2u);
+    u32 first_child_fail = 0xffffffffu;
+    u32 first_parent_fail = 0xffffffffu;
+    for (u32 bi = 0; bi < mir->functions[0].blocks.len; bi++) {
+        const u32 status = mir->functions[0].blocks[bi].term.status_code;
+        if (status == 401u && first_child_fail == 0xffffffffu) first_child_fail = bi;
+        if (status == 402u && first_parent_fail == 0xffffffffu) first_parent_fail = bi;
+    }
+    REQUIRE_NE(first_child_fail, 0xffffffffu);
+    REQUIRE_NE(first_parent_fail, 0xffffffffu);
+    CHECK_LT(first_child_fail, first_parent_fail);
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_if) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1, 2] { let n = item match n { case 1: if n > 0 "
+        "{ return 201 } else { return 202 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.matches[0].arms[0].body_kind),
+             static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 4u);
+    const auto& arm_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(arm_cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_if) {
+    const char* src =
+        "route GET \"/x\" { for item in [1, 2] { let n = item match n { case 1: if n > 0 "
+        "{ return 201 } else { return 202 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.matches[0].arms[0].body_kind),
+             static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 4u);
+    const auto& arm_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(arm_cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_let_if) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let n = item match n { case 1: { let ok = n "
+        "> 0 if ok { return 201 } else { return 202 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 1u);
+    CHECK(arm.locals[0].name.eq(lit("ok")));
+    CHECK_EQ(static_cast<u8>(arm.body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    CHECK_EQ(static_cast<u8>(arm.cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 4u);
+    const auto& arm_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(arm_cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_let_if) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let n = item match n { case 1: { let ok = n "
+        "> 0 if ok { return 201 } else { return 202 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 1u);
+    CHECK(arm.locals[0].name.eq(lit("ok")));
+    CHECK_EQ(static_cast<u8>(arm.body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    CHECK_EQ(static_cast<u8>(arm.cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 4u);
+    const auto& arm_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(arm_cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_payload_binding_in_arm_block_let_if) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): { let ok = code > 0 if ok { return 201 } else { return 202 } } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    CHECK(arm.bind_payload);
+    REQUIRE_EQ(arm.locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(arm.locals[0].init.kind), static_cast<u8>(HirExprKind::Gt));
+    REQUIRE(arm.locals[0].init.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.locals[0].init.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK_EQ(static_cast<u8>(arm.cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const auto& arm_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_cond.lhs->kind), static_cast<u8>(MirValueKind::MatchPayload));
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_payload_binding_in_arm_block_let_if) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): { let ok = code > 0 if ok { return 201 } else { return 202 } } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    CHECK(arm.bind_payload);
+    REQUIRE_EQ(arm.locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(arm.locals[0].init.kind), static_cast<u8>(HirExprKind::Gt));
+    REQUIRE(arm.locals[0].init.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.locals[0].init.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK_EQ(static_cast<u8>(arm.cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const auto& arm_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_cond.lhs->kind), static_cast<u8>(MirValueKind::MatchPayload));
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_let_chain_if) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let n = item match n { case 1: { let a = n "
+        "let ok = a > 0 if ok { return 201 } else { return 202 } } case _: return 402 } } return "
+        "500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 2u);
+    CHECK(arm.locals[0].name.eq(lit("a")));
+    CHECK(arm.locals[1].name.eq(lit("ok")));
+    CHECK_EQ(static_cast<u8>(arm.locals[1].init.kind), static_cast<u8>(HirExprKind::Gt));
+    REQUIRE(arm.locals[1].init.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.locals[1].init.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(arm.cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const auto& arm_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(arm_cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_let_chain_if) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let n = item match n { case 1: { let a = n "
+        "let ok = a > 0 if ok { return 201 } else { return 202 } } case _: return 402 } } return "
+        "500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 2u);
+    CHECK(arm.locals[0].name.eq(lit("a")));
+    CHECK(arm.locals[1].name.eq(lit("ok")));
+    CHECK_EQ(static_cast<u8>(arm.locals[1].init.kind), static_cast<u8>(HirExprKind::Gt));
+    REQUIRE(arm.locals[1].init.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.locals[1].init.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(arm.cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const auto& arm_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_cond.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(arm_cond.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_guard_prefix) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let n = item match n { case 1: { let ok = n "
+        "> 0 guard ok else { return 499 } if ok { return 201 } else { return 202 } } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 1u);
+    REQUIRE_EQ(arm.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(arm.guards[0].cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(arm.body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 5u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_guard_prefix) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let n = item match n { case 1: { let ok = n "
+        "> 0 guard ok else { return 499 } if ok { return 201 } else { return 202 } } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 1u);
+    REQUIRE_EQ(arm.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(arm.guards[0].cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(arm.body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 5u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.cond.kind),
+             static_cast<u8>(MirValueKind::Gt));
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_payload_binding_in_arm_block_guard_prefix) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): { let ok = code > 0 guard ok else { return 499 } if ok { return 201 } "
+        "else { return 202 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    CHECK(arm.bind_payload);
+    REQUIRE_EQ(arm.locals.len, 1u);
+    REQUIRE_EQ(arm.guards.len, 1u);
+    REQUIRE(arm.locals[0].init.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.locals[0].init.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK_EQ(static_cast<u8>(arm.guards[0].cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const auto& guard_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(guard_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(guard_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(guard_cond.lhs->kind), static_cast<u8>(MirValueKind::MatchPayload));
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_payload_binding_in_arm_block_guard_prefix) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): { let ok = code > 0 guard ok else { return 499 } if ok { return 201 } "
+        "else { return 202 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    CHECK(arm.bind_payload);
+    REQUIRE_EQ(arm.locals.len, 1u);
+    REQUIRE_EQ(arm.guards.len, 1u);
+    REQUIRE(arm.locals[0].init.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.locals[0].init.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK_EQ(static_cast<u8>(arm.guards[0].cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    const auto& guard_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(guard_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(guard_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(guard_cond.lhs->kind), static_cast<u8>(MirValueKind::MatchPayload));
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_guard_let_prefix) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case 1: { guard let n = item "
+        "else { return 498 } if n == 1 { return 201 } else { return 202 } } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 1u);
+    REQUIRE_EQ(arm.guards.len, 1u);
+    CHECK(arm.locals[0].name.eq(lit("n")));
+    CHECK_EQ(arm.locals[0].type, HirTypeKind::I32);
+    CHECK_EQ(static_cast<u8>(arm.locals[0].init.kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(arm.cond.kind), static_cast<u8>(HirExprKind::Eq));
+    REQUIRE(arm.cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.cond.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 498u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_guard_let_prefix) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: { guard let n = item "
+        "else { return 498 } if n == 1 { return 201 } else { return 202 } } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 1u);
+    REQUIRE_EQ(arm.guards.len, 1u);
+    CHECK(arm.locals[0].name.eq(lit("n")));
+    CHECK_EQ(arm.locals[0].type, HirTypeKind::I32);
+    CHECK_EQ(static_cast<u8>(arm.locals[0].init.kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(arm.cond.kind), static_cast<u8>(HirExprKind::Eq));
+    REQUIRE(arm.cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.cond.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 498u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_guard_match_prefix) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case 1: { let failed = "
+        "error(.timeout) guard match failed else { case .timeout: return 498 case _: return 499 } "
+        "if item == 1 { return 201 } else { return 202 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 1u);
+    REQUIRE_EQ(arm.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(arm.locals[0].init.kind), static_cast<u8>(HirExprKind::Error));
+    CHECK_EQ(static_cast<u8>(arm.guards[0].fail_kind), static_cast<u8>(HirGuard::FailKind::Match));
+    CHECK_EQ(static_cast<u8>(arm.guards[0].fail_match_expr.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 9u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    CHECK(mir->functions[0].blocks[6].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[6].term.then_block, 7u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.else_block, 8u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 498u);
+    CHECK_EQ(mir->functions[0].blocks[8].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_guard_match_prefix) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: { let failed = "
+        "error(.timeout) guard match failed else { case .timeout: return 498 case _: return 499 } "
+        "if item == 1 { return 201 } else { return 202 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 1u);
+    REQUIRE_EQ(arm.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(arm.locals[0].init.kind), static_cast<u8>(HirExprKind::Error));
+    CHECK_EQ(static_cast<u8>(arm.guards[0].fail_kind), static_cast<u8>(HirGuard::FailKind::Match));
+    CHECK_EQ(static_cast<u8>(arm.guards[0].fail_match_expr.kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 9u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    CHECK(mir->functions[0].blocks[6].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[6].term.then_block, 7u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.else_block, 8u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 498u);
+    CHECK_EQ(mir->functions[0].blocks[8].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_rejects_for_loop_body_guard_match_on_non_error_value) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { guard match item > 0 else { case true: return "
+        "498 case _: return 499 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_plain_for_rejects_for_loop_body_guard_match_on_non_error_value) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { guard match item > 0 else { case true: return "
+        "498 case _: return 499 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_for_rejects_for_loop_body_guard_match_on_non_error_value) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { guard match item > 0 else { case true: return "
+        "498 case _: return 499 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_rejects_for_loop_after_loop_body_return) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { return 200 inline for other in [2] { return "
+        "201 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_plain_for_rejects_for_loop_after_loop_body_return) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { return 200 for other in [2] { return 201 } } return "
+        "500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_guard_fail_body) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case 1: { let ok = item > 1 "
+        "guard ok else { let fail = item == 1 if fail { return 498 } else { return 499 } } "
+        "return 201 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 1u);
+    REQUIRE_EQ(arm.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(arm.guards[0].fail_kind), static_cast<u8>(HirGuard::FailKind::Body));
+    CHECK_EQ(static_cast<u8>(arm.guards[0].fail_body.body_kind),
+             static_cast<u8>(HirGuardBody::BodyKind::If));
+    REQUIRE_EQ(arm.guards[0].fail_body.locals.len, 1u);
+    CHECK(arm.guards[0].fail_body.locals[0].name.eq(lit("fail")));
+    CHECK_EQ(static_cast<u8>(arm.guards[0].fail_body.locals[0].init.kind),
+             static_cast<u8>(HirExprKind::Eq));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.then_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 498u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_guard_fail_body) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: { let ok = item > 1 "
+        "guard ok else { let fail = item == 1 if fail { return 498 } else { return 499 } } "
+        "return 201 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 1u);
+    REQUIRE_EQ(arm.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(arm.guards[0].fail_kind), static_cast<u8>(HirGuard::FailKind::Body));
+    CHECK_EQ(static_cast<u8>(arm.guards[0].fail_body.body_kind),
+             static_cast<u8>(HirGuardBody::BodyKind::If));
+    REQUIRE_EQ(arm.guards[0].fail_body.locals.len, 1u);
+    CHECK(arm.guards[0].fail_body.locals[0].name.eq(lit("fail")));
+    CHECK_EQ(static_cast<u8>(arm.guards[0].fail_body.locals[0].init.kind),
+             static_cast<u8>(HirExprKind::Eq));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 7u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.then_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 498u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_nested_match) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case \"/users\": return 201 case _: return 404 } case _: return 402 } } "
+        "return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.kind), static_cast<u8>(HirExprKind::Eq));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK_FALSE(arms[1].is_wildcard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_nested_match) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case \"/users\": return 201 case _: return 404 } case _: return 402 } } "
+        "return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.kind), static_cast<u8>(HirExprKind::Eq));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK_FALSE(arms[1].is_wildcard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_nested_match_if) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case \"/users\": if item == 1 { return 201 } else { return 202 } case _: "
+        "return 404 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 8u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 7u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_nested_match_if) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case \"/users\": if item == 1 { return 201 } else { return 202 } case _: "
+        "return 404 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 8u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 7u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_for_loop_body_nested_match_preserves_outer_arm_guard) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case 1 if false: match item { "
+        "case 1: return 201 case _: return 202 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK(arms[1].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[1].arm_guard.kind), static_cast<u8>(HirExprKind::BoolLit));
+    CHECK_FALSE(arms[1].arm_guard.bool_value);
+    CHECK(arms[2].is_wildcard);
+    CHECK_FALSE(arms[2].has_arm_guard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_plain_for_loop_body_nested_match_preserves_outer_arm_guard) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1 if false: match item { "
+        "case 1: return 201 case _: return 202 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK(arms[1].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[1].arm_guard.kind), static_cast<u8>(HirExprKind::BoolLit));
+    CHECK_FALSE(arms[1].arm_guard.bool_value);
+    CHECK(arms[2].is_wildcard);
+    CHECK_FALSE(arms[2].has_arm_guard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_for_loop_nested_match_rejects_guard_match_on_non_error_value) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case 1: match item { case 1: { "
+        "guard match item > 0 else { case true: return 401 case _: return 402 } return 201 } case "
+        "_: return 404 } case _: return 500 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_plain_for_loop_nested_match_rejects_guard_match_on_non_error_value) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: match item { case 1: { guard "
+        "match item > 0 else { case true: return 401 case _: return 402 } return 201 } case _: "
+        "return 404 } case _: return 500 } } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_nested_variant_match) {
+    const char* src =
+        "variant Result { ok, err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok match item { case 1: "
+        "match state { case .ok: return 201 case _: return 404 } case _: return 402 } } return "
+        "500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.kind), static_cast<u8>(HirExprKind::Eq));
+    REQUIRE(arms[0].arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.lhs->kind),
+             static_cast<u8>(HirExprKind::VariantTag));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_nested_variant_match) {
+    const char* src =
+        "variant Result { ok, err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok match item { case 1: "
+        "match state { case .ok: return 201 case _: return 404 } case _: return 402 } } return "
+        "500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.kind), static_cast<u8>(HirExprKind::Eq));
+    REQUIRE(arms[0].arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.lhs->kind),
+             static_cast<u8>(HirExprKind::VariantTag));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_for_loop_body_match_arm_nested_match_rejects_inner_arm_guard) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case \"/users\" if true: return 201 case _: return 404 } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_body_match_arm_nested_match_rejects_inner_arm_guard) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case \"/users\" if true: return 201 case _: return 404 } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_body_match_arm_nested_match_rejects_inner_payload_binding) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok(item) match item { "
+        "case 1: match state { case .ok(code): return 201 case _: return 404 } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_body_match_arm_nested_match_rejects_inner_payload_binding) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok(item) match item { "
+        "case 1: match state { case .ok(code): return 201 case _: return 404 } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_body_match_arm_nested_match_rejects_missing_inner_wildcard) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case \"/users\": return 201 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_body_match_arm_nested_match_rejects_missing_inner_wildcard) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case \"/users\": return 201 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_body_match_arm_nested_match_rejects_inner_wildcard_before_last) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case _: return 404 case \"/users\": return 201 } case _: return 402 } } "
+        "return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend,
+     analyze_plain_for_loop_body_match_arm_nested_match_rejects_inner_wildcard_before_last) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case _: return 404 case \"/users\": return 201 } case _: return 402 } } "
+        "return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_body_match_arm_nested_match_rejects_duplicate_inner_bool_case) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let allowed = true match item { case 1: "
+        "match allowed { case true: return 201 case true: return 202 case _: return 404 } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend,
+     analyze_plain_for_loop_body_match_arm_nested_match_rejects_duplicate_inner_bool_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let allowed = true match item { case 1: "
+        "match allowed { case true: return 201 case true: return 202 case _: return 404 } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_body_match_arm_nested_match_rejects_duplicate_inner_int_case) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let code = 1 match item { case 1: "
+        "match code { case 1: return 201 case 1: return 202 case _: return 404 } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend,
+     analyze_plain_for_loop_body_match_arm_nested_match_rejects_duplicate_inner_int_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let code = 1 match item { case 1: "
+        "match code { case 1: return 201 case 1: return 202 case _: return 404 } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_body_match_arm_nested_match_rejects_duplicate_inner_string_case) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case \"/users\": return 201 case \"/users\": return 202 case _: return "
+        "404 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend,
+     analyze_plain_for_loop_body_match_arm_nested_match_rejects_duplicate_inner_string_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let path = \"/users\" match item { case 1: "
+        "match path { case \"/users\": return 201 case \"/users\": return 202 case _: return "
+        "404 } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_body_match_arm_nested_match_rejects_duplicate_inner_variant_case) {
+    const char* src =
+        "variant Result { ok, err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok match item { case 1: "
+        "match state { case .ok: return 201 case .ok: return 202 case _: return 404 } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend,
+     analyze_plain_for_loop_body_match_arm_nested_match_rejects_duplicate_inner_variant_case) {
+    const char* src =
+        "variant Result { ok, err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok match item { case 1: "
+        "match state { case .ok: return 201 case .ok: return 202 case _: return 404 } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_body_match_arm_nested_match_rejects_foreign_inner_variant_case) {
+    const char* src =
+        "variant Result { ok, err }\n"
+        "variant Other { ok, err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok match item { case 1: "
+        "match state { case Other.ok: return 201 case _: return 404 } case _: return 402 } } "
+        "return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend,
+     analyze_plain_for_loop_body_match_arm_nested_match_rejects_foreign_inner_variant_case) {
+    const char* src =
+        "variant Result { ok, err }\n"
+        "variant Other { ok, err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok match item { case 1: "
+        "match state { case Other.ok: return 201 case _: return 404 } case _: return 402 } } "
+        "return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_for_loop_body_match_arm_nested_match_rejects_fallible_inner_subject) {
+    const char* src =
+        "func maybe_path(ok: bool) -> str { if ok { \"/users\" } else { error(.timeout) } }\n"
+        "route GET \"/x\" { inline for item in [1] { let path = maybe_path(false) match item { "
+        "case 1: match path { case \"/users\": return 201 case _: return 404 } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_body_match_arm_nested_match_rejects_fallible_inner_subject) {
+    const char* src =
+        "func maybe_path(ok: bool) -> str { if ok { \"/users\" } else { error(.timeout) } }\n"
+        "route GET \"/x\" { for item in [1] { let path = maybe_path(false) match item { "
+        "case 1: match path { case \"/users\": return 201 case _: return 404 } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_let_nested_match) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case 1: { let path = "
+        "\"/users\" match path { case \"/users\": return 201 case _: return 404 } } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    REQUIRE_EQ(arms[0].locals.len, 1u);
+    CHECK(arms[0].locals[0].name.eq(lit("path")));
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.kind), static_cast<u8>(HirExprKind::Eq));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK_FALSE(arms[1].is_wildcard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_let_nested_match) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: { let path = "
+        "\"/users\" match path { case \"/users\": return 201 case _: return 404 } } case _: "
+        "return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    REQUIRE_EQ(arms[0].locals.len, 1u);
+    CHECK(arms[0].locals[0].name.eq(lit("path")));
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.kind), static_cast<u8>(HirExprKind::Eq));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK_FALSE(arms[1].is_wildcard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_let_nested_variant_match) {
+    const char* src =
+        "variant Result { ok, err }\n"
+        "route GET \"/x\" { inline for item in [1] { match item { case 1: { let state = Result.ok "
+        "match state { case .ok: return 201 case _: return 404 } } case _: return 402 } } return "
+        "500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    REQUIRE_EQ(arms[0].locals.len, 1u);
+    CHECK(arms[0].locals[0].name.eq(lit("state")));
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.kind), static_cast<u8>(HirExprKind::Eq));
+    REQUIRE(arms[0].arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.lhs->kind),
+             static_cast<u8>(HirExprKind::VariantTag));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_let_nested_variant_match) {
+    const char* src =
+        "variant Result { ok, err }\n"
+        "route GET \"/x\" { for item in [1] { match item { case 1: { let state = Result.ok "
+        "match state { case .ok: return 201 case _: return 404 } } case _: return 402 } } return "
+        "500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    REQUIRE_EQ(arms[0].locals.len, 1u);
+    CHECK(arms[0].locals[0].name.eq(lit("state")));
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.kind), static_cast<u8>(HirExprKind::Eq));
+    REQUIRE(arms[0].arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.lhs->kind),
+             static_cast<u8>(HirExprKind::VariantTag));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_let_nested_match_if) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case 1: { let path = "
+        "\"/users\" match path { case \"/users\": if item == 1 { return 201 } else { return 202 } "
+        "case _: return 404 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    REQUIRE_EQ(arms[0].locals.len, 1u);
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 8u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 7u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_let_nested_match_if) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: { let path = "
+        "\"/users\" match path { case \"/users\": if item == 1 { return 201 } else { return 202 } "
+        "case _: return 404 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    REQUIRE_EQ(arms[0].locals.len, 1u);
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 8u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 7u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_nested_match_on_payload) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): { match code { case 1: return 201 case _: return 404 } } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].bind_payload);
+    CHECK(arms[0].has_arm_guard);
+    REQUIRE(arms[0].arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK(arms[1].bind_payload);
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_nested_match_on_payload) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): { match code { case 1: return 201 case _: return 404 } } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].bind_payload);
+    CHECK(arms[0].has_arm_guard);
+    REQUIRE(arms[0].arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK(arms[1].bind_payload);
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_nested_match_on_payload) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): match code { case 1: return 201 case _: return 404 } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].bind_payload);
+    CHECK(arms[0].has_arm_guard);
+    REQUIRE(arms[0].arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK(arms[1].bind_payload);
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_nested_match_on_payload) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): match code { case 1: return 201 case _: return 404 } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].bind_payload);
+    CHECK(arms[0].has_arm_guard);
+    REQUIRE(arms[0].arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK(arms[1].bind_payload);
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_guard_payload_then_nested_match) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): { guard code > 0 else { return 499 } match code { case 1: return 201 "
+        "case _: return 404 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].bind_payload);
+    REQUIRE_EQ(arms[0].guards.len, 1u);
+    REQUIRE(arms[0].guards[0].cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].guards[0].cond.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK(arms[0].has_arm_guard);
+    REQUIRE(arms[0].arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK(arms[1].bind_payload);
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    bool saw_payload_guard = false;
+    bool saw_201 = false;
+    bool saw_402 = false;
+    bool saw_404 = false;
+    bool saw_499 = false;
+    for (u32 bi = 0; bi < mir->functions[0].blocks.len; bi++) {
+        const auto& term = mir->functions[0].blocks[bi].term;
+        if (term.cond.kind == MirValueKind::Gt && term.cond.lhs != nullptr &&
+            term.cond.lhs->kind == MirValueKind::MatchPayload)
+            saw_payload_guard = true;
+        if (term.status_code == 201) saw_201 = true;
+        if (term.status_code == 402) saw_402 = true;
+        if (term.status_code == 404) saw_404 = true;
+        if (term.status_code == 499) saw_499 = true;
+    }
+    CHECK(saw_payload_guard);
+    CHECK(saw_201);
+    CHECK(saw_402);
+    CHECK(saw_404);
+    CHECK(saw_499);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_guard_payload_then_nested_match) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): { guard code > 0 else { return 499 } match code { case 1: return 201 "
+        "case _: return 404 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].bind_payload);
+    REQUIRE_EQ(arms[0].guards.len, 1u);
+    REQUIRE(arms[0].guards[0].cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].guards[0].cond.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK(arms[0].has_arm_guard);
+    REQUIRE(arms[0].arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].arm_guard.lhs->kind),
+             static_cast<u8>(HirExprKind::MatchPayload));
+    CHECK(arms[1].bind_payload);
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    bool saw_payload_guard = false;
+    bool saw_201 = false;
+    bool saw_402 = false;
+    bool saw_404 = false;
+    bool saw_499 = false;
+    for (u32 bi = 0; bi < mir->functions[0].blocks.len; bi++) {
+        const auto& term = mir->functions[0].blocks[bi].term;
+        if (term.cond.kind == MirValueKind::Gt && term.cond.lhs != nullptr &&
+            term.cond.lhs->kind == MirValueKind::MatchPayload)
+            saw_payload_guard = true;
+        if (term.status_code == 201) saw_201 = true;
+        if (term.status_code == 402) saw_402 = true;
+        if (term.status_code == 404) saw_404 = true;
+        if (term.status_code == 499) saw_499 = true;
+    }
+    CHECK(saw_payload_guard);
+    CHECK(saw_201);
+    CHECK(saw_402);
+    CHECK(saw_404);
+    CHECK(saw_499);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_nested_match_if_uses_payload) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): { let path = \"/users\" match path { case \"/users\": if code > 0 { "
+        "return 201 } else { return 202 } case _: return 404 } } case _: return 402 } } return "
+        "500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].bind_payload);
+    REQUIRE_EQ(arms[0].locals.len, 1u);
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    REQUIRE(arms[0].cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].cond.lhs->kind), static_cast<u8>(HirExprKind::MatchPayload));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 8u);
+    const auto& payload_cond = mir->functions[0].blocks[3].term.cond;
+    CHECK_EQ(static_cast<u8>(payload_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(payload_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(payload_cond.lhs->kind), static_cast<u8>(MirValueKind::MatchPayload));
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_nested_match_if_uses_payload) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): { let path = \"/users\" match path { case \"/users\": if code > 0 { "
+        "return 201 } else { return 202 } case _: return 404 } } case _: return 402 } } return "
+        "500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    CHECK(arms[0].bind_payload);
+    REQUIRE_EQ(arms[0].locals.len, 1u);
+    CHECK(arms[0].has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arms[0].body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    REQUIRE(arms[0].cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arms[0].cond.lhs->kind), static_cast<u8>(HirExprKind::MatchPayload));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 8u);
+    const auto& payload_cond = mir->functions[0].blocks[3].term.cond;
+    CHECK_EQ(static_cast<u8>(payload_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(payload_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(payload_cond.lhs->kind), static_cast<u8>(MirValueKind::MatchPayload));
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_guard_nested_match) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let path = \"/users\" match item { case 1: { "
+        "guard item == 1 else { return 499 } match path { case \"/users\": return 201 case _: "
+        "return 404 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    REQUIRE_EQ(arms[0].guards.len, 1u);
+    CHECK(arms[0].has_arm_guard);
+    REQUIRE_EQ(arms[1].guards.len, 1u);
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 10u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 7u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.then_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.else_block, 8u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.then_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.else_block, 9u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[8].term.status_code, 499u);
+    CHECK_EQ(mir->functions[0].blocks[9].term.status_code, 499u);
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_guard_nested_match) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let path = \"/users\" match item { case 1: { "
+        "guard item == 1 else { return 499 } match path { case \"/users\": return 201 case _: "
+        "return 404 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    const auto& arms = hir->routes[0].for_loops[0].body.matches[0].arms;
+    REQUIRE_EQ(arms[0].guards.len, 1u);
+    CHECK(arms[0].has_arm_guard);
+    REQUIRE_EQ(arms[1].guards.len, 1u);
+    CHECK_FALSE(arms[1].has_arm_guard);
+    CHECK(arms[2].is_wildcard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 10u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 7u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.then_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.else_block, 8u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.then_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.else_block, 9u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 404u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[8].term.status_code, 499u);
+    CHECK_EQ(mir->functions[0].blocks[9].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend,
+     analyze_for_loop_body_match_arm_block_nested_match_rejects_duplicate_inner_int_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: { let code = 1 match "
+        "code { case 1: return 201 case 1: return 202 case _: return 404 } } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend,
+     analyze_for_loop_body_match_arm_block_nested_match_rejects_duplicate_inner_string_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: { let path = "
+        "\"/users\" match path { case \"/users\": return 201 case \"/users\": return 202 case _: "
+        "return 404 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend,
+     analyze_plain_for_loop_body_match_arm_block_nested_match_rejects_duplicate_inner_int_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: { let code = 1 match "
+        "code { case 1: return 201 case 1: return 202 case _: return 404 } } case _: return "
+        "402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend,
+     analyze_plain_for_loop_body_match_arm_block_nested_match_rejects_duplicate_inner_string_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: { let path = "
+        "\"/users\" match path { case \"/users\": return 201 case \"/users\": return 202 case _: "
+        "return 404 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_block_multiple_guard_prefixes) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let n = item match n { case 1: { let ok = n "
+        "> 0 let still_ok = ok guard ok else { return 498 } guard still_ok else { return 499 } if "
+        "still_ok { return 201 } else { return 202 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 2u);
+    REQUIRE_EQ(arm.guards.len, 2u);
+    CHECK_EQ(static_cast<u8>(arm.guards[0].cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(arm.guards[1].cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 9u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 7u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 8u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 498u);
+    CHECK_EQ(mir->functions[0].blocks[8].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_block_multiple_guard_prefixes) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let n = item match n { case 1: { let ok = n "
+        "> 0 let still_ok = ok guard ok else { return 498 } guard still_ok else { return 499 } if "
+        "still_ok { return 201 } else { return 202 } } case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    REQUIRE_EQ(arm.locals.len, 2u);
+    REQUIRE_EQ(arm.guards.len, 2u);
+    CHECK_EQ(static_cast<u8>(arm.guards[0].cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(arm.guards[1].cond.kind), static_cast<u8>(HirExprKind::LocalRef));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 9u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 6u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 7u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 8u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[6].term.status_code, 402u);
+    CHECK_EQ(mir->functions[0].blocks[7].term.status_code, 498u);
+    CHECK_EQ(mir->functions[0].blocks[8].term.status_code, 499u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_payload_binding_in_arm_if) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): if code > 0 { return 201 } else { return 202 } case _: return 402 } } "
+        "return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    CHECK(arm.bind_payload);
+    CHECK(arm.bind_name.eq(lit("code")));
+    CHECK_EQ(arm.bind_type, HirTypeKind::I32);
+    CHECK_EQ(static_cast<u8>(arm.body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    CHECK_EQ(static_cast<u8>(arm.cond.kind), static_cast<u8>(HirExprKind::Gt));
+    REQUIRE(arm.cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.cond.lhs->kind), static_cast<u8>(HirExprKind::MatchPayload));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const auto& arm_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_cond.lhs->kind), static_cast<u8>(MirValueKind::MatchPayload));
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_payload_binding_in_arm_if) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code): if code > 0 { return 201 } else { return 202 } case _: return 402 } } "
+        "return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    CHECK(arm.bind_payload);
+    CHECK(arm.bind_name.eq(lit("code")));
+    CHECK_EQ(arm.bind_type, HirTypeKind::I32);
+    CHECK_EQ(static_cast<u8>(arm.body_kind), static_cast<u8>(HirForLoopMatchArm::BodyKind::If));
+    CHECK_EQ(static_cast<u8>(arm.cond.kind), static_cast<u8>(HirExprKind::Gt));
+    REQUIRE(arm.cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.cond.lhs->kind), static_cast<u8>(HirExprKind::MatchPayload));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    const auto& arm_cond = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_cond.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_cond.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_cond.lhs->kind), static_cast<u8>(MirValueKind::MatchPayload));
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_arm_guard) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let n = item match n { case 1 if n > 0: "
+        "return 201 case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].has_arm_guard);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 4u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 3u);
+    const auto& arm_guard = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_guard.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_guard.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(arm_guard.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_arm_guard) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let n = item match n { case 1 if n > 0: "
+        "return 201 case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].has_arm_guard);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 4u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 3u);
+    const auto& arm_guard = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_guard.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_guard.lhs->kind), static_cast<u8>(MirValueKind::IntConst));
+    CHECK_EQ(arm_guard.lhs->int_value, 1);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_payload_binding_in_arm_guard) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code) if code > 0: return 201 case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    CHECK(arm.bind_payload);
+    CHECK(arm.bind_name.eq(lit("code")));
+    CHECK(arm.has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arm.arm_guard.kind), static_cast<u8>(HirExprKind::Gt));
+    REQUIRE(arm.arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.arm_guard.lhs->kind), static_cast<u8>(HirExprKind::MatchPayload));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 4u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 3u);
+    const auto& arm_guard = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_guard.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_guard.lhs->kind), static_cast<u8>(MirValueKind::MatchPayload));
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_payload_binding_in_arm_guard) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code) if code > 0: return 201 case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 2u);
+    const auto& arm = hir->routes[0].for_loops[0].body.matches[0].arms[0];
+    CHECK(arm.bind_payload);
+    CHECK(arm.bind_name.eq(lit("code")));
+    CHECK(arm.has_arm_guard);
+    CHECK_EQ(static_cast<u8>(arm.arm_guard.kind), static_cast<u8>(HirExprKind::Gt));
+    REQUIRE(arm.arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm.arm_guard.lhs->kind), static_cast<u8>(HirExprKind::MatchPayload));
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 4u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 3u);
+    const auto& arm_guard = mir->functions[0].blocks[1].term.cond;
+    CHECK_EQ(static_cast<u8>(arm_guard.kind), static_cast<u8>(MirValueKind::Gt));
+    REQUIRE(arm_guard.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(arm_guard.lhs->kind), static_cast<u8>(MirValueKind::MatchPayload));
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 402u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_for_loop_body_match_rejects_payload_binding_on_payloadless_case) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.err match state { "
+        "case .err(code): return 201 case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_body_match_rejects_payload_binding_on_payloadless_case) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.err match state { "
+        "case .err(code): return 201 case _: return 402 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_guarded_variant_case_falls_through_to_same_case) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { inline for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code) if code > 200: return 200 case .ok(code): return 201 case _: return 404 "
+        "} } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].has_arm_guard);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].bind_payload);
+    CHECK_FALSE(hir->routes[0].for_loops[0].body.matches[0].arms[1].has_arm_guard);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[1].bind_payload);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 200u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 404u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend,
+     mir_unrolls_plain_for_loop_body_match_guarded_variant_case_falls_through_to_same_case) {
+    const char* src =
+        "variant Result { ok(i32), err }\n"
+        "route GET \"/x\" { for item in [1] { let state = Result.ok(item) match state { "
+        "case .ok(code) if code > 200: return 200 case .ok(code): return 201 case _: return 404 "
+        "} } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].has_arm_guard);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].bind_payload);
+    CHECK_FALSE(hir->routes[0].for_loops[0].body.matches[0].arms[1].has_arm_guard);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[1].bind_payload);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 200u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 404u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_guarded_bool_case_falls_through_to_same_case) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let flag = true match flag { case true if "
+        "item > 1: return 201 case true: return 202 case _: return 404 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].has_arm_guard);
+    CHECK_FALSE(hir->routes[0].for_loops[0].body.matches[0].arms[1].has_arm_guard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 404u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_guarded_bool_case_falls_through_to_same_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let flag = true match flag { case true if "
+        "item > 1: return 201 case true: return 202 case _: return 404 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].has_arm_guard);
+    CHECK_FALSE(hir->routes[0].for_loops[0].body.matches[0].arms[1].has_arm_guard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[2].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 404u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_guarded_int_case_falls_through_to_same_case) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let n = item match n { case 1 if item > 1: "
+        "return 201 case 1: return 202 case _: return 404 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].has_arm_guard);
+    CHECK_FALSE(hir->routes[0].for_loops[0].body.matches[0].arms[1].has_arm_guard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 404u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_match_guarded_int_case_falls_through_to_same_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let n = item match n { case 1 if item > 1: "
+        "return 201 case 1: return 202 case _: return 404 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].has_arm_guard);
+    CHECK_FALSE(hir->routes[0].for_loops[0].body.matches[0].arms[1].has_arm_guard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 404u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_for_loop_body_match_rejects_unguarded_duplicate_string_case) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let s = \"a\" match s { case \"a\": return "
+        "201 case \"a\": return 202 case _: return 404 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_body_match_rejects_unguarded_duplicate_string_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let s = \"a\" match s { case \"a\": return "
+        "201 case \"a\": return 202 case _: return 404 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_match_guarded_string_case_falls_through_to_same_case) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let s = \"a\" match s { case \"a\" if item "
+        "> 1: return 201 case \"a\": return 202 case _: return 404 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].has_arm_guard);
+    CHECK_FALSE(hir->routes[0].for_loops[0].body.matches[0].arms[1].has_arm_guard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 404u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend,
+     mir_unrolls_plain_for_loop_body_match_guarded_string_case_falls_through_to_same_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let s = \"a\" match s { case \"a\" if item "
+        "> 1: return 201 case \"a\": return 202 case _: return 404 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.matches[0].arms.len, 3u);
+    CHECK(hir->routes[0].for_loops[0].body.matches[0].arms[0].has_arm_guard);
+    CHECK_FALSE(hir->routes[0].for_loops[0].body.matches[0].arms[1].has_arm_guard);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 6u);
+    CHECK(mir->functions[0].blocks[0].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[0].term.then_block, 2u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 1u);
+    CHECK(mir->functions[0].blocks[1].term.use_cmp);
+    CHECK_EQ(mir->functions[0].blocks[1].term.then_block, 4u);
+    CHECK_EQ(mir->functions[0].blocks[1].term.else_block, 5u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.then_block, 3u);
+    CHECK_EQ(mir->functions[0].blocks[2].term.else_block, 1u);
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 201u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 202u);
+    CHECK_EQ(mir->functions[0].blocks[5].term.status_code, 404u);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered);
+    rir.destroy();
+}
+
+TEST(frontend, analyze_for_loop_body_match_rejects_unguarded_duplicate_int_case) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { match item { case 1: return 201 case 1: "
+        "return 202 case _: return 404 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_body_match_rejects_unguarded_duplicate_int_case) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { match item { case 1: return 201 case 1: "
+        "return 202 case _: return 404 } } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, mir_unrolls_for_loop_body_guard_match_with_body_local_subject) {
+    const char* src = R"(
+route GET "/x" {
+    inline for item in [1] {
+        let failed = error(.timeout)
+        guard match failed else { case .timeout: return 401 case _: return 402 }
+    }
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.guards[0].fail_kind),
+             static_cast<u8>(HirGuard::FailKind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    const auto& fail_test = mir->functions[0].blocks[2].term;
+    CHECK(fail_test.use_cmp);
+    CHECK_EQ(static_cast<u8>(fail_test.lhs.kind), static_cast<u8>(MirValueKind::Error));
+    CHECK_EQ(static_cast<u8>(fail_test.rhs.kind), static_cast<u8>(MirValueKind::VariantCase));
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 401u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+}
+
+TEST(frontend, mir_unrolls_plain_for_loop_body_guard_match_with_body_local_subject) {
+    const char* src = R"(
+route GET "/x" {
+    for item in [1] {
+        let failed = error(.timeout)
+        guard match failed else { case .timeout: return 401 case _: return 402 }
+    }
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].for_loops.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.locals.len, 1u);
+    REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].for_loops[0].body.guards[0].fail_kind),
+             static_cast<u8>(HirGuard::FailKind::Match));
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE_EQ(mir->functions[0].blocks.len, 5u);
+    CHECK_EQ(mir->functions[0].blocks[0].term.else_block, 2u);
+    const auto& fail_test = mir->functions[0].blocks[2].term;
+    CHECK(fail_test.use_cmp);
+    CHECK_EQ(static_cast<u8>(fail_test.lhs.kind), static_cast<u8>(MirValueKind::Error));
+    CHECK_EQ(static_cast<u8>(fail_test.rhs.kind), static_cast<u8>(MirValueKind::VariantCase));
+    CHECK_EQ(mir->functions[0].blocks[3].term.status_code, 401u);
+    CHECK_EQ(mir->functions[0].blocks[4].term.status_code, 402u);
+}
+
+TEST(frontend, analyze_for_loop_body_let_scoped_to_body) {
+    const char* src =
+        "route GET \"/x\" { inline for item in [1] { let n = item guard n > 0 else "
+        "{ return 400 } } let x = n return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    CHECK(!hir);
+}
+
+TEST(frontend, analyze_plain_for_loop_body_let_scoped_to_body) {
+    const char* src =
+        "route GET \"/x\" { for item in [1] { let n = item guard n > 0 else "
+        "{ return 400 } } let x = n return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -18008,7 +24363,16 @@ TEST(frontend, analyze_for_loop_rejects_let_in_body) {
 }
 
 TEST(frontend, parse_for_loop_rejects_missing_in) {
-    // `for item <missing in> [1, 2, 3]` — expect must see KwIn, else unexpected-token.
+    // `inline for item <missing in> [1, 2, 3]` — expect must see KwIn, else unexpected-token.
+    const char* src = "route GET \"/x\" { inline for item [1, 2, 3] { return 200 } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    CHECK(!ast);
+}
+
+TEST(frontend, parse_plain_for_loop_rejects_missing_in) {
+    // `for item <missing in> [1, 2, 3]` — parse should fail before analysis.
     const char* src = "route GET \"/x\" { for item [1, 2, 3] { return 200 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -4718,8 +4718,9 @@ TEST(jit, frontend_guard_match_routes_fail_and_success_paths) {
 
     {
         const char* src =
-            "route GET \"/users\" { let ok = 200 guard match ok else { case .timeout: return 503 "
-            "case _: return 500 } return 200 }\n";
+            "func maybefail(ok: bool) -> i32 { if ok { 200 } else { error(.timeout) } }\n"
+            "route GET \"/users\" { let ok = maybefail(true) guard match ok else { case .timeout: "
+            "return 503 case _: return 500 } return 200 }\n";
 
         auto lexed = lex(lit(src));
         REQUIRE(lexed);


### PR DESCRIPTION
## Summary

Adds compiler support for static `for` loops. Both `for ... in ...` and the compatibility spelling `inline for ... in ...` are parsed, analyzed as `HirForLoop`, and lowered by compile-time unrolling when the iterator is a statically-known array.

`inline` is intentionally contextual rather than a globally reserved keyword, so existing identifiers named `inline` remain valid.

## Supported scenarios

- Static array literals and route-local static array aliases as loop iterators
- Typed empty arrays and zero-iteration loops
- Plain `for` and `inline for` using the same compiler-selected static unroll path
- Array elements with scalar, tuple, struct, and variant shapes
- Loop-body `let` bindings, guards, direct terminators, terminal `if`, and terminal `match`
- Match-arm guards, guard prefix blocks, payload bindings, nested matches, and duplicate-case validation inside loop-body matches
- Nested static `for` loops, including inner iterator expressions that reference outer loop variables
- Source-ordered lowering with route-level guards and direct/if/match route control

## Validation and limits

- Rejects for-loop use after `wait`, and rejects routes that combine waits with static for-loop lowering
- Rejects non-static or non-array iterators
- Rejects array locals escaping into ordinary runtime expressions; array locals are only allowed as static for-loop iter sources
- Rejects fallible/nil predicates in loop-body `if` and match-arm `if` paths
- Rejects non-error `guard match` forms that would otherwise lower to invalid failure behavior
- Improves block-budget overflow location so the diagnostic points at the overflowing loop step/guard/arm instead of always using the first loop span

Most rejects currently use existing frontend error categories such as `UnsupportedSyntax` or `TooManyItems`; this PR focuses on accepting/rejecting the right shapes and improving spans, not on adding new dedicated diagnostic messages.

## Tests

- `ninja -C build tests/test_frontend`
- `./build/tests/test_frontend --filter=for,inline,plain_for --order-by=file`
- `clang-format --dry-run --Werror include/rut/compiler/lexer.h include/rut/compiler/ast.h include/rut/compiler/hir.h src/compiler/lexer.cc src/compiler/parser.cc src/compiler/analyze.cc src/compiler/mir_build.cc src/compiler/lower_rir.cc tests/test_frontend.cc`
- `git diff --check`
