### PR TITLE
[codex] Allow post-wait guards in decorated routes

### DIFF
--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -152,11 +152,11 @@ The decorator runs before the timer yield is armed:
 - If `auth` returns `401`, the handler immediately returns `401`.
 - If `auth` returns `0`, the handler yields the timer and resumes to `return 200`.
 
-Decorated `wait(...)` routes may include pre-wait `let` bindings and top-level
-`guard` statements before or after the wait. The decorator guards run first,
-then pre-wait user guards, then the wait is armed. Post-wait guards run after
-resume and may read request fields, but they cannot read user locals that were
-initialized before the wait:
+Decorated `wait(...)` routes may include pre-wait `let` bindings, and may use
+top-level `guard` statements before or after the wait. The decorator guards run
+first, then pre-wait user guards, then the wait is armed. Post-wait guards run
+after resume and may read request fields, but they cannot read user locals that
+were initialized before the wait:
 
 ```rut
 route {

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -152,9 +152,11 @@ The decorator runs before the timer yield is armed:
 - If `auth` returns `401`, the handler immediately returns `401`.
 - If `auth` returns `0`, the handler yields the timer and resumes to `return 200`.
 
-Decorated `wait(...)` routes may include `let` bindings and top-level `guard`
-statements before the first wait. The decorator guards run first, then the
-pre-wait user guards, then the wait is armed:
+Decorated `wait(...)` routes may include pre-wait `let` bindings and top-level
+`guard` statements before or after the wait. The decorator guards run first,
+then pre-wait user guards, then the wait is armed. Post-wait guards run after
+resume and may read request fields, but they cannot read user locals that were
+initialized before the wait:
 
 ```rut
 route {
@@ -168,9 +170,21 @@ route {
 }
 ```
 
+```rut
+route {
+    @auth "*"
+    GET "/x" {
+        wait(50)
+        guard req.path == "/" else { return 404 }
+        return 204
+    }
+}
+```
+
 Current limitation: decorated `wait(...)` routes must still use direct terminal
-control, cannot contain user `let` bindings after a wait, and cannot bind wait
-results into locals. These forms are rejected today:
+control, cannot contain user `let` bindings after a wait, cannot bind wait
+results into locals, and cannot use post-wait guards that read pre-wait user
+locals. These forms are rejected today:
 
 ```rut
 route {
@@ -193,8 +207,20 @@ route {
 }
 ```
 
-Decorated wait routes with post-wait user guards or for-loops are also
-rejected. Those shapes need a fuller source-ordered state-machine lowering.
+```rut
+route {
+    @auth "*"
+    GET "/x" {
+        let allowed = req.path == "/"
+        wait(50)
+        guard allowed else { return 404 }
+        return 204
+    }
+}
+```
+
+Decorated wait routes with for-loops are also rejected. Those shapes need a
+fuller source-ordered state-machine lowering.
 
 ## Unsupported Today
 

--- a/docs/wait.md
+++ b/docs/wait.md
@@ -318,8 +318,13 @@ route {
 ```
 
 Decorator guards run before the first timer yield is armed. Decorated wait
-routes currently reject user `let` bindings, user top-level guards, for-loops,
-and non-direct terminal control such as `if` / `match`.
+routes may use pre-wait `let` bindings and top-level guards before or after the
+wait. Post-wait guards run after resume and may read request fields, but they
+cannot read user locals initialized before the wait and cannot contain
+fail-body `let` bindings. Decorated wait routes still reject user `let`
+bindings after a wait, wait-result locals, for-loops, and non-direct terminal
+control such as `if` / `match`. See [decorators.md](decorators.md) for the
+full decorated wait subset.
 
 For the current static for-loop subset, including the route-level restriction
 that rejects mixing `wait(...)` with static loop lowering, see

--- a/docs/wait.md
+++ b/docs/wait.md
@@ -318,13 +318,13 @@ route {
 ```
 
 Decorator guards run before the first timer yield is armed. Decorated wait
-routes may use pre-wait `let` bindings and top-level guards before or after the
-wait. Post-wait guards run after resume and may read request fields, but they
-cannot read user locals initialized before the wait and cannot contain
-fail-body `let` bindings. Decorated wait routes still reject user `let`
-bindings after a wait, wait-result locals, for-loops, and non-direct terminal
-control such as `if` / `match`. See [decorators.md](decorators.md) for the
-full decorated wait subset.
+routes may use pre-wait `let` bindings, and may use top-level guards before or
+after the wait. Post-wait guards run after resume and may read request fields,
+but they cannot read user locals initialized before the wait and cannot contain
+fail-body `let` bindings. Decorated wait routes still reject user `let` bindings
+after a wait, wait-result locals, for-loops, and non-direct terminal control such
+as `if` / `match`. See [decorators.md](decorators.md) for the full decorated
+wait subset.
 
 For the current static for-loop subset, including the route-level restriction
 that rejects mixing `wait(...)` with static loop lowering, see

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -7224,6 +7224,50 @@ static bool terminator_reads_any_local(const HirTerminator& term,
     return false;
 }
 
+static bool expr_reads_any_local(const HirExpr& expr, const HirLocal* locals, u32 local_count) {
+    if (expr.kind == HirExprKind::LocalRef) {
+        for (u32 li = 0; li < local_count; li++) {
+            if (locals[li].ref_index == expr.local_index) return true;
+        }
+    }
+    if (expr.lhs != nullptr && expr_reads_any_local(*expr.lhs, locals, local_count)) return true;
+    if (expr.rhs != nullptr && expr_reads_any_local(*expr.rhs, locals, local_count)) return true;
+    for (u32 fi = 0; fi < expr.field_inits.len; fi++) {
+        if (expr.field_inits[fi].value != nullptr &&
+            expr_reads_any_local(*expr.field_inits[fi].value, locals, local_count))
+            return true;
+    }
+    for (u32 ai = 0; ai < expr.args.len; ai++) {
+        if (expr.args[ai] != nullptr && expr_reads_any_local(*expr.args[ai], locals, local_count))
+            return true;
+    }
+    return false;
+}
+
+static bool guard_reads_any_local(const HirGuard& guard,
+                                  const HirModule& mod,
+                                  const HirLocal* locals,
+                                  u32 local_count) {
+    if (expr_reads_any_local(guard.cond, locals, local_count)) return true;
+    if (terminator_reads_any_local(guard.fail_term, locals, local_count)) return true;
+    if (expr_reads_any_local(guard.fail_match_expr, locals, local_count)) return true;
+    for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
+        if (terminator_reads_any_local(
+                mod.guard_match_arms[guard.fail_match_start + ai].direct_term,
+                locals,
+                local_count))
+            return true;
+    }
+    for (u32 li = 0; li < guard.fail_body.locals.len; li++) {
+        if (expr_reads_any_local(guard.fail_body.locals[li].init, locals, local_count))
+            return true;
+    }
+    if (expr_reads_any_local(guard.fail_body.cond, locals, local_count)) return true;
+    return terminator_reads_any_local(guard.fail_body.then_term, locals, local_count) ||
+           terminator_reads_any_local(guard.fail_body.else_term, locals, local_count) ||
+           terminator_reads_any_local(guard.fail_body.direct_term, locals, local_count);
+}
+
 static FrontendResult<void> analyze_guard_match_arms(
     const FixedVec<AstStatement::MatchArm, AstStatement::kMaxMatchArms>& ast_arms,
     const HirExpr& subject,
@@ -14036,7 +14080,6 @@ static FrontendResult<HirModule*> analyze_file_internal(
         // and would stall 1s under the wheel fallback.
         bool seen_wait = false;
         bool seen_for = false;
-        bool user_guard_after_wait = false;
         for (u32 si = 0; si < item.route.statements.len; si++) {
             const auto& stmt = item.route.statements[si];
             if (stmt.kind == AstStmtKind::Wait) {
@@ -14194,7 +14237,6 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 continue;
             }
             if (stmt.kind == AstStmtKind::Guard) {
-                if (seen_wait) user_guard_after_wait = true;
                 if (si + 1 >= item.route.statements.len)
                     return frontend_error(FrontendError::UnsupportedSyntax, stmt.span);
                 HirGuard guard{};
@@ -14815,9 +14857,17 @@ static FrontendResult<HirModule*> analyze_file_internal(
                     return frontend_error(FrontendError::UnsupportedSyntax, route.locals[li].span);
                 }
             }
-            if (user_guard_after_wait || route.control.kind != HirControlKind::Direct ||
-                route.for_loops.len != 0) {
+            if (route.control.kind != HirControlKind::Direct || route.for_loops.len != 0) {
                 return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
+            }
+            for (u32 gi = route.decorator_guard_count; gi < route.guards.len; gi++) {
+                if (route.guards[gi].span.start > first_wait_start &&
+                    guard_reads_any_local(route.guards[gi],
+                                          mod,
+                                          route.locals.data,
+                                          user_local_count_before_decorators)) {
+                    return frontend_error(FrontendError::UnsupportedSyntax, route.guards[gi].span);
+                }
             }
             // The resumed terminal path skips pre-wait local initialization.
             // Keep decorated wait routes from reading user locals there.

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -7252,9 +7252,9 @@ static bool guard_reads_any_local(const HirGuard& guard,
     if (terminator_reads_any_local(guard.fail_term, locals, local_count)) return true;
     if (expr_reads_any_local(guard.fail_match_expr, locals, local_count)) return true;
     for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
-        if (terminator_reads_any_local(
-                mod.guard_match_arms[guard.fail_match_start + ai].direct_term, locals, local_count))
-            return true;
+        const auto& arm = mod.guard_match_arms[guard.fail_match_start + ai];
+        if (expr_reads_any_local(arm.pattern, locals, local_count)) return true;
+        if (terminator_reads_any_local(arm.direct_term, locals, local_count)) return true;
     }
     for (u32 li = 0; li < guard.fail_body.locals.len; li++) {
         if (expr_reads_any_local(guard.fail_body.locals[li].init, locals, local_count)) return true;
@@ -14858,12 +14858,14 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
             }
             for (u32 gi = route.decorator_guard_count; gi < route.guards.len; gi++) {
-                if (route.guards[gi].span.start > first_wait_start &&
-                    guard_reads_any_local(route.guards[gi],
-                                          mod,
-                                          route.locals.data,
-                                          user_local_count_before_decorators)) {
-                    return frontend_error(FrontendError::UnsupportedSyntax, route.guards[gi].span);
+                const HirGuard& guard = route.guards[gi];
+                if (guard.span.start > first_wait_start) {
+                    if (guard.fail_body.locals.len != 0)
+                        return frontend_error(FrontendError::UnsupportedSyntax, guard.span);
+                    if (guard_reads_any_local(
+                            guard, mod, route.locals.data, user_local_count_before_decorators)) {
+                        return frontend_error(FrontendError::UnsupportedSyntax, guard.span);
+                    }
                 }
             }
             // The resumed terminal path skips pre-wait local initialization.

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -7253,14 +7253,11 @@ static bool guard_reads_any_local(const HirGuard& guard,
     if (expr_reads_any_local(guard.fail_match_expr, locals, local_count)) return true;
     for (u32 ai = 0; ai < guard.fail_match_count; ai++) {
         if (terminator_reads_any_local(
-                mod.guard_match_arms[guard.fail_match_start + ai].direct_term,
-                locals,
-                local_count))
+                mod.guard_match_arms[guard.fail_match_start + ai].direct_term, locals, local_count))
             return true;
     }
     for (u32 li = 0; li < guard.fail_body.locals.len; li++) {
-        if (expr_reads_any_local(guard.fail_body.locals[li].init, locals, local_count))
-            return true;
+        if (expr_reads_any_local(guard.fail_body.locals[li].init, locals, local_count)) return true;
     }
     if (expr_reads_any_local(guard.fail_body.cond, locals, local_count)) return true;
     return terminator_reads_any_local(guard.fail_body.then_term, locals, local_count) ||

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1789,6 +1789,30 @@ route {
     CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
+TEST(frontend, analyze_rejects_decorated_wait_with_post_wait_guard_fail_body_local) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/x" {
+        wait(50)
+        guard req.path == "/" else {
+            let code = 404
+            if code == 404 { return 404 } else { return 500 }
+        }
+        return 204
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
 TEST(frontend, analyze_rejects_decorated_wait_with_terminal_control) {
     const char* src = R"rut(
 func auth(_ req: i32) -> i32 => 0

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -1743,14 +1743,39 @@ route {
     REQUIRE_EQ(hir->routes[0].waits.len, 1u);
 }
 
-TEST(frontend, analyze_rejects_decorated_wait_with_post_wait_guard) {
+TEST(frontend, analyze_accepts_decorated_wait_with_post_wait_guard) {
     const char* src = R"rut(
 func auth(_ req: i32) -> i32 => 0
 route {
     @auth "*"
     GET "/x" {
         wait(50)
-        guard true else { return 405 }
+        guard req.path == "/" else { return 404 }
+        return 204
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].decorators.len, 1u);
+    REQUIRE_EQ(hir->routes[0].decorator_guard_count, 1u);
+    REQUIRE_EQ(hir->routes[0].guards.len, 2u);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+}
+
+TEST(frontend, analyze_rejects_decorated_wait_with_post_wait_guard_using_pre_wait_local) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 => 0
+route {
+    @auth "*"
+    GET "/x" {
+        let allowed = req.path == "/"
+        wait(50)
+        guard allowed else { return 404 }
         return 204
     }
 }

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -15782,6 +15782,120 @@ route {
     rir.destroy();
 }
 
+TEST(jit, frontend_route_decorator_passes_then_waits_then_post_wait_guard) {
+    const auto src = R"rut(
+func passing(_ req: i32) -> i32 => 0
+route {
+    @passing "*"
+    GET "/sleep" {
+        wait(1000)
+        guard req.path == "/" else { return 404 }
+        return 200
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
+    ctx.state = 0;
+    auto r0 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r0.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(r0.next_state, 1);
+    CHECK_EQ(static_cast<u8>(r0.yield_kind), static_cast<u8>(YieldKind::Timer));
+    CHECK_EQ(r0.yield_payload_u32(), 1000u);
+
+    ctx.state = r0.next_state;
+    auto r1 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r1.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r1.status_code, 200);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_route_decorator_passes_then_post_wait_guard_can_reject_after_resume) {
+    const auto src = R"rut(
+func passing(_ req: i32) -> i32 => 0
+route {
+    @passing "*"
+    GET "/sleep" {
+        wait(1000)
+        guard req.path == "/nope" else { return 404 }
+        return 200
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
+    ctx.state = 0;
+    auto r0 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r0.action), static_cast<u8>(HandlerAction::Yield));
+    CHECK_EQ(r0.next_state, 1);
+    CHECK_EQ(static_cast<u8>(r0.yield_kind), static_cast<u8>(YieldKind::Timer));
+    CHECK_EQ(r0.yield_payload_u32(), 1000u);
+
+    ctx.state = r0.next_state;
+    auto r1 = HandlerResult::unpack(handler(nullptr,
+                                            &ctx,
+                                            reinterpret_cast<const u8*>(kGetRootRequest),
+                                            sizeof(kGetRootRequest) - 1,
+                                            nullptr));
+    CHECK_EQ(static_cast<u8>(r1.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r1.status_code, 404);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_route_decorator_passes_then_pre_wait_local_guard_then_waits) {
     const auto src = R"rut(
 func passing(_ req: i32) -> i32 => 0


### PR DESCRIPTION
## Summary

- Allow decorated `wait(...)` routes to use top-level post-wait guards when those guards do not read pre-wait user locals.
- Keep resume-safety checks for decorated wait routes by rejecting post-wait guards that depend on pre-wait locals.
- Add frontend and JIT coverage for post-wait guard pass/reject behavior, and update decorator docs.

## Why

Decorated wait routes already use source-ordered wait/guard lowering for the supported direct-terminal subset. The previous analyzer restriction rejected all post-wait user guards, even when they only read request data and can safely run after resume.

## Validation

- `ninja -C build test_frontend test_jit`
- `build/tests/test_frontend` (`1060 passed, 0 failed`)
- `build/tests/test_jit` (`373 passed, 0 failed`)
- `git diff --check`