### PR TITLE
[codex] allow pre-wait guards in decorated wait routes

### DIFF
--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -152,7 +152,22 @@ The decorator runs before the timer yield is armed:
 - If `auth` returns `401`, the handler immediately returns `401`.
 - If `auth` returns `0`, the handler yields the timer and resumes to `return 200`.
 
-Current limitation: decorated `wait(...)` routes must use direct terminal
+Decorated `wait(...)` routes may include top-level `guard` statements before
+the first wait. The decorator guards run first, then the user guards, then the
+wait is armed:
+
+```rut
+route {
+    @auth "*"
+    GET "/x" {
+        guard req.method == GET else { return 405 }
+        wait(50)
+        return 204
+    }
+}
+```
+
+Current limitation: decorated `wait(...)` routes must still use direct terminal
 control and cannot contain user `let` bindings. These forms are rejected today:
 
 ```rut
@@ -169,8 +184,8 @@ route {
 }
 ```
 
-Decorated wait routes with user top-level guards or for-loops are also rejected.
-Those shapes need a fuller source-ordered state-machine lowering.
+Decorated wait routes with post-wait user guards or for-loops are also
+rejected. Those shapes need a fuller source-ordered state-machine lowering.
 
 ## Unsupported Today
 

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -14024,6 +14024,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
         // and would stall 1s under the wheel fallback.
         bool seen_wait = false;
         bool seen_for = false;
