### PR TITLE
diagnostics: clarify static for-loop rejects

### DIFF
--- a/include/rut/common/types.h
+++ b/include/rut/common/types.h
@@ -40,6 +40,11 @@ struct Str {
     [[nodiscard]] Str slice(u32 start, u32 end) const { return {ptr + start, end - start}; }
 };
 
+template <size_t N>
+constexpr Str lit_str(const char (&s)[N]) {
+    return {s, static_cast<u32>(N - 1)};
+}
+
 // Fixed-capacity vector, no heap allocation
 template <typename T, u32 Cap>
 struct FixedVec {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5744,7 +5744,11 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         return out;
     }
     if (expr.kind == AstExprKind::ArrayLit) {
-        if (!allow_array_lit) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        if (!allow_array_lit)
+            return frontend_error(
+                FrontendError::UnsupportedSyntax,
+                expr.span,
+                lit_str("array literals are only supported as static for-loop iterators"));
         // Empty array `[]` has no inferable element type; Rutlang has no
         // push/append so the element type can't be resolved later either.
         // Future: contextual inference from a declared type annotation can
@@ -6130,7 +6134,10 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                 return tuple;
             }
             if (locals[i].type == HirTypeKind::Array && !allow_array_lit)
-                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax,
+                    expr.span,
+                    lit_str("array locals are only supported as static for-loop iterators"));
             out.kind = HirExprKind::LocalRef;
             out.type = locals[i].type;
             out.is_wait_result = locals[i].is_wait_result;
@@ -9429,13 +9436,25 @@ static FrontendResult<void> analyze_wait_any_stmt_control(const AstStatement& st
 static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
                                             HirRoute* route,
                                             HirModule& mod) {
+    if (stmt.expr.kind == AstExprKind::Call || stmt.expr.kind == AstExprKind::MethodCall ||
+        stmt.expr.kind == AstExprKind::Field || stmt.expr.kind == AstExprKind::Pipe)
+        return frontend_error(
+            FrontendError::UnsupportedSyntax,
+            stmt.expr.span,
+            lit_str("static for-loop iterator must be a compile-time array literal or alias"));
+
     auto iter =
         analyze_array_iter_expr(stmt.expr, route, mod, route->locals.data, route->locals.len);
     if (!iter) return core::make_unexpected(iter.error());
     if (iter->type != HirTypeKind::Array || iter->shape_index >= mod.type_shapes.len)
-        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+        return frontend_error(FrontendError::UnsupportedSyntax,
+                              stmt.expr.span,
+                              lit_str("static for-loop iterator must be an array"));
     if (!is_static_for_iter_expr(iter.value(), route->locals.data, route->locals.len, 0))
-        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+        return frontend_error(
+            FrontendError::UnsupportedSyntax,
+            stmt.expr.span,
+            lit_str("static for-loop iterator must be a compile-time array literal or alias"));
 
     const auto& iter_shape = mod.type_shapes[iter->shape_index];
     if (iter_shape.array_elem_shape_index >= mod.type_shapes.len)
@@ -9444,7 +9463,9 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
 
     for (u32 li = 0; li < route->locals.len; li++) {
         if (route->locals[li].name.len != 0 && route->locals[li].name.eq(stmt.name))
-            return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+            return frontend_error(FrontendError::UnsupportedSyntax,
+                                  stmt.span,
+                                  lit_str("static for-loop variable cannot shadow a local"));
     }
 
     const u32 locals_saved = route->locals.len;
@@ -9511,9 +9532,15 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
             (body->kind == AstStmtKind::Block) ? *body->block_stmts[bi] : *body;
         if (bstmt.kind == AstStmtKind::Let) {
             if (loop.body.has_term)
-                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax,
+                    bstmt.span,
+                    lit_str("static for-loop body cannot continue after a route terminator"));
             if (bstmt.expr.kind == AstExprKind::Wait || bstmt.expr.kind == AstExprKind::ArrayLit)
-                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.expr.span);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax,
+                    bstmt.expr.span,
+                    lit_str("static for-loop body locals cannot be wait or array literals"));
             for (u32 li = 0; li < route->locals.len; li++) {
                 if (route->locals[li].name.len != 0 && route->locals[li].name.eq(bstmt.name))
                     return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
@@ -9569,7 +9596,10 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
         }
         if (bstmt.kind == AstStmtKind::Guard) {
             if (loop.body.has_term)
-                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax,
+                    bstmt.span,
+                    lit_str("static for-loop body cannot continue after a route terminator"));
             if (bstmt.match_arms.len == 0 && bstmt.else_stmt == nullptr)
                 return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
             HirGuard guard{};
