### PR TITLE
runtime: add firewall default allow/deny policy switch

### DIFF
--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -99,3 +99,4 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_deny_localhost_cidr_real_socket`
 - `firewall_allowlist_cidr_localhost_real_socket`
 - `firewall_clear_rules_reenables_localhost_real_socket`
+- `firewall_remove_deny_rule_reenables_localhost_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -93,6 +93,7 @@ Coverage is in `tests/test_network.cc` under `route_coverage`:
 - `firewall_remove_ip_and_cidr_rules`
 - `firewall_remove_rejects_missing_or_invalid_rules`
 - `firewall_remove_allow_rules_updates_policy_mode`
+- `firewall_remove_deny_restores_allow_match`
 
 Integration coverage in `tests/test_integration.cc` includes:
 

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -80,3 +80,11 @@ Coverage is in `tests/test_network.cc` under `route_coverage`:
 - `firewall_deny_rule_returns_403`
 - `firewall_allowlist_blocks_non_members`
 - `firewall_cidr_allow_and_deny_rules`
+- `firewall_clear_rules_recovers_capacity`
+
+Integration coverage in `tests/test_integration.cc` includes:
+
+- `firewall_deny_localhost_real_socket`
+- `firewall_deny_localhost_cidr_real_socket`
+- `firewall_allowlist_cidr_localhost_real_socket`
+- `firewall_clear_rules_reenables_localhost_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -37,13 +37,14 @@ Defined on `RouteConfig`:
 - `remove_firewall_deny_cidr("a.b.c.d/prefix")`
 - `clear_firewall_rules()`
 
-All `u32` IPv4 arguments are host-order (same convention as
+All `u32` IPv4 arguments are packed host-order values in the form
+`(a << 24) | (b << 16) | (c << 8) | d` for `a.b.c.d` (same convention as
 `UpstreamTarget::set_addr`).
 Firewall tables also store rule IP values in host-order.
 String overloads parse dotted IPv4/CIDR literals and return `false` on
 malformed input.
 `Connection.peer_addr` comes from accept/getpeername in network byte order;
-the runtime converts as needed during firewall evaluation.
+`firewall_allows_peer` converts it once to packed host-order before evaluation.
 
 Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
 return `false` on cap overflow or invalid CIDR prefix.
@@ -85,7 +86,7 @@ cfg.add_firewall_allow_ip(0x7f000001);       // 127.0.0.1
 
 ## Tests
 
-Coverage is in `tests/test_network.cc` under `route_coverage`:
+Current coverage in `tests/test_network.cc` (`route_coverage`) includes:
 
 - `firewall_deny_rule_returns_403`
 - `firewall_allowlist_blocks_non_members`
@@ -102,7 +103,7 @@ Coverage is in `tests/test_network.cc` under `route_coverage`:
 - `firewall_remove_last_allow_cidr_keeps_deny_cidr_active`
 - `firewall_remove_deny_restores_allow_match`
 
-Integration coverage in `tests/test_integration.cc` includes:
+Current integration coverage in `tests/test_integration.cc` includes:
 
 - `firewall_deny_localhost_real_socket`
 - `firewall_deny_localhost_cidr_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -106,6 +106,7 @@ Integration coverage in `tests/test_integration.cc` includes:
 
 - `firewall_deny_localhost_real_socket`
 - `firewall_deny_localhost_cidr_real_socket`
+- `firewall_allowlist_exact_localhost_real_socket`
 - `firewall_allowlist_cidr_localhost_real_socket`
 - `firewall_clear_rules_reenables_localhost_real_socket`
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -43,6 +43,9 @@ Defined on `RouteConfig`:
 - `remove_firewall_deny_ip("a.b.c.d")`
 - `remove_firewall_allow_cidr("a.b.c.d/prefix")`
 - `remove_firewall_deny_cidr("a.b.c.d/prefix")`
+- `set_firewall_default_allow(bool allow)`
+- `set_firewall_default_deny()`
+- `firewall_default_is_allow()`
 - `clear_firewall_rules()`
 
 All `u32` IPv4 arguments are packed host-order values in the form
@@ -62,6 +65,8 @@ Adding the same exact IP or same CIDR repeatedly is idempotent (returns `true`
 without consuming additional rule slots).
 Remove APIs return `true` only when a matching rule exists and is deleted.
 `clear_firewall_rules()` clears all allow/deny exact and CIDR rules.
+Default policy is allow unless changed via `set_firewall_default_allow(false)`
+or `set_firewall_default_deny()`.
 
 ## Evaluation order
 
@@ -69,7 +74,7 @@ For each request:
 
 1. Any deny IP match => reject
 2. Any deny CIDR match => reject
-3. If no allow rules exist => allow
+3. If no allow rules exist => apply default policy (allow by default)
 4. Otherwise require allow IP or allow CIDR match
 
 In other words, deny rules always win over allow rules.
@@ -112,6 +117,7 @@ Current coverage in `tests/test_network.cc` (`route_coverage`) includes:
 - `firewall_remove_last_allow_keeps_deny_active`
 - `firewall_remove_last_allow_cidr_keeps_deny_cidr_active`
 - `firewall_remove_deny_restores_allow_match`
+- `firewall_default_deny_requires_explicit_allow`
 
 Current integration coverage in `tests/test_integration.cc` includes:
 
@@ -133,3 +139,4 @@ Current integration coverage in `tests/test_integration.cc` includes:
 - `firewall_remove_deny_ip_restores_allow_ip_real_socket`
 - `firewall_remove_last_allow_ip_keeps_deny_cidr_real_socket`
 - `firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket`
+- `firewall_default_deny_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -109,3 +109,4 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_remove_allow_cidr_restores_default_allow_real_socket`
 - `firewall_remove_deny_cidr_restores_allow_cidr_real_socket`
 - `firewall_remove_deny_ip_restores_allow_ip_real_socket`
+- `firewall_remove_last_allow_ip_keeps_deny_cidr_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -104,3 +104,4 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`
 - `firewall_remove_deny_cidr_reenables_localhost_real_socket`
 - `firewall_remove_allow_rule_restores_default_allow_real_socket`
+- `firewall_remove_allow_cidr_restores_default_allow_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -23,10 +23,18 @@ Defined on `RouteConfig`:
 - `add_firewall_deny_ip(u32 ip_host_order)`
 - `add_firewall_allow_cidr(u32 ip_host_order, u8 prefix_len)`
 - `add_firewall_deny_cidr(u32 ip_host_order, u8 prefix_len)`
+- `remove_firewall_allow_ip(u32 ip_host_order)`
+- `remove_firewall_deny_ip(u32 ip_host_order)`
+- `remove_firewall_allow_cidr(u32 ip_host_order, u8 prefix_len)`
+- `remove_firewall_deny_cidr(u32 ip_host_order, u8 prefix_len)`
 - `add_firewall_allow_ip("a.b.c.d")`
 - `add_firewall_deny_ip("a.b.c.d")`
 - `add_firewall_allow_cidr("a.b.c.d/prefix")`
 - `add_firewall_deny_cidr("a.b.c.d/prefix")`
+- `remove_firewall_allow_ip("a.b.c.d")`
+- `remove_firewall_deny_ip("a.b.c.d")`
+- `remove_firewall_allow_cidr("a.b.c.d/prefix")`
+- `remove_firewall_deny_cidr("a.b.c.d/prefix")`
 - `clear_firewall_rules()`
 
 All `u32` IPv4 arguments are host-order (same convention as
@@ -40,6 +48,7 @@ Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
 return `false` on cap overflow or invalid CIDR prefix.
 Adding the same exact IP or same CIDR repeatedly is idempotent (returns `true`
 without consuming additional rule slots).
+Remove APIs return `true` only when a matching rule exists and is deleted.
 `clear_firewall_rules()` clears all allow/deny exact and CIDR rules.
 
 ## Evaluation order
@@ -81,6 +90,8 @@ Coverage is in `tests/test_network.cc` under `route_coverage`:
 - `firewall_allowlist_blocks_non_members`
 - `firewall_cidr_allow_and_deny_rules`
 - `firewall_clear_rules_recovers_capacity`
+- `firewall_remove_ip_and_cidr_rules`
+- `firewall_remove_rejects_missing_or_invalid_rules`
 
 Integration coverage in `tests/test_integration.cc` includes:
 

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -92,6 +92,7 @@ Coverage is in `tests/test_network.cc` under `route_coverage`:
 - `firewall_clear_rules_recovers_capacity`
 - `firewall_remove_ip_and_cidr_rules`
 - `firewall_remove_rejects_missing_or_invalid_rules`
+- `firewall_remove_cidr_u32_rejects_invalid_prefix`
 - `firewall_remove_allow_rules_updates_policy_mode`
 - `firewall_remove_last_allow_keeps_deny_active`
 - `firewall_remove_last_allow_cidr_keeps_deny_cidr_active`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -108,6 +108,7 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_deny_localhost_cidr_real_socket`
 - `firewall_allowlist_exact_localhost_real_socket`
 - `firewall_deny_exact_over_allow_exact_real_socket`
+- `firewall_deny_exact_over_allow_cidr_real_socket`
 - `firewall_allowlist_cidr_localhost_real_socket`
 - `firewall_clear_rules_reenables_localhost_real_socket`
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -93,6 +93,7 @@ Coverage is in `tests/test_network.cc` under `route_coverage`:
 - `firewall_remove_ip_and_cidr_rules`
 - `firewall_remove_rejects_missing_or_invalid_rules`
 - `firewall_remove_allow_rules_updates_policy_mode`
+- `firewall_remove_last_allow_keeps_deny_active`
 - `firewall_remove_deny_restores_allow_match`
 
 Integration coverage in `tests/test_integration.cc` includes:

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -107,6 +107,7 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_deny_localhost_real_socket`
 - `firewall_deny_localhost_cidr_real_socket`
 - `firewall_allowlist_exact_localhost_real_socket`
+- `firewall_deny_exact_over_allow_exact_real_socket`
 - `firewall_allowlist_cidr_localhost_real_socket`
 - `firewall_clear_rules_reenables_localhost_real_socket`
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -22,9 +22,15 @@ Defined on `RouteConfig`:
 - `add_firewall_deny_ip(u32 ip_host_order)`
 - `add_firewall_allow_cidr(u32 network_host_order, u8 prefix_len)`
 - `add_firewall_deny_cidr(u32 network_host_order, u8 prefix_len)`
+- `add_firewall_allow_ip("a.b.c.d")`
+- `add_firewall_deny_ip("a.b.c.d")`
+- `add_firewall_allow_cidr("a.b.c.d/prefix")`
+- `add_firewall_deny_cidr("a.b.c.d/prefix")`
 
 All `u32` IPv4 arguments are host-order (same convention as
 `UpstreamTarget::set_addr`).
+String overloads parse dotted IPv4/CIDR literals and return `false` on
+malformed input.
 
 Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
 return `false` on cap overflow or invalid CIDR prefix.

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -39,6 +39,7 @@ Defined on `RouteConfig`:
 
 All `u32` IPv4 arguments are host-order (same convention as
 `UpstreamTarget::set_addr`).
+Firewall tables also store rule IP values in host-order.
 String overloads parse dotted IPv4/CIDR literals and return `false` on
 malformed input.
 `Connection.peer_addr` comes from accept/getpeername in network byte order;

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -36,6 +36,8 @@ the runtime converts as needed during firewall evaluation.
 
 Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
 return `false` on cap overflow or invalid CIDR prefix.
+Adding the same exact IP or same CIDR repeatedly is idempotent (returns `true`
+without consuming additional rule slots).
 
 ## Evaluation order
 

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -111,3 +111,4 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_remove_deny_cidr_restores_allow_cidr_real_socket`
 - `firewall_remove_deny_ip_restores_allow_ip_real_socket`
 - `firewall_remove_last_allow_ip_keeps_deny_cidr_real_socket`
+- `firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -78,9 +78,9 @@ On reject:
 ```cpp
 RouteConfig cfg;
 cfg.add_static("/ok", 0, 200);
-cfg.add_firewall_allow_cidr(0x0a000000, 8);   // 10.0.0.0/8
-cfg.add_firewall_deny_cidr(0x0a010000, 16);   // 10.1.0.0/16
-cfg.add_firewall_allow_ip(0x7f000001);        // 127.0.0.1
+cfg.add_firewall_allow_cidr(0x0a000000, 8);  // 10.0.0.0/8
+cfg.add_firewall_deny_cidr(0x0a010000, 16);  // 10.1.0.0/16
+cfg.add_firewall_allow_ip(0x7f000001);       // 127.0.0.1
 ```
 
 ## Tests
@@ -109,6 +109,7 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_allowlist_exact_localhost_real_socket`
 - `firewall_deny_exact_over_allow_exact_real_socket`
 - `firewall_deny_exact_over_allow_cidr_real_socket`
+- `firewall_deny_cidr_over_allow_exact_real_socket`
 - `firewall_allowlist_cidr_localhost_real_socket`
 - `firewall_clear_rules_reenables_localhost_real_socket`
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -20,8 +20,8 @@ Defined on `RouteConfig`:
 
 - `add_firewall_allow_ip(u32 ip_host_order)`
 - `add_firewall_deny_ip(u32 ip_host_order)`
-- `add_firewall_allow_cidr(u32 network_host_order, u8 prefix_len)`
-- `add_firewall_deny_cidr(u32 network_host_order, u8 prefix_len)`
+- `add_firewall_allow_cidr(u32 ip_host_order, u8 prefix_len)`
+- `add_firewall_deny_cidr(u32 ip_host_order, u8 prefix_len)`
 - `add_firewall_allow_ip("a.b.c.d")`
 - `add_firewall_deny_ip("a.b.c.d")`
 - `add_firewall_allow_cidr("a.b.c.d/prefix")`
@@ -31,6 +31,8 @@ All `u32` IPv4 arguments are host-order (same convention as
 `UpstreamTarget::set_addr`).
 String overloads parse dotted IPv4/CIDR literals and return `false` on
 malformed input.