+        bool user_guard_after_wait = false;
         for (u32 si = 0; si < item.route.statements.len; si++) {
             const auto& stmt = item.route.statements[si];
             if (stmt.kind == AstStmtKind::Wait) {
@@ -14181,6 +14182,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 continue;
             }
             if (stmt.kind == AstStmtKind::Guard) {
+                if (seen_wait) user_guard_after_wait = true;
                 if (si + 1 >= item.route.statements.len)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 HirGuard guard{};
@@ -14795,8 +14797,8 @@ static FrontendResult<HirModule*> analyze_file_internal(
                     return frontend_error(FrontendError::UnsupportedSyntax, route.locals[li].span);
                 }
             }
-            if (route.guards.len != route.decorator_guard_count ||
-                route.control.kind != HirControlKind::Direct || route.for_loops.len != 0) {
+            if (user_guard_after_wait || route.control.kind != HirControlKind::Direct ||
+                route.for_loops.len != 0) {
                 return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
             }
         }

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -2334,24 +2334,23 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
         }
 
         if (fn.waits.len != 0 && module.routes[i].decorator_guard_count != 0) {
-            const u32 deco_count = module.routes[i].decorator_guard_count;
+            const u32 guard_count = module.routes[i].guards.len;
             const bool scope = module.routes[i].control.kind == HirControlKind::Direct &&
-                               module.routes[i].guards.len == deco_count &&
                                fn.waits.len <= MirFunction::kMaxWaits;
             if (!scope) return frontend_error(FrontendError::UnsupportedSyntax, fn.span);
 
-            const u32 yield_index = deco_count;
+            const u32 yield_index = guard_count;
             const u32 terminal_index = yield_index + 1;
             u32 guard_fail_index[HirRoute::kMaxGuards]{};
             u32 fail_cursor = terminal_index + 1;
-            for (u32 gi = 0; gi < deco_count; gi++) {
+            for (u32 gi = 0; gi < guard_count; gi++) {
                 guard_fail_index[gi] = fail_cursor;
                 fail_cursor += guard_fail_block_count(module.routes[i].guards[gi]);
             }
             if (fail_cursor > MirFunction::kMaxBlocks)
                 return frontend_error(FrontendError::TooManyItems, fn.span);
 
-            for (u32 gi = 0; gi < deco_count; gi++) {
+            for (u32 gi = 0; gi < guard_count; gi++) {
                 const auto& guard = module.routes[i].guards[gi];
                 MirBlock guard_block{};
                 guard_block.label = gi == 0 ? entry_label() : cont_label();
@@ -2360,7 +2359,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                 auto cond = mir_value(guard.cond, module, &fn);
                 if (!cond) return core::make_unexpected(cond.error());
                 guard_block.term.cond = cond.value();
-                guard_block.term.then_block = gi + 1 < deco_count ? gi + 1 : yield_index;
+                guard_block.term.then_block = gi + 1 < guard_count ? gi + 1 : yield_index;
                 guard_block.term.else_block = guard_fail_index[gi];
                 if (!fn.blocks.push(guard_block))
                     return frontend_error(FrontendError::TooManyItems, fn.span);
@@ -2382,7 +2381,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             if (!fn.blocks.push(terminal_block))
                 return frontend_error(FrontendError::TooManyItems, fn.span);
 
-            for (u32 gi = 0; gi < deco_count; gi++) {
+            for (u32 gi = 0; gi < guard_count; gi++) {
                 auto emitted = emit_guard_fail(module.routes[i].guards[gi]);
                 if (!emitted) return core::make_unexpected(emitted.error());
             }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1691,6 +1691,51 @@ route {
     REQUIRE_EQ(hir->routes[0].waits.len, 1u);
 }
 
+TEST(frontend, analyze_accepts_decorated_wait_with_pre_wait_guard) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/x" {
+        guard req.method == GET else { return 405 }
+        wait(50)
+        return 204
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].decorators.len, 1u);
+    REQUIRE_EQ(hir->routes[0].decorator_guard_count, 1u);
+    REQUIRE_EQ(hir->routes[0].guards.len, 2u);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+}
+
+TEST(frontend, analyze_rejects_decorated_wait_with_post_wait_guard) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/x" {
+        wait(50)
+        guard true else { return 405 }
+        return 204
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
 TEST(frontend, analyze_rejects_decorated_wait_with_terminal_control) {
     const char* src = R"rut(
 func auth(_ req: i32) -> i32 => 0

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -15679,6 +15679,109 @@ route {
     rir.destroy();
 }
 
+TEST(jit, frontend_route_decorator_passes_then_pre_wait_guard_then_waits) {
+    const auto src = R"rut(
+func passing(_ req: i32) -> i32 => 0
+route {
+    @passing "*"
+    GET "/sleep" {
+        guard req.path == "/" else { return 404 }
+        wait(1000)
+        return 200
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
+    ctx.state = 0;
+    auto r0 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r0.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(r0.next_state, 1);
+    CHECK_EQ(static_cast<u8>(r0.yield_kind), static_cast<u8>(YieldKind::Timer));
+    CHECK_EQ(r0.yield_payload_u32(), 1000u);
+
+    ctx.state = r0.next_state;
+    auto r1 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r1.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r1.status_code, 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_decorator_passes_then_pre_wait_guard_can_reject) {
+    const auto src = R"rut(
+func passing(_ req: i32) -> i32 => 0
+route {
+    @passing "*"
+    GET "/sleep" {
+        guard req.path == "/nope" else { return 404 }
+        wait(1000)
+        return 200
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
+    ctx.state = 0;
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           &ctx,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK_EQ(static_cast<u8>(r.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r.status_code, 404);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_route_decorator_passes_then_multiple_waits) {
     const auto src = R"rut(
 func passing(_ req: i32) -> i32 => 0


### PR DESCRIPTION
## Summary

Allow decorated `wait(...)` routes to include top-level user `guard` statements before the first wait. Decorator guards still run first, followed by pre-wait user guards, then the timer yield and direct terminal return.

The analyzer keeps the current conservative limits for decorated wait routes: no user `let` bindings, no post-wait guards, no for-loops, and direct terminal control only. MIR lowering now emits all pre-wait guards in source order before arming the wait.

## Impact

This removes an unnecessary limitation for guarded async routes while preserving the shapes that still need fuller source-ordered state-machine lowering.

## Validation

- `ninja -C build test_frontend test_jit`
- `./build/tests/test_frontend`
- `./build/tests/test_jit`
- focused frontend and jit filters for decorated wait guard behavior
- `git diff --check`