### PR TITLE
runtime: add configurable firewall default policy and targeted clear APIs

### DIFF
--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -43,6 +43,9 @@ Defined on `RouteConfig`:
 - `remove_firewall_deny_ip("a.b.c.d")`
 - `remove_firewall_allow_cidr("a.b.c.d/prefix")`
 - `remove_firewall_deny_cidr("a.b.c.d/prefix")`
+- `set_firewall_default_allow(bool allow)`
+- `set_firewall_default_deny()`
+- `firewall_default_is_allow()`
 - `clear_firewall_rules()`
 
 All `u32` IPv4 arguments are packed host-order values in the form
@@ -62,6 +65,8 @@ Adding the same exact IP or same CIDR repeatedly is idempotent (returns `true`
 without consuming additional rule slots).
 Remove APIs return `true` only when a matching rule exists and is deleted.
 `clear_firewall_rules()` clears all allow/deny exact and CIDR rules.
+Default policy is allow unless changed via `set_firewall_default_allow(false)`
+or `set_firewall_default_deny()`.
 
 ## Evaluation order
 
@@ -69,7 +74,7 @@ For each request:
 
 1. Any deny IP match => reject
 2. Any deny CIDR match => reject
-3. If no allow rules exist => allow
+3. If no allow rules exist => apply default policy (allow by default)
 4. Otherwise require allow IP or allow CIDR match
 
 In other words, deny rules always win over allow rules.
@@ -112,6 +117,7 @@ Current coverage in `tests/test_network.cc` (`route_coverage`) includes:
 - `firewall_remove_last_allow_keeps_deny_active`
 - `firewall_remove_last_allow_cidr_keeps_deny_cidr_active`
 - `firewall_remove_deny_restores_allow_match`
+- `firewall_default_deny_requires_explicit_allow`
 
 Current integration coverage in `tests/test_integration.cc` includes:
 
@@ -133,3 +139,4 @@ Current integration coverage in `tests/test_integration.cc` includes:
 - `firewall_remove_deny_ip_restores_allow_ip_real_socket`
 - `firewall_remove_last_allow_ip_keeps_deny_cidr_real_socket`
 - `firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket`
