### PR TITLE
tests: keep send failure cleanup reachable in integration tests

### DIFF
--- a/tests/test_fault_injection.cc
+++ b/tests/test_fault_injection.cc
@@ -27,6 +27,8 @@ namespace {
 struct timespec* opaque_null_timespec() {
     uintptr_t bits = 0;
 #if defined(__GNUC__) || defined(__clang__)
+    // Prevent compilers from optimizing the nullptr value away before the call site.
+    // This keeps the wrapper under test from relying on compile-time nullness assumptions.
     asm volatile("" : "+r"(bits));
 #endif
     return reinterpret_cast<struct timespec*>(bits);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -658,14 +658,15 @@ TEST(error, send_no_read_close) {
     REQUIRE(srv.setup(20));
     i32 c = connect_to(srv.port);
     REQUIRE(c >= 0);
-    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     close(c);
     usleep(100000);
     i32 c2 = connect_to(srv.port);
     REQUIRE(c2 >= 0);
-    CHECK(send_all(c2, HTTP_REQ, HTTP_REQ_LEN));
+    const bool ok = send_all(c2, HTTP_REQ, HTTP_REQ_LEN);
+    CHECK(ok);
     char buf[4096];
-    CHECK(recv_timeout(c2, buf, sizeof(buf), 2000) > 0);
+    if (ok) CHECK(recv_timeout(c2, buf, sizeof(buf), 2000) > 0);
     close(c2);
     srv.teardown();
 }

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -698,14 +698,14 @@ TEST(error, fd_recycle_no_stale) {
     REQUIRE(srv.setup(30));
     i32 c1 = connect_to(srv.port);
     REQUIRE(c1 >= 0);
-    REQUIRE(send_all(c1, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c1, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     recv_timeout(c1, buf, sizeof(buf), 1000);
     close(c1);
     usleep(50000);
     i32 c2 = connect_to(srv.port);
     REQUIRE(c2 >= 0);
-    REQUIRE(send_all(c2, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c2, HTTP_REQ, HTTP_REQ_LEN));
     CHECK(recv_timeout(c2, buf, sizeof(buf), 2000) > 0);
     close(c2);
     srv.teardown();
@@ -1465,7 +1465,7 @@ TEST(shard, serves_requests) {
     usleep(50000);  // let shard start
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
-    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
     CHECK(n > 0);
@@ -1691,7 +1691,7 @@ TEST(shard, ephemeral_port_two_shards) {
     usleep(50000);
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
-    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     CHECK(recv_timeout(c, buf, sizeof(buf), 2000) > 0);
     close(c);
@@ -1852,7 +1852,7 @@ TEST(epoll_drain, drain_with_active_connections) {
     // Connect and send request
     i32 c = connect_to(srv.port);
     REQUIRE(c >= 0);
-    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
     CHECK(n > 0);
@@ -1908,7 +1908,7 @@ TEST(epoll_epoch, epoch_increments_on_request) {
     usleep(10000);
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
-    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     recv_timeout(c, buf, sizeof(buf), 2000);
     close(c);
@@ -1988,7 +1988,7 @@ TEST(epoll_drain, drain_completes_naturally) {
     // Connect and send a request (creates active connection)
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
-    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     recv_timeout(c, buf, sizeof(buf), 2000);
 

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -658,7 +658,7 @@ TEST(error, send_no_read_close) {
     REQUIRE(srv.setup(20));
     i32 c = connect_to(srv.port);
     REQUIRE(c >= 0);
-    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     close(c);
     usleep(100000);
     i32 c2 = connect_to(srv.port);
@@ -1465,7 +1465,7 @@ TEST(shard, serves_requests) {
     usleep(50000);  // let shard start
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
-    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
     CHECK(n > 0);
@@ -1691,7 +1691,7 @@ TEST(shard, ephemeral_port_two_shards) {
     usleep(50000);
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
-    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     CHECK(recv_timeout(c, buf, sizeof(buf), 2000) > 0);
     close(c);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -732,7 +732,7 @@ TEST(loop, stop_from_outside) {
     REQUIRE(srv.setup(1000));
     i32 c = connect_to(srv.port);
     REQUIRE(c >= 0);
-    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     recv_timeout(c, buf, sizeof(buf), 1000);
     srv.loop->stop();

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -658,12 +658,12 @@ TEST(error, send_no_read_close) {
     REQUIRE(srv.setup(20));
     i32 c = connect_to(srv.port);
     REQUIRE(c >= 0);
-    send_all(c, HTTP_REQ, HTTP_REQ_LEN);
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     close(c);
     usleep(100000);
     i32 c2 = connect_to(srv.port);
     REQUIRE(c2 >= 0);
-    send_all(c2, HTTP_REQ, HTTP_REQ_LEN);
+    REQUIRE(send_all(c2, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     CHECK(recv_timeout(c2, buf, sizeof(buf), 2000) > 0);
     close(c2);
@@ -698,14 +698,14 @@ TEST(error, fd_recycle_no_stale) {
     REQUIRE(srv.setup(30));
     i32 c1 = connect_to(srv.port);
     REQUIRE(c1 >= 0);
-    send_all(c1, HTTP_REQ, HTTP_REQ_LEN);
+    REQUIRE(send_all(c1, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     recv_timeout(c1, buf, sizeof(buf), 1000);
     close(c1);
     usleep(50000);
     i32 c2 = connect_to(srv.port);
     REQUIRE(c2 >= 0);
-    send_all(c2, HTTP_REQ, HTTP_REQ_LEN);
+    REQUIRE(send_all(c2, HTTP_REQ, HTTP_REQ_LEN));
     CHECK(recv_timeout(c2, buf, sizeof(buf), 2000) > 0);
     close(c2);
     srv.teardown();
@@ -732,7 +732,7 @@ TEST(loop, stop_from_outside) {
     REQUIRE(srv.setup(1000));
     i32 c = connect_to(srv.port);
     REQUIRE(c >= 0);
-    send_all(c, HTTP_REQ, HTTP_REQ_LEN);
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     recv_timeout(c, buf, sizeof(buf), 1000);
     srv.loop->stop();
@@ -1852,7 +1852,7 @@ TEST(epoll_drain, drain_with_active_connections) {
     // Connect and send request
     i32 c = connect_to(srv.port);
     REQUIRE(c >= 0);
-    send_all(c, HTTP_REQ, HTTP_REQ_LEN);
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
     CHECK(n > 0);
@@ -1908,7 +1908,7 @@ TEST(epoll_epoch, epoch_increments_on_request) {
     usleep(10000);
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
-    send_all(c, HTTP_REQ, HTTP_REQ_LEN);
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     recv_timeout(c, buf, sizeof(buf), 2000);
     close(c);
@@ -1988,7 +1988,7 @@ TEST(epoll_drain, drain_completes_naturally) {
     // Connect and send a request (creates active connection)
     i32 c = connect_to(port);
     REQUIRE(c >= 0);
-    send_all(c, HTTP_REQ, HTTP_REQ_LEN);
+    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     recv_timeout(c, buf, sizeof(buf), 2000);
 

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -658,12 +658,12 @@ TEST(error, send_no_read_close) {
     REQUIRE(srv.setup(20));
     i32 c = connect_to(srv.port);
     REQUIRE(c >= 0);
-    REQUIRE(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c, HTTP_REQ, HTTP_REQ_LEN));
     close(c);
     usleep(100000);
     i32 c2 = connect_to(srv.port);
     REQUIRE(c2 >= 0);
-    REQUIRE(send_all(c2, HTTP_REQ, HTTP_REQ_LEN));
+    CHECK(send_all(c2, HTTP_REQ, HTTP_REQ_LEN));
     char buf[4096];
     CHECK(recv_timeout(c2, buf, sizeof(buf), 2000) > 0);
     close(c2);


### PR DESCRIPTION
## Changes
- Replace the two new `REQUIRE(send_all(...))` calls in `send_no_read_close` with `CHECK`.
- This preserves `srv.teardown()`/socket close cleanup when the first send fails, avoiding leaked stack-backed loop state and unstable test teardown paths.

## Validation
- `ctest --test-dir build -R "test_integration|test_fault_injection" --output-on-failure` (currently `test_integration` fails in this container due pre-existing environment socket/listen setup issues; `test_fault_injection` passes).
