### PR TITLE
Improve parser unsupported syntax diagnostics

### DIFF
--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -8,6 +8,9 @@ namespace rut {
 
 namespace {
 
+constexpr Str kGuardMatchArmIfDetail = lit_str("guard match arms do not support if guards");
+constexpr Str kEmptyBlockDetail = lit_str("empty block is not supported");
+
 struct Parser {
     const LexedTokens* toks = nullptr;
     AstFile* file = nullptr;
@@ -75,7 +78,8 @@ struct Parser {
         auto rbrace = expect(TokenType::RBrace);
         if (!rbrace) return core::make_unexpected(rbrace.error());
         if (block.block_stmts.len == 0)
-            return frontend_error(FrontendError::UnsupportedSyntax, span_from(*rbrace.value()));
+            return frontend_error(
+                FrontendError::UnsupportedSyntax, span_from(*rbrace.value()), kEmptyBlockDetail);
         block.span.end = rbrace.value()->end;
         if (block.block_stmts.len == 1) return *block.block_stmts[0];
         return block;
@@ -114,7 +118,9 @@ struct Parser {
                     arm.pattern = pattern.value();
                 }
                 if (const Token* kw_if = take(TokenType::KwIf))
-                    return frontend_error(FrontendError::UnsupportedSyntax, span_from(*kw_if));
+                    return frontend_error(FrontendError::UnsupportedSyntax,
+                                          span_from(*kw_if),
+                                          kGuardMatchArmIfDetail);
                 auto arrow = expect(TokenType::Arrow);
                 if (!arrow) return core::make_unexpected(arrow.error());
                 auto arm_stmt = parse_func_body_stmt();
@@ -337,7 +343,10 @@ struct Parser {
                 auto msg_expr = parse_expr();
                 if (!msg_expr) return core::make_unexpected(msg_expr.error());
                 if (msg_expr->kind != AstExprKind::StrLit)
-                    return frontend_error(FrontendError::UnsupportedSyntax, msg_expr->span);
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax,
+                        msg_expr->span,
+                        lit_str("error message argument must be a string literal"));
                 msg = msg_expr->str_value;
                 while (take(TokenType::Comma)) {
                     auto field_name = expect_field_name();
@@ -460,7 +469,8 @@ struct Parser {
             if (all_digits && index > 0) {
                 if (index > 10)
                     return frontend_error(FrontendError::UnsupportedSyntax,
-                                          span_from(*ident.value()));
+                                          span_from(*ident.value()),
+                                          lit_str("placeholder index must be between _1 and _10"));
                 expr.kind = AstExprKind::Placeholder;
                 expr.int_value = index;
                 expr.span = span_from(*ident.value());
@@ -738,7 +748,9 @@ struct Parser {
             auto rbrace = expect(TokenType::RBrace);
             if (!rbrace) return core::make_unexpected(rbrace.error());
             if (stmt.block_stmts.len == 0)
-                return frontend_error(FrontendError::UnsupportedSyntax, span_from(*rbrace.value()));
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      span_from(*rbrace.value()),
+                                      kEmptyBlockDetail);
             stmt.span.end = rbrace.value()->end;
             return stmt;
         }
@@ -803,7 +815,9 @@ struct Parser {
                         arm.pattern = pattern.value();
                     }
                     if (const Token* kw_if = take(TokenType::KwIf))
-                        return frontend_error(FrontendError::UnsupportedSyntax, span_from(*kw_if));
+                        return frontend_error(FrontendError::UnsupportedSyntax,
+                                              span_from(*kw_if),
+                                              kGuardMatchArmIfDetail);
                     auto colon = expect(TokenType::Colon);
                     if (!colon) return core::make_unexpected(colon.error());
                     auto arm_stmt = parse_stmt();
@@ -1152,8 +1166,11 @@ struct Parser {
                 return core::make_unexpected(for_kw.error());
             auto var_name = expect(TokenType::Ident);
             if (!var_name) return core::make_unexpected(var_name.error());
-            auto in_kw = expect(TokenType::KwIn);
-            if (!in_kw) return core::make_unexpected(in_kw.error());
+            auto in_kw = take(TokenType::KwIn);
+            if (!in_kw)
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      span_from(*var_name.value()),
+                                      lit_str("for loop expects 'in' after iterator name"));
             auto iter_expr = parse_expr();
             if (!iter_expr) return core::make_unexpected(iter_expr.error());
             auto lbrace = expect(TokenType::LBrace);
@@ -1489,7 +1506,9 @@ struct Parser {
             auto rbrace = expect(TokenType::RBrace);
             if (!rbrace) return core::make_unexpected(rbrace.error());
             if (block.block_stmts.len == 0)
-                return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      span_from(*rbrace.value()),
+                                      kEmptyBlockDetail);
             block.span = Span{start.start, rbrace.value()->end, start.line, start.col};
             return block;
         }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1625,6 +1625,36 @@ TEST(frontend, parse_wait_rejects_unknown_suffix) {
     CHECK(!ast);
 }
 
+TEST(frontend, parse_rejects_empty_if_block_with_detail) {
+    const char* src = "route GET \"/x\" { if true { } else { return 200 } return 500 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE_FALSE(ast.has_value());
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(ast.error().detail.eq(lit("empty block is not supported")));
+}
+
+TEST(frontend, parse_rejects_empty_statement_block_with_detail) {
+    const char* src = "route GET \"/x\" { { } return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE_FALSE(ast.has_value());
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(ast.error().detail.eq(lit("empty block is not supported")));
+}
+
+TEST(frontend, parse_rejects_non_string_error_message_with_detail) {
+    const char* src = "route GET \"/x\" { let failed = error(.timeout, 42) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE_FALSE(ast.has_value());
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(ast.error().detail.eq(lit("error message argument must be a string literal")));
+}
+
 TEST(frontend, analyze_accepts_let_guard_wait_source_order) {
     // Guards and waits are threaded in source order after pre-wait locals.
     const char* src =
@@ -9749,6 +9779,7 @@ TEST(frontend, parse_rejects_guard_match_arm_guard) {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE_FALSE(ast.has_value());
     CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(ast.error().detail.eq(lit("guard match arms do not support if guards")));
 }
 TEST(frontend, analyze_rejects_guard_match_without_wildcard) {
     const char* src =
@@ -16699,6 +16730,7 @@ route GET "/users" { return 200 }
     auto ast = parse_file_heap(lexed.value());
     REQUIRE_FALSE(ast.has_value());
     CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(ast.error().detail.eq(lit("guard match arms do not support if guards")));
 }
 TEST(frontend, analyze_rejects_function_block_guard_match_without_wildcard) {
     const auto src = R"(
@@ -17882,6 +17914,7 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE_FALSE(ast.has_value());
     CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(ast.error().detail.eq(lit("placeholder index must be between _1 and _10")));
 }
 TEST(frontend, source_pipe_runtime_optional_lhs_flows_via_or) {
     const auto src = R"(
@@ -24827,21 +24860,27 @@ TEST(frontend, analyze_plain_for_loop_body_let_scoped_to_body) {
 }
 
 TEST(frontend, parse_for_loop_rejects_missing_in) {
-    // `inline for item <missing in> [1, 2, 3]` — expect must see KwIn, else unexpected-token.
+    // Missing `in` is reported at the iterator name, not at the following expression.
     const char* src = "route GET \"/x\" { inline for item [1, 2, 3] { return 200 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
-    CHECK(!ast);
+    REQUIRE_FALSE(ast.has_value());
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(ast.error().detail.eq(lit("for loop expects 'in' after iterator name")));
+    CHECK_EQ(ast.error().span.col, 29u);
 }
 
 TEST(frontend, parse_plain_for_loop_rejects_missing_in) {
-    // `for item <missing in> [1, 2, 3]` — parse should fail before analysis.
+    // Plain `for` uses the same missing-`in` diagnostic as `inline for`.
     const char* src = "route GET \"/x\" { for item [1, 2, 3] { return 200 } return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
-    CHECK(!ast);
+    REQUIRE_FALSE(ast.has_value());
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(ast.error().detail.eq(lit("for loop expects 'in' after iterator name")));
+    CHECK_EQ(ast.error().span.col, 22u);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary
- Add explicit parser diagnostic details for empty blocks, unsupported guard-match arm guards, non-string error messages, and placeholder indices above _10
- Report a clear parser detail when for loops omit the required in keyword
- Extend frontend tests to assert the new detail messages

## Tests
- clang-format -i src/compiler/parser.cc tests/test_frontend.cc
- git diff --check
- cmake --build build --target test_frontend
- ./build/tests/test_frontend --filter=parse_rejects_empty_if_block_with_detail,parse_rejects_non_string_error_message_with_detail,parse_rejects_guard_match_arm_guard,parse_rejects_function_block_guard_match_arm_guard,parse_rejects_pipe_with_placeholder_slot_eleven,parse_for_loop_rejects_missing_in,parse_plain_for_loop_rejects_missing_in
- ./build/tests/test_frontend