+`Connection.peer_addr` comes from accept/getpeername in network byte order;
+the runtime converts as needed during firewall evaluation.
 
 Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
 return `false` on cap overflow or invalid CIDR prefix.

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -101,3 +101,4 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_allowlist_cidr_localhost_real_socket`
 - `firewall_clear_rules_reenables_localhost_real_socket`
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`
+- `firewall_remove_deny_cidr_reenables_localhost_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -1,0 +1,69 @@
+# Firewall (runtime RouteConfig)
+
+This document describes the firewall capability currently available in runtime
+configuration (`RouteConfig`), independent of DSL parsing.
+
+## Scope
+
+Current support is IPv4 source-address filtering on accepted downstream
+connections.
+
+- Exact IP rules
+- CIDR subnet rules
+- Allowlist + denylist precedence
+
+Rules are evaluated from `Connection.peer_addr` captured at accept-time.
+
+## APIs
+
+Defined on `RouteConfig`:
+
+- `add_firewall_allow_ip(u32 ip_host_order)`
+- `add_firewall_deny_ip(u32 ip_host_order)`
+- `add_firewall_allow_cidr(u32 network_host_order, u8 prefix_len)`
+- `add_firewall_deny_cidr(u32 network_host_order, u8 prefix_len)`
+
+All `u32` IPv4 arguments are host-order (same convention as
+`UpstreamTarget::set_addr`).
+
+Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
+return `false` on cap overflow or invalid CIDR prefix.
+
+## Evaluation order
+
+For each request:
+
+1. Any deny IP match => reject
+2. Any deny CIDR match => reject
+3. If no allow rules exist => allow
+4. Otherwise require allow IP or allow CIDR match
+
+In other words, deny rules always win over allow rules.
+
+## Runtime behavior on reject
+
+Firewall checks run in `on_header_received` before route matching.
+
+On reject:
+
+- response status is `403`
+- response is sent immediately
+- keep-alive is disabled for that connection
+
+## Example
+
+```cpp
+RouteConfig cfg;
+cfg.add_static("/ok", 0, 200);
+cfg.add_firewall_allow_cidr(0x0a000000, 8);   // 10.0.0.0/8
+cfg.add_firewall_deny_cidr(0x0a010000, 16);   // 10.1.0.0/16
+cfg.add_firewall_allow_ip(0x7f000001);        // 127.0.0.1
+```
+
+## Tests
+
+Coverage is in `tests/test_network.cc` under `route_coverage`:
+
+- `firewall_deny_rule_returns_403`
+- `firewall_allowlist_blocks_non_members`
+- `firewall_cidr_allow_and_deny_rules`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -13,6 +13,7 @@ connections.
 - Allowlist + denylist precedence
 
 Rules are evaluated from `Connection.peer_addr` captured at accept-time.
+For host-order callers, `firewall_allows_peer_host(u32)` is also available.
 
 ## APIs
 

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -94,6 +94,7 @@ Coverage is in `tests/test_network.cc` under `route_coverage`:
 - `firewall_remove_rejects_missing_or_invalid_rules`
 - `firewall_remove_allow_rules_updates_policy_mode`
 - `firewall_remove_last_allow_keeps_deny_active`
+- `firewall_remove_last_allow_cidr_keeps_deny_cidr_active`
 - `firewall_remove_deny_restores_allow_match`
 
 Integration coverage in `tests/test_integration.cc` includes:

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -92,6 +92,7 @@ Coverage is in `tests/test_network.cc` under `route_coverage`:
 - `firewall_clear_rules_recovers_capacity`
 - `firewall_remove_ip_and_cidr_rules`
 - `firewall_remove_rejects_missing_or_invalid_rules`
+- `firewall_remove_allow_rules_updates_policy_mode`
 
 Integration coverage in `tests/test_integration.cc` includes:
 

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -90,6 +90,9 @@ Coverage is in `tests/test_network.cc` under `route_coverage`:
 - `firewall_deny_rule_returns_403`
 - `firewall_allowlist_blocks_non_members`
 - `firewall_cidr_allow_and_deny_rules`
+- `firewall_string_ip_and_cidr_helpers`
+- `firewall_exact_ip_rules_use_host_order_storage`
+- `firewall_exact_ip_remove_roundtrip_with_network_peer_addr`
 - `firewall_clear_rules_recovers_capacity`
 - `firewall_remove_ip_and_cidr_rules`
 - `firewall_remove_rejects_missing_or_invalid_rules`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -27,6 +27,14 @@ Defined on `RouteConfig`:
 - `remove_firewall_deny_ip(u32 ip_host_order)`
 - `remove_firewall_allow_cidr(u32 ip_host_order, u8 prefix_len)`
 - `remove_firewall_deny_cidr(u32 ip_host_order, u8 prefix_len)`
+- `add_firewall_allow_ip_network_order(u32 ip_network_order)`
+- `add_firewall_deny_ip_network_order(u32 ip_network_order)`
+- `add_firewall_allow_cidr_network_order(u32 ip_network_order, u8 prefix_len)`
+- `add_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len)`
+- `remove_firewall_allow_ip_network_order(u32 ip_network_order)`
+- `remove_firewall_deny_ip_network_order(u32 ip_network_order)`
+- `remove_firewall_allow_cidr_network_order(u32 ip_network_order, u8 prefix_len)`
+- `remove_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len)`
 - `add_firewall_allow_ip("a.b.c.d")`
 - `add_firewall_deny_ip("a.b.c.d")`
 - `add_firewall_allow_cidr("a.b.c.d/prefix")`
@@ -45,6 +53,8 @@ String overloads parse dotted IPv4/CIDR literals and return `false` on
 malformed input.
 `Connection.peer_addr` comes from accept/getpeername in network byte order;
 `firewall_allows_peer` converts it once to packed host-order before evaluation.
+For callers already holding network-order IPv4 (`in_addr.s_addr` style),
+`*_network_order` helper overloads convert to packed host-order internally.
 
 Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
 return `false` on cap overflow or invalid CIDR prefix.

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -102,3 +102,4 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_clear_rules_reenables_localhost_real_socket`
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`
 - `firewall_remove_deny_cidr_reenables_localhost_real_socket`
+- `firewall_remove_allow_rule_restores_default_allow_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -43,6 +43,8 @@ Defined on `RouteConfig`:
 - `remove_firewall_deny_ip("a.b.c.d")`
 - `remove_firewall_allow_cidr("a.b.c.d/prefix")`
 - `remove_firewall_deny_cidr("a.b.c.d/prefix")`
+- `clear_firewall_allow_rules()`
+- `clear_firewall_deny_rules()`
 - `set_firewall_default_allow(bool allow)`
 - `set_firewall_default_deny()`
 - `firewall_default_is_allow()`
@@ -64,6 +66,8 @@ return `false` on cap overflow or invalid CIDR prefix.
 Adding the same exact IP or same CIDR repeatedly is idempotent (returns `true`
 without consuming additional rule slots).
 Remove APIs return `true` only when a matching rule exists and is deleted.
+`clear_firewall_allow_rules()` clears both allow exact-IP and allow CIDR tables.
+`clear_firewall_deny_rules()` clears both deny exact-IP and deny CIDR tables.
 `clear_firewall_rules()` clears all allow/deny exact and CIDR rules.
 Default policy is allow unless changed via `set_firewall_default_allow(false)`
 or `set_firewall_default_deny()`.

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -117,11 +117,13 @@ Current integration coverage in `tests/test_integration.cc` includes:
 
 - `firewall_deny_localhost_real_socket`
 - `firewall_deny_localhost_cidr_real_socket`
+- `firewall_deny_localhost_network_order_real_socket`
 - `firewall_allowlist_exact_localhost_real_socket`
 - `firewall_deny_exact_over_allow_exact_real_socket`
 - `firewall_deny_exact_over_allow_cidr_real_socket`
 - `firewall_deny_cidr_over_allow_exact_real_socket`
 - `firewall_allowlist_cidr_localhost_real_socket`
+- `firewall_allowlist_network_order_cidr_localhost_real_socket`
 - `firewall_clear_rules_reenables_localhost_real_socket`
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`
 - `firewall_remove_deny_cidr_reenables_localhost_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -105,3 +105,4 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_remove_deny_cidr_reenables_localhost_real_socket`
 - `firewall_remove_allow_rule_restores_default_allow_real_socket`
 - `firewall_remove_allow_cidr_restores_default_allow_real_socket`
+- `firewall_remove_deny_cidr_restores_allow_cidr_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -106,3 +106,4 @@ Integration coverage in `tests/test_integration.cc` includes:
 - `firewall_remove_allow_rule_restores_default_allow_real_socket`
 - `firewall_remove_allow_cidr_restores_default_allow_real_socket`
 - `firewall_remove_deny_cidr_restores_allow_cidr_real_socket`