@@ -9595,7 +9625,10 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
                                                                &guard);
                     if (!fail_match) return core::make_unexpected(fail_match.error());
                 } else {
-                    return frontend_error(FrontendError::UnsupportedSyntax, bstmt.expr.span);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax,
+                        bstmt.expr.span,
+                        lit_str("guard match inside static for-loop requires an error value"));
                 }
             } else if (bstmt.else_stmt->kind == AstStmtKind::ReturnStatus ||
                        bstmt.else_stmt->kind == AstStmtKind::ForwardUpstream) {
@@ -9625,7 +9658,10 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
             if (bstmt.bind_value) {
                 if (known_value_state(bound.value(), route->locals.data, route->locals.len, 0) ==
                     KnownValueState::Error)
-                    return frontend_error(FrontendError::UnsupportedSyntax, bstmt.expr.span);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax,
+                        bstmt.expr.span,
+                        lit_str("guard let inside static for-loop cannot bind a known error"));
                 for (u32 li = 0; li < route->locals.len; li++) {
                     if (route->locals[li].name.len != 0 && route->locals[li].name.eq(bstmt.name))
                         return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
@@ -9676,7 +9712,10 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
         }
         if (bstmt.kind == AstStmtKind::ReturnStatus || bstmt.kind == AstStmtKind::ForwardUpstream) {
             if (loop.body.has_term)
-                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax,
+                    bstmt.span,
+                    lit_str("static for-loop body cannot continue after a route terminator"));
             auto t = analyze_term(bstmt, mod);
             if (!t) return core::make_unexpected(t.error());
             loop.body.term = t.value();
@@ -9690,7 +9729,10 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
         }
         if (bstmt.kind == AstStmtKind::If) {
             if (loop.body.has_term)
-                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax,
+                    bstmt.span,
+                    lit_str("static for-loop body cannot continue after a route terminator"));
             const auto simple_branch = [](const AstStatement& branch) {
                 return branch.kind == AstStmtKind::ReturnStatus ||
                        branch.kind == AstStmtKind::ForwardUpstream;
@@ -9704,7 +9746,10 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
                 bstmt.expr, route, mod, route->locals.data, route->locals.len, nullptr);
             if (!cond) return core::make_unexpected(cond.error());
             if (cond->type != HirTypeKind::Bool || cond->may_nil || cond->may_error)
-                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.expr.span);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax,
+                    bstmt.expr.span,
+                    lit_str("static for-loop if condition must be a non-fallible bool"));
             body_if.cond = cond.value();
             auto then_term = analyze_term(*bstmt.then_stmt, mod);
             if (!then_term) return core::make_unexpected(then_term.error());
@@ -9726,7 +9771,10 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
         }
         if (bstmt.kind == AstStmtKind::Match) {
             if (loop.body.has_term)
-                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax,
+                    bstmt.span,
+                    lit_str("static for-loop body cannot continue after a route terminator"));
             HirForLoopMatch body_match{};
             body_match.span = bstmt.span;
             auto subject = analyze_expr(
@@ -9961,8 +10009,11 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
                             if (!cond_expr) return core::make_unexpected(cond_expr.error());
                             if (cond_expr->type != HirTypeKind::Bool || cond_expr->may_nil ||
                                 cond_expr->may_error)
-                                return frontend_error(FrontendError::UnsupportedSyntax,
-                                                      inner_arm.stmt->expr.span);
+                                return frontend_error(
+                                    FrontendError::UnsupportedSyntax,
+                                    inner_arm.stmt->expr.span,
+                                    lit_str("static for-loop match-arm if condition must be a "
+                                            "non-fallible bool"));
                             auto then_term = analyze_term(*inner_arm.stmt->then_stmt, mod);
                             if (!then_term) return core::make_unexpected(then_term.error());
                             auto else_term = analyze_term(*inner_arm.stmt->else_stmt, mod);
@@ -10207,8 +10258,11 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
                                     if (!fail_match)
                                         return core::make_unexpected(fail_match.error());
                                 } else {
-                                    return frontend_error(FrontendError::UnsupportedSyntax,
-                                                          inner.expr.span);
+                                    return frontend_error(
+                                        FrontendError::UnsupportedSyntax,
+                                        inner.expr.span,
+                                        lit_str("guard match inside static for-loop requires an "
+                                                "error value"));
                                 }
                             } else {
                                 if (inner.else_stmt->kind == AstStmtKind::ReturnStatus ||
@@ -10465,8 +10519,11 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
                                                      arm_binding_ptr);
                             if (!cond) return core::make_unexpected(cond.error());
                             if (cond->type != HirTypeKind::Bool || cond->may_nil || cond->may_error)
-                                return frontend_error(FrontendError::UnsupportedSyntax,
-                                                      inner_ast_arm.stmt->expr.span);
+                                return frontend_error(
+                                    FrontendError::UnsupportedSyntax,
+                                    inner_ast_arm.stmt->expr.span,
+                                    lit_str("static for-loop match-arm if condition must be a "
+                                            "non-fallible bool"));
                             auto then_term = analyze_term(*inner_ast_arm.stmt->then_stmt, mod);
                             if (!then_term) return core::make_unexpected(then_term.error());
                             auto else_term = analyze_term(*inner_ast_arm.stmt->else_stmt, mod);
@@ -10505,8 +10562,11 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
                         arm_stmt->expr, route, mod, arm_locals, arm_local_count, arm_binding_ptr);
                     if (!cond) return core::make_unexpected(cond.error());
                     if (cond->type != HirTypeKind::Bool || cond->may_nil || cond->may_error)
