### PR TITLE
[codex] allow pre-wait locals in decorated wait routes

### DIFF
--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -152,15 +152,16 @@ The decorator runs before the timer yield is armed:
 - If `auth` returns `401`, the handler immediately returns `401`.
 - If `auth` returns `0`, the handler yields the timer and resumes to `return 200`.
 
-Decorated `wait(...)` routes may include top-level `guard` statements before
-the first wait. The decorator guards run first, then the user guards, then the
-wait is armed:
+Decorated `wait(...)` routes may include `let` bindings and top-level `guard`
+statements before the first wait. The decorator guards run first, then the
+pre-wait user guards, then the wait is armed:
 
 ```rut
 route {
     @auth "*"
     GET "/x" {
-        guard req.method == GET else { return 405 }
+        let allowed = req.method == GET
+        guard allowed else { return 405 }
         wait(50)
         return 204
     }
@@ -168,7 +169,8 @@ route {
 ```
 
 Current limitation: decorated `wait(...)` routes must still use direct terminal
-control and cannot contain user `let` bindings. These forms are rejected today:
+control, cannot contain user `let` bindings after a wait, and cannot bind wait
+results into locals. These forms are rejected today:
 
 ```rut
 route {
@@ -180,7 +182,14 @@ route {
 ```rut
 route {
     @auth "*"
-    GET "/x" { let code = 200 wait(50) return 200 }
+    GET "/x" { wait(50) let code = 200 return 200 }
+}
+```
+
+```rut
+route {
+    @auth "*"
+    GET "/x" { let ev = wait(downstream.recv()) return 204 }
 }
 ```
 

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -7212,6 +7212,18 @@ static FrontendResult<HirTerminator> analyze_term(const AstStatement& stmt, cons
     return term;
 }
 
+static bool terminator_reads_any_local(const HirTerminator& term,
+                                       const HirLocal* locals,
+                                       u32 local_count) {
+    if (term.kind != HirTerminatorKind::ReturnStatus ||
+        term.source_kind != HirTerminatorSourceKind::LocalRef)
+        return false;
+    for (u32 li = 0; li < local_count; li++) {
+        if (locals[li].ref_index == term.local_ref_index) return true;
+    }
+    return false;
+}
+
 static FrontendResult<void> analyze_guard_match_arms(
     const FixedVec<AstStatement::MatchArm, AstStatement::kMaxMatchArms>& ast_arms,
     const HirExpr& subject,
@@ -14792,14 +14804,28 @@ static FrontendResult<HirModule*> analyze_file_internal(
             for (u32 i = 0; i < num_user_guards; i++) route.guards[num_deco_guards + i] = tmp[i];
         }
         if (route.waits.len != 0 && route.decorator_guard_count != 0) {
+            const u32 first_wait_start = route.waits[0].span.start;
+            // Pre-wait locals are allowed only for pre-wait work. They may feed
+            // user guards before the first wait, but must not be introduced by a
+            // wait expression or after the first resume boundary.
             for (u32 li = 0; li < user_local_count_before_decorators; li++) {
-                if (route.locals[li].name.len != 0) {
+                if (route.locals[li].name.len != 0 &&
+                    (route.locals[li].is_wait_result ||
+                     route.locals[li].span.start > first_wait_start)) {
                     return frontend_error(FrontendError::UnsupportedSyntax, route.locals[li].span);
                 }
             }
             if (user_guard_after_wait || route.control.kind != HirControlKind::Direct ||
                 route.for_loops.len != 0) {
                 return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
+            }
+            // The resumed terminal path skips pre-wait local initialization.
+            // Keep decorated wait routes from reading user locals there.
+            if (terminator_reads_any_local(route.control.direct_term,
+                                           route.locals.data,
+                                           user_local_count_before_decorators)) {
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      route.control.direct_term.span);
             }
         }
 

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1715,6 +1715,34 @@ route {
     REQUIRE_EQ(hir->routes[0].waits.len, 1u);
 }
 
+TEST(frontend, analyze_accepts_decorated_wait_with_pre_wait_local) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/x" {
+        let allowed = req.path == "/"
+        guard allowed else { return 404 }
+        wait(50)
+        return 204
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].decorators.len, 1u);
+    REQUIRE_EQ(hir->routes[0].decorator_guard_count, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].name.eq(lit("allowed")));
+    CHECK(!hir->routes[0].locals[0].is_wait_result);
+    REQUIRE_EQ(hir->routes[0].guards.len, 2u);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+}
+
 TEST(frontend, analyze_rejects_decorated_wait_with_post_wait_guard) {
     const char* src = R"rut(
 func auth(_ req: i32) -> i32 => 0
@@ -1753,12 +1781,32 @@ route {
     CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
-TEST(frontend, analyze_rejects_decorated_wait_with_user_local) {
+TEST(frontend, analyze_rejects_decorated_wait_with_post_wait_user_local) {
     const char* src = R"rut(
 func auth(_ req: i32) -> i32 => 0
 route {
     @auth "*"
-    GET "/x" { let code = 200 wait(50) return 200 }
+    GET "/x" { wait(50) let code = 200 return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, analyze_rejects_decorated_wait_with_wait_result_local) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/x" {
+        let ev = wait(downstream.recv())
+        return 204
+    }
 }
 )rut";
     auto lexed = lex(lit(src));

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -15782,6 +15782,64 @@ route {
     rir.destroy();
 }
 
+TEST(jit, frontend_route_decorator_passes_then_pre_wait_local_guard_then_waits) {
+    const auto src = R"rut(
+func passing(_ req: i32) -> i32 => 0
+route {
+    @passing "*"
+    GET "/sleep" {
+        let allowed = req.path == "/"
+        guard allowed else { return 404 }
+        wait(1000)
+        return 200
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
+    ctx.state = 0;
+    auto r0 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r0.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(r0.next_state, 1);
+    CHECK_EQ(static_cast<u8>(r0.yield_kind), static_cast<u8>(YieldKind::Timer));
+    CHECK_EQ(r0.yield_payload_u32(), 1000u);
+
+    ctx.state = r0.next_state;
+    auto r1 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r1.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r1.status_code, 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_route_decorator_passes_then_multiple_waits) {
     const auto src = R"rut(
 func passing(_ req: i32) -> i32 => 0


### PR DESCRIPTION
## Summary

Allow decorated `wait(...)` routes to include ordinary user `let` bindings before the first wait. These locals can feed pre-wait user guards, with decorator guards still running first and the route then yielding/resuming through the existing wait state machine.

The analyzer keeps the conservative boundaries for shapes that still need fuller lowering: post-wait locals, `let ev = wait(...)` in decorated wait routes, post-wait guards, for-loops, and non-direct terminal control remain rejected.

## Impact

This removes another unnecessary decorated-wait limitation while preserving source-order guarantees across yield/resume boundaries.

## Validation

- `ninja -C build test_frontend test_jit`
- focused frontend and jit filters for decorated wait locals
- `./build/tests/test_frontend`
- `./build/tests/test_jit`
- `git diff --check`