### PR TITLE
Improve pipe unsupported syntax diagnostics

### DIFF
--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6136,6 +6136,13 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                        value.type == HirTypeKind::Str || value.type == HirTypeKind::Variant ||
                        value.type == HirTypeKind::Struct;
             };
+            auto unsupported_missing_result = [&]() -> FrontendResult<HirExpr> {
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax,
+                    method_stage.span,
+                    lit_str("pipe method stage with nil/error propagation must return bool, i32, "
+                            "str, variant, or struct"));
+            };
             auto shape_only_result = [](HirExpr value) {
                 value.lhs = nullptr;
                 value.rhs = nullptr;
@@ -6195,8 +6202,7 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             if (lhs_state == KnownValueState::Nil) {
                 auto ret = infer_known_missing_method_result();
                 if (!ret) return core::make_unexpected(ret.error());
-                if (!is_lowerable_missing_result(ret.value()))
-                    return frontend_error(FrontendError::UnsupportedSyntax, method_stage.span);
+                if (!is_lowerable_missing_result(ret.value())) return unsupported_missing_result();
                 HirExpr folded{};
                 folded.kind = HirExprKind::Nil;
                 copy_result_shape(&folded, ret.value());
@@ -6210,8 +6216,7 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                     return frontend_error(FrontendError::UnsupportedSyntax, method_stage.span);
                 auto ret = infer_known_missing_method_result();
                 if (!ret) return core::make_unexpected(ret.error());
-                if (!is_lowerable_missing_result(ret.value()))
-                    return frontend_error(FrontendError::UnsupportedSyntax, method_stage.span);
+                if (!is_lowerable_missing_result(ret.value())) return unsupported_missing_result();
                 HirExpr folded = *err_expr;
                 const u32 error_struct_index = folded.error_struct_index;
                 const u32 error_variant_index = folded.error_variant_index;
@@ -6240,11 +6245,14 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                     method_stage, route, mod, locals, local_count, binding, &unwrapped);
                 if (!then_expr) return core::make_unexpected(then_expr.error());
                 if (!is_lowerable_missing_result(then_expr.value()))
-                    return frontend_error(FrontendError::UnsupportedSyntax, method_stage.span);
+                    return unsupported_missing_result();
                 if (lhs->may_error && then_expr->may_error &&
                     (lhs->error_struct_index != then_expr->error_struct_index ||
                      lhs->error_variant_index != then_expr->error_variant_index))
-                    return frontend_error(FrontendError::UnsupportedSyntax, method_stage.span);
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          method_stage.span,
+                                          lit_str("pipe method stage cannot combine different "
+                                                  "propagated error variants"));
                 if (!route->exprs.push(then_expr.value()))
                     return frontend_error(FrontendError::TooManyItems, expr.span);
                 HirExpr* then_ptr = &route->exprs[route->exprs.len - 1];
@@ -6300,7 +6308,9 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         if (expr.rhs->kind == AstExprKind::Call)
             return analyze_call_expr(
                 *expr.rhs, route, mod, locals, local_count, binding, &lhs.value());
-        return frontend_error(FrontendError::UnsupportedSyntax, expr.rhs->span);
+        return frontend_error(FrontendError::UnsupportedSyntax,
+                              expr.rhs->span,
+                              lit_str("pipe rhs must be a call stage or _.method(...) stage"));
     }
     if (expr.kind == AstExprKind::Eq || expr.kind == AstExprKind::Lt ||
         expr.kind == AstExprKind::Gt) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -17586,6 +17586,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(
+        hir.error().detail.eq(lit("pipe method stage with nil/error propagation must return bool, "
+                                  "i32, str, variant, or struct")));
 }
 TEST(frontend, analyze_rejects_pipe_method_stage_known_nil_tuple_return) {
     const auto src = R"(
@@ -17607,6 +17610,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(
+        hir.error().detail.eq(lit("pipe method stage with nil/error propagation must return bool, "
+                                  "i32, str, variant, or struct")));
 }
 TEST(frontend, analyze_rejects_pipe_method_stage_known_error_tuple_return) {
     const auto src = R"(
@@ -17628,6 +17634,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(
+        hir.error().detail.eq(lit("pipe method stage with nil/error propagation must return bool, "
+                                  "i32, str, variant, or struct")));
 }
 TEST(frontend, analyze_rejects_pipe_method_stage_known_nil_typed_cmp_mismatch) {
     const auto src = R"(
@@ -17826,6 +17835,7 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("pipe rhs must be a call stage or _.method(...) stage")));
 }
 TEST(frontend, analyze_rejects_pipe_with_placeholder_slot_two) {
     const auto src = R"(
@@ -18062,6 +18072,32 @@ route GET "/users" {
     CHECK(hir->routes[0].locals[1].type == HirTypeKind::Str);
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+TEST(frontend, analyze_rejects_pipe_method_stage_different_error_variants_detail) {
+    const auto src = R"(
+struct Box { value: i32 }
+struct AuthError { err: Error, token: str }
+protocol MaybeFail { func failstage() -> Box }
+Box impl MaybeFail {
+    func failstage(self: Box) -> Box => error(.forbidden)
+}
+func maybeBox(ok: bool) -> Box {
+    if ok { Box(value: 200) } else { error(AuthError, .timeout, "timed out", token: "abc") }
+}
+route GET "/users" {
+    let box = maybeBox(req.http11) | _.failstage()
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(
+        lit("pipe method stage cannot combine different propagated error variants")));
 }
 TEST(frontend, source_pipe_runtime_optional_lhs_flows_into_optional_error_stage_via_or) {
     const auto src = R"(


### PR DESCRIPTION
## Summary
- Add explicit diagnostic detail for pipe method stages that cannot lower nil/error propagation results
- Add explicit diagnostic detail when a pipe RHS is not a supported stage form
- Cover the new messages in frontend tests

## Tests
- clang-format -i src/compiler/analyze.cc tests/test_frontend.cc
- git diff --check
- cmake --build build --target test_frontend
- ./build/tests/test_frontend --filter=pipe
- ./build/tests/test_frontend