### PR TITLE
[codex] Cover arena mmap fault paths

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,7 +70,11 @@ add_dependencies(test_integration test_tls_fixtures)
 add_test(NAME test_integration COMMAND test_integration)
 set_tests_properties(test_integration PROPERTIES LABELS "integration;network")
 
-add_executable(test_arena test_arena.cc ${PROJECT_SOURCE_DIR}/src/placement_new.cc)
+add_executable(test_arena
+    test_arena.cc
+    ${PROJECT_SOURCE_DIR}/src/placement_new.cc
+    ${PROJECT_SOURCE_DIR}/testing/fault_injection.cc
+)
 target_link_libraries(test_arena rut_runtime)
 target_include_directories(test_arena PRIVATE
     ${PROJECT_SOURCE_DIR}/include

--- a/tests/test_arena.cc
+++ b/tests/test_arena.cc
@@ -1,11 +1,13 @@
 // Arena tests — comprehensive code path coverage for both backends.
 // MmapArena: mmap-backed, variable-size blocks (compiler use).
 // SliceArena: SlicePool-backed, fixed 16KB blocks (runtime hot path).
+#include "fault_injection.h"
 #include "rut/runtime/arena.h"
 #include "rut/runtime/slice_pool.h"
 #include "test.h"
 
 using namespace rut;
+using rut::test_fault::ScopedMemoryFault;
 
 // ============================================================
 // Block internals
@@ -88,6 +90,17 @@ TEST(arena, init_succeeds) {
     CHECK(a.current != nullptr);
     CHECK_GT(a.space_allocated(), 0u);
     a.destroy();
+}
+
+TEST(arena, init_reports_mmap_failure) {
+    ScopedMemoryFault fault(1);
+    MmapArena a;
+    auto rc = a.init(4096);
+    CHECK(!rc.has_value());
+    CHECK_EQ(rc.error().code, ENOMEM);
+    CHECK(rc.error().source == Error::Source::Arena);
+    CHECK(a.current == nullptr);
+    CHECK_EQ(a.space_allocated(), 0u);
 }
 
 TEST(arena, init_min_256) {
@@ -176,6 +189,26 @@ TEST(arena, overflow_to_new_block) {
     a.alloc(64);
     CHECK(a.current->prev != nullptr);
     CHECK_GE(a.space_allocated(), 256u * 2);
+    a.destroy();
+}
+
+TEST(arena, overflow_mmap_failure_keeps_existing_block_usable) {
+    MmapArena a;
+    REQUIRE(a.init(256).has_value());
+    MmapArena::Block* first = a.current;
+    const u64 initial_allocated = a.space_allocated();
+    REQUIRE(a.alloc(first->capacity()) != nullptr);
+
+    {
+        ScopedMemoryFault fault(1);
+        CHECK(a.alloc(64) == nullptr);
+    }
+
+    CHECK_EQ(a.current, first);
+    CHECK_EQ(a.space_allocated(), initial_allocated);
+    a.reset();
+    CHECK_EQ(a.current, first);
+    CHECK(a.alloc(32) != nullptr);
     a.destroy();
 }
 


### PR DESCRIPTION
## Summary
- add MmapArena init mmap-failure coverage using the shared fault-injection helper
- cover failed overflow block allocation while preserving the existing arena block
- link the arena test target with the fault-injection helper implementation

## Testing
- `cmake --build build --target test_arena`
- `build/tests/test_arena --filter=arena.init_reports_mmap_failure,arena.overflow_mmap_failure_keeps_existing_block_usable`
- `build/tests/test_arena`
- `git diff --check`
- `clang-format --dry-run --Werror tests/test_arena.cc`