-                        return frontend_error(FrontendError::UnsupportedSyntax,
-                                              arm_stmt->expr.span);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax,
+                            arm_stmt->expr.span,
+                            lit_str("static for-loop match-arm if condition must be a "
+                                    "non-fallible bool"));
                     auto then_term = analyze_term(*arm_stmt->then_stmt, mod);
                     if (!then_term) return core::make_unexpected(then_term.error());
                     auto else_term = analyze_term(*arm_stmt->else_stmt, mod);
@@ -10541,7 +10601,10 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
         }
         if (bstmt.kind == AstStmtKind::For) {
             if (loop.body.has_term)
-                return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax,
+                    bstmt.span,
+                    lit_str("static for-loop body cannot continue after a route terminator"));
             auto nested = analyze_for_stmt(bstmt, route, mod);
             if (!nested) return core::make_unexpected(nested.error());
             HirForLoopBody::Step step{};
@@ -10562,11 +10625,21 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
                 loop.body.has_term = true;
             continue;
         }
-        return frontend_error(FrontendError::UnsupportedSyntax, bstmt.span);
+        return frontend_error(FrontendError::UnsupportedSyntax,
+                              bstmt.span,
+                              lit_str("unsupported statement in static for-loop body"));
     }
 
     if (route->locals.len < locals_saved + 1)
-        return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+        return frontend_error(
+            FrontendError::UnsupportedSyntax,
+            stmt.span,
+            lit_str("static for-loop body must contain at least one supported step"));
+    if (loop.body.steps.len == 0)
+        return frontend_error(
+            FrontendError::UnsupportedSyntax,
+            stmt.span,
+            lit_str("static for-loop body must contain at least one supported step"));
     for (u32 li = locals_saved; li < route->locals.len; li++) route->locals[li].name = {};
     return for_index;
 }
