### PR TITLE
[codex] Add clock fault injection support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,7 @@ Outstanding work items, prioritized for the next implementation passes.
 - [x] Malformed upstream E2E coverage drives real proxy sockets through malformed status, EOF, header, and framing failures.
 - [x] Replay/simulate route-action matrix coverage documents Static, Default, Proxy/JIT Forward, JIT ReturnStatus, mismatch, and malformed capture behavior.
 - [x] Coverage helper now keeps the runtime threshold gate while printing per-area summaries for runtime, compiler, replay/sim, JIT, and optional changed first-party files.
+- [x] Fault injection harness can now inject deterministic `clock_gettime` values and failures; access-log time helpers fail closed on clock errors.
 
 ## P0: State Invariant Coverage Follow-ups
 

--- a/include/rut/runtime/access_log.h
+++ b/include/rut/runtime/access_log.h
@@ -45,10 +45,13 @@ struct AccessLogEntry {
 static_assert(sizeof(AccessLogEntry) == 128, "AccessLogEntry must be 128 bytes");
 
 // Microsecond wall-clock timestamp (for access log timestamp field).
+// Returns 0 if CLOCK_REALTIME cannot be read.
 u64 realtime_us();
 
 // Monotonic microsecond clock (for elapsed duration measurement).
 // Immune to NTP adjustments and wall-clock jumps.
+// Returns a per-thread nonzero monotonic fallback if CLOCK_MONOTONIC fails; successful reads are
+// clamped to never move backward.
 u64 monotonic_us();
 
 // SPSC (single-producer, single-consumer) ring buffer for access log entries.

--- a/src/runtime/access_log.cc
+++ b/src/runtime/access_log.cc
@@ -14,6 +14,8 @@ namespace rut {
 
 // --- Text formatting helpers (no stdlib) ---
 
+static std::atomic<u64> g_last_monotonic_us{1};
+
 u64 realtime_us() {
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0) return 0;
@@ -22,8 +24,12 @@ u64 realtime_us() {
 
 u64 monotonic_us() {
     struct timespec ts;
-    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) return 0;
-    return static_cast<u64>(ts.tv_sec) * 1000000ULL + static_cast<u64>(ts.tv_nsec) / 1000ULL;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+        return g_last_monotonic_us.load(std::memory_order_relaxed);
+    u64 now = static_cast<u64>(ts.tv_sec) * 1000000ULL + static_cast<u64>(ts.tv_nsec) / 1000ULL;
+    if (now == 0) now = 1;
+    g_last_monotonic_us.store(now, std::memory_order_relaxed);
+    return now;
 }
 
 static u32 write_u64_dec(char* buf, u64 val) {

--- a/src/runtime/access_log.cc
+++ b/src/runtime/access_log.cc
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <pthread.h>
+#include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
 #include <zstd.h>
@@ -14,7 +15,15 @@ namespace rut {
 
 // --- Text formatting helpers (no stdlib) ---
 
-static thread_local u64 g_last_monotonic_us = 1;
+static u64 raw_monotonic_us() {
+    struct timespec ts;
+    if (syscall(SYS_clock_gettime, CLOCK_MONOTONIC, &ts) != 0) return 1;
+    u64 now = static_cast<u64>(ts.tv_sec) * 1000000ULL + static_cast<u64>(ts.tv_nsec) / 1000ULL;
+    return now == 0 ? 1 : now;
+}
+
+static thread_local u64 g_last_monotonic_us = raw_monotonic_us();
+
 u64 realtime_us() {
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0) return 0;

--- a/src/runtime/access_log.cc
+++ b/src/runtime/access_log.cc
@@ -24,6 +24,7 @@ u64 realtime_us() {
 
 u64 monotonic_us() {
     struct timespec ts;
+    // Preserve the nonzero in-flight sentinel even when the monotonic clock fails.
     if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) return g_last_monotonic_us;
     u64 now = static_cast<u64>(ts.tv_sec) * 1000000ULL + static_cast<u64>(ts.tv_nsec) / 1000ULL;
     if (now == 0) now = 1;

--- a/src/runtime/access_log.cc
+++ b/src/runtime/access_log.cc
@@ -15,6 +15,7 @@ namespace rut {
 // --- Text formatting helpers (no stdlib) ---
 
 static thread_local u64 g_last_monotonic_us = 1;
+static thread_local bool g_last_monotonic_failed = false;
 
 u64 realtime_us() {
     struct timespec ts;
@@ -25,11 +26,16 @@ u64 realtime_us() {
 u64 monotonic_us() {
     struct timespec ts;
     // Preserve the nonzero in-flight sentinel even when the monotonic clock fails.
-    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) return g_last_monotonic_us;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        g_last_monotonic_failed = true;
+        return g_last_monotonic_us;
+    }
     u64 now = static_cast<u64>(ts.tv_sec) * 1000000ULL + static_cast<u64>(ts.tv_nsec) / 1000ULL;
     if (now == 0) now = 1;
+    const u64 result = g_last_monotonic_failed ? g_last_monotonic_us : now;
     g_last_monotonic_us = now;
-    return now;
+    g_last_monotonic_failed = false;
+    return result;
 }
 
 static u32 write_u64_dec(char* buf, u64 val) {

--- a/src/runtime/access_log.cc
+++ b/src/runtime/access_log.cc
@@ -15,8 +15,6 @@ namespace rut {
 // --- Text formatting helpers (no stdlib) ---
 
 static thread_local u64 g_last_monotonic_us = 1;
-static thread_local bool g_last_monotonic_failed = false;
-
 u64 realtime_us() {
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) != 0) return 0;
@@ -27,14 +25,12 @@ u64 monotonic_us() {
     struct timespec ts;
     // Preserve the nonzero in-flight sentinel even when the monotonic clock fails.
     if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
-        g_last_monotonic_failed = true;
         return g_last_monotonic_us;
     }
     u64 now = static_cast<u64>(ts.tv_sec) * 1000000ULL + static_cast<u64>(ts.tv_nsec) / 1000ULL;
     if (now == 0) now = 1;
-    const u64 result = g_last_monotonic_failed ? g_last_monotonic_us : now;
-    g_last_monotonic_us = now;
-    g_last_monotonic_failed = false;
+    const u64 result = now < g_last_monotonic_us ? g_last_monotonic_us : now;
+    g_last_monotonic_us = result;
     return result;
 }
 

--- a/src/runtime/access_log.cc
+++ b/src/runtime/access_log.cc
@@ -24,8 +24,7 @@ u64 realtime_us() {
 
 u64 monotonic_us() {
     struct timespec ts;
-    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
-        return g_last_monotonic_us;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) return g_last_monotonic_us;
     u64 now = static_cast<u64>(ts.tv_sec) * 1000000ULL + static_cast<u64>(ts.tv_nsec) / 1000ULL;
     if (now == 0) now = 1;
     g_last_monotonic_us = now;

--- a/src/runtime/access_log.cc
+++ b/src/runtime/access_log.cc
@@ -16,13 +16,13 @@ namespace rut {
 
 u64 realtime_us() {
     struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0) return 0;
     return static_cast<u64>(ts.tv_sec) * 1000000ULL + static_cast<u64>(ts.tv_nsec) / 1000ULL;
 }
 
 u64 monotonic_us() {
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) return 0;
     return static_cast<u64>(ts.tv_sec) * 1000000ULL + static_cast<u64>(ts.tv_nsec) / 1000ULL;
 }
 

--- a/src/runtime/access_log.cc
+++ b/src/runtime/access_log.cc
@@ -14,7 +14,7 @@ namespace rut {
 
 // --- Text formatting helpers (no stdlib) ---
 
-static std::atomic<u64> g_last_monotonic_us{1};
+static thread_local u64 g_last_monotonic_us = 1;
 
 u64 realtime_us() {
     struct timespec ts;
@@ -25,10 +25,10 @@ u64 realtime_us() {
 u64 monotonic_us() {
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
-        return g_last_monotonic_us.load(std::memory_order_relaxed);
+        return g_last_monotonic_us;
     u64 now = static_cast<u64>(ts.tv_sec) * 1000000ULL + static_cast<u64>(ts.tv_nsec) / 1000ULL;
     if (now == 0) now = 1;
-    g_last_monotonic_us.store(now, std::memory_order_relaxed);
+    g_last_monotonic_us = now;
     return now;
 }
 

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -823,6 +823,9 @@ extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
         rut::test_fault::g_clock_gettime_clock_id.load(std::memory_order_relaxed);
     if (rut::test_fault::g_clock_gettime_fixed.load(std::memory_order_relaxed) &&
         (match_all || configured_clock == clockid)) {
+        if (syscall(SYS_clock_gettime, CLOCK_REALTIME, ts) != 0) {
+            return -1;
+        }
         ts->tv_sec = static_cast<time_t>(
             rut::test_fault::g_clock_gettime_sec.load(std::memory_order_relaxed));
         ts->tv_nsec = rut::test_fault::g_clock_gettime_nsec.load(std::memory_order_relaxed);

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -796,19 +796,7 @@ extern "C" int unlink(const char* path) {
 
 extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
     pthread_once(&rut::test_fault::g_syscall_once, rut::test_fault::resolve_syscalls);
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull-compare"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wnonnull-compare"
-#endif
-    const bool ts_is_null = ts == nullptr || rut::test_fault::is_null_ptr(ts);
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
+    const bool ts_is_null = rut::test_fault::is_null_ptr(ts);
     if (rut::test_fault::consume_fault(rut::test_fault::g_clock_gettime_fail_count)) {
         errno =
             rut::test_fault::fail_errno_or_default(rut::test_fault::g_clock_gettime_errno, EINVAL);

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -823,7 +823,7 @@ extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
         rut::test_fault::g_clock_gettime_clock_id.load(std::memory_order_relaxed);
     if (rut::test_fault::g_clock_gettime_fixed.load(std::memory_order_relaxed) &&
         (match_all || configured_clock == clockid)) {
-        if (syscall(SYS_clock_gettime, CLOCK_REALTIME, ts) != 0) {
+        if (syscall(SYS_clock_gettime, clockid, ts) != 0) {
             return -1;
         }
         ts->tv_sec = static_cast<time_t>(

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -14,6 +14,7 @@
 #include <sys/syscall.h>
 #include <sys/timerfd.h>
 #include <sys/types.h>
+#include <time.h>
 #include <unistd.h>
 
 namespace rut::test_fault {
@@ -41,6 +42,7 @@ using Accept4Fn = int (*)(int, struct sockaddr*, socklen_t*, int);
 using OpenFn = int (*)(const char*, int, ...);
 using MkstempFn = int (*)(char*);
 using UnlinkFn = int (*)(const char*);
+using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
 
 MmapFn g_real_mmap = nullptr;
 MprotectFn g_real_mprotect = nullptr;
@@ -62,6 +64,7 @@ Accept4Fn g_real_accept4 = nullptr;
 OpenFn g_real_open = nullptr;
 MkstempFn g_real_mkstemp = nullptr;
 UnlinkFn g_real_unlink = nullptr;
+ClockGettimeFn g_real_clock_gettime = nullptr;
 pthread_once_t g_syscall_once = PTHREAD_ONCE_INIT;
 
 std::atomic<int> g_io_fault_fd{-1};
@@ -108,6 +111,12 @@ std::atomic<int> g_mkstemp_errno{0};
 std::atomic<int> g_mkstemp_fail_count{0};
 std::atomic<int> g_unlink_errno{0};
 std::atomic<int> g_unlink_fail_count{0};
+std::atomic<int> g_clock_gettime_errno{0};
+std::atomic<int> g_clock_gettime_fail_count{0};
+std::atomic<bool> g_clock_gettime_fixed{false};
+std::atomic<int> g_clock_gettime_clock_id{kMatchAllClockIds};
+std::atomic<long long> g_clock_gettime_sec{0};
+std::atomic<long> g_clock_gettime_nsec{0};
 
 void resolve_syscalls() {
     g_real_mmap = reinterpret_cast<MmapFn>(dlsym(RTLD_NEXT, "mmap"));
@@ -131,6 +140,7 @@ void resolve_syscalls() {
     g_real_open = reinterpret_cast<OpenFn>(dlsym(RTLD_NEXT, "open"));
     g_real_mkstemp = reinterpret_cast<MkstempFn>(dlsym(RTLD_NEXT, "mkstemp"));
     g_real_unlink = reinterpret_cast<UnlinkFn>(dlsym(RTLD_NEXT, "unlink"));
+    g_real_clock_gettime = reinterpret_cast<ClockGettimeFn>(dlsym(RTLD_NEXT, "clock_gettime"));
 }
 
 bool consume_fault(std::atomic<int>& counter) {
@@ -220,6 +230,13 @@ SyscallFaultConfig current_syscall_fault_config() {
     config.mkstemp_failures = g_mkstemp_fail_count.load(std::memory_order_relaxed);
     config.unlink_errno = g_unlink_errno.load(std::memory_order_relaxed);
     config.unlink_failures = g_unlink_fail_count.load(std::memory_order_relaxed);
+    config.clock_gettime_errno = g_clock_gettime_errno.load(std::memory_order_relaxed);
+    config.clock_gettime_failures = g_clock_gettime_fail_count.load(std::memory_order_relaxed);
+    config.clock_gettime_fixed = g_clock_gettime_fixed.load(std::memory_order_relaxed);
+    config.clock_gettime_clock_id = g_clock_gettime_clock_id.load(std::memory_order_relaxed);
+    config.clock_gettime_sec =
+        static_cast<time_t>(g_clock_gettime_sec.load(std::memory_order_relaxed));
+    config.clock_gettime_nsec = g_clock_gettime_nsec.load(std::memory_order_relaxed);
     return config;
 }
 
@@ -243,6 +260,13 @@ void apply_syscall_fault_config(const SyscallFaultConfig& config) {
     g_mkstemp_fail_count.store(config.mkstemp_failures, std::memory_order_relaxed);
     g_unlink_errno.store(config.unlink_errno, std::memory_order_relaxed);
     g_unlink_fail_count.store(config.unlink_failures, std::memory_order_relaxed);
+    g_clock_gettime_errno.store(config.clock_gettime_errno, std::memory_order_relaxed);
+    g_clock_gettime_fail_count.store(config.clock_gettime_failures, std::memory_order_relaxed);
+    g_clock_gettime_fixed.store(config.clock_gettime_fixed, std::memory_order_relaxed);
+    g_clock_gettime_clock_id.store(config.clock_gettime_clock_id, std::memory_order_relaxed);
+    g_clock_gettime_sec.store(static_cast<long long>(config.clock_gettime_sec),
+                              std::memory_order_relaxed);
+    g_clock_gettime_nsec.store(config.clock_gettime_nsec, std::memory_order_relaxed);
 }
 
 int fail_errno_or_default(std::atomic<int>& configured_errno, int default_errno) {
@@ -755,4 +779,27 @@ extern "C" int unlink(const char* path) {
         return -1;
     }
     return rut::test_fault::g_real_unlink(path);
+}
+
+extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
+    pthread_once(&rut::test_fault::g_syscall_once, rut::test_fault::resolve_syscalls);
+    if (rut::test_fault::consume_fault(rut::test_fault::g_clock_gettime_fail_count)) {
+        errno =
+            rut::test_fault::fail_errno_or_default(rut::test_fault::g_clock_gettime_errno, EINVAL);
+        return -1;
+    }
+    const int configured_clock =
+        rut::test_fault::g_clock_gettime_clock_id.load(std::memory_order_relaxed);
+    if (rut::test_fault::g_clock_gettime_fixed.load(std::memory_order_relaxed) &&
+        (configured_clock == rut::test_fault::kMatchAllClockIds || configured_clock == clockid)) {
+        ts->tv_sec = static_cast<time_t>(
+            rut::test_fault::g_clock_gettime_sec.load(std::memory_order_relaxed));
+        ts->tv_nsec = rut::test_fault::g_clock_gettime_nsec.load(std::memory_order_relaxed);
+        return 0;
+    }
+    if (!rut::test_fault::g_real_clock_gettime) {
+        errno = ENOSYS;
+        return -1;
+    }
+    return rut::test_fault::g_real_clock_gettime(clockid, ts);
 }

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -809,10 +809,6 @@ extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
 #elif defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
-    if (ts_is_null) {
-        errno = EFAULT;
-        return -1;
-    }
     if (rut::test_fault::consume_fault(rut::test_fault::g_clock_gettime_fail_count)) {
         errno =
             rut::test_fault::fail_errno_or_default(rut::test_fault::g_clock_gettime_errno, EINVAL);
@@ -824,7 +820,12 @@ extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
         rut::test_fault::g_clock_gettime_clock_id.load(std::memory_order_relaxed);
     if (rut::test_fault::g_clock_gettime_fixed.load(std::memory_order_relaxed) &&
         (match_all || configured_clock == clockid)) {
-        if (syscall(SYS_clock_gettime, clockid, ts) != 0) {
+        struct timespec probe_ts{};
+        if (syscall(SYS_clock_gettime, clockid, &probe_ts) != 0) {
+            return -1;
+        }
+        if (ts_is_null) {
+            errno = EFAULT;
             return -1;
         }
         const long configured_nsec =
@@ -833,10 +834,17 @@ extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
             errno = EINVAL;
             return -1;
         }
+        if (syscall(SYS_clock_gettime, clockid, ts) != 0) {
+            return -1;
+        }
         ts->tv_sec = static_cast<time_t>(
             rut::test_fault::g_clock_gettime_sec.load(std::memory_order_relaxed));
         ts->tv_nsec = configured_nsec;
         return 0;
+    }
+    if (ts_is_null) {
+        errno = EFAULT;
+        return -1;
     }
     if (!rut::test_fault::g_real_clock_gettime) {
         errno = ENOSYS;

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -351,6 +351,7 @@ bool open_flags_require_mode(int flags) {
 bool is_null_ptr(const void* ptr) {
     uintptr_t bits = reinterpret_cast<uintptr_t>(ptr);
 #if defined(__GNUC__) || defined(__clang__)
+    // Hide the value from nonnull-related optimizations so tests can exercise NULL safely.
     asm volatile("" : "+r"(bits));
 #endif
     return bits == 0;

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -835,8 +835,7 @@ extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
         return -1;
     }
     if (!rut::test_fault::g_real_clock_gettime) {
-        errno = ENOSYS;
-        return -1;
+        return static_cast<int>(syscall(SYS_clock_gettime, clockid, ts));
     }
     return rut::test_fault::g_real_clock_gettime(clockid, ts);
 }

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -831,6 +831,10 @@ extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
         return 0;
     }
     if (ts_is_null) {
+        struct timespec probe_ts{};
+        if (syscall(SYS_clock_gettime, clockid, &probe_ts) != 0) {
+            return -1;
+        }
         errno = EFAULT;
         return -1;
     }

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -826,9 +826,15 @@ extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
         if (syscall(SYS_clock_gettime, clockid, ts) != 0) {
             return -1;
         }
+        const long configured_nsec =
+            rut::test_fault::g_clock_gettime_nsec.load(std::memory_order_relaxed);
+        if (configured_nsec < 0 || configured_nsec >= 1000000000L) {
+            errno = EINVAL;
+            return -1;
+        }
         ts->tv_sec = static_cast<time_t>(
             rut::test_fault::g_clock_gettime_sec.load(std::memory_order_relaxed));
-        ts->tv_nsec = rut::test_fault::g_clock_gettime_nsec.load(std::memory_order_relaxed);
+        ts->tv_nsec = configured_nsec;
         return 0;
     }
     if (!rut::test_fault::g_real_clock_gettime) {

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -115,7 +115,8 @@ std::atomic<int> g_unlink_fail_count{0};
 std::atomic<int> g_clock_gettime_errno{0};
 std::atomic<int> g_clock_gettime_fail_count{0};
 std::atomic<bool> g_clock_gettime_fixed{false};
-std::atomic<int> g_clock_gettime_clock_id{kMatchAllClockIds};
+std::atomic<bool> g_clock_gettime_match_all{true};
+std::atomic<clockid_t> g_clock_gettime_clock_id{CLOCK_REALTIME};
 std::atomic<long long> g_clock_gettime_sec{0};
 std::atomic<long> g_clock_gettime_nsec{0};
 
@@ -234,6 +235,7 @@ SyscallFaultConfig current_syscall_fault_config() {
     config.clock_gettime_errno = g_clock_gettime_errno.load(std::memory_order_relaxed);
     config.clock_gettime_failures = g_clock_gettime_fail_count.load(std::memory_order_relaxed);
     config.clock_gettime_fixed = g_clock_gettime_fixed.load(std::memory_order_relaxed);
+    config.clock_gettime_match_all = g_clock_gettime_match_all.load(std::memory_order_relaxed);
     config.clock_gettime_clock_id = g_clock_gettime_clock_id.load(std::memory_order_relaxed);
     config.clock_gettime_sec =
         static_cast<time_t>(g_clock_gettime_sec.load(std::memory_order_relaxed));
@@ -264,6 +266,7 @@ void apply_syscall_fault_config(const SyscallFaultConfig& config) {
     g_clock_gettime_errno.store(config.clock_gettime_errno, std::memory_order_relaxed);
     g_clock_gettime_fail_count.store(config.clock_gettime_failures, std::memory_order_relaxed);
     g_clock_gettime_fixed.store(config.clock_gettime_fixed, std::memory_order_relaxed);
+    g_clock_gettime_match_all.store(config.clock_gettime_match_all, std::memory_order_relaxed);
     g_clock_gettime_clock_id.store(config.clock_gettime_clock_id, std::memory_order_relaxed);
     g_clock_gettime_sec.store(static_cast<long long>(config.clock_gettime_sec),
                               std::memory_order_relaxed);
@@ -814,10 +817,12 @@ extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
             rut::test_fault::fail_errno_or_default(rut::test_fault::g_clock_gettime_errno, EINVAL);
         return -1;
     }
-    const int configured_clock =
+    const bool match_all =
+        rut::test_fault::g_clock_gettime_match_all.load(std::memory_order_relaxed);
+    const clockid_t configured_clock =
         rut::test_fault::g_clock_gettime_clock_id.load(std::memory_order_relaxed);
     if (rut::test_fault::g_clock_gettime_fixed.load(std::memory_order_relaxed) &&
-        (configured_clock == rut::test_fault::kMatchAllClockIds || configured_clock == clockid)) {
+        (match_all || configured_clock == clockid)) {
         ts->tv_sec = static_cast<time_t>(
             rut::test_fault::g_clock_gettime_sec.load(std::memory_order_relaxed));
         ts->tv_nsec = rut::test_fault::g_clock_gettime_nsec.load(std::memory_order_relaxed);

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -8,6 +8,7 @@
 #include <poll.h>
 #include <pthread.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <sys/epoll.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
@@ -342,6 +343,14 @@ bool open_flags_require_mode(int flags) {
     if ((flags & O_TMPFILE) == O_TMPFILE) return true;
 #endif
     return false;
+}
+
+bool is_null_ptr(const void* ptr) {
+    uintptr_t bits = reinterpret_cast<uintptr_t>(ptr);
+#if defined(__GNUC__) || defined(__clang__)
+    asm volatile("" : "+r"(bits));
+#endif
+    return bits == 0;
 }
 
 }  // namespace
@@ -783,6 +792,10 @@ extern "C" int unlink(const char* path) {
 
 extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
     pthread_once(&rut::test_fault::g_syscall_once, rut::test_fault::resolve_syscalls);
+    if (rut::test_fault::is_null_ptr(ts)) {
+        errno = EFAULT;
+        return -1;
+    }
     if (rut::test_fault::consume_fault(rut::test_fault::g_clock_gettime_fail_count)) {
         errno =
             rut::test_fault::fail_errno_or_default(rut::test_fault::g_clock_gettime_errno, EINVAL);

--- a/testing/fault_injection.cc
+++ b/testing/fault_injection.cc
@@ -792,7 +792,20 @@ extern "C" int unlink(const char* path) {
 
 extern "C" int clock_gettime(clockid_t clockid, struct timespec* ts) {
     pthread_once(&rut::test_fault::g_syscall_once, rut::test_fault::resolve_syscalls);
-    if (rut::test_fault::is_null_ptr(ts)) {
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull-compare"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull-compare"
+#endif
+    const bool ts_is_null = ts == nullptr || rut::test_fault::is_null_ptr(ts);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+    if (ts_is_null) {
         errno = EFAULT;
         return -1;
     }

--- a/testing/fault_injection.h
+++ b/testing/fault_injection.h
@@ -9,7 +9,6 @@ namespace rut::test_fault {
 
 inline constexpr int kNoIoFaultFd = -1;
 inline constexpr int kMatchAllIoFds = -2;
-inline constexpr int kMatchAllClockIds = -1;
 
 struct FaultState {
     int mmap_fail_call = 0;
@@ -74,7 +73,8 @@ struct SyscallFaultConfig {
     int clock_gettime_errno = 0;
     int clock_gettime_failures = 0;
     bool clock_gettime_fixed = false;
-    int clock_gettime_clock_id = kMatchAllClockIds;
+    bool clock_gettime_match_all = true;
+    clockid_t clock_gettime_clock_id = CLOCK_REALTIME;
     time_t clock_gettime_sec = 0;
     long clock_gettime_nsec = 0;
 };

--- a/testing/fault_injection.h
+++ b/testing/fault_injection.h
@@ -3,11 +3,13 @@
 #include "rut/common/types.h"
 
 #include <stddef.h>
+#include <time.h>
 
 namespace rut::test_fault {
 
 inline constexpr int kNoIoFaultFd = -1;
 inline constexpr int kMatchAllIoFds = -2;
+inline constexpr int kMatchAllClockIds = -1;
 
 struct FaultState {
     int mmap_fail_call = 0;
@@ -69,6 +71,12 @@ struct SyscallFaultConfig {
     int mkstemp_failures = 0;
     int unlink_errno = 0;
     int unlink_failures = 0;
+    int clock_gettime_errno = 0;
+    int clock_gettime_failures = 0;
+    bool clock_gettime_fixed = false;
+    int clock_gettime_clock_id = kMatchAllClockIds;
+    time_t clock_gettime_sec = 0;
+    long clock_gettime_nsec = 0;
 };
 
 FaultState& state();

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -18,7 +18,6 @@
 
 using namespace rut;
 using rut::test_fault::IoFaultConfig;
-using rut::test_fault::kMatchAllClockIds;
 using rut::test_fault::ScopedIoFault;
 using rut::test_fault::ScopedSyscallFault;
 using rut::test_fault::SyscallFaultConfig;
@@ -144,6 +143,7 @@ TEST(syscall_fault, mkstemp_and_unlink_failures_are_injected) {
 TEST(syscall_fault, clock_gettime_fixed_time_is_injected_by_clock_id) {
     SyscallFaultConfig realtime_config;
     realtime_config.clock_gettime_fixed = true;
+    realtime_config.clock_gettime_match_all = false;
     realtime_config.clock_gettime_clock_id = CLOCK_REALTIME;
     realtime_config.clock_gettime_sec = 1711123456;
     realtime_config.clock_gettime_nsec = 789123000;
@@ -156,7 +156,6 @@ TEST(syscall_fault, clock_gettime_fixed_time_is_injected_by_clock_id) {
 TEST(syscall_fault, clock_gettime_fixed_time_can_match_all_clock_ids) {
     SyscallFaultConfig fault_config;
     fault_config.clock_gettime_fixed = true;
-    fault_config.clock_gettime_clock_id = kMatchAllClockIds;
     fault_config.clock_gettime_sec = 42;
     fault_config.clock_gettime_nsec = 123456000;
 
@@ -168,18 +167,13 @@ TEST(syscall_fault, clock_gettime_fixed_time_can_match_all_clock_ids) {
 TEST(syscall_fault, clock_gettime_null_timespec_fails_with_efault) {
     SyscallFaultConfig fault_config;
     fault_config.clock_gettime_fixed = true;
-    fault_config.clock_gettime_clock_id = kMatchAllClockIds;
     fault_config.clock_gettime_sec = 42;
     fault_config.clock_gettime_nsec = 123456000;
 
     ScopedSyscallFault fault(fault_config);
-    uintptr_t raw = static_cast<uintptr_t>(getpid());
-    raw -= raw;
-    auto* null_ts = reinterpret_cast<struct timespec*>(raw);
     using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
-    ClockGettimeFn injected_clock_gettime =
-        reinterpret_cast<ClockGettimeFn>(reinterpret_cast<void*>(&clock_gettime));
-    CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, null_ts), -1);
+    ClockGettimeFn injected_clock_gettime = &clock_gettime;
+    CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, nullptr), -1);
     CHECK_EQ(errno, EFAULT);
 }
 

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -1,4 +1,5 @@
 #include "fault_injection.h"
+#include "rut/runtime/access_log.h"
 #include "rut/runtime/epoll_backend.h"
 #include "rut/runtime/error.h"
 #include "test.h"
@@ -16,6 +17,7 @@
 
 using namespace rut;
 using rut::test_fault::IoFaultConfig;
+using rut::test_fault::kMatchAllClockIds;
 using rut::test_fault::ScopedIoFault;
 using rut::test_fault::ScopedSyscallFault;
 using rut::test_fault::SyscallFaultConfig;
@@ -136,6 +138,40 @@ TEST(syscall_fault, mkstemp_and_unlink_failures_are_injected) {
     }
 
     unlink(path);
+}
+
+TEST(syscall_fault, clock_gettime_fixed_time_is_injected_by_clock_id) {
+    SyscallFaultConfig realtime_config;
+    realtime_config.clock_gettime_fixed = true;
+    realtime_config.clock_gettime_clock_id = CLOCK_REALTIME;
+    realtime_config.clock_gettime_sec = 1711123456;
+    realtime_config.clock_gettime_nsec = 789123000;
+
+    ScopedSyscallFault realtime_fault(realtime_config);
+    CHECK_EQ(realtime_us(), 1711123456789123ULL);
+    CHECK(monotonic_us() > 0);
+}
+
+TEST(syscall_fault, clock_gettime_fixed_time_can_match_all_clock_ids) {
+    SyscallFaultConfig fault_config;
+    fault_config.clock_gettime_fixed = true;
+    fault_config.clock_gettime_clock_id = kMatchAllClockIds;
+    fault_config.clock_gettime_sec = 42;
+    fault_config.clock_gettime_nsec = 123456000;
+
+    ScopedSyscallFault fault(fault_config);
+    CHECK_EQ(realtime_us(), 42123456ULL);
+    CHECK_EQ(monotonic_us(), 42123456ULL);
+}
+
+TEST(syscall_fault, access_log_time_helpers_fail_closed_on_clock_error) {
+    SyscallFaultConfig fault_config;
+    fault_config.clock_gettime_errno = EIO;
+    fault_config.clock_gettime_failures = 2;
+
+    ScopedSyscallFault fault(fault_config);
+    CHECK_EQ(realtime_us(), 0ULL);
+    CHECK_EQ(monotonic_us(), 0ULL);
 }
 
 TEST(epoll_fault, init_reports_epoll_create_failure) {

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -219,6 +219,20 @@ TEST(syscall_fault, clock_gettime_fixed_time_preserves_invalid_clock_errno) {
     CHECK_EQ(errno, EINVAL);
 }
 
+TEST(syscall_fault, clock_gettime_fixed_time_validates_clock_before_null_timespec) {
+    SyscallFaultConfig fault_config;
+    fault_config.clock_gettime_fixed = true;
+    fault_config.clock_gettime_sec = 42;
+    fault_config.clock_gettime_nsec = 123456000;
+
+    ScopedSyscallFault fault(fault_config);
+    using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
+    ClockGettimeFn injected_clock_gettime = &clock_gettime;
+    errno = 0;
+    CHECK_EQ(injected_clock_gettime(static_cast<clockid_t>(-999999), opaque_null_timespec()), -1);
+    CHECK_EQ(errno, EINVAL);
+}
+
 TEST(syscall_fault, clock_gettime_fixed_time_rejects_invalid_nsec) {
     using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
     ClockGettimeFn injected_clock_gettime = &clock_gettime;

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -164,14 +165,35 @@ TEST(syscall_fault, clock_gettime_fixed_time_can_match_all_clock_ids) {
     CHECK_EQ(monotonic_us(), 42123456ULL);
 }
 
+TEST(syscall_fault, clock_gettime_null_timespec_fails_with_efault) {
+    SyscallFaultConfig fault_config;
+    fault_config.clock_gettime_fixed = true;
+    fault_config.clock_gettime_clock_id = kMatchAllClockIds;
+    fault_config.clock_gettime_sec = 42;
+    fault_config.clock_gettime_nsec = 123456000;
+
+    ScopedSyscallFault fault(fault_config);
+    uintptr_t raw = static_cast<uintptr_t>(getpid());
+    raw -= raw;
+    auto* null_ts = reinterpret_cast<struct timespec*>(raw);
+    using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
+    ClockGettimeFn injected_clock_gettime =
+        reinterpret_cast<ClockGettimeFn>(reinterpret_cast<void*>(&clock_gettime));
+    CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, null_ts), -1);
+    CHECK_EQ(errno, EFAULT);
+}
+
 TEST(syscall_fault, access_log_time_helpers_fail_closed_on_clock_error) {
+    const u64 last_monotonic = monotonic_us();
+    REQUIRE(last_monotonic != 0);
+
     SyscallFaultConfig fault_config;
     fault_config.clock_gettime_errno = EIO;
     fault_config.clock_gettime_failures = 2;
 
     ScopedSyscallFault fault(fault_config);
     CHECK_EQ(realtime_us(), 0ULL);
-    CHECK_EQ(monotonic_us(), 0ULL);
+    CHECK_EQ(monotonic_us(), last_monotonic);
 }
 
 TEST(epoll_fault, init_reports_epoll_create_failure) {

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -177,6 +177,21 @@ TEST(syscall_fault, clock_gettime_null_timespec_fails_with_efault) {
     CHECK_EQ(errno, EFAULT);
 }
 
+TEST(syscall_fault, clock_gettime_invalid_timespec_fails_with_efault) {
+    SyscallFaultConfig fault_config;
+    fault_config.clock_gettime_fixed = true;
+    fault_config.clock_gettime_sec = 42;
+    fault_config.clock_gettime_nsec = 123456000;
+
+    ScopedSyscallFault fault(fault_config);
+    using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
+    ClockGettimeFn injected_clock_gettime = &clock_gettime;
+    errno = 0;
+    auto* invalid_ts = reinterpret_cast<struct timespec*>(static_cast<uintptr_t>(1));
+    CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, invalid_ts), -1);
+    CHECK_EQ(errno, EFAULT);
+}
+
 TEST(syscall_fault, access_log_time_helpers_fail_closed_on_clock_error) {
     const u64 last_monotonic = monotonic_us();
     REQUIRE(last_monotonic != 0);

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -207,6 +207,35 @@ TEST(syscall_fault, clock_gettime_fixed_time_preserves_invalid_clock_errno) {
     CHECK_EQ(errno, EINVAL);
 }
 
+TEST(syscall_fault, clock_gettime_fixed_time_rejects_invalid_nsec) {
+    using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
+    ClockGettimeFn injected_clock_gettime = &clock_gettime;
+
+    {
+        SyscallFaultConfig fault_config;
+        fault_config.clock_gettime_fixed = true;
+        fault_config.clock_gettime_sec = 42;
+        fault_config.clock_gettime_nsec = 1000000000L;
+        ScopedSyscallFault fault(fault_config);
+        struct timespec ts{};
+        errno = 0;
+        CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, &ts), -1);
+        CHECK_EQ(errno, EINVAL);
+    }
+
+    {
+        SyscallFaultConfig fault_config;
+        fault_config.clock_gettime_fixed = true;
+        fault_config.clock_gettime_sec = 42;
+        fault_config.clock_gettime_nsec = -1;
+        ScopedSyscallFault fault(fault_config);
+        struct timespec ts{};
+        errno = 0;
+        CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, &ts), -1);
+        CHECK_EQ(errno, EINVAL);
+    }
+}
+
 TEST(syscall_fault, access_log_time_helpers_fail_closed_on_clock_error) {
     const u64 last_monotonic = monotonic_us();
     REQUIRE(last_monotonic != 0);

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -235,6 +235,14 @@ TEST(syscall_fault, clock_gettime_fixed_time_validates_clock_before_null_timespe
     CHECK_EQ(errno, EINVAL);
 }
 
+TEST(syscall_fault, clock_gettime_default_validates_clock_before_null_timespec) {
+    using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
+    ClockGettimeFn injected_clock_gettime = &clock_gettime;
+    errno = 0;
+    CHECK_EQ(injected_clock_gettime(static_cast<clockid_t>(-999999), opaque_null_timespec()), -1);
+    CHECK_EQ(errno, EINVAL);
+}
+
 TEST(syscall_fault, clock_gettime_fixed_time_rejects_invalid_nsec) {
     using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
     ClockGettimeFn injected_clock_gettime = &clock_gettime;

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -192,6 +192,21 @@ TEST(syscall_fault, clock_gettime_invalid_timespec_fails_with_efault) {
     CHECK_EQ(errno, EFAULT);
 }
 
+TEST(syscall_fault, clock_gettime_fixed_time_preserves_invalid_clock_errno) {
+    SyscallFaultConfig fault_config;
+    fault_config.clock_gettime_fixed = true;
+    fault_config.clock_gettime_sec = 42;
+    fault_config.clock_gettime_nsec = 123456000;
+
+    ScopedSyscallFault fault(fault_config);
+    using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
+    ClockGettimeFn injected_clock_gettime = &clock_gettime;
+    struct timespec ts{};
+    errno = 0;
+    CHECK_EQ(injected_clock_gettime(static_cast<clockid_t>(-999999), &ts), -1);
+    CHECK_EQ(errno, EINVAL);
+}
+
 TEST(syscall_fault, access_log_time_helpers_fail_closed_on_clock_error) {
     const u64 last_monotonic = monotonic_us();
     REQUIRE(last_monotonic != 0);

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -166,14 +166,15 @@ TEST(syscall_fault, clock_gettime_fixed_time_is_injected_by_clock_id) {
 }
 
 TEST(syscall_fault, clock_gettime_fixed_time_can_match_all_clock_ids) {
+    const u64 fixed_us = monotonic_us() + 1000000ULL;
     SyscallFaultConfig fault_config;
     fault_config.clock_gettime_fixed = true;
-    fault_config.clock_gettime_sec = 42;
-    fault_config.clock_gettime_nsec = 123456000;
+    fault_config.clock_gettime_sec = static_cast<time_t>(fixed_us / 1000000ULL);
+    fault_config.clock_gettime_nsec = static_cast<long>((fixed_us % 1000000ULL) * 1000ULL);
 
     ScopedSyscallFault fault(fault_config);
-    CHECK_EQ(realtime_us(), 42123456ULL);
-    CHECK_EQ(monotonic_us(), 42123456ULL);
+    CHECK_EQ(realtime_us(), fixed_us);
+    CHECK_EQ(monotonic_us(), fixed_us);
 }
 
 TEST(syscall_fault, clock_gettime_null_timespec_fails_with_efault) {
@@ -244,9 +245,13 @@ TEST(syscall_fault, clock_gettime_fixed_time_rejects_invalid_nsec) {
         fault_config.clock_gettime_nsec = 1000000000L;
         ScopedSyscallFault fault(fault_config);
         struct timespec ts{};
+        ts.tv_sec = 7;
+        ts.tv_nsec = 8;
         errno = 0;
         CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, &ts), -1);
         CHECK_EQ(errno, EINVAL);
+        CHECK_EQ(ts.tv_sec, 7);
+        CHECK_EQ(ts.tv_nsec, 8);
     }
 
     {
@@ -256,9 +261,13 @@ TEST(syscall_fault, clock_gettime_fixed_time_rejects_invalid_nsec) {
         fault_config.clock_gettime_nsec = -1;
         ScopedSyscallFault fault(fault_config);
         struct timespec ts{};
+        ts.tv_sec = 7;
+        ts.tv_nsec = 8;
         errno = 0;
         CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, &ts), -1);
         CHECK_EQ(errno, EINVAL);
+        CHECK_EQ(ts.tv_sec, 7);
+        CHECK_EQ(ts.tv_nsec, 8);
     }
 }
 
@@ -276,17 +285,20 @@ TEST(syscall_fault, access_log_time_helpers_fail_closed_on_clock_error) {
 }
 
 TEST(syscall_fault, monotonic_us_clamps_first_success_after_clock_error) {
-    REQUIRE(monotonic_us() != 0);
+    const u64 last_monotonic = monotonic_us();
+    REQUIRE(last_monotonic != 0);
 
     SyscallFaultConfig fault_config;
     fault_config.clock_gettime_errno = EIO;
     fault_config.clock_gettime_failures = 1;
+    fault_config.clock_gettime_fixed = true;
+    fault_config.clock_gettime_sec = static_cast<time_t>(last_monotonic / 1000000ULL + 10ULL);
+    fault_config.clock_gettime_nsec = static_cast<long>((last_monotonic % 1000000ULL) * 1000ULL);
 
     ScopedSyscallFault fault(fault_config);
     const u64 failure_value = monotonic_us();
-    CHECK_NE(failure_value, 0ULL);
-    CHECK_EQ(monotonic_us(), failure_value);
-    CHECK_GE(monotonic_us(), failure_value);
+    CHECK_EQ(failure_value, last_monotonic);
+    CHECK_GT(monotonic_us(), failure_value);
 }
 
 TEST(epoll_fault, init_reports_epoll_create_failure) {

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -22,6 +22,18 @@ using rut::test_fault::ScopedIoFault;
 using rut::test_fault::ScopedSyscallFault;
 using rut::test_fault::SyscallFaultConfig;
 
+namespace {
+
+struct timespec* opaque_null_timespec() {
+    uintptr_t bits = 0;
+#if defined(__GNUC__) || defined(__clang__)
+    asm volatile("" : "+r"(bits));
+#endif
+    return reinterpret_cast<struct timespec*>(bits);
+}
+
+}  // namespace
+
 TEST(syscall_fault, close_and_fcntl_failures_are_injected) {
     i32 fd = dup(2);
     REQUIRE(fd >= 0);
@@ -173,7 +185,7 @@ TEST(syscall_fault, clock_gettime_null_timespec_fails_with_efault) {
     ScopedSyscallFault fault(fault_config);
     using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
     ClockGettimeFn injected_clock_gettime = &clock_gettime;
-    CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, nullptr), -1);
+    CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, opaque_null_timespec()), -1);
     CHECK_EQ(errno, EFAULT);
 }
 
@@ -247,6 +259,20 @@ TEST(syscall_fault, access_log_time_helpers_fail_closed_on_clock_error) {
     ScopedSyscallFault fault(fault_config);
     CHECK_EQ(realtime_us(), 0ULL);
     CHECK_EQ(monotonic_us(), last_monotonic);
+}
+
+TEST(syscall_fault, monotonic_us_clamps_first_success_after_clock_error) {
+    REQUIRE(monotonic_us() != 0);
+
+    SyscallFaultConfig fault_config;
+    fault_config.clock_gettime_errno = EIO;
+    fault_config.clock_gettime_failures = 1;
+
+    ScopedSyscallFault fault(fault_config);
+    const u64 failure_value = monotonic_us();
+    CHECK_NE(failure_value, 0ULL);
+    CHECK_EQ(monotonic_us(), failure_value);
+    CHECK_GE(monotonic_us(), failure_value);
 }
 
 TEST(epoll_fault, init_reports_epoll_create_failure) {

--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -186,6 +186,7 @@ TEST(syscall_fault, clock_gettime_null_timespec_fails_with_efault) {
     ScopedSyscallFault fault(fault_config);
     using ClockGettimeFn = int (*)(clockid_t, struct timespec*);
     ClockGettimeFn injected_clock_gettime = &clock_gettime;
+    errno = 0;
     CHECK_EQ(injected_clock_gettime(CLOCK_REALTIME, opaque_null_timespec()), -1);
     CHECK_EQ(errno, EFAULT);
 }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -13,7 +13,6 @@
 #include "rut/runtime/socket.h"
 #include "rut/runtime/timer_wheel.h"
 #include "rut/runtime/traffic_capture.h"
-#include <atomic>
 
 #include <errno.h>
 #include <fcntl.h>
@@ -996,7 +995,6 @@ struct LoopThread {
     RealLoop* loop;
     pthread_t thread;
     i32 max_iters;
-    std::atomic<bool> done{false};
     static void* run(void* arg) {
         auto* lt = static_cast<LoopThread*>(arg);
         auto* lp = lt->loop;
@@ -1008,13 +1006,9 @@ struct LoopThread {
             for (u32 i = 0; i < n; i++) lp->dispatch(events[i]);
             if (++iters >= lt->max_iters) break;
         }
-        lt->done.store(true, std::memory_order_release);
         return nullptr;
     }
-    void start() {
-        done.store(false, std::memory_order_release);
-        pthread_create(&thread, nullptr, run, this);
-    }
+    void start() { pthread_create(&thread, nullptr, run, this); }
     void stop() {
         loop->stop();
         pthread_join(thread, nullptr);
@@ -1045,7 +1039,6 @@ struct TestServer {
         lt.loop = loop;
         lt.thread = {};
         lt.max_iters = iters;
-        lt.done.store(false, std::memory_order_release);
         lt.start();
         return true;
     }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -996,6 +996,7 @@ struct LoopThread {
     RealLoop* loop;
     pthread_t thread;
     i32 max_iters;
+    std::atomic<bool> done{false};
     static void* run(void* arg) {
         auto* lt = static_cast<LoopThread*>(arg);
         auto* lp = lt->loop;
@@ -1007,9 +1008,13 @@ struct LoopThread {
             for (u32 i = 0; i < n; i++) lp->dispatch(events[i]);
             if (++iters >= lt->max_iters) break;
         }
+        lt->done.store(true, std::memory_order_release);
         return nullptr;
     }
-    void start() { pthread_create(&thread, nullptr, run, this); }
+    void start() {
+        done.store(false, std::memory_order_release);
+        pthread_create(&thread, nullptr, run, this);
+    }
     void stop() {
         loop->stop();
         pthread_join(thread, nullptr);
@@ -1037,7 +1042,10 @@ struct TestServer {
             destroy_real_loop(loop);
             return false;
         }
-        lt = {loop, {}, iters};
+        lt.loop = loop;
+        lt.thread = {};
+        lt.max_iters = iters;
+        lt.done.store(false, std::memory_order_release);
         lt.start();
         return true;
     }

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1880,6 +1880,7 @@ TEST(epoll_metrics, accept_and_request_counted) {
     send_all(c, HTTP_REQ, HTTP_REQ_LEN);
     char buf[4096];
     recv_timeout(c, buf, sizeof(buf), 2000);
+    for (i32 i = 0; i < 200 && metrics.requests_total == 0; i++) usleep(1000);
     close(c);
     lt.stop();
     CHECK_GT(metrics.connections_total, 0u);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1877,7 +1877,7 @@ TEST(epoll_metrics, accept_and_request_counted) {
     usleep(100000);
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
-    send_all(c, HTTP_REQ, HTTP_REQ_LEN);
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
     CHECK(n > 0);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1881,10 +1881,9 @@ TEST(epoll_metrics, accept_and_request_counted) {
     char buf[4096];
     i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
     CHECK(n > 0);
-    for (i32 i = 0; i < 200 && !lt.done.load(std::memory_order_acquire); i++) usleep(1000);
-    CHECK(lt.done.load(std::memory_order_acquire));
+    loop->stop();
     close(c);
-    lt.stop();
+    pthread_join(lt.thread, nullptr);
     CHECK_GT(metrics.connections_total, 0u);
     CHECK_GT(metrics.requests_total, 0u);
     loop->shutdown();
@@ -2915,7 +2914,6 @@ struct ScopedProxyLoop {
         lt.loop = loop;
         lt.thread = {};
         lt.max_iters = iters;
-        lt.done.store(false, std::memory_order_release);
         lt.start();
         loop_started = true;
         return true;

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1880,7 +1880,7 @@ TEST(epoll_metrics, accept_and_request_counted) {
     send_all(c, HTTP_REQ, HTTP_REQ_LEN);
     char buf[4096];
     recv_timeout(c, buf, sizeof(buf), 2000);
-    for (i32 i = 0; i < 200 && metrics.requests_total == 0; i++) usleep(1000);
+    usleep(200000);
     close(c);
     lt.stop();
     CHECK_GT(metrics.connections_total, 0u);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1872,15 +1872,17 @@ TEST(epoll_metrics, accept_and_request_counted) {
     ShardMetrics metrics{};
     loop->metrics = &metrics;
     u16 port = get_port(lfd);
-    LoopThread lt = {loop, {}, 20};
+    LoopThread lt = {loop, {}, 3};
     lt.start();
     usleep(100000);
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
     send_all(c, HTTP_REQ, HTTP_REQ_LEN);
     char buf[4096];
-    recv_timeout(c, buf, sizeof(buf), 2000);
-    usleep(200000);
+    i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+    CHECK(n > 0);
+    for (i32 i = 0; i < 200 && !lt.done.load(std::memory_order_acquire); i++) usleep(1000);
+    CHECK(lt.done.load(std::memory_order_acquire));
     close(c);
     lt.stop();
     CHECK_GT(metrics.connections_total, 0u);
@@ -2910,7 +2912,10 @@ struct ScopedProxyLoop {
             return false;
         }
         loop->config_ptr = active;
-        lt = {loop, {}, iters};
+        lt.loop = loop;
+        lt.thread = {};
+        lt.max_iters = iters;
+        lt.done.store(false, std::memory_order_release);
         lt.start();
         loop_started = true;
         return true;

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1881,6 +1881,9 @@ TEST(epoll_metrics, accept_and_request_counted) {
     char buf[4096];
     i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
     CHECK(n > 0);
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    n = recv_timeout(c, buf, sizeof(buf), 2000);
+    CHECK(n > 0);
     close(c);
     lt.stop();
     CHECK_GT(metrics.connections_total, 0u);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -1872,7 +1872,7 @@ TEST(epoll_metrics, accept_and_request_counted) {
     ShardMetrics metrics{};
     loop->metrics = &metrics;
     u16 port = get_port(lfd);
-    LoopThread lt = {loop, {}, 3};
+    LoopThread lt = {loop, {}, 20};
     lt.start();
     usleep(100000);
     i32 c = connect_to(port);
@@ -1881,9 +1881,8 @@ TEST(epoll_metrics, accept_and_request_counted) {
     char buf[4096];
     i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
     CHECK(n > 0);
-    loop->stop();
     close(c);
-    pthread_join(lt.thread, nullptr);
+    lt.stop();
     CHECK_GT(metrics.connections_total, 0u);
     CHECK_GT(metrics.requests_total, 0u);
     loop->shutdown();


### PR DESCRIPTION
## Summary

Adds shared `clock_gettime` fault injection support to the test harness.

## Details

- Adds deterministic fixed-time injection for `clock_gettime`, scoped by a specific clock id or by a separate match-all flag.
- Adds injected `clock_gettime` failure support through `SyscallFaultConfig`.
- Makes `realtime_us()` fail closed by returning `0` when the underlying realtime clock syscall fails.
- Makes `monotonic_us()` preserve a nonzero runtime sentinel by returning the last successful monotonic timestamp when the underlying monotonic clock syscall fails.
- Covers the new harness behavior in `test_fault_injection` and records the completed P0 harness item in `TODO.md`.

## Validation

- `git diff --check`
- `ninja -C build test_fault_injection`
- `build/tests/test_fault_injection`
- `ninja -C build test_access_log`
- `build/tests/test_access_log`