+- `firewall_remove_deny_ip_restores_allow_ip_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -27,6 +27,7 @@ Defined on `RouteConfig`:
 - `add_firewall_deny_ip("a.b.c.d")`
 - `add_firewall_allow_cidr("a.b.c.d/prefix")`
 - `add_firewall_deny_cidr("a.b.c.d/prefix")`
+- `clear_firewall_rules()`
 
 All `u32` IPv4 arguments are host-order (same convention as
 `UpstreamTarget::set_addr`).
@@ -39,6 +40,7 @@ Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
 return `false` on cap overflow or invalid CIDR prefix.
 Adding the same exact IP or same CIDR repeatedly is idempotent (returns `true`
 without consuming additional rule slots).
+`clear_firewall_rules()` clears all allow/deny exact and CIDR rules.
 
 ## Evaluation order
 

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -225,6 +225,15 @@ void on_header_received(void* lp, Connection& conn, IoEvent ev) {
     // different upstream table.
     const RouteConfig* config = loop->config_ptr ? *loop->config_ptr : nullptr;
     conn.request_config = config;
+    if (config && !config->firewall_allows_peer(conn.peer_addr)) {
+        conn.state = ConnState::Sending;
+        conn.resp_status = 403;
+        format_static_response(conn, 403, /*keep_alive=*/false);
+        conn.keep_alive = false;
+        conn.set_slots(nullptr, &on_response_sent<Loop>, nullptr, nullptr);
+        loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
+        return;
+    }
     const RouteEntry* route = nullptr;
     RouteParam route_params[kMaxRouteParams]{};
     u32 route_param_count = 0;

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -204,6 +204,7 @@ struct RouteConfig {
     u32 firewall_deny_count = 0;
     u32 firewall_allow_cidr_count = 0;
     u32 firewall_deny_cidr_count = 0;
+    bool firewall_default_allow = true;
 
     // Reject route paths that aren't in origin-form. Required by the
     // segment trie (which would otherwise silently mismatch malformed
@@ -715,6 +716,9 @@ struct RouteConfig {
         firewall_allow_cidr_count = 0;
         firewall_deny_cidr_count = 0;
     }
+    void set_firewall_default_allow(bool allow) { firewall_default_allow = allow; }
+    void set_firewall_default_deny() { firewall_default_allow = false; }
+    bool firewall_default_is_allow() const { return firewall_default_allow; }
 
     // `peer_addr` must be in network byte order (same as getpeername()).
     // It is converted to packed host-order u32 before matching:
@@ -728,7 +732,7 @@ struct RouteConfig {
             const auto& r = firewall_deny_cidrs[i];
             if ((peer_host & r.mask) == r.net_addr) return false;
         }
-        if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0) return true;
+        if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0) return firewall_default_allow;
         for (u32 i = 0; i < firewall_allow_count; i++) {
             if (firewall_allow_ips[i] == peer_host) return true;
         }

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -184,9 +184,10 @@ struct RouteConfig {
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
 
-    // Firewall rules (all in host byte order).
-    // Connection.peer_addr is network order; firewall_allows_peer converts it
-    // once to host order before rule evaluation.
+    // Firewall rules use packed host-order u32 IPv4 values:
+    //   ip = (a << 24) | (b << 16) | (c << 8) | d  for a.b.c.d
+    // Connection.peer_addr is stored in network byte order; firewall_allows_peer
+    // converts it once to the packed host-order representation before evaluation.
     // Evaluation order:
     //   1) deny list (if hit => reject)
     //   2) allow list (if non-empty => require hit)
@@ -691,6 +692,8 @@ struct RouteConfig {
     }
 
     // `peer_addr` must be in network byte order (same as getpeername()).
+    // It is converted to packed host-order u32 before matching:
+    //   (a << 24) | (b << 16) | (c << 8) | d
     bool firewall_allows_peer(u32 peer_addr) const {
         const u32 peer_host = __builtin_bswap32(peer_addr);
         for (u32 i = 0; i < firewall_deny_count; i++) {

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -529,6 +529,10 @@ struct RouteConfig {
         if (!ip_lit) return false;
         return add_firewall_allow_ip(cstr_as_str(ip_lit));
     }
+    // `ip_network_order` uses in_addr.s_addr/getpeername representation.
+    bool add_firewall_allow_ip_network_order(u32 ip_network_order) {
+        return add_firewall_allow_ip(__builtin_bswap32(ip_network_order));
+    }
     bool remove_firewall_allow_ip(u32 ip) {
         for (u32 i = 0; i < firewall_allow_count; i++) {
             if (firewall_allow_ips[i] != ip) continue;
@@ -549,6 +553,9 @@ struct RouteConfig {
         if (!ip_lit) return false;
         return remove_firewall_allow_ip(cstr_as_str(ip_lit));
     }
+    bool remove_firewall_allow_ip_network_order(u32 ip_network_order) {
+        return remove_firewall_allow_ip(__builtin_bswap32(ip_network_order));
+    }
     bool add_firewall_deny_ip(u32 ip) {
         for (u32 i = 0; i < firewall_deny_count; i++) {
             if (firewall_deny_ips[i] == ip) return true;
@@ -565,6 +572,9 @@ struct RouteConfig {
     bool add_firewall_deny_ip(const char* ip_lit) {
         if (!ip_lit) return false;
         return add_firewall_deny_ip(cstr_as_str(ip_lit));
+    }
+    bool add_firewall_deny_ip_network_order(u32 ip_network_order) {
+        return add_firewall_deny_ip(__builtin_bswap32(ip_network_order));
     }
     bool remove_firewall_deny_ip(u32 ip) {
         for (u32 i = 0; i < firewall_deny_count; i++) {
@@ -585,6 +595,9 @@ struct RouteConfig {
     bool remove_firewall_deny_ip(const char* ip_lit) {
         if (!ip_lit) return false;
         return remove_firewall_deny_ip(cstr_as_str(ip_lit));
+    }
+    bool remove_firewall_deny_ip_network_order(u32 ip_network_order) {
+        return remove_firewall_deny_ip(__builtin_bswap32(ip_network_order));
     }
     bool add_firewall_allow_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
@@ -607,6 +620,9 @@ struct RouteConfig {
     bool add_firewall_allow_cidr(const char* cidr_lit) {
         if (!cidr_lit) return false;
         return add_firewall_allow_cidr(cstr_as_str(cidr_lit));
+    }
+    bool add_firewall_allow_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
+        return add_firewall_allow_cidr(__builtin_bswap32(ip_network_order), prefix_len);
     }
     bool remove_firewall_allow_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
@@ -633,6 +649,9 @@ struct RouteConfig {
         if (!cidr_lit) return false;
         return remove_firewall_allow_cidr(cstr_as_str(cidr_lit));
     }
+    bool remove_firewall_allow_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
+        return remove_firewall_allow_cidr(__builtin_bswap32(ip_network_order), prefix_len);
+    }
     bool add_firewall_deny_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
         const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
@@ -654,6 +673,9 @@ struct RouteConfig {
     bool add_firewall_deny_cidr(const char* cidr_lit) {
         if (!cidr_lit) return false;
         return add_firewall_deny_cidr(cstr_as_str(cidr_lit));
+    }
+    bool add_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
+        return add_firewall_deny_cidr(__builtin_bswap32(ip_network_order), prefix_len);
     }
     bool remove_firewall_deny_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
@@ -679,6 +701,9 @@ struct RouteConfig {
     bool remove_firewall_deny_cidr(const char* cidr_lit) {
         if (!cidr_lit) return false;
         return remove_firewall_deny_cidr(cstr_as_str(cidr_lit));
+    }
+    bool remove_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
+        return remove_firewall_deny_cidr(__builtin_bswap32(ip_network_order), prefix_len);
     }
     void clear_firewall_rules() {
         for (u32 i = 0; i < firewall_allow_count; i++) firewall_allow_ips[i] = 0;

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -706,15 +706,21 @@ struct RouteConfig {
     bool remove_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
         return remove_firewall_deny_cidr(ntohl(ip_network_order), prefix_len);
     }
-    void clear_firewall_rules() {
+    void clear_firewall_allow_rules() {
         for (u32 i = 0; i < firewall_allow_count; i++) firewall_allow_ips[i] = 0;
-        for (u32 i = 0; i < firewall_deny_count; i++) firewall_deny_ips[i] = 0;
         for (u32 i = 0; i < firewall_allow_cidr_count; i++) firewall_allow_cidrs[i] = {0, 0};
-        for (u32 i = 0; i < firewall_deny_cidr_count; i++) firewall_deny_cidrs[i] = {0, 0};
         firewall_allow_count = 0;
-        firewall_deny_count = 0;
         firewall_allow_cidr_count = 0;
+    }
+    void clear_firewall_deny_rules() {
+        for (u32 i = 0; i < firewall_deny_count; i++) firewall_deny_ips[i] = 0;
+        for (u32 i = 0; i < firewall_deny_cidr_count; i++) firewall_deny_cidrs[i] = {0, 0};
+        firewall_deny_count = 0;
         firewall_deny_cidr_count = 0;
+    }
+    void clear_firewall_rules() {
+        clear_firewall_allow_rules();
+        clear_firewall_deny_rules();
     }
     void set_firewall_default_allow(bool allow) { firewall_default_allow = allow; }
     void set_firewall_default_deny() { firewall_default_allow = false; }

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -100,6 +100,9 @@ struct RouteConfig {
     // any risk of silent truncation. Must match the buffer size used
     // by handle_jit_outcome in callbacks_impl.h.
     static constexpr u32 kMaxHeadersPerSet = 32;
+    // Firewall IPv4 rule caps. Small fixed arrays keep match checks
+    // branch-predictable and allocation-free on the hot path.
+    static constexpr u32 kMaxFirewallRules = 64;
 
     // Non-copyable: the embedded `trie` stores non-owning Str views
     // pointing into routes[].path. A by-value copy would leave the
@@ -180,6 +183,16 @@ struct RouteConfig {
 
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
+
+    // Firewall rules (IPv4 exact-match, network byte order).
+    // Evaluation order:
+    //   1) deny list (if hit => reject)
+    //   2) allow list (if non-empty => require hit)
+    //   3) default allow
+    u32 firewall_allow_ips[kMaxFirewallRules]{};
+    u32 firewall_deny_ips[kMaxFirewallRules]{};
+    u32 firewall_allow_count = 0;
+    u32 firewall_deny_count = 0;
 
     // Reject route paths that aren't in origin-form. Required by the
     // segment trie (which would otherwise silently mismatch malformed
@@ -484,6 +497,31 @@ struct RouteConfig {
         upstreams[idx].set_name(name);
         upstreams[idx].set_addr(ip, port);
         return idx;
+    }
+
+    // Firewall helpers.
+    // `ip` is host-order IPv4 (for consistency with UpstreamTarget::set_addr).
+    bool add_firewall_allow_ip(u32 ip) {
+        if (firewall_allow_count >= kMaxFirewallRules) return false;
+        firewall_allow_ips[firewall_allow_count++] = __builtin_bswap32(ip);
+        return true;
+    }
+    bool add_firewall_deny_ip(u32 ip) {
+        if (firewall_deny_count >= kMaxFirewallRules) return false;
+        firewall_deny_ips[firewall_deny_count++] = __builtin_bswap32(ip);
+        return true;
+    }
+
+    // `peer_addr` must be in network byte order (same as getpeername()).
+    bool firewall_allows_peer(u32 peer_addr) const {
+        for (u32 i = 0; i < firewall_deny_count; i++) {
+            if (firewall_deny_ips[i] == peer_addr) return false;
+        }
+        if (firewall_allow_count == 0) return true;
+        for (u32 i = 0; i < firewall_allow_count; i++) {
+            if (firewall_allow_ips[i] == peer_addr) return true;
+        }
+        return false;
     }
 
     // Match a request path. Semantics depend on the chosen dispatch

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -514,10 +514,28 @@ struct RouteConfig {
         firewall_allow_ips[firewall_allow_count++] = __builtin_bswap32(ip);
         return true;
     }
+    bool add_firewall_allow_ip(Str ip_lit) {
+        u32 ip = 0;
+        if (!parse_ipv4_dotted(ip_lit, ip)) return false;
+        return add_firewall_allow_ip(ip);
+    }
+    bool add_firewall_allow_ip(const char* ip_lit) {
+        if (!ip_lit) return false;
+        return add_firewall_allow_ip(cstr_as_str(ip_lit));
+    }
     bool add_firewall_deny_ip(u32 ip) {
         if (firewall_deny_count >= kMaxFirewallRules) return false;
         firewall_deny_ips[firewall_deny_count++] = __builtin_bswap32(ip);
         return true;
+    }
+    bool add_firewall_deny_ip(Str ip_lit) {
+        u32 ip = 0;
+        if (!parse_ipv4_dotted(ip_lit, ip)) return false;
+        return add_firewall_deny_ip(ip);
+    }
+    bool add_firewall_deny_ip(const char* ip_lit) {
+        if (!ip_lit) return false;
+        return add_firewall_deny_ip(cstr_as_str(ip_lit));
     }
     bool add_firewall_allow_cidr(u32 ip, u8 prefix_len) {
         if (firewall_allow_cidr_count >= kMaxFirewallRules) return false;
@@ -526,12 +544,32 @@ struct RouteConfig {
         firewall_allow_cidrs[firewall_allow_cidr_count++] = {ip & mask, mask};
         return true;
     }
+    bool add_firewall_allow_cidr(Str cidr_lit) {
+        u32 ip = 0;
+        u8 prefix_len = 0;
+        if (!parse_ipv4_cidr(cidr_lit, ip, prefix_len)) return false;
+        return add_firewall_allow_cidr(ip, prefix_len);
+    }
+    bool add_firewall_allow_cidr(const char* cidr_lit) {
+        if (!cidr_lit) return false;
+        return add_firewall_allow_cidr(cstr_as_str(cidr_lit));
+    }
     bool add_firewall_deny_cidr(u32 ip, u8 prefix_len) {
         if (firewall_deny_cidr_count >= kMaxFirewallRules) return false;
         if (prefix_len > 32) return false;
         const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
         firewall_deny_cidrs[firewall_deny_cidr_count++] = {ip & mask, mask};
         return true;
+    }
+    bool add_firewall_deny_cidr(Str cidr_lit) {
+        u32 ip = 0;
+        u8 prefix_len = 0;
+        if (!parse_ipv4_cidr(cidr_lit, ip, prefix_len)) return false;
+        return add_firewall_deny_cidr(ip, prefix_len);
+    }
+    bool add_firewall_deny_cidr(const char* cidr_lit) {
+        if (!cidr_lit) return false;
+        return add_firewall_deny_cidr(cstr_as_str(cidr_lit));
     }
 
     // `peer_addr` must be in network byte order (same as getpeername()).
@@ -554,6 +592,60 @@ struct RouteConfig {
         }
         return false;
     }
+
+private:
+    static Str cstr_as_str(const char* s) {
+        u32 len = 0;
+        while (s[len]) len++;
+        return {s, len};
+    }
+
+    static bool parse_ipv4_dotted(Str s, u32& out_ip) {
+        u32 octets[4] = {0, 0, 0, 0};
+        u32 octet_idx = 0;
+        u32 digit_count = 0;
+        u32 cur = 0;
+        for (u32 i = 0; i < s.len; i++) {
+            const char c = s.ptr[i];
+            if (c == '.') {
+                if (digit_count == 0 || octet_idx >= 3) return false;
+                octets[octet_idx++] = cur;
+                cur = 0;
+                digit_count = 0;
+                continue;
+            }
+            if (c < '0' || c > '9') return false;
+            cur = cur * 10 + static_cast<u32>(c - '0');
+            if (cur > 255 || ++digit_count > 3) return false;
+        }
+        if (digit_count == 0 || octet_idx != 3) return false;
+        octets[3] = cur;
+        out_ip = (octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3];
+        return true;
+    }
+
+    static bool parse_ipv4_cidr(Str s, u32& out_ip, u8& out_prefix_len) {
+        u32 slash_idx = 0xffffffffu;
+        for (u32 i = 0; i < s.len; i++) {
+            if (s.ptr[i] == '/') {
+                if (slash_idx != 0xffffffffu) return false;
+                slash_idx = i;
+            }
+        }
+        if (slash_idx == 0xffffffffu || slash_idx == 0 || slash_idx + 1 >= s.len) return false;
+        if (!parse_ipv4_dotted({s.ptr, slash_idx}, out_ip)) return false;
+        u32 prefix = 0;
+        for (u32 i = slash_idx + 1; i < s.len; i++) {
+            const char c = s.ptr[i];
+            if (c < '0' || c > '9') return false;
+            prefix = prefix * 10 + static_cast<u32>(c - '0');
+            if (prefix > 32) return false;
+        }
+        out_prefix_len = static_cast<u8>(prefix);
+        return true;
+    }
+
+public:
 
     // Match a request path. Semantics depend on the chosen dispatch
     // (`this->dispatch`), but the default linear-scan dispatch keeps

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -184,7 +184,11 @@ struct RouteConfig {
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
 
-    // Firewall rules (IPv4 exact-match and CIDR subnet, network byte order).
+    // Firewall rules.
+    // - exact IP rules are stored in network byte order (for direct compare
+    //   against Connection.peer_addr)
+    // - CIDR rules are stored in host byte order as (net, mask) pairs
+    //   and matched against bswap(peer_addr)
     // Evaluation order:
     //   1) deny list (if hit => reject)
     //   2) allow list (if non-empty => require hit)

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -614,6 +614,10 @@ struct RouteConfig {
         }
         return false;
     }
+    // Convenience overload for host-order IPv4 callers.
+    bool firewall_allows_peer_host(u32 peer_host_addr) const {
+        return firewall_allows_peer(__builtin_bswap32(peer_host_addr));
+    }
 
 private:
     static Str cstr_as_str(const char* s) {

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -184,15 +184,23 @@ struct RouteConfig {
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
 
-    // Firewall rules (IPv4 exact-match, network byte order).
+    // Firewall rules (IPv4 exact-match and CIDR subnet, network byte order).
     // Evaluation order:
     //   1) deny list (if hit => reject)
     //   2) allow list (if non-empty => require hit)
     //   3) default allow
     u32 firewall_allow_ips[kMaxFirewallRules]{};
     u32 firewall_deny_ips[kMaxFirewallRules]{};
+    struct FirewallCidrRule {
+        u32 net_addr;
+        u32 mask;
+    };
+    FirewallCidrRule firewall_allow_cidrs[kMaxFirewallRules]{};
+    FirewallCidrRule firewall_deny_cidrs[kMaxFirewallRules]{};
     u32 firewall_allow_count = 0;
     u32 firewall_deny_count = 0;
+    u32 firewall_allow_cidr_count = 0;
+    u32 firewall_deny_cidr_count = 0;
 
     // Reject route paths that aren't in origin-form. Required by the
     // segment trie (which would otherwise silently mismatch malformed
@@ -511,15 +519,38 @@ struct RouteConfig {
         firewall_deny_ips[firewall_deny_count++] = __builtin_bswap32(ip);
         return true;
     }
+    bool add_firewall_allow_cidr(u32 ip, u8 prefix_len) {
+        if (firewall_allow_cidr_count >= kMaxFirewallRules) return false;
+        if (prefix_len > 32) return false;
+        const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
+        firewall_allow_cidrs[firewall_allow_cidr_count++] = {ip & mask, mask};
+        return true;
+    }
+    bool add_firewall_deny_cidr(u32 ip, u8 prefix_len) {
+        if (firewall_deny_cidr_count >= kMaxFirewallRules) return false;
+        if (prefix_len > 32) return false;
+        const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
+        firewall_deny_cidrs[firewall_deny_cidr_count++] = {ip & mask, mask};
+        return true;
+    }
 
     // `peer_addr` must be in network byte order (same as getpeername()).
     bool firewall_allows_peer(u32 peer_addr) const {
+        const u32 peer_host = __builtin_bswap32(peer_addr);
         for (u32 i = 0; i < firewall_deny_count; i++) {
             if (firewall_deny_ips[i] == peer_addr) return false;
         }
-        if (firewall_allow_count == 0) return true;
+        for (u32 i = 0; i < firewall_deny_cidr_count; i++) {
+            const auto& r = firewall_deny_cidrs[i];
+            if ((peer_host & r.mask) == r.net_addr) return false;
+        }
+        if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0) return true;
         for (u32 i = 0; i < firewall_allow_count; i++) {
             if (firewall_allow_ips[i] == peer_addr) return true;
+        }
+        for (u32 i = 0; i < firewall_allow_cidr_count; i++) {
+            const auto& r = firewall_allow_cidrs[i];
+            if ((peer_host & r.mask) == r.net_addr) return true;
         }
         return false;
     }

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -46,8 +46,8 @@ struct UpstreamTarget {
     void set_addr(u32 ip, u16 port) {
         memset(&addr, 0, sizeof(addr));
         addr.sin_family = AF_INET;
-        addr.sin_addr.s_addr = __builtin_bswap32(ip);
-        addr.sin_port = __builtin_bswap16(port);
+        addr.sin_addr.s_addr = htonl(ip);
+        addr.sin_port = htons(port);
     }
 };
 
@@ -531,7 +531,7 @@ struct RouteConfig {
     }
     // `ip_network_order` uses in_addr.s_addr/getpeername representation.
     bool add_firewall_allow_ip_network_order(u32 ip_network_order) {
-        return add_firewall_allow_ip(__builtin_bswap32(ip_network_order));
+        return add_firewall_allow_ip(ntohl(ip_network_order));
     }
     bool remove_firewall_allow_ip(u32 ip) {
         for (u32 i = 0; i < firewall_allow_count; i++) {
@@ -554,7 +554,7 @@ struct RouteConfig {
         return remove_firewall_allow_ip(cstr_as_str(ip_lit));
     }
     bool remove_firewall_allow_ip_network_order(u32 ip_network_order) {
-        return remove_firewall_allow_ip(__builtin_bswap32(ip_network_order));
+        return remove_firewall_allow_ip(ntohl(ip_network_order));
     }
     bool add_firewall_deny_ip(u32 ip) {
         for (u32 i = 0; i < firewall_deny_count; i++) {
@@ -574,7 +574,7 @@ struct RouteConfig {
         return add_firewall_deny_ip(cstr_as_str(ip_lit));
     }
     bool add_firewall_deny_ip_network_order(u32 ip_network_order) {
-        return add_firewall_deny_ip(__builtin_bswap32(ip_network_order));
+        return add_firewall_deny_ip(ntohl(ip_network_order));
     }
     bool remove_firewall_deny_ip(u32 ip) {
         for (u32 i = 0; i < firewall_deny_count; i++) {
@@ -597,7 +597,7 @@ struct RouteConfig {
         return remove_firewall_deny_ip(cstr_as_str(ip_lit));
     }
     bool remove_firewall_deny_ip_network_order(u32 ip_network_order) {
-        return remove_firewall_deny_ip(__builtin_bswap32(ip_network_order));
+        return remove_firewall_deny_ip(ntohl(ip_network_order));
     }
     bool add_firewall_allow_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
@@ -622,7 +622,7 @@ struct RouteConfig {
         return add_firewall_allow_cidr(cstr_as_str(cidr_lit));
     }
     bool add_firewall_allow_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
-        return add_firewall_allow_cidr(__builtin_bswap32(ip_network_order), prefix_len);
+        return add_firewall_allow_cidr(ntohl(ip_network_order), prefix_len);
     }
     bool remove_firewall_allow_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
@@ -650,7 +650,7 @@ struct RouteConfig {
         return remove_firewall_allow_cidr(cstr_as_str(cidr_lit));
     }
     bool remove_firewall_allow_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
-        return remove_firewall_allow_cidr(__builtin_bswap32(ip_network_order), prefix_len);
+        return remove_firewall_allow_cidr(ntohl(ip_network_order), prefix_len);
     }
     bool add_firewall_deny_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
@@ -675,7 +675,7 @@ struct RouteConfig {
         return add_firewall_deny_cidr(cstr_as_str(cidr_lit));
     }
     bool add_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
-        return add_firewall_deny_cidr(__builtin_bswap32(ip_network_order), prefix_len);
+        return add_firewall_deny_cidr(ntohl(ip_network_order), prefix_len);
     }
     bool remove_firewall_deny_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
@@ -703,7 +703,7 @@ struct RouteConfig {
         return remove_firewall_deny_cidr(cstr_as_str(cidr_lit));
     }
     bool remove_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
-        return remove_firewall_deny_cidr(__builtin_bswap32(ip_network_order), prefix_len);
+        return remove_firewall_deny_cidr(ntohl(ip_network_order), prefix_len);
     }
     void clear_firewall_rules() {
         for (u32 i = 0; i < firewall_allow_count; i++) firewall_allow_ips[i] = 0;
@@ -720,7 +720,7 @@ struct RouteConfig {
     // It is converted to packed host-order u32 before matching:
     //   (a << 24) | (b << 16) | (c << 8) | d
     bool firewall_allows_peer(u32 peer_addr) const {
-        const u32 peer_host = __builtin_bswap32(peer_addr);
+        const u32 peer_host = ntohl(peer_addr);
         for (u32 i = 0; i < firewall_deny_count; i++) {
             if (firewall_deny_ips[i] == peer_host) return false;
         }
@@ -740,7 +740,7 @@ struct RouteConfig {
     }
     // Convenience overload for host-order IPv4 callers.
     bool firewall_allows_peer_host(u32 peer_host_addr) const {
-        return firewall_allows_peer(__builtin_bswap32(peer_host_addr));
+        return firewall_allows_peer(htonl(peer_host_addr));
     }
 
 private:

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -184,11 +184,9 @@ struct RouteConfig {
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
 
-    // Firewall rules.
-    // - exact IP rules are stored in network byte order (for direct compare
-    //   against Connection.peer_addr)
-    // - CIDR rules are stored in host byte order as (net, mask) pairs
-    //   and matched against bswap(peer_addr)
+    // Firewall rules (all in host byte order).
+    // Connection.peer_addr is network order; firewall_allows_peer converts it
+    // once to host order before rule evaluation.
     // Evaluation order:
     //   1) deny list (if hit => reject)
     //   2) allow list (if non-empty => require hit)
@@ -514,12 +512,11 @@ struct RouteConfig {
     // Firewall helpers.
     // `ip` is host-order IPv4 (for consistency with UpstreamTarget::set_addr).
     bool add_firewall_allow_ip(u32 ip) {
-        const u32 net_ip = __builtin_bswap32(ip);
         for (u32 i = 0; i < firewall_allow_count; i++) {
-            if (firewall_allow_ips[i] == net_ip) return true;
+            if (firewall_allow_ips[i] == ip) return true;
         }
         if (firewall_allow_count >= kMaxFirewallRules) return false;
-        firewall_allow_ips[firewall_allow_count++] = net_ip;
+        firewall_allow_ips[firewall_allow_count++] = ip;
         return true;
     }
     bool add_firewall_allow_ip(Str ip_lit) {
@@ -532,9 +529,8 @@ struct RouteConfig {
         return add_firewall_allow_ip(cstr_as_str(ip_lit));
     }
     bool remove_firewall_allow_ip(u32 ip) {
-        const u32 net_ip = __builtin_bswap32(ip);
         for (u32 i = 0; i < firewall_allow_count; i++) {
-            if (firewall_allow_ips[i] != net_ip) continue;
+            if (firewall_allow_ips[i] != ip) continue;
             for (u32 j = i + 1; j < firewall_allow_count; j++)
                 firewall_allow_ips[j - 1] = firewall_allow_ips[j];
             firewall_allow_ips[firewall_allow_count - 1] = 0;
@@ -553,12 +549,11 @@ struct RouteConfig {
         return remove_firewall_allow_ip(cstr_as_str(ip_lit));
     }
     bool add_firewall_deny_ip(u32 ip) {
-        const u32 net_ip = __builtin_bswap32(ip);
         for (u32 i = 0; i < firewall_deny_count; i++) {
-            if (firewall_deny_ips[i] == net_ip) return true;
+            if (firewall_deny_ips[i] == ip) return true;
         }
         if (firewall_deny_count >= kMaxFirewallRules) return false;
-        firewall_deny_ips[firewall_deny_count++] = net_ip;
+        firewall_deny_ips[firewall_deny_count++] = ip;
         return true;
     }
     bool add_firewall_deny_ip(Str ip_lit) {
@@ -571,9 +566,8 @@ struct RouteConfig {
         return add_firewall_deny_ip(cstr_as_str(ip_lit));
     }
     bool remove_firewall_deny_ip(u32 ip) {
-        const u32 net_ip = __builtin_bswap32(ip);
         for (u32 i = 0; i < firewall_deny_count; i++) {
-            if (firewall_deny_ips[i] != net_ip) continue;
+            if (firewall_deny_ips[i] != ip) continue;
             for (u32 j = i + 1; j < firewall_deny_count; j++)
                 firewall_deny_ips[j - 1] = firewall_deny_ips[j];
             firewall_deny_ips[firewall_deny_count - 1] = 0;
@@ -700,7 +694,7 @@ struct RouteConfig {
     bool firewall_allows_peer(u32 peer_addr) const {
         const u32 peer_host = __builtin_bswap32(peer_addr);
         for (u32 i = 0; i < firewall_deny_count; i++) {
-            if (firewall_deny_ips[i] == peer_addr) return false;
+            if (firewall_deny_ips[i] == peer_host) return false;
         }
         for (u32 i = 0; i < firewall_deny_cidr_count; i++) {
             const auto& r = firewall_deny_cidrs[i];
@@ -708,7 +702,7 @@ struct RouteConfig {
         }
         if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0) return true;
         for (u32 i = 0; i < firewall_allow_count; i++) {
-            if (firewall_allow_ips[i] == peer_addr) return true;
+            if (firewall_allow_ips[i] == peer_host) return true;
         }
         for (u32 i = 0; i < firewall_allow_cidr_count; i++) {
             const auto& r = firewall_allow_cidrs[i];
@@ -774,7 +768,6 @@ private:
     }
 
 public:
-
     // Match a request path. Semantics depend on the chosen dispatch
     // (`this->dispatch`), but the default linear-scan dispatch keeps
     // the historical contract: first-match-wins byte-prefix scan,

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -594,6 +594,10 @@ struct RouteConfig {
         return add_firewall_deny_cidr(cstr_as_str(cidr_lit));
     }
     void clear_firewall_rules() {
+        for (u32 i = 0; i < firewall_allow_count; i++) firewall_allow_ips[i] = 0;
+        for (u32 i = 0; i < firewall_deny_count; i++) firewall_deny_ips[i] = 0;
+        for (u32 i = 0; i < firewall_allow_cidr_count; i++) firewall_allow_cidrs[i] = {0, 0};
+        for (u32 i = 0; i < firewall_deny_cidr_count; i++) firewall_deny_cidrs[i] = {0, 0};
         firewall_allow_count = 0;
         firewall_deny_count = 0;
         firewall_allow_cidr_count = 0;

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -514,8 +514,12 @@ struct RouteConfig {
     // Firewall helpers.
     // `ip` is host-order IPv4 (for consistency with UpstreamTarget::set_addr).
     bool add_firewall_allow_ip(u32 ip) {
+        const u32 net_ip = __builtin_bswap32(ip);
+        for (u32 i = 0; i < firewall_allow_count; i++) {
+            if (firewall_allow_ips[i] == net_ip) return true;
+        }
         if (firewall_allow_count >= kMaxFirewallRules) return false;
-        firewall_allow_ips[firewall_allow_count++] = __builtin_bswap32(ip);
+        firewall_allow_ips[firewall_allow_count++] = net_ip;
         return true;
     }
     bool add_firewall_allow_ip(Str ip_lit) {
@@ -528,8 +532,12 @@ struct RouteConfig {
         return add_firewall_allow_ip(cstr_as_str(ip_lit));
     }
     bool add_firewall_deny_ip(u32 ip) {
+        const u32 net_ip = __builtin_bswap32(ip);
+        for (u32 i = 0; i < firewall_deny_count; i++) {
+            if (firewall_deny_ips[i] == net_ip) return true;
+        }
         if (firewall_deny_count >= kMaxFirewallRules) return false;
-        firewall_deny_ips[firewall_deny_count++] = __builtin_bswap32(ip);
+        firewall_deny_ips[firewall_deny_count++] = net_ip;
         return true;
     }
     bool add_firewall_deny_ip(Str ip_lit) {
@@ -542,10 +550,15 @@ struct RouteConfig {
         return add_firewall_deny_ip(cstr_as_str(ip_lit));
     }
     bool add_firewall_allow_cidr(u32 ip, u8 prefix_len) {
-        if (firewall_allow_cidr_count >= kMaxFirewallRules) return false;
         if (prefix_len > 32) return false;
         const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
-        firewall_allow_cidrs[firewall_allow_cidr_count++] = {ip & mask, mask};
+        const u32 net_addr = ip & mask;
+        for (u32 i = 0; i < firewall_allow_cidr_count; i++) {
+            const auto& r = firewall_allow_cidrs[i];
+            if (r.net_addr == net_addr && r.mask == mask) return true;
+        }
+        if (firewall_allow_cidr_count >= kMaxFirewallRules) return false;
+        firewall_allow_cidrs[firewall_allow_cidr_count++] = {net_addr, mask};
         return true;
     }
     bool add_firewall_allow_cidr(Str cidr_lit) {
@@ -559,10 +572,15 @@ struct RouteConfig {
         return add_firewall_allow_cidr(cstr_as_str(cidr_lit));
     }
     bool add_firewall_deny_cidr(u32 ip, u8 prefix_len) {
-        if (firewall_deny_cidr_count >= kMaxFirewallRules) return false;
         if (prefix_len > 32) return false;
         const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
-        firewall_deny_cidrs[firewall_deny_cidr_count++] = {ip & mask, mask};
+        const u32 net_addr = ip & mask;
+        for (u32 i = 0; i < firewall_deny_cidr_count; i++) {
+            const auto& r = firewall_deny_cidrs[i];
+            if (r.net_addr == net_addr && r.mask == mask) return true;
+        }
+        if (firewall_deny_cidr_count >= kMaxFirewallRules) return false;
+        firewall_deny_cidrs[firewall_deny_cidr_count++] = {net_addr, mask};
         return true;
     }
     bool add_firewall_deny_cidr(Str cidr_lit) {

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -531,6 +531,27 @@ struct RouteConfig {
         if (!ip_lit) return false;
         return add_firewall_allow_ip(cstr_as_str(ip_lit));
     }
+    bool remove_firewall_allow_ip(u32 ip) {
+        const u32 net_ip = __builtin_bswap32(ip);
+        for (u32 i = 0; i < firewall_allow_count; i++) {
+            if (firewall_allow_ips[i] != net_ip) continue;
+            for (u32 j = i + 1; j < firewall_allow_count; j++)
+                firewall_allow_ips[j - 1] = firewall_allow_ips[j];
+            firewall_allow_ips[firewall_allow_count - 1] = 0;
+            firewall_allow_count--;
+            return true;
+        }
+        return false;
+    }
+    bool remove_firewall_allow_ip(Str ip_lit) {
+        u32 ip = 0;
+        if (!parse_ipv4_dotted(ip_lit, ip)) return false;
+        return remove_firewall_allow_ip(ip);
+    }
+    bool remove_firewall_allow_ip(const char* ip_lit) {
+        if (!ip_lit) return false;
+        return remove_firewall_allow_ip(cstr_as_str(ip_lit));
+    }
     bool add_firewall_deny_ip(u32 ip) {
         const u32 net_ip = __builtin_bswap32(ip);
         for (u32 i = 0; i < firewall_deny_count; i++) {
@@ -548,6 +569,27 @@ struct RouteConfig {
     bool add_firewall_deny_ip(const char* ip_lit) {
         if (!ip_lit) return false;
         return add_firewall_deny_ip(cstr_as_str(ip_lit));
+    }
+    bool remove_firewall_deny_ip(u32 ip) {
+        const u32 net_ip = __builtin_bswap32(ip);
+        for (u32 i = 0; i < firewall_deny_count; i++) {
+            if (firewall_deny_ips[i] != net_ip) continue;
+            for (u32 j = i + 1; j < firewall_deny_count; j++)
+                firewall_deny_ips[j - 1] = firewall_deny_ips[j];
+            firewall_deny_ips[firewall_deny_count - 1] = 0;
+            firewall_deny_count--;
+            return true;
+        }
+        return false;
+    }
+    bool remove_firewall_deny_ip(Str ip_lit) {
+        u32 ip = 0;
+        if (!parse_ipv4_dotted(ip_lit, ip)) return false;
+        return remove_firewall_deny_ip(ip);
+    }
+    bool remove_firewall_deny_ip(const char* ip_lit) {
+        if (!ip_lit) return false;
+        return remove_firewall_deny_ip(cstr_as_str(ip_lit));
     }
     bool add_firewall_allow_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
@@ -571,6 +613,31 @@ struct RouteConfig {
         if (!cidr_lit) return false;
         return add_firewall_allow_cidr(cstr_as_str(cidr_lit));
     }
+    bool remove_firewall_allow_cidr(u32 ip, u8 prefix_len) {
+        if (prefix_len > 32) return false;
+        const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
+        const u32 net_addr = ip & mask;
+        for (u32 i = 0; i < firewall_allow_cidr_count; i++) {
+            const auto& r = firewall_allow_cidrs[i];
+            if (r.net_addr != net_addr || r.mask != mask) continue;
+            for (u32 j = i + 1; j < firewall_allow_cidr_count; j++)
+                firewall_allow_cidrs[j - 1] = firewall_allow_cidrs[j];
+            firewall_allow_cidrs[firewall_allow_cidr_count - 1] = {0, 0};
+            firewall_allow_cidr_count--;
+            return true;
+        }
+        return false;
+    }
+    bool remove_firewall_allow_cidr(Str cidr_lit) {
+        u32 ip = 0;
+        u8 prefix_len = 0;
+        if (!parse_ipv4_cidr(cidr_lit, ip, prefix_len)) return false;
+        return remove_firewall_allow_cidr(ip, prefix_len);
+    }
+    bool remove_firewall_allow_cidr(const char* cidr_lit) {
+        if (!cidr_lit) return false;
+        return remove_firewall_allow_cidr(cstr_as_str(cidr_lit));
+    }
     bool add_firewall_deny_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
         const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
@@ -592,6 +659,31 @@ struct RouteConfig {
     bool add_firewall_deny_cidr(const char* cidr_lit) {
         if (!cidr_lit) return false;
         return add_firewall_deny_cidr(cstr_as_str(cidr_lit));
+    }
+    bool remove_firewall_deny_cidr(u32 ip, u8 prefix_len) {
+        if (prefix_len > 32) return false;
+        const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
+        const u32 net_addr = ip & mask;
+        for (u32 i = 0; i < firewall_deny_cidr_count; i++) {
+            const auto& r = firewall_deny_cidrs[i];
+            if (r.net_addr != net_addr || r.mask != mask) continue;
+            for (u32 j = i + 1; j < firewall_deny_cidr_count; j++)
+                firewall_deny_cidrs[j - 1] = firewall_deny_cidrs[j];
+            firewall_deny_cidrs[firewall_deny_cidr_count - 1] = {0, 0};
+            firewall_deny_cidr_count--;
+            return true;
+        }
+        return false;
+    }
+    bool remove_firewall_deny_cidr(Str cidr_lit) {
+        u32 ip = 0;
+        u8 prefix_len = 0;
+        if (!parse_ipv4_cidr(cidr_lit, ip, prefix_len)) return false;
+        return remove_firewall_deny_cidr(ip, prefix_len);
+    }
+    bool remove_firewall_deny_cidr(const char* cidr_lit) {
+        if (!cidr_lit) return false;
+        return remove_firewall_deny_cidr(cstr_as_str(cidr_lit));
     }
     void clear_firewall_rules() {
         for (u32 i = 0; i < firewall_allow_count; i++) firewall_allow_ips[i] = 0;

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -593,6 +593,12 @@ struct RouteConfig {
         if (!cidr_lit) return false;
         return add_firewall_deny_cidr(cstr_as_str(cidr_lit));
     }
+    void clear_firewall_rules() {
+        firewall_allow_count = 0;
+        firewall_deny_count = 0;
+        firewall_allow_cidr_count = 0;
+        firewall_deny_cidr_count = 0;
+    }
 
     // `peer_addr` must be in network byte order (same as getpeername()).
     bool firewall_allows_peer(u32 peer_addr) const {

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2470,6 +2470,41 @@ TEST(route, firewall_remove_allow_cidr_restores_default_allow_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_remove_deny_cidr_restores_allow_cidr_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_cidr("127.0.0.0/8"));
+    REQUIRE(cfg.add_firewall_deny_cidr("127.0.0.0/8"));
+    REQUIRE(cfg.remove_firewall_deny_cidr("127.0.0.0/8"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2271,6 +2271,43 @@ TEST(route, firewall_deny_localhost_cidr_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_deny_localhost_network_order_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_deny_ip_network_order(__builtin_bswap32(0x7f000001)));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    i32 lfd = -1;
+    for (i32 attempt = 0; attempt < 5 && lfd < 0; attempt++) {
+        lfd = create_listen_socket(0).value_or(-1);
+        if (lfd < 0) usleep(1000);
+    }
+    REQUIRE(lfd >= 0);
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 403 Forbidden", 22));
+    CHECK(buf_contains(buf, len, "Connection: close", 17));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, firewall_allowlist_exact_localhost_real_socket) {
     RouteConfig cfg;
     REQUIRE(cfg.add_static("/health", 0, 200));
@@ -2423,6 +2460,42 @@ TEST(route, firewall_allowlist_cidr_localhost_real_socket) {
     auto lfd_result = create_listen_socket(0);
     REQUIRE(lfd_result.has_value());
     i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(route, firewall_allowlist_network_order_cidr_localhost_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_cidr_network_order(__builtin_bswap32(0x7f000000), 8));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    i32 lfd = -1;
+    for (i32 attempt = 0; attempt < 5 && lfd < 0; attempt++) {
+        lfd = create_listen_socket(0).value_or(-1);
+        if (lfd < 0) usleep(1000);
+    }
+    REQUIRE(lfd >= 0);
     u16 port = get_port(lfd);
     REQUIRE(loop->init(0, lfd).has_value());
     loop->config_ptr = &active;

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2576,6 +2576,42 @@ TEST(route, firewall_remove_last_allow_ip_keeps_deny_cidr_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    // Keep localhost denied while allowlist CIDR mode is removed.
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    REQUIRE(cfg.remove_firewall_allow_cidr("10.0.0.0/8"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 403 Forbidden", 22));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2265,6 +2265,39 @@ TEST(route, firewall_deny_localhost_cidr_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_allowlist_cidr_localhost_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_cidr("127.0.0.0/8"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2832,6 +2832,49 @@ TEST(route, firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_default_deny_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    cfg.set_firewall_default_deny();
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c1 = connect_to(port);
+    REQUIRE(c1 >= 0);
+    send_all(c1, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf1[1024];
+    i32 n1 = recv_timeout(c1, buf1, sizeof(buf1), 500);
+    CHECK_GT(n1, 0);
+    CHECK(buf_contains(buf1, static_cast<u32>(n1), "HTTP/1.1 403 Forbidden", 22));
+    close(c1);
+
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+
+    i32 c2 = connect_to(port);
+    REQUIRE(c2 >= 0);
+    send_all(c2, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf2[1024];
+    i32 n2 = recv_timeout(c2, buf2, sizeof(buf2), 500);
+    CHECK_GT(n2, 0);
+    CHECK(buf_contains(buf2, static_cast<u32>(n2), "HTTP/1.1 200 OK", 15));
+    close(c2);
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2540,6 +2540,42 @@ TEST(route, firewall_remove_deny_ip_restores_allow_ip_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_remove_last_allow_ip_keeps_deny_cidr_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    // Keep localhost denied while allowlist mode is removed.
+    REQUIRE(cfg.add_firewall_allow_ip("10.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_cidr("127.0.0.0/8"));
+    REQUIRE(cfg.remove_firewall_allow_ip("10.0.0.1"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 403 Forbidden", 22));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2265,6 +2265,39 @@ TEST(route, firewall_deny_localhost_cidr_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_allowlist_exact_localhost_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, firewall_allowlist_cidr_localhost_real_socket) {
     RouteConfig cfg;
     REQUIRE(cfg.add_static("/health", 0, 200));

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2435,6 +2435,41 @@ TEST(route, firewall_remove_allow_rule_restores_default_allow_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_remove_allow_cidr_restores_default_allow_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    // This unmatched allowlist CIDR would block localhost if not removed.
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    REQUIRE(cfg.remove_firewall_allow_cidr("10.0.0.0/8"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2338,6 +2338,43 @@ TEST(route, firewall_deny_exact_over_allow_exact_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_deny_exact_over_allow_cidr_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_cidr("127.0.0.0/8"));
+    REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    i32 lfd = -1;
+    for (i32 attempt = 0; attempt < 5 && lfd < 0; attempt++) {
+        lfd = create_listen_socket(0).value_or(-1);
+        if (lfd < 0) usleep(1000);
+    }
+    REQUIRE(lfd >= 0);
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 403 Forbidden", 22));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, firewall_allowlist_cidr_localhost_real_socket) {
     RouteConfig cfg;
     REQUIRE(cfg.add_static("/health", 0, 200));

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2400,6 +2400,41 @@ TEST(route, firewall_remove_deny_cidr_reenables_localhost_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_remove_allow_rule_restores_default_allow_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    // This unmatched allowlist entry would block localhost if not removed.
+    REQUIRE(cfg.add_firewall_allow_ip(0x0a000001));  // 10.0.0.1
+    REQUIRE(cfg.remove_firewall_allow_ip(0x0a000001));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2332,6 +2332,40 @@ TEST(route, firewall_clear_rules_reenables_localhost_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_remove_deny_rule_reenables_localhost_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_deny_ip(0x7f000001));  // 127.0.0.1
+    REQUIRE(cfg.remove_firewall_deny_ip(0x7f000001));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2366,6 +2366,40 @@ TEST(route, firewall_remove_deny_rule_reenables_localhost_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_remove_deny_cidr_reenables_localhost_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_deny_cidr("127.0.0.0/8"));
+    REQUIRE(cfg.remove_firewall_deny_cidr("127.0.0.0/8"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2197,6 +2197,59 @@ TEST(route, post_put_patch_method_filter_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_deny_localhost_real_socket) {
+    RouteConfig cfg;
+    cfg.add_static("/health", 0, 200);
+    REQUIRE(cfg.add_firewall_deny_ip(0x7f000001));  // 127.0.0.1
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+
+    bool found_403 = false;
+    bool found_close = false;
+    for (i32 i = 0; i < n - 2; i++) {
+        if (buf[i] == '4' && buf[i + 1] == '0' && buf[i + 2] == '3') found_403 = true;
+    }
+    const char kCloseHdr[] = "Connection: close";
+    for (i32 i = 0; i + static_cast<i32>(sizeof(kCloseHdr) - 1) <= n; i++) {
+        bool same = true;
+        for (u32 j = 0; j < sizeof(kCloseHdr) - 1; j++) {
+            if (buf[i + static_cast<i32>(j)] != kCloseHdr[j]) {
+                same = false;
+                break;
+            }
+        }
+        if (same) {
+            found_close = true;
+            break;
+        }
+    }
+    CHECK(found_403);
+    CHECK(found_close);
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2199,7 +2199,7 @@ TEST(route, post_put_patch_method_filter_real_socket) {
 
 TEST(route, firewall_deny_localhost_real_socket) {
     RouteConfig cfg;
-    cfg.add_static("/health", 0, 200);
+    REQUIRE(cfg.add_static("/health", 0, 200));
     REQUIRE(cfg.add_firewall_deny_ip(0x7f000001));  // 127.0.0.1
     const RouteConfig* active = &cfg;
 
@@ -2220,28 +2220,9 @@ TEST(route, firewall_deny_localhost_real_socket) {
     char buf[1024];
     i32 n = recv_timeout(c, buf, sizeof(buf), 500);
     CHECK_GT(n, 0);
-
-    bool found_403 = false;
-    bool found_close = false;
-    for (i32 i = 0; i < n - 2; i++) {
-        if (buf[i] == '4' && buf[i + 1] == '0' && buf[i + 2] == '3') found_403 = true;
-    }
-    const char kCloseHdr[] = "Connection: close";
-    for (i32 i = 0; i + static_cast<i32>(sizeof(kCloseHdr) - 1) <= n; i++) {
-        bool same = true;
-        for (u32 j = 0; j < sizeof(kCloseHdr) - 1; j++) {
-            if (buf[i + static_cast<i32>(j)] != kCloseHdr[j]) {
-                same = false;
-                break;
-            }
-        }
-        if (same) {
-            found_close = true;
-            break;
-        }
-    }
-    CHECK(found_403);
-    CHECK(found_close);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 403 Forbidden", 22));
+    CHECK(buf_contains(buf, len, "Connection: close", 17));
 
     close(c);
     lt.stop();

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2033,9 +2033,9 @@ TEST(route, static_200_real_socket) {
     RealLoop* loop = create_real_loop();
     REQUIRE(loop != nullptr);
     i32 lfd = -1;
-    for (i32 attempt = 0; attempt < 5 && lfd < 0; attempt++) {
+    for (i32 attempt = 0; attempt < 50 && lfd < 0; attempt++) {
         lfd = create_listen_socket(0).value_or(-1);
-        if (lfd < 0) usleep(1000);
+        if (lfd < 0) usleep(10000);
     }
     REQUIRE(lfd >= 0);
     u16 port = get_port(lfd);
@@ -2343,6 +2343,43 @@ TEST(route, firewall_deny_exact_over_allow_cidr_real_socket) {
     REQUIRE(cfg.add_static("/health", 0, 200));
     REQUIRE(cfg.add_firewall_allow_cidr("127.0.0.0/8"));
     REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    i32 lfd = -1;
+    for (i32 attempt = 0; attempt < 5 && lfd < 0; attempt++) {
+        lfd = create_listen_socket(0).value_or(-1);
+        if (lfd < 0) usleep(1000);
+    }
+    REQUIRE(lfd >= 0);
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 403 Forbidden", 22));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(route, firewall_deny_cidr_over_allow_exact_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_cidr("127.0.0.0/8"));
     const RouteConfig* active = &cfg;
 
     RealLoop* loop = create_real_loop();

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2505,6 +2505,41 @@ TEST(route, firewall_remove_deny_cidr_restores_allow_cidr_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_remove_deny_ip_restores_allow_ip_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    REQUIRE(cfg.remove_firewall_deny_ip("127.0.0.1"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2231,6 +2231,40 @@ TEST(route, firewall_deny_localhost_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_deny_localhost_cidr_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_deny_cidr("127.0.0.0/8"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 403 Forbidden", 22));
+    CHECK(buf_contains(buf, len, "Connection: close", 17));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2274,7 +2274,7 @@ TEST(route, firewall_deny_localhost_cidr_real_socket) {
 TEST(route, firewall_deny_localhost_network_order_real_socket) {
     RouteConfig cfg;
     REQUIRE(cfg.add_static("/health", 0, 200));
-    REQUIRE(cfg.add_firewall_deny_ip_network_order(__builtin_bswap32(0x7f000001)));
+    REQUIRE(cfg.add_firewall_deny_ip_network_order(htonl(0x7f000001)));
     const RouteConfig* active = &cfg;
 
     RealLoop* loop = create_real_loop();
@@ -2485,7 +2485,7 @@ TEST(route, firewall_allowlist_cidr_localhost_real_socket) {
 TEST(route, firewall_allowlist_network_order_cidr_localhost_real_socket) {
     RouteConfig cfg;
     REQUIRE(cfg.add_static("/health", 0, 200));
-    REQUIRE(cfg.add_firewall_allow_cidr_network_order(__builtin_bswap32(0x7f000000), 8));
+    REQUIRE(cfg.add_firewall_allow_cidr_network_order(htonl(0x7f000000), 8));
     const RouteConfig* active = &cfg;
 
     RealLoop* loop = create_real_loop();

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2298,6 +2298,40 @@ TEST(route, firewall_allowlist_cidr_localhost_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_clear_rules_reenables_localhost_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_deny_ip(0x7f000001));  // 127.0.0.1
+    cfg.clear_firewall_rules();
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2032,9 +2032,12 @@ TEST(route, static_200_real_socket) {
 
     RealLoop* loop = create_real_loop();
     REQUIRE(loop != nullptr);
-    auto lfd_result = create_listen_socket(0);
-    REQUIRE(lfd_result.has_value());
-    i32 lfd = lfd_result.value();
+    i32 lfd = -1;
+    for (i32 attempt = 0; attempt < 5 && lfd < 0; attempt++) {
+        lfd = create_listen_socket(0).value_or(-1);
+        if (lfd < 0) usleep(1000);
+    }
+    REQUIRE(lfd >= 0);
     u16 port = get_port(lfd);
     REQUIRE(loop->init(0, lfd).has_value());
     loop->config_ptr = &active;
@@ -2062,9 +2065,12 @@ TEST(route, static_404_real_socket) {
 
     RealLoop* loop = create_real_loop();
     REQUIRE(loop != nullptr);
-    auto lfd_result = create_listen_socket(0);
-    REQUIRE(lfd_result.has_value());
-    i32 lfd = lfd_result.value();
+    i32 lfd = -1;
+    for (i32 attempt = 0; attempt < 5 && lfd < 0; attempt++) {
+        lfd = create_listen_socket(0).value_or(-1);
+        if (lfd < 0) usleep(1000);
+    }
+    REQUIRE(lfd >= 0);
     u16 port = get_port(lfd);
     REQUIRE(loop->init(0, lfd).has_value());
     loop->config_ptr = &active;
@@ -2290,6 +2296,40 @@ TEST(route, firewall_allowlist_exact_localhost_real_socket) {
     CHECK_GT(n, 0);
     const u32 len = static_cast<u32>(n);
     CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(route, firewall_deny_exact_over_allow_exact_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 403 Forbidden", 22));
 
     close(c);
     lt.stop();

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11199,6 +11199,25 @@ TEST(route_coverage, firewall_allows_peer_host_helper) {
     CHECK(cfg.firewall_allows_peer_host(0x0a020304));
 }
 
+TEST(route_coverage, firewall_clear_rules_resets_policy) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_cidr("10.0.0.0/8"));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a000001));
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001));
+    CHECK_EQ(cfg.firewall_allow_count, 1u);
+    CHECK_EQ(cfg.firewall_deny_cidr_count, 1u);
+
+    cfg.clear_firewall_rules();
+    CHECK_EQ(cfg.firewall_allow_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_count, 0u);
+    CHECK_EQ(cfg.firewall_allow_cidr_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_cidr_count, 0u);
+    // No allow/deny rules => default allow.
+    CHECK(cfg.firewall_allows_peer_host(0x0a000001));
+    CHECK(cfg.firewall_allows_peer_host(0xc0a80102));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11307,6 +11307,22 @@ TEST(route_coverage, firewall_remove_allow_rules_updates_policy_mode) {
     CHECK(cfg.firewall_allows_peer_host(0xc0a80101));
 }
 
+TEST(route_coverage, firewall_remove_last_allow_keeps_deny_active) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_ip("10.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_ip("10.1.2.3"));
+
+    // Allowlist mode: unmatched peers are blocked, denied peer is blocked.
+    CHECK(cfg.firewall_allows_peer_host(0x0a000001));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+    CHECK(!cfg.firewall_allows_peer_host(0xc0a80101));
+
+    // Removing final allow exits allowlist mode, but deny rule must remain active.
+    CHECK(cfg.remove_firewall_allow_ip("10.0.0.1"));
+    CHECK(cfg.firewall_allows_peer_host(0xc0a80101));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+}
+
 TEST(route_coverage, firewall_remove_deny_restores_allow_match) {
     RouteConfig cfg;
     REQUIRE(cfg.add_firewall_allow_ip("10.1.2.3"));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11133,6 +11133,29 @@ TEST(route_coverage, firewall_cidr_rejects_invalid_prefix) {
     CHECK(cfg.add_firewall_deny_cidr(0x0a000000, 0));
 }
 
+TEST(route_coverage, firewall_string_ip_and_cidr_helpers) {
+    RouteConfig cfg;
+    CHECK(cfg.add_firewall_allow_ip("127.0.0.1"));
+    CHECK(cfg.add_firewall_deny_ip("10.0.0.1"));
+    CHECK(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    CHECK(cfg.add_firewall_deny_cidr("10.1.0.0/16"));
+    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a000001)));
+    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
+}
+
+TEST(route_coverage, firewall_string_helpers_reject_invalid_input) {
+    RouteConfig cfg;
+    CHECK(!cfg.add_firewall_allow_ip(nullptr));
+    CHECK(!cfg.add_firewall_allow_ip(""));
+    CHECK(!cfg.add_firewall_allow_ip("256.0.0.1"));
+    CHECK(!cfg.add_firewall_deny_ip("1.2.3"));
+    CHECK(!cfg.add_firewall_allow_cidr("10.0.0.0"));
+    CHECK(!cfg.add_firewall_allow_cidr("10.0.0.0/"));
+    CHECK(!cfg.add_firewall_allow_cidr("/8"));
+    CHECK(!cfg.add_firewall_allow_cidr("10.0.0.0/33"));
+    CHECK(!cfg.add_firewall_deny_cidr("10.0.0.0/a"));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11246,6 +11246,45 @@ TEST(route_coverage, firewall_clear_rules_recovers_capacity) {
     CHECK(!cfg.firewall_allows_peer_host(0x0b000001));
 }
 
+TEST(route_coverage, firewall_remove_ip_and_cidr_rules) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_ip("10.0.0.1"));
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    REQUIRE(cfg.add_firewall_deny_ip("10.1.2.3"));
+    REQUIRE(cfg.add_firewall_deny_cidr("10.2.0.0/16"));
+
+    CHECK_EQ(cfg.firewall_allow_count, 1u);
+    CHECK_EQ(cfg.firewall_allow_cidr_count, 1u);
+    CHECK_EQ(cfg.firewall_deny_count, 1u);
+    CHECK_EQ(cfg.firewall_deny_cidr_count, 1u);
+
+    CHECK(cfg.remove_firewall_allow_ip("10.0.0.1"));
+    CHECK(cfg.remove_firewall_allow_cidr("10.0.0.0/8"));
+    CHECK(cfg.remove_firewall_deny_ip("10.1.2.3"));
+    CHECK(cfg.remove_firewall_deny_cidr("10.2.0.0/16"));
+
+    CHECK_EQ(cfg.firewall_allow_count, 0u);
+    CHECK_EQ(cfg.firewall_allow_cidr_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_cidr_count, 0u);
+    CHECK(cfg.firewall_allows_peer_host(0x0a010203));
+}
+
+TEST(route_coverage, firewall_remove_rejects_missing_or_invalid_rules) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_deny_ip("10.1.2.3"));
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+
+    CHECK(!cfg.remove_firewall_deny_ip("10.1.2.4"));
+    CHECK(!cfg.remove_firewall_allow_cidr("10.0.0.0/33"));
+    CHECK(!cfg.remove_firewall_allow_cidr("not-cidr"));
+    CHECK(!cfg.remove_firewall_allow_ip(nullptr));
+    CHECK(!cfg.remove_firewall_deny_cidr(nullptr));
+
+    CHECK_EQ(cfg.firewall_deny_count, 1u);
+    CHECK_EQ(cfg.firewall_allow_cidr_count, 1u);
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11218,6 +11218,19 @@ TEST(route_coverage, firewall_clear_rules_resets_policy) {
     CHECK(cfg.firewall_allows_peer_host(0xc0a80102));
 }
 
+TEST(route_coverage, firewall_clear_rules_then_readd) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
+
+    cfg.clear_firewall_rules();
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001));
+
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    CHECK(cfg.firewall_allows_peer_host(0x0a010203));
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11173,6 +11173,22 @@ TEST(route_coverage, firewall_duplicate_rules_do_not_consume_capacity) {
     CHECK_EQ(cfg.firewall_allow_count, 2u);
 }
 
+TEST(route_coverage, firewall_deny_precedence_over_allow) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/ok", 0, 200));
+
+    // deny CIDR wins over allow exact
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_cidr("127.0.0.0/8"));
+    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
+
+    // deny exact wins over allow CIDR
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    REQUIRE(cfg.add_firewall_deny_ip("10.1.2.3"));
+    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
+    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a020304)));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11022,6 +11022,73 @@ TEST(route_coverage, with_metrics_and_access_log) {
     CHECK_EQ(log_ring.available(), 1u);
 }
 
+TEST(route_coverage, firewall_deny_rule_returns_403) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/ok", 0, 200));
+    REQUIRE(cfg.add_firewall_deny_ip(0x7f000001));  // 127.0.0.1
+    const RouteConfig* active = &cfg;
+
+    SmallLoop loop;
+    loop.setup();
+    loop.config_ptr = &active;
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    c->peer_addr = __builtin_bswap32(0x7f000001);
+    c->recv_buf.reset();
+    const char req[] = "GET /ok HTTP/1.1\r\nHost: x\r\n\r\n";
+    c->recv_buf.write(reinterpret_cast<const u8*>(req), sizeof(req) - 1);
+    IoEvent rev = {c->id, static_cast<i32>(sizeof(req) - 1), 0, 0, IoEventType::Recv, 0};
+    loop.backend.inject(rev);
+    IoEvent events[8];
+    u32 n = loop.backend.wait(events, 8);
+    for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
+    CHECK_EQ(c->resp_status, 403);
+    CHECK(!c->keep_alive);
+}
+
+TEST(route_coverage, firewall_allowlist_blocks_non_members) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/ok", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_ip(0x7f000001));  // 127.0.0.1
+    const RouteConfig* active = &cfg;
+
+    SmallLoop loop;
+    loop.setup();
+    loop.config_ptr = &active;
+
+    // non-member IP => forbidden
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* blocked = loop.find_fd(42);
+    REQUIRE(blocked != nullptr);
+    blocked->peer_addr = __builtin_bswap32(0x0a000001);  // 10.0.0.1
+    blocked->recv_buf.reset();
+    const char req[] = "GET /ok HTTP/1.1\r\nHost: x\r\n\r\n";
+    blocked->recv_buf.write(reinterpret_cast<const u8*>(req), sizeof(req) - 1);
+    IoEvent blocked_ev = {
+        blocked->id, static_cast<i32>(sizeof(req) - 1), 0, 0, IoEventType::Recv, 0};
+    loop.backend.inject(blocked_ev);
+    IoEvent events[8];
+    u32 n = loop.backend.wait(events, 8);
+    for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
+    CHECK_EQ(blocked->resp_status, 403);
+
+    // member IP => route dispatch works
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 43));
+    auto* allowed = loop.find_fd(43);
+    REQUIRE(allowed != nullptr);
+    allowed->peer_addr = __builtin_bswap32(0x7f000001);  // 127.0.0.1
+    allowed->recv_buf.reset();
+    allowed->recv_buf.write(reinterpret_cast<const u8*>(req), sizeof(req) - 1);
+    IoEvent allowed_ev = {
+        allowed->id, static_cast<i32>(sizeof(req) - 1), 0, 0, IoEventType::Recv, 0};
+    loop.backend.inject(allowed_ev);
+    n = loop.backend.wait(events, 8);
+    for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
+    CHECK_EQ(allowed->resp_status, 200);
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11231,6 +11231,21 @@ TEST(route_coverage, firewall_clear_rules_then_readd) {
     CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
 }
 
+TEST(route_coverage, firewall_clear_rules_recovers_capacity) {
+    RouteConfig cfg;
+    for (u32 i = 0; i < RouteConfig::kMaxFirewallRules; i++) {
+        REQUIRE(cfg.add_firewall_deny_ip(0x0a000000u + i));
+    }
+    CHECK_EQ(cfg.firewall_deny_count, RouteConfig::kMaxFirewallRules);
+    CHECK(!cfg.add_firewall_deny_ip(0x0b000001));
+
+    cfg.clear_firewall_rules();
+    CHECK_EQ(cfg.firewall_deny_count, 0u);
+    REQUIRE(cfg.add_firewall_deny_ip(0x0b000001));
+    CHECK_EQ(cfg.firewall_deny_count, 1u);
+    CHECK(!cfg.firewall_allows_peer_host(0x0b000001));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11285,6 +11285,28 @@ TEST(route_coverage, firewall_remove_rejects_missing_or_invalid_rules) {
     CHECK_EQ(cfg.firewall_allow_cidr_count, 1u);
 }
 
+TEST(route_coverage, firewall_remove_allow_rules_updates_policy_mode) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+
+    // Allowlist mode: only allow-matched peers pass.
+    CHECK(cfg.firewall_allows_peer_host(0x0a010203));
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001));
+    CHECK(!cfg.firewall_allows_peer_host(0xc0a80101));
+
+    // After removing CIDR allow, only exact-IP allow remains.
+    CHECK(cfg.remove_firewall_allow_cidr("10.0.0.0/8"));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001));
+    CHECK(!cfg.firewall_allows_peer_host(0xc0a80101));
+
+    // Removing final allow exits allowlist mode (default allow).
+    CHECK(cfg.remove_firewall_allow_ip("127.0.0.1"));
+    CHECK(cfg.firewall_allows_peer_host(0x0a010203));
+    CHECK(cfg.firewall_allows_peer_host(0xc0a80101));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11156,6 +11156,23 @@ TEST(route_coverage, firewall_string_helpers_reject_invalid_input) {
     CHECK(!cfg.add_firewall_deny_cidr("10.0.0.0/a"));
 }
 
+TEST(route_coverage, firewall_duplicate_rules_do_not_consume_capacity) {
+    RouteConfig cfg;
+    for (u32 i = 0; i < RouteConfig::kMaxFirewallRules; i++) {
+        REQUIRE(cfg.add_firewall_allow_ip(0x7f000001));
+    }
+    CHECK_EQ(cfg.firewall_allow_count, 1u);
+
+    for (u32 i = 0; i < RouteConfig::kMaxFirewallRules; i++) {
+        REQUIRE(cfg.add_firewall_deny_cidr("10.0.0.0/8"));
+    }
+    CHECK_EQ(cfg.firewall_deny_cidr_count, 1u);
+
+    // Capacity remains available for distinct entries.
+    REQUIRE(cfg.add_firewall_allow_ip(0x7f000002));
+    CHECK_EQ(cfg.firewall_allow_count, 2u);
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11073,6 +11073,7 @@ TEST(route_coverage, firewall_allowlist_blocks_non_members) {
     u32 n = loop.backend.wait(events, 8);
     for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
     CHECK_EQ(blocked->resp_status, 403);
+    CHECK(!blocked->keep_alive);
 
     // member IP => route dispatch works
     loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 43));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11035,7 +11035,7 @@ TEST(route_coverage, firewall_deny_rule_returns_403) {
     loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
     auto* c = loop.find_fd(42);
     REQUIRE(c != nullptr);
-    c->peer_addr = __builtin_bswap32(0x7f000001);
+    c->peer_addr = htonl(0x7f000001);
     c->recv_buf.reset();
     const char req[] = "GET /ok HTTP/1.1\r\nHost: x\r\n\r\n";
     c->recv_buf.write(reinterpret_cast<const u8*>(req), sizeof(req) - 1);
@@ -11062,7 +11062,7 @@ TEST(route_coverage, firewall_allowlist_blocks_non_members) {
     loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
     auto* blocked = loop.find_fd(42);
     REQUIRE(blocked != nullptr);
-    blocked->peer_addr = __builtin_bswap32(0x0a000001);  // 10.0.0.1
+    blocked->peer_addr = htonl(0x0a000001);  // 10.0.0.1
     blocked->recv_buf.reset();
     const char req[] = "GET /ok HTTP/1.1\r\nHost: x\r\n\r\n";
     blocked->recv_buf.write(reinterpret_cast<const u8*>(req), sizeof(req) - 1);
@@ -11079,7 +11079,7 @@ TEST(route_coverage, firewall_allowlist_blocks_non_members) {
     loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 43));
     auto* allowed = loop.find_fd(43);
     REQUIRE(allowed != nullptr);
-    allowed->peer_addr = __builtin_bswap32(0x7f000001);  // 127.0.0.1
+    allowed->peer_addr = htonl(0x7f000001);  // 127.0.0.1
     allowed->recv_buf.reset();
     allowed->recv_buf.write(reinterpret_cast<const u8*>(req), sizeof(req) - 1);
     IoEvent allowed_ev = {
@@ -11097,9 +11097,9 @@ TEST(route_coverage, firewall_cidr_allow_and_deny_rules) {
     REQUIRE(cfg.add_firewall_allow_cidr(0x0a000000, 8));
     REQUIRE(cfg.add_firewall_deny_cidr(0x0a010000, 16));
     // direct rule checks (network-order peer values)
-    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));  // deny subnet
-    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a020304)));   // allow subnet
-    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0xc0a80102)));  // outside allowlist
+    CHECK(!cfg.firewall_allows_peer(htonl(0x0a010203)));  // deny subnet
+    CHECK(cfg.firewall_allows_peer(htonl(0x0a020304)));   // allow subnet
+    CHECK(!cfg.firewall_allows_peer(htonl(0xc0a80102)));  // outside allowlist
     const RouteConfig* active = &cfg;
     const char req[] = "GET /ok HTTP/1.1\r\nHost: x\r\n\r\n";
     IoEvent events[8];
@@ -11121,9 +11121,9 @@ TEST(route_coverage, firewall_cidr_allow_and_deny_rules) {
         CHECK_EQ(c->resp_status, expected);
     };
 
-    run_one(42, __builtin_bswap32(0x0a010203), 403);  // in deny /16
-    run_one(43, __builtin_bswap32(0x0a020304), 200);  // in allow /8
-    run_one(44, __builtin_bswap32(0xc0a80102), 403);  // outside allowlist
+    run_one(42, htonl(0x0a010203), 403);  // in deny /16
+    run_one(43, htonl(0x0a020304), 200);  // in allow /8
+    run_one(44, htonl(0xc0a80102), 403);  // outside allowlist
 }
 
 TEST(route_coverage, firewall_cidr_rejects_invalid_prefix) {
@@ -11140,8 +11140,8 @@ TEST(route_coverage, firewall_string_ip_and_cidr_helpers) {
     CHECK(cfg.add_firewall_deny_ip("10.0.0.1"));
     CHECK(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
     CHECK(cfg.add_firewall_deny_cidr("10.1.0.0/16"));
-    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a000001)));
-    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
+    CHECK(!cfg.firewall_allows_peer(htonl(0x0a000001)));
+    CHECK(cfg.firewall_allows_peer(htonl(0x7f000001)));
 }
 
 TEST(route_coverage, firewall_exact_ip_rules_use_host_order_storage) {
@@ -11152,21 +11152,21 @@ TEST(route_coverage, firewall_exact_ip_rules_use_host_order_storage) {
     CHECK_EQ(cfg.firewall_deny_ips[0], 0x0a010203u);
 
     // firewall_allows_peer() still takes network-order peer_addr.
-    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
-    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
+    CHECK(cfg.firewall_allows_peer(htonl(0x7f000001)));
+    CHECK(!cfg.firewall_allows_peer(htonl(0x0a010203)));
 }
 
 TEST(route_coverage, firewall_exact_ip_remove_roundtrip_with_network_peer_addr) {
     RouteConfig cfg;
     REQUIRE(cfg.add_firewall_allow_ip(0x7f000001));
-    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
+    CHECK(cfg.firewall_allows_peer(htonl(0x7f000001)));
     REQUIRE(cfg.remove_firewall_allow_ip(0x7f000001));
-    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
+    CHECK(cfg.firewall_allows_peer(htonl(0x7f000001)));
 
     REQUIRE(cfg.add_firewall_deny_ip(0x0a010203));
-    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
+    CHECK(!cfg.firewall_allows_peer(htonl(0x0a010203)));
     REQUIRE(cfg.remove_firewall_deny_ip(0x0a010203));
-    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
+    CHECK(cfg.firewall_allows_peer(htonl(0x0a010203)));
 }
 
 TEST(route_coverage, firewall_network_order_exact_ip_helpers_roundtrip) {
@@ -11174,8 +11174,8 @@ TEST(route_coverage, firewall_network_order_exact_ip_helpers_roundtrip) {
 
     const u32 kAllowHost = 0x7f000001;  // 127.0.0.1
     const u32 kDenyHost = 0x0a010203;   // 10.1.2.3
-    const u32 kAllowNet = __builtin_bswap32(kAllowHost);
-    const u32 kDenyNet = __builtin_bswap32(kDenyHost);
+    const u32 kAllowNet = htonl(kAllowHost);
+    const u32 kDenyNet = htonl(kDenyHost);
 
     REQUIRE(cfg.add_firewall_allow_ip_network_order(kAllowNet));
     REQUIRE(cfg.add_firewall_deny_ip_network_order(kDenyNet));
@@ -11194,19 +11194,19 @@ TEST(route_coverage, firewall_network_order_exact_ip_helpers_roundtrip) {
 TEST(route_coverage, firewall_network_order_cidr_helpers_roundtrip) {
     RouteConfig cfg;
 
-    const u32 kAllow10Net = __builtin_bswap32(0x0a000000);  // 10.0.0.0/8
-    const u32 kDeny101Net = __builtin_bswap32(0x0a010000);  // 10.1.0.0/16
+    const u32 kAllow10Net = htonl(0x0a000000);  // 10.0.0.0/8
+    const u32 kDeny101Net = htonl(0x0a010000);  // 10.1.0.0/16
     REQUIRE(cfg.add_firewall_allow_cidr_network_order(kAllow10Net, 8));
     REQUIRE(cfg.add_firewall_deny_cidr_network_order(kDeny101Net, 16));
 
-    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));  // denied /16
-    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a020304)));   // allowed /8
-    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0xc0a80102)));  // outside allowlist
+    CHECK(!cfg.firewall_allows_peer(htonl(0x0a010203)));  // denied /16
+    CHECK(cfg.firewall_allows_peer(htonl(0x0a020304)));   // allowed /8
+    CHECK(!cfg.firewall_allows_peer(htonl(0xc0a80102)));  // outside allowlist
 
     REQUIRE(cfg.remove_firewall_deny_cidr_network_order(kDeny101Net, 16));
-    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
+    CHECK(cfg.firewall_allows_peer(htonl(0x0a010203)));
     REQUIRE(cfg.remove_firewall_allow_cidr_network_order(kAllow10Net, 8));
-    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0xc0a80102)));
+    CHECK(cfg.firewall_allows_peer(htonl(0xc0a80102)));
 }
 
 TEST(route_coverage, firewall_string_helpers_reject_invalid_input) {
@@ -11246,13 +11246,13 @@ TEST(route_coverage, firewall_deny_precedence_over_allow) {
     // deny CIDR wins over allow exact
     REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
     REQUIRE(cfg.add_firewall_deny_cidr("127.0.0.0/8"));
-    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
+    CHECK(!cfg.firewall_allows_peer(htonl(0x7f000001)));
 
     // deny exact wins over allow CIDR
     REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
     REQUIRE(cfg.add_firewall_deny_ip("10.1.2.3"));
-    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
-    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a020304)));
+    CHECK(!cfg.firewall_allows_peer(htonl(0x0a010203)));
+    CHECK(cfg.firewall_allows_peer(htonl(0x0a020304)));
 }
 
 TEST(route_coverage, firewall_allows_peer_host_helper) {

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11189,6 +11189,15 @@ TEST(route_coverage, firewall_deny_precedence_over_allow) {
     CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a020304)));
 }
 
+TEST(route_coverage, firewall_allows_peer_host_helper) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    REQUIRE(cfg.add_firewall_deny_ip("10.1.2.3"));
+
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+    CHECK(cfg.firewall_allows_peer_host(0x0a020304));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11323,6 +11323,23 @@ TEST(route_coverage, firewall_remove_last_allow_keeps_deny_active) {
     CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
 }
 
+TEST(route_coverage, firewall_remove_last_allow_cidr_keeps_deny_cidr_active) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    REQUIRE(cfg.add_firewall_deny_cidr("10.1.0.0/16"));
+
+    // Allowlist mode: only 10/8 can pass, except denied 10.1/16.
+    CHECK(cfg.firewall_allows_peer_host(0x0a020304));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+    CHECK(!cfg.firewall_allows_peer_host(0xc0a80101));
+
+    // Removing final allow CIDR exits allowlist mode, but deny CIDR remains active.
+    CHECK(cfg.remove_firewall_allow_cidr("10.0.0.0/8"));
+    CHECK(cfg.firewall_allows_peer_host(0xc0a80101));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+    CHECK(cfg.firewall_allows_peer_host(0x0a020304));
+}
+
 TEST(route_coverage, firewall_remove_deny_restores_allow_match) {
     RouteConfig cfg;
     REQUIRE(cfg.add_firewall_allow_ip("10.1.2.3"));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11307,6 +11307,19 @@ TEST(route_coverage, firewall_remove_allow_rules_updates_policy_mode) {
     CHECK(cfg.firewall_allows_peer_host(0xc0a80101));
 }
 
+TEST(route_coverage, firewall_remove_deny_restores_allow_match) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_ip("10.1.2.3"));
+    REQUIRE(cfg.add_firewall_deny_ip("10.1.2.3"));
+
+    // Deny takes precedence while present.
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+
+    // Removing deny should expose allow-match again.
+    CHECK(cfg.remove_firewall_deny_ip("10.1.2.3"));
+    CHECK(cfg.firewall_allows_peer_host(0x0a010203));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11455,6 +11455,39 @@ TEST(route_coverage, firewall_default_deny_requires_explicit_allow) {
     CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
 }
 
+TEST(route_coverage, firewall_clear_allow_rules_keeps_deny_active) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    REQUIRE(cfg.add_firewall_deny_ip("10.1.2.3"));
+    REQUIRE(cfg.add_firewall_deny_cidr("192.168.0.0/16"));
+
+    cfg.clear_firewall_allow_rules();
+
+    CHECK_EQ(cfg.firewall_allow_count, 0u);
+    CHECK_EQ(cfg.firewall_allow_cidr_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_count, 1u);
+    CHECK_EQ(cfg.firewall_deny_cidr_count, 1u);
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+    CHECK(!cfg.firewall_allows_peer_host(0xc0a80102));
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001));
+}
+
+TEST(route_coverage, firewall_clear_deny_rules_keeps_allow_mode) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_cidr("10.0.0.0/8"));
+
+    cfg.clear_firewall_deny_rules();
+
+    CHECK_EQ(cfg.firewall_deny_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_cidr_count, 0u);
+    CHECK_EQ(cfg.firewall_allow_count, 1u);
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11169,6 +11169,46 @@ TEST(route_coverage, firewall_exact_ip_remove_roundtrip_with_network_peer_addr) 
     CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
 }
 
+TEST(route_coverage, firewall_network_order_exact_ip_helpers_roundtrip) {
+    RouteConfig cfg;
+
+    const u32 kAllowHost = 0x7f000001;  // 127.0.0.1
+    const u32 kDenyHost = 0x0a010203;   // 10.1.2.3
+    const u32 kAllowNet = __builtin_bswap32(kAllowHost);
+    const u32 kDenyNet = __builtin_bswap32(kDenyHost);
+
+    REQUIRE(cfg.add_firewall_allow_ip_network_order(kAllowNet));
+    REQUIRE(cfg.add_firewall_deny_ip_network_order(kDenyNet));
+
+    CHECK(cfg.firewall_allows_peer(kAllowNet));
+    CHECK(!cfg.firewall_allows_peer(kDenyNet));
+
+    REQUIRE(cfg.remove_firewall_allow_ip_network_order(kAllowNet));
+    REQUIRE(cfg.remove_firewall_deny_ip_network_order(kDenyNet));
+
+    // No rules left => default allow.
+    CHECK(cfg.firewall_allows_peer(kAllowNet));
+    CHECK(cfg.firewall_allows_peer(kDenyNet));
+}
+
+TEST(route_coverage, firewall_network_order_cidr_helpers_roundtrip) {
+    RouteConfig cfg;
+
+    const u32 kAllow10Net = __builtin_bswap32(0x0a000000);  // 10.0.0.0/8
+    const u32 kDeny101Net = __builtin_bswap32(0x0a010000);  // 10.1.0.0/16
+    REQUIRE(cfg.add_firewall_allow_cidr_network_order(kAllow10Net, 8));
+    REQUIRE(cfg.add_firewall_deny_cidr_network_order(kDeny101Net, 16));
+
+    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));  // denied /16
+    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a020304)));   // allowed /8
+    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0xc0a80102)));  // outside allowlist
+
+    REQUIRE(cfg.remove_firewall_deny_cidr_network_order(kDeny101Net, 16));
+    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
+    REQUIRE(cfg.remove_firewall_allow_cidr_network_order(kAllow10Net, 8));
+    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0xc0a80102)));
+}
+
 TEST(route_coverage, firewall_string_helpers_reject_invalid_input) {
     RouteConfig cfg;
     CHECK(!cfg.add_firewall_allow_ip(nullptr));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11432,6 +11432,29 @@ TEST(route_coverage, firewall_remove_deny_restores_allow_match) {
     CHECK(cfg.firewall_allows_peer_host(0x0a010203));
 }
 
+TEST(route_coverage, firewall_default_deny_requires_explicit_allow) {
+    RouteConfig cfg;
+    cfg.set_firewall_default_deny();
+    CHECK(!cfg.firewall_default_is_allow());
+
+    // No allow rules + default deny => block.
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+
+    // Explicit allow admits matched peers.
+    REQUIRE(cfg.add_firewall_allow_cidr("127.0.0.0/8"));
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+
+    // Deny still takes precedence over allow.
+    REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
+
+    // Clearing rules preserves default policy.
+    cfg.clear_firewall_rules();
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11156,6 +11156,19 @@ TEST(route_coverage, firewall_exact_ip_rules_use_host_order_storage) {
     CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
 }
 
+TEST(route_coverage, firewall_exact_ip_remove_roundtrip_with_network_peer_addr) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_ip(0x7f000001));
+    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
+    REQUIRE(cfg.remove_firewall_allow_ip(0x7f000001));
+    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
+
+    REQUIRE(cfg.add_firewall_deny_ip(0x0a010203));
+    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
+    REQUIRE(cfg.remove_firewall_deny_ip(0x0a010203));
+    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
+}
+
 TEST(route_coverage, firewall_string_helpers_reject_invalid_input) {
     RouteConfig cfg;
     CHECK(!cfg.add_firewall_allow_ip(nullptr));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11285,6 +11285,20 @@ TEST(route_coverage, firewall_remove_rejects_missing_or_invalid_rules) {
     CHECK_EQ(cfg.firewall_allow_cidr_count, 1u);
 }
 
+TEST(route_coverage, firewall_remove_cidr_u32_rejects_invalid_prefix) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_cidr(0x0a000000, 8));
+    REQUIRE(cfg.add_firewall_deny_cidr(0x0a010000, 16));
+
+    CHECK(!cfg.remove_firewall_allow_cidr(0x0a000000, 33));
+    CHECK(!cfg.remove_firewall_deny_cidr(0x0a010000, 40));
+
+    CHECK_EQ(cfg.firewall_allow_cidr_count, 1u);
+    CHECK_EQ(cfg.firewall_deny_cidr_count, 1u);
+    CHECK(cfg.firewall_allows_peer_host(0x0a020304));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+}
+
 TEST(route_coverage, firewall_remove_allow_rules_updates_policy_mode) {
     RouteConfig cfg;
     REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11125,6 +11125,14 @@ TEST(route_coverage, firewall_cidr_allow_and_deny_rules) {
     run_one(44, __builtin_bswap32(0xc0a80102), 403);  // outside allowlist
 }
 
+TEST(route_coverage, firewall_cidr_rejects_invalid_prefix) {
+    RouteConfig cfg;
+    CHECK(!cfg.add_firewall_allow_cidr(0x0a000000, 33));
+    CHECK(!cfg.add_firewall_deny_cidr(0x0a000000, 33));
+    CHECK(cfg.add_firewall_allow_cidr(0x0a000000, 32));
+    CHECK(cfg.add_firewall_deny_cidr(0x0a000000, 0));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11144,6 +11144,18 @@ TEST(route_coverage, firewall_string_ip_and_cidr_helpers) {
     CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
 }
 
+TEST(route_coverage, firewall_exact_ip_rules_use_host_order_storage) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_ip(0x7f000001));
+    REQUIRE(cfg.add_firewall_deny_ip(0x0a010203));
+    CHECK_EQ(cfg.firewall_allow_ips[0], 0x7f000001u);
+    CHECK_EQ(cfg.firewall_deny_ips[0], 0x0a010203u);
+
+    // firewall_allows_peer() still takes network-order peer_addr.
+    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x7f000001)));
+    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));
+}
+
 TEST(route_coverage, firewall_string_helpers_reject_invalid_input) {
     RouteConfig cfg;
     CHECK(!cfg.add_firewall_allow_ip(nullptr));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11089,6 +11089,42 @@ TEST(route_coverage, firewall_allowlist_blocks_non_members) {
     CHECK_EQ(allowed->resp_status, 200);
 }
 
+TEST(route_coverage, firewall_cidr_allow_and_deny_rules) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/ok", 0, 200));
+    // allow 10.0.0.0/8, deny 10.1.0.0/16
+    REQUIRE(cfg.add_firewall_allow_cidr(0x0a000000, 8));
+    REQUIRE(cfg.add_firewall_deny_cidr(0x0a010000, 16));
+    // direct rule checks (network-order peer values)
+    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0x0a010203)));  // deny subnet
+    CHECK(cfg.firewall_allows_peer(__builtin_bswap32(0x0a020304)));   // allow subnet
+    CHECK(!cfg.firewall_allows_peer(__builtin_bswap32(0xc0a80102)));  // outside allowlist
+    const RouteConfig* active = &cfg;
+    const char req[] = "GET /ok HTTP/1.1\r\nHost: x\r\n\r\n";
+    IoEvent events[8];
+
+    auto run_one = [&](i32 fd, u32 peer_addr, u16 expected) {
+        SmallLoop loop;
+        loop.setup();
+        loop.config_ptr = &active;
+        loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, fd));
+        auto* c = loop.find_fd(fd);
+        REQUIRE(c != nullptr);
+        c->peer_addr = peer_addr;
+        c->recv_buf.reset();
+        c->recv_buf.write(reinterpret_cast<const u8*>(req), sizeof(req) - 1);
+        IoEvent ev = {c->id, static_cast<i32>(sizeof(req) - 1), 0, 0, IoEventType::Recv, 0};
+        loop.backend.inject(ev);
+        u32 n = loop.backend.wait(events, 8);
+        for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
+        CHECK_EQ(c->resp_status, expected);
+    };
+
+    run_one(42, __builtin_bswap32(0x0a010203), 403);  // in deny /16
+    run_one(43, __builtin_bswap32(0x0a020304), 200);  // in allow /8
+    run_one(44, __builtin_bswap32(0xc0a80102), 403);  // outside allowlist
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line


### PR DESCRIPTION
## Summary
- add configurable firewall default policy via set_firewall_default_allow(bool) and set_firewall_default_deny()
- preserve existing deny-over-allow precedence while allowing fail-closed mode when no allow rules exist
- add firewall_default_is_allow() for policy introspection
- document API and updated evaluation order in docs/firewall.md
- add network and real-socket coverage for default-deny behavior

## Validation
- ./build/tests/test_network --filter=route_coverage.firewall_*
- ./build/tests/test_integration --filter=route.firewall_*