### PR TITLE
runtime: add ipv4 firewall range rules

### DIFF
--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -1,4 +1,4 @@
-# Firewall (runtime RouteConfig)
+#Firewall(runtime RouteConfig)
 
 This document describes the firewall capability currently available in runtime
 configuration (`RouteConfig`), independent of DSL parsing.
@@ -10,6 +10,7 @@ connections.
 
 - Exact IP rules
 - CIDR subnet rules
+- Inclusive IP range rules
 - Allowlist + denylist precedence
 
 Rules are evaluated from `Connection.peer_addr` captured at accept-time.
@@ -23,26 +24,38 @@ Defined on `RouteConfig`:
 - `add_firewall_deny_ip(u32 ip_host_order)`
 - `add_firewall_allow_cidr(u32 ip_host_order, u8 prefix_len)`
 - `add_firewall_deny_cidr(u32 ip_host_order, u8 prefix_len)`
+- `add_firewall_allow_range(u32 start_ip_host_order, u32 end_ip_host_order)`
+- `add_firewall_deny_range(u32 start_ip_host_order, u32 end_ip_host_order)`
 - `remove_firewall_allow_ip(u32 ip_host_order)`
 - `remove_firewall_deny_ip(u32 ip_host_order)`
 - `remove_firewall_allow_cidr(u32 ip_host_order, u8 prefix_len)`
 - `remove_firewall_deny_cidr(u32 ip_host_order, u8 prefix_len)`
+- `remove_firewall_allow_range(u32 start_ip_host_order, u32 end_ip_host_order)`
+- `remove_firewall_deny_range(u32 start_ip_host_order, u32 end_ip_host_order)`
 - `add_firewall_allow_ip_network_order(u32 ip_network_order)`
 - `add_firewall_deny_ip_network_order(u32 ip_network_order)`
 - `add_firewall_allow_cidr_network_order(u32 ip_network_order, u8 prefix_len)`
 - `add_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len)`
+- `add_firewall_allow_range_network_order(u32 start_ip_network_order, u32 end_ip_network_order)`
+- `add_firewall_deny_range_network_order(u32 start_ip_network_order, u32 end_ip_network_order)`
 - `remove_firewall_allow_ip_network_order(u32 ip_network_order)`
 - `remove_firewall_deny_ip_network_order(u32 ip_network_order)`
 - `remove_firewall_allow_cidr_network_order(u32 ip_network_order, u8 prefix_len)`
 - `remove_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len)`
+- `remove_firewall_allow_range_network_order(u32 start_ip_network_order, u32 end_ip_network_order)`
+- `remove_firewall_deny_range_network_order(u32 start_ip_network_order, u32 end_ip_network_order)`
 - `add_firewall_allow_ip("a.b.c.d")`
 - `add_firewall_deny_ip("a.b.c.d")`
 - `add_firewall_allow_cidr("a.b.c.d/prefix")`
 - `add_firewall_deny_cidr("a.b.c.d/prefix")`
+- `add_firewall_allow_range("a.b.c.d-e.f.g.h")`
+- `add_firewall_deny_range("a.b.c.d-e.f.g.h")`
 - `remove_firewall_allow_ip("a.b.c.d")`
 - `remove_firewall_deny_ip("a.b.c.d")`
 - `remove_firewall_allow_cidr("a.b.c.d/prefix")`
 - `remove_firewall_deny_cidr("a.b.c.d/prefix")`
+- `remove_firewall_allow_range("a.b.c.d-e.f.g.h")`
+- `remove_firewall_deny_range("a.b.c.d-e.f.g.h")`
 - `clear_firewall_allow_rules()`
 - `clear_firewall_deny_rules()`
 - `set_firewall_default_allow(bool allow)`
@@ -66,9 +79,9 @@ return `false` on cap overflow or invalid CIDR prefix.
 Adding the same exact IP or same CIDR repeatedly is idempotent (returns `true`
 without consuming additional rule slots).
 Remove APIs return `true` only when a matching rule exists and is deleted.
