### PR TITLE
Add pipe method stages

### DIFF
--- a/docs/pipe.md
+++ b/docs/pipe.md
@@ -111,6 +111,21 @@ route GET "/admin" {
 }
 ```
 
+## Method Stages
+
+The placeholder can also be the receiver of a method-call stage:
+
+```rut
+route GET "/method-stage" {
+    let ok = 200 | _.eq(200)
+    if ok { return 200 } else { return 500 }
+}
+```
+
+`_` and `_1` are accepted as method receivers. Tuple-slot receivers such as
+`_2.method(...)` are still rejected; use a function stage with tuple-slot
+arguments when a pipeline needs to project tuple slots.
+
 ## Optional Header Flow
 
 `req.header(...)` returns an optional string. A pipe stage only runs when the
@@ -226,6 +241,7 @@ route GET "/generic" {
 ## Supported Today
 
 - Function-call stages: `value | fn(_, other_arg)`.
+- Method-call stages with a whole-value receiver: `value | _.method(other_arg)`.
 - Placeholder position anywhere in the function argument list.
 - Single-stage and chained pipes.
 - Tuple slot placeholders `_1` ... `_10`.
@@ -238,7 +254,6 @@ route GET "/generic" {
 
 The following are future work rather than current behavior:
 
-- Method-call stages on the right-hand side.
 - Placeholder-free stages. A pipe stage must consume the left-hand value
   explicitly.
 - Multiple placeholders in a single stage.

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3221,14 +3221,17 @@ static bool magic_req_receiver(const AstExpr& lhs,
            !user_bound_req_name(mod, locals, local_count, binding);
 }
 
-static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
-                                                        HirRoute* route,
-                                                        const HirModule& mod,
-                                                        const HirLocal* locals,
-                                                        u32 local_count,
-                                                        const MatchPayloadBinding* binding) {
+static FrontendResult<HirExpr> analyze_method_call_expr(
+    const AstExpr& expr,
+    HirRoute* route,
+    const HirModule& mod,
+    const HirLocal* locals,
+    u32 local_count,
+    const MatchPayloadBinding* binding,
+    const HirExpr* receiver_override = nullptr) {
     if (expr.lhs == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-    if (expr.lhs->kind == AstExprKind::Ident && has_import_namespace(mod, expr.lhs->name)) {
+    if (receiver_override == nullptr && expr.lhs->kind == AstExprKind::Ident &&
+        has_import_namespace(mod, expr.lhs->name)) {
         Str qualified_member{};
         AstExpr ns_field{};
         ns_field.kind = AstExprKind::Field;
@@ -3245,7 +3248,8 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         return analyze_call_expr(call_expr, route, mod, locals, local_count, binding, nullptr);
     }
     Str qualified_type_name{};
-    if (resolve_import_namespace_member(mod, *expr.lhs, qualified_type_name)) {
+    if (receiver_override == nullptr &&
+        resolve_import_namespace_member(mod, *expr.lhs, qualified_type_name)) {
         AstExpr variant_expr{};
         variant_expr.kind = AstExprKind::VariantCase;
         variant_expr.span = expr.span;
@@ -3259,7 +3263,7 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         auto variant = analyze_expr(variant_expr, route, mod, locals, local_count, binding);
         if (variant) return variant;
     }
-    if (expr.lhs->kind == AstExprKind::Ident) {
+    if (receiver_override == nullptr && expr.lhs->kind == AstExprKind::Ident) {
         AstExpr variant_expr{};
         variant_expr.kind = AstExprKind::VariantCase;
         variant_expr.span = expr.span;
@@ -3273,7 +3277,8 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         auto variant = analyze_expr(variant_expr, route, mod, locals, local_count, binding);
         if (variant) return variant;
     }
-    if (magic_req_receiver(*expr.lhs, mod, locals, local_count, binding) &&
+    if (receiver_override == nullptr &&
+        magic_req_receiver(*expr.lhs, mod, locals, local_count, binding) &&
         (expr.name.eq({"header", 6}) || expr.name.eq({"param", 5}) || expr.name.eq({"cookie", 6}) ||
          expr.name.eq({"query", 5}))) {
         if (expr.args.len != 1 || expr.args[0] == nullptr ||
@@ -3321,17 +3326,35 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
     field_expr.lhs = expr.lhs;
     field_expr.name = expr.name;
 
-    auto recv = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
-    if (!recv) return core::make_unexpected(recv.error());
+    HirExpr recv{};
+    if (receiver_override != nullptr) {
+        recv = *receiver_override;
+    } else {
+        auto analyzed_recv = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
+        if (!analyzed_recv) return core::make_unexpected(analyzed_recv.error());
+        recv = analyzed_recv.value();
+    }
     if (expr.args.len == 0 && is_standard_error_field(expr.name) &&
-        (recv->may_error ||
-         (recv->type == HirTypeKind::Generic && recv->generic_has_error_constraint))) {
+        (recv.may_error ||
+         (recv.type == HirTypeKind::Generic && recv.generic_has_error_constraint))) {
+        if (receiver_override != nullptr) {
+            HirExpr out{};
+            out.kind = HirExprKind::Field;
+            out.span = expr.span;
+            out.type = expr.name.eq({"code", 4}) || expr.name.eq({"line", 4}) ? HirTypeKind::I32
+                                                                              : HirTypeKind::Str;
+            if (!route->exprs.push(recv))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.lhs = &route->exprs[route->exprs.len - 1];
+            out.str_value = expr.name;
+            return out;
+        }
         return analyze_expr(field_expr, route, mod, locals, local_count, binding);
     }
-    if (recv->may_nil || recv->may_error)
+    if (recv.may_nil || recv.may_error)
         return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
 
-    if (expr.name.eq({"matches", 7}) && recv->type == HirTypeKind::Str && expr.args.len == 1 &&
+    if (expr.name.eq({"matches", 7}) && recv.type == HirTypeKind::Str && expr.args.len == 1 &&
         expr.args[0]->kind == AstExprKind::RegexLit) {
 #if RUT_VALIDATE_REGEX_WITH_VECTORSCAN
         std::string regex_error;
@@ -3346,8 +3369,7 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         out.type = HirTypeKind::Bool;
         out.span = expr.span;
         out.str_value = expr.args[0]->str_value;
-        if (!route->exprs.push(recv.value()))
-            return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(recv)) return frontend_error(FrontendError::TooManyItems, expr.span);
         out.lhs = &route->exprs[route->exprs.len - 1];
         return out;
     }
@@ -3361,29 +3383,29 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         if (!rhs) return core::make_unexpected(rhs.error());
         if (rhs->may_nil || rhs->may_error)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-        if (!same_hir_type_shape(mod, *recv, *rhs))
+        if (!same_hir_type_shape(mod, recv, *rhs))
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         if (is_eq_family) {
-            if (recv->type == HirTypeKind::Generic) {
-                if (!recv->generic_has_eq_constraint)
+            if (recv.type == HirTypeKind::Generic) {
+                if (!recv.generic_has_eq_constraint)
                     return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
             } else {
                 bool struct_visiting[HirModule::kMaxStructs]{};
                 bool variant_visiting[HirModule::kMaxVariants]{};
                 if (!hir_type_shape_satisfies_eq_constraint(mod,
-                                                            recv->type,
-                                                            recv->variant_index,
-                                                            recv->struct_index,
-                                                            recv->tuple_len,
-                                                            recv->tuple_types,
-                                                            recv->tuple_variant_indices,
-                                                            recv->tuple_struct_indices,
+                                                            recv.type,
+                                                            recv.variant_index,
+                                                            recv.struct_index,
+                                                            recv.tuple_len,
+                                                            recv.tuple_types,
+                                                            recv.tuple_variant_indices,
+                                                            recv.tuple_struct_indices,
                                                             struct_visiting,
                                                             variant_visiting)) {
                     return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
                 }
             }
-            auto eq_expr = build_cmp(HirExprKind::Eq, recv.value(), rhs.value());
+            auto eq_expr = build_cmp(HirExprKind::Eq, recv, rhs.value());
             if (!eq_expr) return core::make_unexpected(eq_expr.error());
             if (expr.name.eq({"eq", 2})) return eq_expr;
             HirExpr false_expr{};
@@ -3393,32 +3415,29 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
             false_expr.span = expr.span;
             return build_cmp(HirExprKind::Eq, eq_expr.value(), false_expr);
         } else {
-            if (recv->type == HirTypeKind::Generic) {
-                if (!recv->generic_has_ord_constraint)
+            if (recv.type == HirTypeKind::Generic) {
+                if (!recv.generic_has_ord_constraint)
                     return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
             } else {
                 bool struct_visiting[HirModule::kMaxStructs]{};
                 bool variant_visiting[HirModule::kMaxVariants]{};
                 if (!hir_type_shape_satisfies_ord_constraint(mod,
-                                                             recv->type,
-                                                             recv->variant_index,
-                                                             recv->struct_index,
-                                                             recv->tuple_len,
-                                                             recv->tuple_types,
-                                                             recv->tuple_variant_indices,
-                                                             recv->tuple_struct_indices,
+                                                             recv.type,
+                                                             recv.variant_index,
+                                                             recv.struct_index,
+                                                             recv.tuple_len,
+                                                             recv.tuple_types,
+                                                             recv.tuple_variant_indices,
+                                                             recv.tuple_struct_indices,
                                                              struct_visiting,
                                                              variant_visiting)) {
                     return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
                 }
             }
-            if (expr.name.eq({"lt", 2}))
-                return build_cmp(HirExprKind::Lt, recv.value(), rhs.value());
-            if (expr.name.eq({"gt", 2}))
-                return build_cmp(HirExprKind::Gt, recv.value(), rhs.value());
-            auto strict = expr.name.eq({"le", 2})
-                              ? build_cmp(HirExprKind::Gt, recv.value(), rhs.value())
-                              : build_cmp(HirExprKind::Lt, recv.value(), rhs.value());
+            if (expr.name.eq({"lt", 2})) return build_cmp(HirExprKind::Lt, recv, rhs.value());
+            if (expr.name.eq({"gt", 2})) return build_cmp(HirExprKind::Gt, recv, rhs.value());
+            auto strict = expr.name.eq({"le", 2}) ? build_cmp(HirExprKind::Gt, recv, rhs.value())
+                                                  : build_cmp(HirExprKind::Lt, recv, rhs.value());
             if (!strict) return core::make_unexpected(strict.error());
             HirExpr false_expr{};
             false_expr.kind = HirExprKind::BoolLit;
@@ -3428,11 +3447,11 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
             return build_cmp(HirExprKind::Eq, strict.value(), false_expr);
         }
     }
-    if (recv->type == HirTypeKind::Generic && recv->generic_index != 0xffffffffu) {
+    if (recv.type == HirTypeKind::Generic && recv.generic_index != 0xffffffffu) {
         u32 matched_protocol_index = 0xffffffffu;
         const HirProtocol::MethodDecl* matched_req = nullptr;
-        for (u32 gi = 0; gi < recv->generic_protocol_count; gi++) {
-            const u32 proto_index = recv->generic_protocol_indices[gi];
+        for (u32 gi = 0; gi < recv.generic_protocol_count; gi++) {
+            const u32 proto_index = recv.generic_protocol_indices[gi];
             if (proto_index >= mod.protocols.len) continue;
             const auto* req = find_protocol_method(mod.protocols[proto_index], expr.name);
             if (req == nullptr) continue;
@@ -3444,35 +3463,35 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
         if (matched_protocol_index != 0xffffffffu && matched_req != nullptr) {
             GenericBinding recv_bindings[HirFunction::kMaxTypeParams]{};
             u32 recv_binding_count = 0;
-            if (recv->generic_index < HirFunction::kMaxTypeParams) {
-                recv_binding_count = recv->generic_index + 1;
+            if (recv.generic_index < HirFunction::kMaxTypeParams) {
+                recv_binding_count = recv.generic_index + 1;
                 auto bound = fill_bound_binding_from_type_metadata(
-                    &recv_bindings[recv->generic_index],
+                    &recv_bindings[recv.generic_index],
                     const_cast<HirModule*>(&mod),
-                    recv->type,
-                    recv->type == HirTypeKind::Generic ? recv->generic_index : 0xffffffffu,
-                    recv->variant_index,
-                    recv->struct_index,
-                    recv->tuple_len,
-                    recv->tuple_types,
-                    recv->tuple_variant_indices,
-                    recv->tuple_struct_indices,
-                    recv->shape_index,
+                    recv.type,
+                    recv.type == HirTypeKind::Generic ? recv.generic_index : 0xffffffffu,
+                    recv.variant_index,
+                    recv.struct_index,
+                    recv.tuple_len,
+                    recv.tuple_types,
+                    recv.tuple_variant_indices,
+                    recv.tuple_struct_indices,
+                    recv.shape_index,
                     expr.span);
                 if (!bound) return core::make_unexpected(bound.error());
-                recv_bindings[recv->generic_index].generic_has_error_constraint =
-                    recv->generic_has_error_constraint;
-                recv_bindings[recv->generic_index].generic_has_eq_constraint =
-                    recv->generic_has_eq_constraint;
-                recv_bindings[recv->generic_index].generic_has_ord_constraint =
-                    recv->generic_has_ord_constraint;
-                recv_bindings[recv->generic_index].generic_protocol_index =
-                    recv->generic_protocol_index;
-                recv_bindings[recv->generic_index].generic_protocol_count =
-                    recv->generic_protocol_count;
-                for (u32 cpi = 0; cpi < recv->generic_protocol_count; cpi++)
-                    recv_bindings[recv->generic_index].generic_protocol_indices[cpi] =
-                        recv->generic_protocol_indices[cpi];
+                recv_bindings[recv.generic_index].generic_has_error_constraint =
+                    recv.generic_has_error_constraint;
+                recv_bindings[recv.generic_index].generic_has_eq_constraint =
+                    recv.generic_has_eq_constraint;
+                recv_bindings[recv.generic_index].generic_has_ord_constraint =
+                    recv.generic_has_ord_constraint;
+                recv_bindings[recv.generic_index].generic_protocol_index =
+                    recv.generic_protocol_index;
+                recv_bindings[recv.generic_index].generic_protocol_count =
+                    recv.generic_protocol_count;
+                for (u32 cpi = 0; cpi < recv.generic_protocol_count; cpi++)
+                    recv_bindings[recv.generic_index].generic_protocol_indices[cpi] =
+                        recv.generic_protocol_indices[cpi];
             }
             auto concretize_protocol_associated_expr = [&](HirExpr* expected) -> bool {
                 if (recv_binding_count == 0) return true;
@@ -3490,21 +3509,21 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
             out.type = HirTypeKind::Unknown;
             out.protocol_index = matched_protocol_index;
             out.str_value = expr.name;
-            if (!route->exprs.push(recv.value()))
+            if (!route->exprs.push(recv))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
             out.lhs = &route->exprs[route->exprs.len - 1];
             auto bind_req_self_associated = [&](HirExpr* expected) {
                 if (expected->type == HirTypeKind::Associated &&
                     expected->generic_index == 0xffffffffu) {
-                    expected->generic_index = recv->generic_index;
-                    expected->generic_has_error_constraint = recv->generic_has_error_constraint;
-                    expected->generic_has_eq_constraint = recv->generic_has_eq_constraint;
-                    expected->generic_has_ord_constraint = recv->generic_has_ord_constraint;
-                    expected->generic_protocol_index = recv->generic_protocol_index;
-                    expected->generic_protocol_count = recv->generic_protocol_count;
-                    for (u32 cpi = 0; cpi < recv->generic_protocol_count; cpi++)
+                    expected->generic_index = recv.generic_index;
+                    expected->generic_has_error_constraint = recv.generic_has_error_constraint;
+                    expected->generic_has_eq_constraint = recv.generic_has_eq_constraint;
+                    expected->generic_has_ord_constraint = recv.generic_has_ord_constraint;
+                    expected->generic_protocol_index = recv.generic_protocol_index;
+                    expected->generic_protocol_count = recv.generic_protocol_count;
+                    for (u32 cpi = 0; cpi < recv.generic_protocol_count; cpi++)
                         expected->generic_protocol_indices[cpi] =
-                            recv->generic_protocol_indices[cpi];
+                            recv.generic_protocol_indices[cpi];
                 }
             };
             for (u32 i = 0; i < expr.args.len; i++) {
@@ -3565,10 +3584,10 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
                 return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
         }
     }
-    if (recv->type == HirTypeKind::Bool || recv->type == HirTypeKind::I32 ||
-        recv->type == HirTypeKind::Str || recv->type == HirTypeKind::Struct ||
-        recv->type == HirTypeKind::Variant || recv->type == HirTypeKind::Tuple) {
-        const auto* impl = find_impl_for_type(mod, recv->type, recv->struct_index, expr.name);
+    if (recv.type == HirTypeKind::Bool || recv.type == HirTypeKind::I32 ||
+        recv.type == HirTypeKind::Str || recv.type == HirTypeKind::Struct ||
+        recv.type == HirTypeKind::Variant || recv.type == HirTypeKind::Tuple) {
+        const auto* impl = find_impl_for_type(mod, recv.type, recv.struct_index, expr.name);
         if (impl != nullptr) {
             const auto* method = find_impl_method(*impl, expr.name);
             if (method == nullptr || method->function_index >= mod.functions.len)
@@ -3583,32 +3602,38 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
                 if (!call_expr.args.push(expr.args[i]))
                     return frontend_error(FrontendError::TooManyItems, expr.span);
             }
-            return analyze_call_expr(call_expr, route, mod, locals, local_count, binding, nullptr);
+            return analyze_call_expr(call_expr,
+                                     route,
+                                     mod,
+                                     locals,
+                                     local_count,
+                                     binding,
+                                     receiver_override ? &recv : nullptr);
         }
         u32 matched_protocol_index = 0xffffffffu;
         const HirProtocol::MethodDecl* matched_req = nullptr;
         for (u32 ci = 0; ci < mod.conformances.len; ci++) {
             const auto& conf = mod.conformances[ci];
-            if (conf.type != recv->type) continue;
-            if (recv->type == HirTypeKind::Struct && conf.struct_index != recv->struct_index)
+            if (conf.type != recv.type) continue;
+            if (recv.type == HirTypeKind::Struct && conf.struct_index != recv.struct_index)
                 continue;
-            if (recv->type == HirTypeKind::Variant && conf.variant_index != recv->variant_index)
+            if (recv.type == HirTypeKind::Variant && conf.variant_index != recv.variant_index)
                 continue;
-            if (recv->type == HirTypeKind::Tuple) {
-                if (conf.tuple_len != recv->tuple_len) continue;
+            if (recv.type == HirTypeKind::Tuple) {
+                if (conf.tuple_len != recv.tuple_len) continue;
                 bool tuple_match = true;
-                for (u32 ti = 0; ti < recv->tuple_len; ti++) {
-                    if (conf.tuple_types[ti] != recv->tuple_types[ti]) {
+                for (u32 ti = 0; ti < recv.tuple_len; ti++) {
+                    if (conf.tuple_types[ti] != recv.tuple_types[ti]) {
                         tuple_match = false;
                         break;
                     }
                     if (conf.tuple_types[ti] == HirTypeKind::Variant &&
-                        conf.tuple_variant_indices[ti] != recv->tuple_variant_indices[ti]) {
+                        conf.tuple_variant_indices[ti] != recv.tuple_variant_indices[ti]) {
                         tuple_match = false;
                         break;
                     }
                     if (conf.tuple_types[ti] == HirTypeKind::Struct &&
-                        conf.tuple_struct_indices[ti] != recv->tuple_struct_indices[ti]) {
+                        conf.tuple_struct_indices[ti] != recv.tuple_struct_indices[ti]) {
                         tuple_match = false;
                         break;
                     }
@@ -3634,7 +3659,13 @@ static FrontendResult<HirExpr> analyze_method_call_expr(const AstExpr& expr,
                 if (!call_expr.args.push(expr.args[i]))
                     return frontend_error(FrontendError::TooManyItems, expr.span);
             }
-            return analyze_call_expr(call_expr, route, mod, locals, local_count, binding, nullptr);
+            return analyze_call_expr(call_expr,
+                                     route,
+                                     mod,
+                                     locals,
+                                     local_count,
+                                     binding,
+                                     receiver_override ? &recv : nullptr);
         }
     }
     return frontend_error(FrontendError::UnsupportedSyntax, expr.span, expr.name);
@@ -6074,9 +6105,202 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         auto lhs = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
         if (!lhs) return core::make_unexpected(lhs.error());
-        if (expr.rhs->kind != AstExprKind::Call)
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.rhs->span);
-        return analyze_call_expr(*expr.rhs, route, mod, locals, local_count, binding, &lhs.value());
+        if (expr.rhs->kind == AstExprKind::MethodCall && expr.rhs->lhs != nullptr &&
+            expr.rhs->lhs->kind == AstExprKind::Placeholder && expr.rhs->lhs->int_value == 1) {
+            AstExpr method_stage = *expr.rhs;
+            auto copy_result_shape = [](HirExpr* dst, const HirExpr& src) {
+                dst->type = src.type;
+                dst->generic_index = src.generic_index;
+                dst->associated_name = src.associated_name;
+                dst->generic_has_error_constraint = src.generic_has_error_constraint;
+                dst->generic_has_eq_constraint = src.generic_has_eq_constraint;
+                dst->generic_has_ord_constraint = src.generic_has_ord_constraint;
+                dst->generic_protocol_index = src.generic_protocol_index;
+                dst->generic_protocol_count = src.generic_protocol_count;
+                for (u32 cpi = 0; cpi < src.generic_protocol_count; cpi++)
+                    dst->generic_protocol_indices[cpi] = src.generic_protocol_indices[cpi];
+                dst->variant_index = src.variant_index;
+                dst->struct_index = src.struct_index;
+                dst->shape_index = src.shape_index;
+                dst->tuple_len = src.tuple_len;
+                for (u32 i = 0; i < src.tuple_len; i++) {
+                    dst->tuple_types[i] = src.tuple_types[i];
+                    dst->tuple_variant_indices[i] = src.tuple_variant_indices[i];
+                    dst->tuple_struct_indices[i] = src.tuple_struct_indices[i];
+                }
+                dst->error_struct_index = src.error_struct_index;
+                dst->error_variant_index = src.error_variant_index;
+            };
+            auto is_lowerable_missing_result = [](const HirExpr& value) {
+                return value.type == HirTypeKind::Bool || value.type == HirTypeKind::I32 ||
+                       value.type == HirTypeKind::Str || value.type == HirTypeKind::Variant ||
+                       value.type == HirTypeKind::Struct;
+            };
+            auto shape_only_result = [](HirExpr value) {
+                value.lhs = nullptr;
+                value.rhs = nullptr;
+                value.args.len = 0;
+                value.field_inits.len = 0;
+                value.array_len = 0;
+                return value;
+            };
+            auto infer_known_missing_method_result = [&]() -> FrontendResult<HirExpr> {
+                const bool is_cmp =
+                    method_stage.name.eq({"eq", 2}) || method_stage.name.eq({"ne", 2}) ||
+                    method_stage.name.eq({"lt", 2}) || method_stage.name.eq({"gt", 2}) ||
+                    method_stage.name.eq({"le", 2}) || method_stage.name.eq({"ge", 2});
+                if (lhs->type == HirTypeKind::Unknown && is_cmp && method_stage.args.len == 1) {
+                    auto rhs = analyze_expr(
+                        *method_stage.args[0], route, mod, locals, local_count, binding);
+                    if (!rhs) return core::make_unexpected(rhs.error());
+                    if (rhs->may_nil || rhs->may_error)
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              method_stage.args[0]->span);
+                    HirExpr ret{};
+                    ret.type = HirTypeKind::Bool;
+                    return ret;
+                }
+                if (lhs->type == HirTypeKind::Unknown && method_stage.name.eq({"matches", 7}) &&
+                    method_stage.args.len == 1 &&
+                    method_stage.args[0]->kind == AstExprKind::RegexLit) {
+#if RUT_VALIDATE_REGEX_WITH_VECTORSCAN
+                    std::string regex_error;
+                    if (!validate_regex_literal(method_stage.args[0]->str_value, &regex_error)) {
+                        return frontend_error(FrontendError::InvalidRegex,
+                                              method_stage.args[0]->span,
+                                              intern_generated_name(regex_error));
+                    }
+#endif
+                    HirExpr ret{};
+                    ret.type = HirTypeKind::Bool;
+                    return ret;
+                }
+
+                HirExpr recv = lhs.value();
+                recv.kind = HirExprKind::ValueOf;
+                recv.may_nil = false;
+                recv.may_error = lhs->type == HirTypeKind::Unknown &&
+                                 known_value_state(lhs.value(), locals, local_count, 0) ==
+                                     KnownValueState::Error;
+                recv.lhs = nullptr;
+                const u32 expr_len = route->exprs.len;
+                auto ret = analyze_method_call_expr(
+                    method_stage, route, mod, locals, local_count, binding, &recv);
+                route->exprs.len = expr_len;
+                if (!ret) return core::make_unexpected(ret.error());
+                return shape_only_result(ret.value());
+            };
+
+            const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
+            if (lhs_state == KnownValueState::Nil) {
+                auto ret = infer_known_missing_method_result();
+                if (!ret) return core::make_unexpected(ret.error());
+                if (!is_lowerable_missing_result(ret.value()))
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_stage.span);
+                HirExpr folded{};
+                folded.kind = HirExprKind::Nil;
+                copy_result_shape(&folded, ret.value());
+                folded.span = expr.span;
+                folded.may_nil = true;
+                return folded;
+            }
+            if (lhs_state == KnownValueState::Error) {
+                const HirExpr* err_expr = known_error_expr(lhs.value(), locals, local_count, 0);
+                if (!err_expr)
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_stage.span);
+                auto ret = infer_known_missing_method_result();
+                if (!ret) return core::make_unexpected(ret.error());
+                if (!is_lowerable_missing_result(ret.value()))
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_stage.span);
+                HirExpr folded = *err_expr;
+                const u32 error_struct_index = folded.error_struct_index;
+                const u32 error_variant_index = folded.error_variant_index;
+                copy_result_shape(&folded, ret.value());
+                folded.span = expr.span;
+                folded.may_nil = false;
+                folded.may_error = true;
+                folded.error_struct_index = error_struct_index;
+                folded.error_variant_index = error_variant_index;
+                return folded;
+            }
+            if (lhs_state == KnownValueState::Unknown && (lhs->may_nil || lhs->may_error)) {
+                if (!route->exprs.push(lhs.value()))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
+
+                HirExpr unwrapped{};
+                unwrapped.kind = HirExprKind::ValueOf;
+                copy_result_shape(&unwrapped, lhs.value());
+                unwrapped.span = expr.span;
+                unwrapped.may_nil = false;
+                unwrapped.may_error = false;
+                unwrapped.lhs = lhs_ptr;
+
+                auto then_expr = analyze_method_call_expr(
+                    method_stage, route, mod, locals, local_count, binding, &unwrapped);
+                if (!then_expr) return core::make_unexpected(then_expr.error());
+                if (!is_lowerable_missing_result(then_expr.value()))
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_stage.span);
+                if (lhs->may_error && then_expr->may_error &&
+                    (lhs->error_struct_index != then_expr->error_struct_index ||
+                     lhs->error_variant_index != then_expr->error_variant_index))
+                    return frontend_error(FrontendError::UnsupportedSyntax, method_stage.span);
+                if (!route->exprs.push(then_expr.value()))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                HirExpr* then_ptr = &route->exprs[route->exprs.len - 1];
+
+                HirExpr cond{};
+                cond.kind = HirExprKind::HasValue;
+                cond.type = HirTypeKind::Bool;
+                cond.span = expr.span;
+                cond.lhs = lhs_ptr;
+                if (!route->exprs.push(cond))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                HirExpr* cond_ptr = &route->exprs[route->exprs.len - 1];
+
+                HirExpr missing{};
+                missing.kind = HirExprKind::MissingOf;
+                copy_result_shape(&missing, then_expr.value());
+                missing.span = expr.span;
+                missing.may_nil = lhs->may_nil || then_expr->may_nil;
+                missing.may_error = lhs->may_error || then_expr->may_error;
+                missing.error_struct_index =
+                    then_expr->may_error ? then_expr->error_struct_index : lhs->error_struct_index;
+                missing.error_variant_index = then_expr->may_error ? then_expr->error_variant_index
+                                                                   : lhs->error_variant_index;
+                missing.lhs = lhs_ptr;
+                if (!route->exprs.push(missing))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                HirExpr* else_ptr = &route->exprs[route->exprs.len - 1];
+
+                HirExpr out{};
+                out.kind = HirExprKind::IfElse;
+                copy_result_shape(&out, then_expr.value());
+                out.span = expr.span;
+                out.may_nil = lhs->may_nil || then_expr->may_nil;
+                out.may_error = lhs->may_error || then_expr->may_error;
+                out.error_struct_index =
+                    then_expr->may_error ? then_expr->error_struct_index : lhs->error_struct_index;
+                out.error_variant_index = then_expr->may_error ? then_expr->error_variant_index
+                                                               : lhs->error_variant_index;
+                out.lhs = cond_ptr;
+                out.rhs = then_ptr;
+                if (!out.args.push(else_ptr))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                return out;
+            }
+            if (magic_req_receiver(*expr.lhs, mod, locals, local_count, binding)) {
+                method_stage.lhs = expr.lhs;
+                return analyze_method_call_expr(
+                    method_stage, route, mod, locals, local_count, binding);
+            }
+            return analyze_method_call_expr(
+                method_stage, route, mod, locals, local_count, binding, &lhs.value());
+        }
+        if (expr.rhs->kind == AstExprKind::Call)
+            return analyze_call_expr(
+                *expr.rhs, route, mod, locals, local_count, binding, &lhs.value());
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.rhs->span);
     }
     if (expr.kind == AstExprKind::Eq || expr.kind == AstExprKind::Lt ||
         expr.kind == AstExprKind::Gt) {

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2265,17 +2265,18 @@ static FrontendResult<rir::ValueId> materialize_local_init(
             if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
             return inner.value();
         }
-        const rir::TypeKind inner_kind =
-            shape.type == MirTypeKind::Str ? rir::TypeKind::Str : rir::TypeKind::I32;
+        const rir::TypeKind inner_kind = shape.type == MirTypeKind::Bool  ? rir::TypeKind::Bool
+                                         : shape.type == MirTypeKind::Str ? rir::TypeKind::Str
+                                                                          : rir::TypeKind::I32;
         auto inner = b.make_type(inner_kind);
         if (!inner) return frontend_error(FrontendError::OutOfMemory, span);
         return inner.value();
     };
 
     if (local.may_error) {
-        if (local_shape.type != MirTypeKind::I32 && local_shape.type != MirTypeKind::Str &&
-            local_shape.type != MirTypeKind::Variant && local_shape.type != MirTypeKind::Struct &&
-            local_shape.type != MirTypeKind::Unknown)
+        if (local_shape.type != MirTypeKind::Bool && local_shape.type != MirTypeKind::I32 &&
+            local_shape.type != MirTypeKind::Str && local_shape.type != MirTypeKind::Variant &&
+            local_shape.type != MirTypeKind::Struct && local_shape.type != MirTypeKind::Unknown)
             return frontend_error(FrontendError::UnsupportedSyntax, local.span);
         auto inner = make_inner_type(local_shape, local.span);
         if (!inner) return core::make_unexpected(inner.error());
@@ -2446,8 +2447,9 @@ static FrontendResult<rir::ValueId> materialize_local_init(
                                  local_count,
                                  local.span);
 
-    if (local_shape.type != MirTypeKind::I32 && local_shape.type != MirTypeKind::Str &&
-        local_shape.type != MirTypeKind::Variant && local_shape.type != MirTypeKind::Struct)
+    if (local_shape.type != MirTypeKind::Bool && local_shape.type != MirTypeKind::I32 &&
+        local_shape.type != MirTypeKind::Str && local_shape.type != MirTypeKind::Variant &&
+        local_shape.type != MirTypeKind::Struct)
         return frontend_error(FrontendError::UnsupportedSyntax, local.span);
 
     auto inner = make_inner_type(local_shape, local.span);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -17309,6 +17309,373 @@ route GET "/users" {
     REQUIRE_EQ(hir->routes[0].locals.len, 1u);
     CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
 }
+TEST(frontend, source_pipe_accepts_method_stage_receiver_placeholder) {
+    const auto src = R"(
+route GET "/users" {
+    let ok = 200 | _.eq(200)
+    if ok { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Bool);
+}
+TEST(frontend, source_pipe_method_stage_runtime_optional_lhs_flows_via_or) {
+    const auto src = R"(
+route GET "/users" {
+    let ok = req.header("Host") | _.eq("example.com")
+    let safe = or(ok, false)
+    if safe { return 200 } else { return 404 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Bool);
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Bool);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_method_stage_reuses_analyzed_lhs_receiver) {
+    const auto src = R"(
+struct Box { value: i32 }
+route GET "/users" {
+    let box = Box(value: 200)
+    let ok = box.value | _.eq(200)
+    if ok { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Bool);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_method_stage_direct_dispatch_keeps_receiver_placeholder) {
+    const auto src = R"(
+protocol Ident { func id() -> i32 }
+struct Box { value: i32 }
+Box impl Ident {
+    func id(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    let box = Box(value: 200)
+    let code = box | _.id()
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_method_stage_known_nil_falls_back_via_or) {
+    const auto src = R"(
+route GET "/users" {
+    let ok = nil | _.eq(200)
+    let safe = or(ok, false)
+    if safe { return 200 } else { return 404 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::Bool);
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Bool);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_method_stage_known_nil_dispatches_protocol_method_shape) {
+    const auto src = R"(
+protocol MaybeCode { func code() -> i32 }
+struct Box { value: i32 }
+Box impl MaybeCode {
+    func code(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    let box: Box = nil
+    let code = box | _.code()
+    let safe = or(code, 500)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+    CHECK(hir->routes[0].locals[2].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[2].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[2].may_error);
+}
+TEST(frontend, source_pipe_method_stage_runtime_optional_lhs_dispatches_protocol_method) {
+    const auto src = R"(
+protocol MaybeCode { func code() -> i32 }
+struct Box { value: i32 }
+Box impl MaybeCode {
+    func code(self: Box) -> i32 => self.value
+}
+func maybeBox(ok: bool) -> Box {
+    if ok { Box(value: 200) } else { nil }
+}
+route GET "/users" {
+    let code = maybeBox(req.http11) | _.code()
+    let safe = or(code, 500)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, source_pipe_method_stage_known_error_preserves_error_variant) {
+    const auto src = R"(
+route GET "/users" {
+    let failed = error(.timeout)
+    let ok = failed | _.eq(200)
+    let safe = or(ok, false)
+    if safe { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Bool);
+    CHECK(hir->routes[0].locals[1].may_error);
+    CHECK_EQ(hir->routes[0].locals[1].error_variant_index,
+             hir->routes[0].locals[0].error_variant_index);
+    CHECK_EQ(hir->routes[0].locals[1].init.error_variant_index,
+             hir->routes[0].locals[0].init.error_variant_index);
+    CHECK_FALSE(hir->routes[0].locals[2].may_error);
+}
+TEST(frontend, source_pipe_method_stage_known_error_accesses_standard_error_field_shape) {
+    const auto src = R"(
+route GET "/users" {
+    let failed = error(.timeout)
+    let code = failed | _.code()
+    let safe = or(code, 500)
+    if safe == 500 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[1].may_error);
+    CHECK_EQ(hir->routes[0].locals[1].error_variant_index,
+             hir->routes[0].locals[0].error_variant_index);
+    CHECK(hir->routes[0].locals[2].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[2].may_error);
+}
+TEST(frontend, source_pipe_method_stage_known_error_dispatches_value_method_shape) {
+    const auto src = R"(
+protocol MaybeMsg { func msg() -> i32 }
+struct Box { value: i32 }
+Box impl MaybeMsg {
+    func msg(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    let box: Box = error(.timeout)
+    let code = box | _.msg()
+    let safe = or(code, 500)
+    if safe == 500 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[1].may_error);
+    CHECK_EQ(hir->routes[0].locals[1].error_variant_index,
+             hir->routes[0].locals[0].error_variant_index);
+    CHECK(hir->routes[0].locals[2].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[2].may_error);
+}
+#if RUT_VALIDATE_REGEX_WITH_VECTORSCAN
+TEST(frontend, source_pipe_method_stage_known_nil_validates_regex) {
+    const auto src = R"(
+route GET "/users" {
+    let ok = nil | _.matches(re"[")
+    let safe = or(ok, false)
+    if safe { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(hir.error().code, FrontendError::InvalidRegex);
+}
+#endif
+TEST(frontend, analyze_rejects_pipe_method_stage_runtime_optional_tuple_return) {
+    const auto src = R"(
+protocol Pairable { func pair() -> (i32, i32) }
+struct Box { value: i32 }
+Box impl Pairable {
+    func pair(self: Box) -> (i32, i32) => (self.value, 500)
+}
+func maybeBox(ok: bool) -> Box {
+    if ok { Box(value: 200) } else { nil }
+}
+route GET "/users" {
+    let pair = maybeBox(req.http11) | _.pair()
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_pipe_method_stage_known_nil_tuple_return) {
+    const auto src = R"(
+protocol Pairable { func pair() -> (i32, i32) }
+struct Box { value: i32 }
+Box impl Pairable {
+    func pair(self: Box) -> (i32, i32) => (self.value, 500)
+}
+route GET "/users" {
+    let box: Box = nil
+    let pair = box | _.pair()
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_pipe_method_stage_known_error_tuple_return) {
+    const auto src = R"(
+protocol Pairable { func pair() -> (i32, i32) }
+struct Box { value: i32 }
+Box impl Pairable {
+    func pair(self: Box) -> (i32, i32) => (self.value, 500)
+}
+route GET "/users" {
+    let box: Box = error(.timeout)
+    let pair = box | _.pair()
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_pipe_method_stage_known_nil_typed_cmp_mismatch) {
+    const auto src = R"(
+route GET "/users" {
+    let code: i32 = nil
+    let ok = code | _.eq("200")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_pipe_method_stage_known_nil_typed_matches_non_string_receiver) {
+    const auto src = R"(
+route GET "/users" {
+    let code: i32 = nil
+    let ok = code | _.matches(re"2")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(frontend, analyze_rejects_pipe_method_stage_slot_two_receiver) {
+    const auto src = R"(
+route GET "/users" {
+    let ok = 200 | _2.eq(200)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
 TEST(frontend, source_pipe_accepts_tuple_literal_multi_slot_placeholders) {
     const auto src = R"(
 func second(a: i32, b: i32) -> i32 => b

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -14598,6 +14598,121 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_pipe_method_stage_receiver_placeholder) {
+    const auto src = R"(
+route GET "/users" {
+    let ok = 200 | _.eq(200)
+    if ok { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_method_stage_runtime_optional_lhs_flows_via_or) {
+    const auto src = R"(
+route GET "/users" {
+    let ok = req.header("X-Missing") | _.eq("example.com")
+    let safe = or(ok, true)
+    if safe { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_method_stage_runtime_optional_lhs_dispatches_protocol_method) {
+    const auto src = R"(
+protocol MaybeCode { func code() -> i32 }
+struct Box { value: i32 }
+Box impl MaybeCode {
+    func code(self: Box) -> i32 => self.value
+}
+func maybeBox(ok: bool) -> Box {
+    if ok { Box(value: 200) } else { nil }
+}
+route GET "/users" {
+    let code = maybeBox(req.http11) | _.code()
+    let safe = or(code, 500)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_pipe_tuple_literal_multi_slot_placeholders) {
     const auto src = R"(
 func second(a: i32, b: i32) -> i32 => b


### PR DESCRIPTION
## Summary

- Support pipe stages where the placeholder is the method receiver, for example `value | _.method(args)`.
- Keep tuple-slot method receivers such as `_2.method(...)` rejected for now.
- Document method stages in `docs/pipe.md` and update the current pipe feature list.

## Tests

- `cmake --build build --target test_frontend test_jit`
- `./build/tests/test_frontend --filter=pipe`
- `./build/tests/test_jit --filter=pipe`
- `git diff --check`