+- `firewall_default_deny_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -43,6 +43,8 @@ Defined on `RouteConfig`:
 - `remove_firewall_deny_ip("a.b.c.d")`
 - `remove_firewall_allow_cidr("a.b.c.d/prefix")`
 - `remove_firewall_deny_cidr("a.b.c.d/prefix")`
+- `clear_firewall_allow_rules()`
+- `clear_firewall_deny_rules()`
 - `set_firewall_default_allow(bool allow)`
 - `set_firewall_default_deny()`
 - `firewall_default_is_allow()`
@@ -64,6 +66,8 @@ return `false` on cap overflow or invalid CIDR prefix.
 Adding the same exact IP or same CIDR repeatedly is idempotent (returns `true`
 without consuming additional rule slots).
 Remove APIs return `true` only when a matching rule exists and is deleted.
+`clear_firewall_allow_rules()` clears both allow exact-IP and allow CIDR tables.
+`clear_firewall_deny_rules()` clears both deny exact-IP and deny CIDR tables.
 `clear_firewall_rules()` clears all allow/deny exact and CIDR rules.
 Default policy is allow unless changed via `set_firewall_default_allow(false)`
 or `set_firewall_default_deny()`.

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -204,6 +204,7 @@ struct RouteConfig {
     u32 firewall_deny_count = 0;
     u32 firewall_allow_cidr_count = 0;
     u32 firewall_deny_cidr_count = 0;
+    bool firewall_default_allow = true;
 
     // Reject route paths that aren't in origin-form. Required by the
     // segment trie (which would otherwise silently mismatch malformed
@@ -715,6 +716,9 @@ struct RouteConfig {
         firewall_allow_cidr_count = 0;
         firewall_deny_cidr_count = 0;
     }
+    void set_firewall_default_allow(bool allow) { firewall_default_allow = allow; }
+    void set_firewall_default_deny() { firewall_default_allow = false; }
+    bool firewall_default_is_allow() const { return firewall_default_allow; }
 
     // `peer_addr` must be in network byte order (same as getpeername()).
     // It is converted to packed host-order u32 before matching:
@@ -728,7 +732,7 @@ struct RouteConfig {
             const auto& r = firewall_deny_cidrs[i];
             if ((peer_host & r.mask) == r.net_addr) return false;
         }
-        if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0) return true;
+        if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0) return firewall_default_allow;
         for (u32 i = 0; i < firewall_allow_count; i++) {
             if (firewall_allow_ips[i] == peer_host) return true;
         }

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -706,15 +706,21 @@ struct RouteConfig {
     bool remove_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
         return remove_firewall_deny_cidr(ntohl(ip_network_order), prefix_len);
     }
-    void clear_firewall_rules() {
+    void clear_firewall_allow_rules() {
         for (u32 i = 0; i < firewall_allow_count; i++) firewall_allow_ips[i] = 0;
-        for (u32 i = 0; i < firewall_deny_count; i++) firewall_deny_ips[i] = 0;
         for (u32 i = 0; i < firewall_allow_cidr_count; i++) firewall_allow_cidrs[i] = {0, 0};
-        for (u32 i = 0; i < firewall_deny_cidr_count; i++) firewall_deny_cidrs[i] = {0, 0};
         firewall_allow_count = 0;
-        firewall_deny_count = 0;
         firewall_allow_cidr_count = 0;
+    }
+    void clear_firewall_deny_rules() {
+        for (u32 i = 0; i < firewall_deny_count; i++) firewall_deny_ips[i] = 0;
+        for (u32 i = 0; i < firewall_deny_cidr_count; i++) firewall_deny_cidrs[i] = {0, 0};
+        firewall_deny_count = 0;
         firewall_deny_cidr_count = 0;
+    }
+    void clear_firewall_rules() {
+        clear_firewall_allow_rules();
+        clear_firewall_deny_rules();
     }
     void set_firewall_default_allow(bool allow) { firewall_default_allow = allow; }
     void set_firewall_default_deny() { firewall_default_allow = false; }

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -738,7 +738,8 @@ struct RouteConfig {
             const auto& r = firewall_deny_cidrs[i];
             if ((peer_host & r.mask) == r.net_addr) return false;
         }
-        if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0) return firewall_default_allow;
+        if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0)
+            return firewall_default_allow;
         for (u32 i = 0; i < firewall_allow_count; i++) {
             if (firewall_allow_ips[i] == peer_host) return true;
         }

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2832,6 +2832,49 @@ TEST(route, firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_default_deny_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    cfg.set_firewall_default_deny();
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c1 = connect_to(port);
+    REQUIRE(c1 >= 0);
+    send_all(c1, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf1[1024];
+    i32 n1 = recv_timeout(c1, buf1, sizeof(buf1), 500);
+    CHECK_GT(n1, 0);
+    CHECK(buf_contains(buf1, static_cast<u32>(n1), "HTTP/1.1 403 Forbidden", 22));
+    close(c1);
+
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+
+    i32 c2 = connect_to(port);
+    REQUIRE(c2 >= 0);
+    send_all(c2, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf2[1024];
+    i32 n2 = recv_timeout(c2, buf2, sizeof(buf2), 500);
+    CHECK_GT(n2, 0);
+    CHECK(buf_contains(buf2, static_cast<u32>(n2), "HTTP/1.1 200 OK", 15));
+    close(c2);
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, capture_real_socket) {
     RouteConfig cfg;
     cfg.add_static("/", 0, 200);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2833,46 +2833,72 @@ TEST(route, firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket) {
 }
 
 TEST(route, firewall_default_deny_real_socket) {
-    RouteConfig cfg;
-    REQUIRE(cfg.add_static("/health", 0, 200));
-    cfg.set_firewall_default_deny();
-    const RouteConfig* active = &cfg;
+    // Phase 1: default-deny blocks localhost with no allow rules.
+    {
+        RouteConfig cfg;
+        REQUIRE(cfg.add_static("/health", 0, 200));
+        cfg.set_firewall_default_deny();
+        const RouteConfig* active = &cfg;
 
-    RealLoop* loop = create_real_loop();
-    REQUIRE(loop != nullptr);
-    auto lfd_result = create_listen_socket(0);
-    REQUIRE(lfd_result.has_value());
-    i32 lfd = lfd_result.value();
-    u16 port = get_port(lfd);
-    REQUIRE(loop->init(0, lfd).has_value());
-    loop->config_ptr = &active;
-    LoopThread lt = {loop, {}, 20};
-    lt.start();
+        RealLoop* loop = create_real_loop();
+        REQUIRE(loop != nullptr);
+        auto lfd_result = create_listen_socket(0);
+        REQUIRE(lfd_result.has_value());
+        i32 lfd = lfd_result.value();
+        u16 port = get_port(lfd);
+        REQUIRE(loop->init(0, lfd).has_value());
+        loop->config_ptr = &active;
+        LoopThread lt = {loop, {}, 20};
+        lt.start();
 
-    i32 c1 = connect_to(port);
-    REQUIRE(c1 >= 0);
-    send_all(c1, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
-    char buf1[1024];
-    i32 n1 = recv_timeout(c1, buf1, sizeof(buf1), 500);
-    CHECK_GT(n1, 0);
-    CHECK(buf_contains(buf1, static_cast<u32>(n1), "HTTP/1.1 403 Forbidden", 22));
-    close(c1);
+        i32 c1 = connect_to(port);
+        REQUIRE(c1 >= 0);
+        send_all(c1, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+        char buf1[1024];
+        i32 n1 = recv_timeout(c1, buf1, sizeof(buf1), 500);
+        CHECK_GT(n1, 0);
+        CHECK(buf_contains(buf1, static_cast<u32>(n1), "HTTP/1.1 403 Forbidden", 22));
+        close(c1);
 
-    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+        lt.stop();
+        loop->shutdown();
+        close(lfd);
+        destroy_real_loop(loop);
+    }
 
-    i32 c2 = connect_to(port);
-    REQUIRE(c2 >= 0);
-    send_all(c2, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
-    char buf2[1024];
-    i32 n2 = recv_timeout(c2, buf2, sizeof(buf2), 500);
-    CHECK_GT(n2, 0);
-    CHECK(buf_contains(buf2, static_cast<u32>(n2), "HTTP/1.1 200 OK", 15));
-    close(c2);
+    // Phase 2: default-deny + explicit allow permits localhost.
+    {
+        RouteConfig cfg;
+        REQUIRE(cfg.add_static("/health", 0, 200));
+        cfg.set_firewall_default_deny();
+        REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+        const RouteConfig* active = &cfg;
 
-    lt.stop();
-    loop->shutdown();
-    close(lfd);
-    destroy_real_loop(loop);
+        RealLoop* loop = create_real_loop();
+        REQUIRE(loop != nullptr);
+        auto lfd_result = create_listen_socket(0);
+        REQUIRE(lfd_result.has_value());
+        i32 lfd = lfd_result.value();
+        u16 port = get_port(lfd);
+        REQUIRE(loop->init(0, lfd).has_value());
+        loop->config_ptr = &active;
+        LoopThread lt = {loop, {}, 20};
+        lt.start();
+
+        i32 c2 = connect_to(port);
+        REQUIRE(c2 >= 0);
+        send_all(c2, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+        char buf2[1024];
+        i32 n2 = recv_timeout(c2, buf2, sizeof(buf2), 500);
+        CHECK_GT(n2, 0);
+        CHECK(buf_contains(buf2, static_cast<u32>(n2), "HTTP/1.1 200 OK", 15));
+        close(c2);
+
+        lt.stop();
+        loop->shutdown();
+        close(lfd);
+        destroy_real_loop(loop);
+    }
 }
 
 TEST(route, capture_real_socket) {

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11482,6 +11482,39 @@ TEST(route_coverage, firewall_default_deny_requires_explicit_allow) {
     CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
 }
 
+TEST(route_coverage, firewall_clear_allow_rules_keeps_deny_active) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));
+    REQUIRE(cfg.add_firewall_deny_ip("10.1.2.3"));
+    REQUIRE(cfg.add_firewall_deny_cidr("192.168.0.0/16"));
+
+    cfg.clear_firewall_allow_rules();
+
+    CHECK_EQ(cfg.firewall_allow_count, 0u);
+    CHECK_EQ(cfg.firewall_allow_cidr_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_count, 1u);
+    CHECK_EQ(cfg.firewall_deny_cidr_count, 1u);
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+    CHECK(!cfg.firewall_allows_peer_host(0xc0a80102));
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001));
+}
+
+TEST(route_coverage, firewall_clear_deny_rules_keeps_allow_mode) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    REQUIRE(cfg.add_firewall_deny_cidr("10.0.0.0/8"));
+
+    cfg.clear_firewall_deny_rules();
+
+    CHECK_EQ(cfg.firewall_deny_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_cidr_count, 0u);
+    CHECK_EQ(cfg.firewall_allow_count, 1u);
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11459,6 +11459,29 @@ TEST(route_coverage, firewall_remove_deny_restores_allow_match) {
     CHECK(cfg.firewall_allows_peer_host(0x0a010203));
 }
 
+TEST(route_coverage, firewall_default_deny_requires_explicit_allow) {
+    RouteConfig cfg;
+    cfg.set_firewall_default_deny();
+    CHECK(!cfg.firewall_default_is_allow());
+
+    // No allow rules + default deny => block.
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+
+    // Explicit allow admits matched peers.
+    REQUIRE(cfg.add_firewall_allow_cidr("127.0.0.0/8"));
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
+
+    // Deny still takes precedence over allow.
+    REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
+
+    // Clearing rules preserves default policy.
+    cfg.clear_firewall_rules();
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line


### PR DESCRIPTION
## Summary
- add configurable default firewall policy with set_firewall_default_allow(bool), set_firewall_default_deny(), and firewall_default_is_allow()
- add targeted rule reset APIs: clear_firewall_allow_rules() and clear_firewall_deny_rules()
- preserve deny-over-allow precedence and existing IPv4 matching behavior
- document new firewall APIs and evaluation details in docs/firewall.md
- add route_coverage tests for default-deny and targeted clear behavior
- update real-socket test to avoid mutating published RouteConfig while loop thread is running

## Validation
- ./build/tests/test_network --filter=route_coverage.firewall_*
- ./build/tests/test_integration --filter=route.firewall_*