@@ -13724,7 +13797,10 @@ static FrontendResult<HirModule*> analyze_file_internal(
         for (u32 si = 0; si < item.route.statements.len; si++) {
             const auto& stmt = item.route.statements[si];
             if (stmt.kind == AstStmtKind::Wait) {
-                if (seen_for) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                if (seen_for)
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          stmt.span,
+                                          lit_str("wait cannot be used after a static for-loop"));
                 auto wait_spec = analyze_wait_stmt_spec(stmt, mod);
                 if (!wait_spec) return core::make_unexpected(wait_spec.error());
                 if (wait_spec->kind == WaitEventKind::Timer && wait_spec->payload == 0)
@@ -13820,11 +13896,18 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 if (init.value().type == HirTypeKind::Array) {
                     if (!used_for_iter || !is_static_for_iter_expr(
                                               init.value(), route.locals.data, route.locals.len, 0))
-                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax,
+                            stmt.expr.span,
+                            lit_str(
+                                "array locals are only supported as static for-loop iterators"));
                 }
                 if (init->kind == HirExprKind::WaitResult) {
                     if (seen_for)
-                        return frontend_error(FrontendError::UnsupportedSyntax, stmt.expr.span);
+                        return frontend_error(
+                            FrontendError::UnsupportedSyntax,
+                            stmt.expr.span,
+                            lit_str("wait cannot be used after a static for-loop"));
                     HirRoute::Wait w{};
                     w.span = stmt.expr.span;
                     w.event_kind = init->wait_event_kind;
@@ -13955,7 +14038,10 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 continue;
             }
             if (stmt.kind == AstStmtKind::WaitAny) {
-                if (seen_for) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                if (seen_for)
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          stmt.span,
+                                          lit_str("wait cannot be used after a static for-loop"));
                 auto wait_any = analyze_wait_any_stmt_control(stmt, route, mod);
                 if (!wait_any) return core::make_unexpected(wait_any.error());
                 seen_wait = true;
@@ -13965,7 +14051,10 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 break;
             }
             if (stmt.kind == AstStmtKind::For) {
-                if (seen_wait) return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
+                if (seen_wait)
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          stmt.span,
+                                          lit_str("static for-loop cannot be combined with wait"));
                 seen_for = true;
                 auto loop = analyze_for_stmt(stmt, &route, mod);
                 if (!loop) return core::make_unexpected(loop.error());

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -1553,7 +1553,10 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 // be lowered.
                 const bool supported = fl.body.steps.len != 0 && iter_array != nullptr;
                 if (!supported || fl.loop_var_ref_index == 0xffffffffu) {
-                    return frontend_error(FrontendError::UnsupportedSyntax, fl.span);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax,
+                        fl.span,
+                        lit_str("static for-loop body must contain at least one supported step"));
                 }
                 const u32 iter_count =
                     fl.body.has_term && iter_array->args.len != 0 ? 1u : iter_array->args.len;
@@ -1839,7 +1842,9 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     &fail_cursor, guard_fail_block_count(*steps[si].guard), steps[si].span);
             }
             if (fail_cursor > MirFunction::kMaxBlocks)
-                return frontend_error(FrontendError::TooManyItems, block_budget_span);
+                return frontend_error(FrontendError::TooManyItems,
+                                      block_budget_span,
+                                      lit_str("static for-loop block budget exceeded"));
 
             auto extend_for_loop_match_arm_ctx =
                 [&](const HirForLoopMatchArm& arm,

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -2021,6 +2021,9 @@ TEST(frontend, analyze_rejects_wait_after_for_loop) {
         REQUIRE(ast);
         auto hir = analyze_file_heap(ast.value());
         REQUIRE(!hir);
+        CHECK_EQ(static_cast<u8>(hir.error().code),
+                 static_cast<u8>(FrontendError::UnsupportedSyntax));
+        CHECK(hir.error().detail.eq(lit("wait cannot be used after a static for-loop")));
     }
 }
 
@@ -2042,6 +2045,7 @@ TEST(frontend, analyze_rejects_for_loop_after_wait) {
         REQUIRE(ast);
         auto hir = analyze_file_heap(ast.value());
         REQUIRE(!hir);
+        CHECK(hir.error().detail.eq(lit("static for-loop cannot be combined with wait")));
     }
 }
 