-`clear_firewall_allow_rules()` clears both allow exact-IP and allow CIDR tables.
-`clear_firewall_deny_rules()` clears both deny exact-IP and deny CIDR tables.
-`clear_firewall_rules()` clears all allow/deny exact and CIDR rules.
+`clear_firewall_allow_rules()` clears allow exact-IP, CIDR, and range tables.
+`clear_firewall_deny_rules()` clears deny exact-IP, CIDR, and range tables.
+`clear_firewall_rules()` clears all allow/deny exact, CIDR, and range rules.
 Default policy is allow unless changed via `set_firewall_default_allow(false)`
 or `set_firewall_default_deny()`.
 
@@ -103,44 +116,20 @@ cfg.add_firewall_deny_cidr(0x0a010000, 16);  // 10.1.0.0/16
 cfg.add_firewall_allow_ip(0x7f000001);       // 127.0.0.1
 ```
 
-## Tests
+        ##Tests
 
-Current coverage in `tests/test_network.cc` (`route_coverage`) includes:
+            Current coverage in `tests /
+        test_network.cc` (`route_coverage`)includes :
 
-- `firewall_deny_rule_returns_403`
-- `firewall_allowlist_blocks_non_members`
-- `firewall_cidr_allow_and_deny_rules`
-- `firewall_string_ip_and_cidr_helpers`
-- `firewall_exact_ip_rules_use_host_order_storage`
-- `firewall_exact_ip_remove_roundtrip_with_network_peer_addr`
-- `firewall_clear_rules_recovers_capacity`
-- `firewall_remove_ip_and_cidr_rules`
-- `firewall_remove_rejects_missing_or_invalid_rules`
-- `firewall_remove_cidr_u32_rejects_invalid_prefix`
-- `firewall_remove_allow_rules_updates_policy_mode`
-- `firewall_remove_last_allow_keeps_deny_active`
-- `firewall_remove_last_allow_cidr_keeps_deny_cidr_active`
-- `firewall_remove_deny_restores_allow_match`
-- `firewall_default_deny_requires_explicit_allow`
+    - `firewall_deny_rule_returns_403` - `firewall_allowlist_blocks_non_members` - `firewall_cidr_allow_and_deny_rules` - `firewall_string_ip_and_cidr_helpers` - `firewall_exact_ip_rules_use_host_order_storage` - `firewall_exact_ip_remove_roundtrip_with_network_peer_addr` - `firewall_clear_rules_recovers_capacity` - `firewall_remove_ip_and_cidr_rules` - `firewall_remove_rejects_missing_or_invalid_rules` - `firewall_remove_cidr_u32_rejects_invalid_prefix` - `firewall_remove_allow_rules_updates_policy_mode` - `firewall_remove_last_allow_keeps_deny_active` - `firewall_remove_last_allow_cidr_keeps_deny_cidr_active` - `firewall_remove_deny_restores_allow_match` - `firewall_default_deny_requires_explicit_allow` - `firewall_range_allow_and_deny_rules` - `firewall_range_string_and_network_order_helpers` - `firewall_range_rejects_invalid_inputs`
 
-Current integration coverage in `tests/test_integration.cc` includes:
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             Current
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             integration
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             coverage
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             in `tests
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             /
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             test_integration
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 .cc` includes
+    :
 
-- `firewall_deny_localhost_real_socket`
-- `firewall_deny_localhost_cidr_real_socket`
-- `firewall_deny_localhost_network_order_real_socket`
-- `firewall_allowlist_exact_localhost_real_socket`
-- `firewall_deny_exact_over_allow_exact_real_socket`
-- `firewall_deny_exact_over_allow_cidr_real_socket`
-- `firewall_deny_cidr_over_allow_exact_real_socket`
-- `firewall_allowlist_cidr_localhost_real_socket`
-- `firewall_allowlist_network_order_cidr_localhost_real_socket`
-- `firewall_clear_rules_reenables_localhost_real_socket`
-- `firewall_remove_deny_rule_reenables_localhost_real_socket`
-- `firewall_remove_deny_cidr_reenables_localhost_real_socket`
-- `firewall_remove_allow_rule_restores_default_allow_real_socket`
-- `firewall_remove_allow_cidr_restores_default_allow_real_socket`
-- `firewall_remove_deny_cidr_restores_allow_cidr_real_socket`
-- `firewall_remove_deny_ip_restores_allow_ip_real_socket`
-- `firewall_remove_last_allow_ip_keeps_deny_cidr_real_socket`
-- `firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket`
-- `firewall_default_deny_real_socket`
+    - `firewall_deny_localhost_real_socket` - `firewall_deny_localhost_cidr_real_socket` - `firewall_deny_localhost_network_order_real_socket` - `firewall_allowlist_exact_localhost_real_socket` - `firewall_deny_exact_over_allow_exact_real_socket` - `firewall_deny_exact_over_allow_cidr_real_socket` - `firewall_deny_cidr_over_allow_exact_real_socket` - `firewall_allowlist_cidr_localhost_real_socket` - `firewall_allowlist_network_order_cidr_localhost_real_socket` - `firewall_clear_rules_reenables_localhost_real_socket` - `firewall_remove_deny_rule_reenables_localhost_real_socket` - `firewall_remove_deny_cidr_reenables_localhost_real_socket` - `firewall_remove_allow_rule_restores_default_allow_real_socket` - `firewall_remove_allow_cidr_restores_default_allow_real_socket` - `firewall_remove_deny_cidr_restores_allow_cidr_real_socket` - `firewall_remove_deny_ip_restores_allow_ip_real_socket` - `firewall_remove_last_allow_ip_keeps_deny_cidr_real_socket` - `firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket` - `firewall_default_deny_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -1,4 +1,4 @@
-#Firewall(runtime RouteConfig)
+# Firewall (runtime RouteConfig)
 
 This document describes the firewall capability currently available in runtime
 configuration (`RouteConfig`), independent of DSL parsing.