@@ -9843,6 +9847,8 @@ TEST(frontend, analyze_rejects_typed_empty_array_local_used_outside_for_iter) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir);
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(
+        hir.error().detail.eq(lit("array locals are only supported as static for-loop iterators")));
 }
 
 TEST(frontend, analyze_rejects_array_local_alias_chain_used_outside_for_iter) {
@@ -18600,7 +18606,9 @@ TEST(frontend, analyze_for_loop_body_if_rejects_fallible_bool) {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    CHECK(!hir);
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("static for-loop if condition must be a non-fallible bool")));
 }
 
 TEST(frontend, analyze_plain_for_loop_body_if_rejects_fallible_bool) {
@@ -18649,7 +18657,10 @@ TEST(frontend, analyze_for_loop_match_arm_if_rejects_fallible_bool) {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    CHECK(!hir);
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(
+        lit("static for-loop match-arm if condition must be a non-fallible bool")));
 }
 
 TEST(frontend, analyze_plain_for_loop_match_arm_if_rejects_fallible_bool) {
@@ -18767,6 +18778,18 @@ TEST(frontend, analyze_for_loop_guard_body) {
     CHECK_EQ(fl.body.guards[0].fail_term.status_code, 400);
     // No body terminator — control falls through to the next iteration.
     CHECK(!fl.body.has_term);
+}
+
+TEST(frontend, analyze_for_loop_unsupported_body_stmt_has_clear_detail) {
+    const char* src = "route GET \"/x\" { for item in [1] { wait(1) } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("unsupported statement in static for-loop body")));
 }
 
 TEST(frontend, analyze_plain_for_loop_guard_body) {
@@ -18921,6 +18944,40 @@ TEST(frontend, analyze_for_rejects_non_static_for_loop_iter) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_for_loop_reject_details_name_iterator_shape) {
+    struct Case {
+        const char* label;
+        const char* src;
+        Str detail;
+    };
+    const Case cases[] = {
+        {"shadowing loop var",
+         "route GET \"/x\" { let item = 1 for item in [2] { return 200 } return 200 }\n",
+         lit("static for-loop variable cannot shadow a local")},
+        {"known-error guard let",
+         "route GET \"/x\" { for item in [1] { guard let code = error(.timeout) else { return "
+         "400 } } return 200 }\n",
+         lit("guard let inside static for-loop cannot bind a known error")},
+        {"non-array iterator",
+         "route GET \"/x\" { for item in 42 { return 200 } return 200 }\n",
+         lit("static for-loop iterator must be an array")},
+        {"non-static iterator",
+         "route GET \"/x\" { for item in make() { return 200 } return 200 }\n",
+         lit("static for-loop iterator must be a compile-time array literal or alias")},
+    };
+    for (const auto& tc : cases) {
+        auto lexed = lex(lit(tc.src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE_FALSE(hir);
+        CHECK_EQ(static_cast<u8>(hir.error().code),
+                 static_cast<u8>(FrontendError::UnsupportedSyntax));
+        CHECK_MSG(hir.error().detail.eq(tc.detail), tc.label);
+    }
 }
 
 TEST(frontend, analyze_rejects_non_static_for_loop_iter_via_alias_chain) {
@@ -19972,6 +20029,7 @@ TEST(frontend, mir_rejects_for_loop_exceeding_block_budget) {
     auto mir = build_mir_heap(hir.value());
     REQUIRE(!mir);
     CHECK_EQ(mir.error().code, FrontendError::TooManyItems);
+    CHECK(mir.error().detail.eq(lit("static for-loop block budget exceeded")));
     REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 1u);
     CHECK_EQ(mir.error().span.start, hir->routes[0].for_loops[0].body.guards[0].span.start);
 }
@@ -19989,6 +20047,7 @@ TEST(frontend, mir_rejects_plain_for_loop_exceeding_block_budget) {
     auto mir = build_mir_heap(hir.value());
     REQUIRE(!mir);
     CHECK_EQ(mir.error().code, FrontendError::TooManyItems);
+    CHECK(mir.error().detail.eq(lit("static for-loop block budget exceeded")));
     REQUIRE_EQ(hir->routes[0].for_loops[0].body.guards.len, 1u);
     CHECK_EQ(mir.error().span.start, hir->routes[0].for_loops[0].body.guards[0].span.start);
 }
@@ -20351,7 +20410,8 @@ TEST(frontend, analyze_for_loop_rejects_shadowing_outer_local) {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    CHECK(!hir);
+    REQUIRE_FALSE(hir);
+    CHECK(hir.error().detail.eq(lit("static for-loop variable cannot shadow a local")));
 }
 
 TEST(frontend, analyze_plain_for_loop_rejects_shadowing_outer_local) {
@@ -22010,6 +22070,7 @@ TEST(frontend, analyze_rejects_for_loop_body_guard_match_on_non_error_value) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir);
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("guard match inside static for-loop requires an error value")));
 }
 
 TEST(frontend, analyze_plain_for_rejects_for_loop_body_guard_match_on_non_error_value) {


### PR DESCRIPTION
## Summary

Closes #70.

This PR adds clear diagnostic `detail` messages for static for-loop validation failures instead of returning only generic `UnsupportedSyntax` or `TooManyItems` errors.

Covered rejection paths include:

- `wait` mixed with static for-loop lowering, in both orders
- non-array and non-static for-loop iterators
- array locals escaping into ordinary runtime expressions
- fallible or nil loop-body `if` and match-arm `if` predicates
- non-error `guard match` forms inside static for-loop bodies
- empty or unsupported static for-loop bodies
- MIR block-budget overflow, while preserving the existing improved source span

## Validation

- `./build/tests/test_frontend`
- `git diff --check`