@@ -91,8 +91,9 @@ For each request:
 
 1. Any deny IP match => reject
 2. Any deny CIDR match => reject
-3. If no allow rules exist => apply default policy (allow by default)
-4. Otherwise require allow IP or allow CIDR match
+3. Any deny range match => reject
+4. If no allow rules exist => apply default policy (allow by default)
+5. Otherwise require allow IP, allow CIDR, or allow range match
 
 In other words, deny rules always win over allow rules.
 
@@ -116,20 +117,49 @@ cfg.add_firewall_deny_cidr(0x0a010000, 16);  // 10.1.0.0/16
 cfg.add_firewall_allow_ip(0x7f000001);       // 127.0.0.1
 ```
 
-        ##Tests
+## Tests
 
-            Current coverage in `tests /
-        test_network.cc` (`route_coverage`)includes :
+Current coverage in `tests/test_network.cc` (`route_coverage`) includes:
 
-    - `firewall_deny_rule_returns_403` - `firewall_allowlist_blocks_non_members` - `firewall_cidr_allow_and_deny_rules` - `firewall_string_ip_and_cidr_helpers` - `firewall_exact_ip_rules_use_host_order_storage` - `firewall_exact_ip_remove_roundtrip_with_network_peer_addr` - `firewall_clear_rules_recovers_capacity` - `firewall_remove_ip_and_cidr_rules` - `firewall_remove_rejects_missing_or_invalid_rules` - `firewall_remove_cidr_u32_rejects_invalid_prefix` - `firewall_remove_allow_rules_updates_policy_mode` - `firewall_remove_last_allow_keeps_deny_active` - `firewall_remove_last_allow_cidr_keeps_deny_cidr_active` - `firewall_remove_deny_restores_allow_match` - `firewall_default_deny_requires_explicit_allow` - `firewall_range_allow_and_deny_rules` - `firewall_range_string_and_network_order_helpers` - `firewall_range_rejects_invalid_inputs`
+- `firewall_deny_rule_returns_403`
+- `firewall_allowlist_blocks_non_members`
+- `firewall_cidr_allow_and_deny_rules`
+- `firewall_string_ip_and_cidr_helpers`
+- `firewall_exact_ip_rules_use_host_order_storage`
+- `firewall_exact_ip_remove_roundtrip_with_network_peer_addr`
+- `firewall_clear_rules_recovers_capacity`
+- `firewall_remove_ip_and_cidr_rules`
+- `firewall_remove_rejects_missing_or_invalid_rules`
+- `firewall_remove_cidr_u32_rejects_invalid_prefix`
+- `firewall_remove_allow_rules_updates_policy_mode`
+- `firewall_remove_last_allow_keeps_deny_active`
+- `firewall_remove_last_allow_cidr_keeps_deny_cidr_active`
+- `firewall_remove_deny_restores_allow_match`
+- `firewall_default_deny_requires_explicit_allow`
+- `firewall_range_allow_and_deny_rules`
+- `firewall_range_string_and_network_order_helpers`
+- `firewall_range_rejects_invalid_inputs`
 
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             Current
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             integration
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             coverage
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             in `tests
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             /
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             test_integration
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 .cc` includes
-    :
+Current integration coverage in `tests/test_integration.cc` includes:
 
-    - `firewall_deny_localhost_real_socket` - `firewall_deny_localhost_cidr_real_socket` - `firewall_deny_localhost_network_order_real_socket` - `firewall_allowlist_exact_localhost_real_socket` - `firewall_deny_exact_over_allow_exact_real_socket` - `firewall_deny_exact_over_allow_cidr_real_socket` - `firewall_deny_cidr_over_allow_exact_real_socket` - `firewall_allowlist_cidr_localhost_real_socket` - `firewall_allowlist_network_order_cidr_localhost_real_socket` - `firewall_clear_rules_reenables_localhost_real_socket` - `firewall_remove_deny_rule_reenables_localhost_real_socket` - `firewall_remove_deny_cidr_reenables_localhost_real_socket` - `firewall_remove_allow_rule_restores_default_allow_real_socket` - `firewall_remove_allow_cidr_restores_default_allow_real_socket` - `firewall_remove_deny_cidr_restores_allow_cidr_real_socket` - `firewall_remove_deny_ip_restores_allow_ip_real_socket` - `firewall_remove_last_allow_ip_keeps_deny_cidr_real_socket` - `firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket` - `firewall_default_deny_real_socket`
+- `firewall_deny_localhost_real_socket`
+- `firewall_deny_localhost_cidr_real_socket`
+- `firewall_deny_localhost_network_order_real_socket`
+- `firewall_allowlist_exact_localhost_real_socket`
+- `firewall_deny_exact_over_allow_exact_real_socket`
+- `firewall_deny_exact_over_allow_cidr_real_socket`
+- `firewall_deny_cidr_over_allow_exact_real_socket`
+- `firewall_allowlist_cidr_localhost_real_socket`
+- `firewall_allowlist_network_order_cidr_localhost_real_socket`
+- `firewall_clear_rules_reenables_localhost_real_socket`
+- `firewall_remove_deny_rule_reenables_localhost_real_socket`
+- `firewall_remove_deny_cidr_reenables_localhost_real_socket`
+- `firewall_remove_allow_rule_restores_default_allow_real_socket`
+- `firewall_remove_allow_cidr_restores_default_allow_real_socket`
+- `firewall_remove_deny_cidr_restores_allow_cidr_real_socket`
+- `firewall_remove_deny_ip_restores_allow_ip_real_socket`
+- `firewall_remove_last_allow_ip_keeps_deny_cidr_real_socket`
+- `firewall_remove_last_allow_cidr_keeps_deny_ip_real_socket`
+- `firewall_default_deny_real_socket`
+- `firewall_deny_localhost_range_real_socket`
+- `firewall_allowlist_range_localhost_real_socket`

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -198,12 +198,20 @@ struct RouteConfig {
         u32 net_addr;
         u32 mask;
     };
+    struct FirewallRangeRule {
+        u32 start_ip;
+        u32 end_ip;
+    };
     FirewallCidrRule firewall_allow_cidrs[kMaxFirewallRules]{};
     FirewallCidrRule firewall_deny_cidrs[kMaxFirewallRules]{};
+    FirewallRangeRule firewall_allow_ranges[kMaxFirewallRules]{};
+    FirewallRangeRule firewall_deny_ranges[kMaxFirewallRules]{};
     u32 firewall_allow_count = 0;
     u32 firewall_deny_count = 0;
     u32 firewall_allow_cidr_count = 0;
     u32 firewall_deny_cidr_count = 0;
+    u32 firewall_allow_range_count = 0;
+    u32 firewall_deny_range_count = 0;
     bool firewall_default_allow = true;
 
     // Reject route paths that aren't in origin-form. Required by the
@@ -625,6 +633,58 @@ struct RouteConfig {
     bool add_firewall_allow_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
         return add_firewall_allow_cidr(ntohl(ip_network_order), prefix_len);
     }
+    bool add_firewall_allow_range(u32 start_ip, u32 end_ip) {
+        if (start_ip > end_ip) return false;
+        for (u32 i = 0; i < firewall_allow_range_count; i++) {
+            const auto& r = firewall_allow_ranges[i];
+            if (r.start_ip == start_ip && r.end_ip == end_ip) return true;
+        }
+        if (firewall_allow_range_count >= kMaxFirewallRules) return false;
+        firewall_allow_ranges[firewall_allow_range_count++] = {start_ip, end_ip};
+        return true;
+    }
+    bool add_firewall_allow_range(Str range_lit) {
+        u32 start_ip = 0;
+        u32 end_ip = 0;
+        if (!parse_ipv4_range(range_lit, start_ip, end_ip)) return false;
+        return add_firewall_allow_range(start_ip, end_ip);
+    }
+    bool add_firewall_allow_range(const char* range_lit) {
+        if (!range_lit) return false;
+        return add_firewall_allow_range(cstr_as_str(range_lit));
+    }
+    bool add_firewall_allow_range_network_order(u32 start_ip_network_order,
+                                                u32 end_ip_network_order) {
+        return add_firewall_allow_range(ntohl(start_ip_network_order), ntohl(end_ip_network_order));
+    }
+    bool remove_firewall_allow_range(u32 start_ip, u32 end_ip) {
+        if (start_ip > end_ip) return false;
+        for (u32 i = 0; i < firewall_allow_range_count; i++) {
+            const auto& r = firewall_allow_ranges[i];
+            if (r.start_ip != start_ip || r.end_ip != end_ip) continue;
+            for (u32 j = i + 1; j < firewall_allow_range_count; j++)
+                firewall_allow_ranges[j - 1] = firewall_allow_ranges[j];
+            firewall_allow_ranges[firewall_allow_range_count - 1] = {0, 0};
+            firewall_allow_range_count--;
+            return true;
+        }
+        return false;
+    }
+    bool remove_firewall_allow_range(Str range_lit) {
+        u32 start_ip = 0;
+        u32 end_ip = 0;
+        if (!parse_ipv4_range(range_lit, start_ip, end_ip)) return false;
+        return remove_firewall_allow_range(start_ip, end_ip);
+    }
+    bool remove_firewall_allow_range(const char* range_lit) {
+        if (!range_lit) return false;
+        return remove_firewall_allow_range(cstr_as_str(range_lit));
+    }
+    bool remove_firewall_allow_range_network_order(u32 start_ip_network_order,
+                                                   u32 end_ip_network_order) {
+        return remove_firewall_allow_range(ntohl(start_ip_network_order),
+                                           ntohl(end_ip_network_order));
+    }
     bool remove_firewall_allow_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
         const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
@@ -678,6 +738,58 @@ struct RouteConfig {
     bool add_firewall_deny_cidr_network_order(u32 ip_network_order, u8 prefix_len) {
         return add_firewall_deny_cidr(ntohl(ip_network_order), prefix_len);
     }
+    bool add_firewall_deny_range(u32 start_ip, u32 end_ip) {
+        if (start_ip > end_ip) return false;
+        for (u32 i = 0; i < firewall_deny_range_count; i++) {
+            const auto& r = firewall_deny_ranges[i];
+            if (r.start_ip == start_ip && r.end_ip == end_ip) return true;
+        }
+        if (firewall_deny_range_count >= kMaxFirewallRules) return false;
+        firewall_deny_ranges[firewall_deny_range_count++] = {start_ip, end_ip};
+        return true;
+    }
+    bool add_firewall_deny_range(Str range_lit) {
+        u32 start_ip = 0;
+        u32 end_ip = 0;
+        if (!parse_ipv4_range(range_lit, start_ip, end_ip)) return false;
+        return add_firewall_deny_range(start_ip, end_ip);
+    }
+    bool add_firewall_deny_range(const char* range_lit) {
+        if (!range_lit) return false;
+        return add_firewall_deny_range(cstr_as_str(range_lit));
+    }
+    bool add_firewall_deny_range_network_order(u32 start_ip_network_order,
+                                               u32 end_ip_network_order) {
+        return add_firewall_deny_range(ntohl(start_ip_network_order), ntohl(end_ip_network_order));
+    }
+    bool remove_firewall_deny_range(u32 start_ip, u32 end_ip) {
+        if (start_ip > end_ip) return false;
+        for (u32 i = 0; i < firewall_deny_range_count; i++) {
+            const auto& r = firewall_deny_ranges[i];
+            if (r.start_ip != start_ip || r.end_ip != end_ip) continue;
+            for (u32 j = i + 1; j < firewall_deny_range_count; j++)
+                firewall_deny_ranges[j - 1] = firewall_deny_ranges[j];
+            firewall_deny_ranges[firewall_deny_range_count - 1] = {0, 0};
+            firewall_deny_range_count--;
+            return true;
+        }
+        return false;
+    }
+    bool remove_firewall_deny_range(Str range_lit) {
+        u32 start_ip = 0;
+        u32 end_ip = 0;
+        if (!parse_ipv4_range(range_lit, start_ip, end_ip)) return false;
+        return remove_firewall_deny_range(start_ip, end_ip);
+    }
+    bool remove_firewall_deny_range(const char* range_lit) {
+        if (!range_lit) return false;
+        return remove_firewall_deny_range(cstr_as_str(range_lit));
+    }
+    bool remove_firewall_deny_range_network_order(u32 start_ip_network_order,
+                                                  u32 end_ip_network_order) {
+        return remove_firewall_deny_range(ntohl(start_ip_network_order),
+                                          ntohl(end_ip_network_order));
+    }
     bool remove_firewall_deny_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
         const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
@@ -709,14 +821,18 @@ struct RouteConfig {
     void clear_firewall_allow_rules() {
         for (u32 i = 0; i < firewall_allow_count; i++) firewall_allow_ips[i] = 0;
         for (u32 i = 0; i < firewall_allow_cidr_count; i++) firewall_allow_cidrs[i] = {0, 0};
+        for (u32 i = 0; i < firewall_allow_range_count; i++) firewall_allow_ranges[i] = {0, 0};
         firewall_allow_count = 0;
         firewall_allow_cidr_count = 0;
+        firewall_allow_range_count = 0;
     }
     void clear_firewall_deny_rules() {
         for (u32 i = 0; i < firewall_deny_count; i++) firewall_deny_ips[i] = 0;
         for (u32 i = 0; i < firewall_deny_cidr_count; i++) firewall_deny_cidrs[i] = {0, 0};
+        for (u32 i = 0; i < firewall_deny_range_count; i++) firewall_deny_ranges[i] = {0, 0};
         firewall_deny_count = 0;
         firewall_deny_cidr_count = 0;
+        firewall_deny_range_count = 0;
     }
     void clear_firewall_rules() {
         clear_firewall_allow_rules();
@@ -738,7 +854,12 @@ struct RouteConfig {
             const auto& r = firewall_deny_cidrs[i];
             if ((peer_host & r.mask) == r.net_addr) return false;
         }
-        if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0)
+        for (u32 i = 0; i < firewall_deny_range_count; i++) {
+            const auto& r = firewall_deny_ranges[i];
+            if (peer_host >= r.start_ip && peer_host <= r.end_ip) return false;
+        }
+        if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0 &&
+            firewall_allow_range_count == 0)
             return firewall_default_allow;
         for (u32 i = 0; i < firewall_allow_count; i++) {
             if (firewall_allow_ips[i] == peer_host) return true;
@@ -746,6 +867,10 @@ struct RouteConfig {
         for (u32 i = 0; i < firewall_allow_cidr_count; i++) {
             const auto& r = firewall_allow_cidrs[i];
             if ((peer_host & r.mask) == r.net_addr) return true;
+        }
+        for (u32 i = 0; i < firewall_allow_range_count; i++) {
+            const auto& r = firewall_allow_ranges[i];
+            if (peer_host >= r.start_ip && peer_host <= r.end_ip) return true;
         }
         return false;
     }
@@ -804,6 +929,20 @@ private:
         }
         out_prefix_len = static_cast<u8>(prefix);
         return true;
+    }
+    static bool parse_ipv4_range(Str s, u32& out_start_ip, u32& out_end_ip) {
+        u32 dash_idx = 0xffffffffu;
+        for (u32 i = 0; i < s.len; i++) {
+            if (s.ptr[i] == '-') {
+                if (dash_idx != 0xffffffffu) return false;
+                dash_idx = i;
+            }
+        }
+        if (dash_idx == 0xffffffffu || dash_idx == 0 || dash_idx + 1 >= s.len) return false;
+        if (!parse_ipv4_dotted({s.ptr, dash_idx}, out_start_ip)) return false;
+        if (!parse_ipv4_dotted({s.ptr + dash_idx + 1, s.len - dash_idx - 1}, out_end_ip))
+            return false;
+        return out_start_ip <= out_end_ip;
     }
 
 public:

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2518,6 +2518,73 @@ TEST(route, firewall_allowlist_network_order_cidr_localhost_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_deny_localhost_range_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_deny_range(0x7f000001, 0x7f000001));  // 127.0.0.1-127.0.0.1
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 403 Forbidden", 22));
+    CHECK(buf_contains(buf, len, "Connection: close", 17));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(route, firewall_allowlist_range_localhost_real_socket) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_range(0x7f000001, 0x7f000001));  // 127.0.0.1-127.0.0.1
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to(port);
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    const u32 len = static_cast<u32>(n);
+    CHECK(buf_contains(buf, len, "HTTP/1.1 200 OK", 15));
+
+    close(c);
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, firewall_clear_rules_reenables_localhost_real_socket) {
     RouteConfig cfg;
     REQUIRE(cfg.add_static("/health", 0, 200));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11515,6 +11515,44 @@ TEST(route_coverage, firewall_clear_deny_rules_keeps_allow_mode) {
     CHECK(!cfg.firewall_allows_peer_host(0x0a010203));
 }
 
+TEST(route_coverage, firewall_range_allow_and_deny_rules) {
+    RouteConfig cfg;
+    // allow 10.0.0.10 - 10.0.0.20
+    REQUIRE(cfg.add_firewall_allow_range(0x0a00000a, 0x0a000014));
+    // deny 10.0.0.15 - 10.0.0.17
+    REQUIRE(cfg.add_firewall_deny_range(0x0a00000f, 0x0a000011));
+
+    CHECK(!cfg.firewall_allows_peer_host(0x0a000009));  // outside allow range
+    CHECK(cfg.firewall_allows_peer_host(0x0a00000a));   // allow range start
+    CHECK(cfg.firewall_allows_peer_host(0x0a000014));   // allow range end
+    CHECK(!cfg.firewall_allows_peer_host(0x0a000010));  // denied sub-range
+}
+
+TEST(route_coverage, firewall_range_string_and_network_order_helpers) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_range("10.0.0.1-10.0.0.3"));
+    REQUIRE(cfg.add_firewall_deny_range_network_order(htonl(0x0a000002), htonl(0x0a000002)));
+
+    CHECK(cfg.firewall_allows_peer_host(0x0a000001));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a000002));
+    CHECK(cfg.firewall_allows_peer_host(0x0a000003));
+    CHECK(!cfg.firewall_allows_peer_host(0x0a000004));
+
+    REQUIRE(cfg.remove_firewall_allow_range("10.0.0.1-10.0.0.3"));
+    REQUIRE(cfg.remove_firewall_deny_range_network_order(htonl(0x0a000002), htonl(0x0a000002)));
+}
+
+TEST(route_coverage, firewall_range_rejects_invalid_inputs) {
+    RouteConfig cfg;
+    CHECK(!cfg.add_firewall_allow_range(0x0a000010, 0x0a00000f));  // start > end
+    CHECK(!cfg.add_firewall_allow_range("10.0.0.2-10.0.0.1"));
+    CHECK(!cfg.add_firewall_allow_range("10.0.0.1"));
+    CHECK(!cfg.add_firewall_allow_range("10.0.0.1-"));
+    CHECK(!cfg.add_firewall_allow_range("-10.0.0.2"));
+    CHECK(!cfg.add_firewall_allow_range("10.0.0.1-10.0.0.256"));
+    CHECK(!cfg.add_firewall_deny_range(nullptr));
+}
+
 // === AsyncSmallLoop coverage ===
 // These exercise callbacks.h template instantiations for AsyncSmallLoop,
 // covering the proxy body streaming paths that inflate uncovered line


### PR DESCRIPTION
## Summary
- add IPv4 inclusive range rules for firewall allow/deny tables
- add host-order, network-order, and string range helpers for add/remove
- include range matching in policy evaluation while preserving deny precedence
- extend clear helpers to wipe range tables
- document range APIs and behavior in docs/firewall.md
- add route_coverage tests for range allow/deny, helper roundtrip, and invalid input rejection

## Validation
- ./build/tests/test_network --filter=route_coverage.firewall_*