### PR TITLE
runtime: firewall add source-port allow/deny rules

### DIFF
--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -11,9 +11,11 @@ connections.
 - Exact IP rules
 - CIDR subnet rules
 - Inclusive IP range rules
+- Source port rules
 - Allowlist + denylist precedence
 
-Rules are evaluated from `Connection.peer_addr` captured at accept-time.
+Rules are evaluated from `Connection.peer_addr` and `Connection.peer_port`
+captured at accept-time.
 For host-order callers, `firewall_allows_peer_host(u32)` is also available.
 
 ## APIs
@@ -26,12 +28,16 @@ Defined on `RouteConfig`:
 - `add_firewall_deny_cidr(u32 ip_host_order, u8 prefix_len)`
 - `add_firewall_allow_range(u32 start_ip_host_order, u32 end_ip_host_order)`
 - `add_firewall_deny_range(u32 start_ip_host_order, u32 end_ip_host_order)`
+- `add_firewall_allow_port(u16 peer_port_host_order)`
+- `add_firewall_deny_port(u16 peer_port_host_order)`
 - `remove_firewall_allow_ip(u32 ip_host_order)`
 - `remove_firewall_deny_ip(u32 ip_host_order)`
 - `remove_firewall_allow_cidr(u32 ip_host_order, u8 prefix_len)`
 - `remove_firewall_deny_cidr(u32 ip_host_order, u8 prefix_len)`
 - `remove_firewall_allow_range(u32 start_ip_host_order, u32 end_ip_host_order)`
 - `remove_firewall_deny_range(u32 start_ip_host_order, u32 end_ip_host_order)`
+- `remove_firewall_allow_port(u16 peer_port_host_order)`
+- `remove_firewall_deny_port(u16 peer_port_host_order)`
 - `add_firewall_allow_ip_network_order(u32 ip_network_order)`
 - `add_firewall_deny_ip_network_order(u32 ip_network_order)`
 - `add_firewall_allow_cidr_network_order(u32 ip_network_order, u8 prefix_len)`
@@ -78,10 +84,11 @@ Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
 return `false` on cap overflow or invalid CIDR prefix.
 Adding the same exact IP or same CIDR repeatedly is idempotent (returns `true`
 without consuming additional rule slots).
+Port rules reject `0` (invalid TCP/UDP port).
 Remove APIs return `true` only when a matching rule exists and is deleted.
-`clear_firewall_allow_rules()` clears allow exact-IP, CIDR, and range tables.
-`clear_firewall_deny_rules()` clears deny exact-IP, CIDR, and range tables.
-`clear_firewall_rules()` clears all allow/deny exact, CIDR, and range rules.
+`clear_firewall_allow_rules()` clears allow exact-IP, CIDR, range, and port tables.
+`clear_firewall_deny_rules()` clears deny exact-IP, CIDR, range, and port tables.
+`clear_firewall_rules()` clears all allow/deny exact, CIDR, range, and port rules.
 Default policy is allow unless changed via `set_firewall_default_allow(false)`
 or `set_firewall_default_deny()`.
 
@@ -92,10 +99,14 @@ For each request:
 1. Any deny IP match => reject
 2. Any deny CIDR match => reject
 3. Any deny range match => reject
-4. If no allow rules exist => apply default policy (allow by default)
-5. Otherwise require allow IP, allow CIDR, or allow range match
+4. Any deny port match => reject
+5. If no allow rules exist => apply default policy (allow by default)
+6. Otherwise require allow IP, allow CIDR, allow range, or allow port match
 
 In other words, deny rules always win over allow rules.
+Allow-match semantics are OR across categories: if any allow IP, allow CIDR,
+allow range, or allow port rule matches, the request is allowed (unless denied
+earlier).
 
 ## Runtime behavior on reject
 

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -134,6 +134,7 @@ Current coverage in `tests/test_network.cc` (`route_coverage`) includes:
 
 - `firewall_deny_rule_returns_403`
 - `firewall_allowlist_blocks_non_members`
+- `firewall_port_rejects_in_request_path`
 - `firewall_cidr_allow_and_deny_rules`
 - `firewall_string_ip_and_cidr_helpers`
 - `firewall_exact_ip_rules_use_host_order_storage`
@@ -146,6 +147,8 @@ Current coverage in `tests/test_network.cc` (`route_coverage`) includes:
 - `firewall_remove_last_allow_keeps_deny_active`
 - `firewall_remove_last_allow_cidr_keeps_deny_cidr_active`
 - `firewall_remove_deny_restores_allow_match`
+- `firewall_port_allow_and_deny_rules`
+- `firewall_port_rule_remove_and_clear`
 - `firewall_default_deny_requires_explicit_allow`
 - `firewall_range_allow_and_deny_rules`
 - `firewall_range_string_and_network_order_helpers`
@@ -162,6 +165,8 @@ Current integration coverage in `tests/test_integration.cc` includes:
 - `firewall_deny_cidr_over_allow_exact_real_socket`
 - `firewall_allowlist_cidr_localhost_real_socket`
 - `firewall_allowlist_network_order_cidr_localhost_real_socket`
+- `firewall_deny_localhost_source_port_real_socket`
+- `firewall_allowlist_source_port_real_socket`
 - `firewall_clear_rules_reenables_localhost_real_socket`
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`
 - `firewall_remove_deny_cidr_reenables_localhost_real_socket`

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -225,7 +225,7 @@ void on_header_received(void* lp, Connection& conn, IoEvent ev) {
     // different upstream table.
     const RouteConfig* config = loop->config_ptr ? *loop->config_ptr : nullptr;
     conn.request_config = config;
-    if (config && !config->firewall_allows_peer(conn.peer_addr)) {
+    if (config && !config->firewall_allows_peer(conn.peer_addr, conn.peer_port)) {
         conn.state = ConnState::Sending;
         conn.resp_status = 403;
         format_static_response(conn, 403, /*keep_alive=*/false);

--- a/include/rut/runtime/connection_base.h
+++ b/include/rut/runtime/connection_base.h
@@ -182,6 +182,7 @@ struct ConnectionBase {
     u8 req_method;
     u32 req_size;
     u32 peer_addr;
+    u16 peer_port;
     char req_path[kMaxReqPathLen];
     // View into req_path covering the canonical-for-routing path slice
     // (leading '/' stripped, trailing '/' run trimmed, bytes after first
@@ -290,6 +291,7 @@ struct ConnectionBase {
         req_method = 0;
         req_size = 0;
         peer_addr = 0;
+        peer_port = 0;
         req_path[0] = '\0';
         req_path_canon = {nullptr, 0};
         upstream_us = 0;

--- a/include/rut/runtime/epoll_event_loop.h
+++ b/include/rut/runtime/epoll_event_loop.h
@@ -615,6 +615,7 @@ private:
         if (::getpeername(c->fd, reinterpret_cast<struct sockaddr*>(&peer), &peer_len) == 0 &&
             peer.sin_family == AF_INET) {
             c->peer_addr = peer.sin_addr.s_addr;
+            c->peer_port = ntohs(peer.sin_port);
         }
         if (tls_server) {
             auto tls_result = create_tls_server_ssl(tls_server, c->fd);

--- a/include/rut/runtime/event_loop.h
+++ b/include/rut/runtime/event_loop.h
@@ -158,6 +158,7 @@ public:
     static constexpr u32 kMaxDeferredAccepts = 64;
     i32 deferred_accepts[kMaxDeferredAccepts];
     u32 deferred_accept_addrs[kMaxDeferredAccepts];
+    u16 deferred_accept_ports[kMaxDeferredAccepts];
     u32 deferred_accept_count;
 
     u32 keepalive_timeout = kDefaultKeepaliveTimeout;
@@ -676,11 +677,13 @@ private:
         if (ev.result < 0) return;
         i32 fd = ev.result;
         u32 peer_addr = 0;
+        u16 peer_port = 0;
         struct sockaddr_in peer = {};
         socklen_t peer_len = sizeof(peer);
         if (::getpeername(fd, reinterpret_cast<struct sockaddr*>(&peer), &peer_len) == 0 &&
             peer.sin_family == AF_INET) {
             peer_addr = peer.sin_addr.s_addr;
+            peer_port = ntohs(peer.sin_port);
         }
         Connection* c = this->alloc_conn();
         if (!c) {
@@ -694,6 +697,7 @@ private:
                     if (deferred_accept_count < kMaxDeferredAccepts) {
                         deferred_accepts[deferred_accept_count] = fd;
                         deferred_accept_addrs[deferred_accept_count] = peer_addr;
+                        deferred_accept_ports[deferred_accept_count] = peer_port;
                         deferred_accept_count++;
                     } else {
                         ::close(fd);
@@ -707,6 +711,7 @@ private:
         }
         c->fd = fd;
         c->peer_addr = peer_addr;
+        c->peer_port = peer_port;
         if (tls_server) {
             auto tls_result = create_tls_server_ssl(tls_server, fd);
             if (!tls_result) {
@@ -740,6 +745,7 @@ private:
             }
             c->fd = fd;
             c->peer_addr = deferred_accept_addrs[i];
+            c->peer_port = deferred_accept_ports[i];
             if (tls_server) {
                 auto tls_result = create_tls_server_ssl(tls_server, fd);
                 if (!tls_result) {

--- a/include/rut/runtime/iouring_event_loop.h
+++ b/include/rut/runtime/iouring_event_loop.h
@@ -645,6 +645,7 @@ private:
         if (::getpeername(c->fd, reinterpret_cast<struct sockaddr*>(&peer), &peer_len) == 0 &&
             peer.sin_family == AF_INET) {
             c->peer_addr = peer.sin_addr.s_addr;
+            c->peer_port = ntohs(peer.sin_port);
         }
         c->state = ConnState::ReadingHeader;
         c->keep_alive = !draining_.load(std::memory_order_relaxed);
@@ -668,6 +669,7 @@ private:
             if (::getpeername(c->fd, reinterpret_cast<struct sockaddr*>(&peer), &peer_len) == 0 &&
                 peer.sin_family == AF_INET) {
                 c->peer_addr = peer.sin_addr.s_addr;
+                c->peer_port = ntohs(peer.sin_port);
             }
             c->state = ConnState::ReadingHeader;
             c->keep_alive = !draining_.load(std::memory_order_relaxed);

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -939,8 +939,7 @@ struct RouteConfig {
             if (firewall_deny_ports[i] == peer_port) return false;
         }
         if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0 &&
-            firewall_allow_range_count == 0 &&
-            firewall_allow_port_count == 0)
+            firewall_allow_range_count == 0 && firewall_allow_port_count == 0)
             return firewall_default_allow;
         for (u32 i = 0; i < firewall_allow_count; i++) {
             if (firewall_allow_ips[i] == peer_host) return true;

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -194,6 +194,8 @@ struct RouteConfig {
     //   3) default allow
     u32 firewall_allow_ips[kMaxFirewallRules]{};
     u32 firewall_deny_ips[kMaxFirewallRules]{};
+    u16 firewall_allow_ports[kMaxFirewallRules]{};
+    u16 firewall_deny_ports[kMaxFirewallRules]{};
     struct FirewallCidrRule {
         u32 net_addr;
         u32 mask;
@@ -212,6 +214,8 @@ struct RouteConfig {
     u32 firewall_deny_cidr_count = 0;
     u32 firewall_allow_range_count = 0;
     u32 firewall_deny_range_count = 0;
+    u32 firewall_allow_port_count = 0;
+    u32 firewall_deny_port_count = 0;
     bool firewall_default_allow = true;
 
     // Reject route paths that aren't in origin-form. Required by the
@@ -608,6 +612,46 @@ struct RouteConfig {
     bool remove_firewall_deny_ip_network_order(u32 ip_network_order) {
         return remove_firewall_deny_ip(ntohl(ip_network_order));
     }
+    bool add_firewall_allow_port(u16 port) {
+        if (port == 0) return false;
+        for (u32 i = 0; i < firewall_allow_port_count; i++) {
+            if (firewall_allow_ports[i] == port) return true;
+        }
+        if (firewall_allow_port_count >= kMaxFirewallRules) return false;
+        firewall_allow_ports[firewall_allow_port_count++] = port;
+        return true;
+    }
+    bool remove_firewall_allow_port(u16 port) {
+        for (u32 i = 0; i < firewall_allow_port_count; i++) {
+            if (firewall_allow_ports[i] != port) continue;
+            for (u32 j = i + 1; j < firewall_allow_port_count; j++)
+                firewall_allow_ports[j - 1] = firewall_allow_ports[j];
+            firewall_allow_ports[firewall_allow_port_count - 1] = 0;
+            firewall_allow_port_count--;
+            return true;
+        }
+        return false;
+    }
+    bool add_firewall_deny_port(u16 port) {
+        if (port == 0) return false;
+        for (u32 i = 0; i < firewall_deny_port_count; i++) {
+            if (firewall_deny_ports[i] == port) return true;
+        }
+        if (firewall_deny_port_count >= kMaxFirewallRules) return false;
+        firewall_deny_ports[firewall_deny_port_count++] = port;
+        return true;
+    }
+    bool remove_firewall_deny_port(u16 port) {
+        for (u32 i = 0; i < firewall_deny_port_count; i++) {
+            if (firewall_deny_ports[i] != port) continue;
+            for (u32 j = i + 1; j < firewall_deny_port_count; j++)
+                firewall_deny_ports[j - 1] = firewall_deny_ports[j];
+            firewall_deny_ports[firewall_deny_port_count - 1] = 0;
+            firewall_deny_port_count--;
+            return true;
+        }
+        return false;
+    }
     bool add_firewall_allow_cidr(u32 ip, u8 prefix_len) {
         if (prefix_len > 32) return false;
         const u32 mask = prefix_len == 0 ? 0u : (0xffffffffu << (32u - prefix_len));
@@ -822,17 +866,21 @@ struct RouteConfig {
         for (u32 i = 0; i < firewall_allow_count; i++) firewall_allow_ips[i] = 0;
         for (u32 i = 0; i < firewall_allow_cidr_count; i++) firewall_allow_cidrs[i] = {0, 0};
         for (u32 i = 0; i < firewall_allow_range_count; i++) firewall_allow_ranges[i] = {0, 0};
+        for (u32 i = 0; i < firewall_allow_port_count; i++) firewall_allow_ports[i] = 0;
         firewall_allow_count = 0;
         firewall_allow_cidr_count = 0;
         firewall_allow_range_count = 0;
+        firewall_allow_port_count = 0;
     }
     void clear_firewall_deny_rules() {
         for (u32 i = 0; i < firewall_deny_count; i++) firewall_deny_ips[i] = 0;
         for (u32 i = 0; i < firewall_deny_cidr_count; i++) firewall_deny_cidrs[i] = {0, 0};
         for (u32 i = 0; i < firewall_deny_range_count; i++) firewall_deny_ranges[i] = {0, 0};
+        for (u32 i = 0; i < firewall_deny_port_count; i++) firewall_deny_ports[i] = 0;
         firewall_deny_count = 0;
         firewall_deny_cidr_count = 0;
         firewall_deny_range_count = 0;
+        firewall_deny_port_count = 0;
     }
     void clear_firewall_rules() {
         clear_firewall_allow_rules();
@@ -874,9 +922,48 @@ struct RouteConfig {
         }
         return false;
     }
+    bool firewall_allows_peer(u32 peer_addr, u16 peer_port) const {
+        const u32 peer_host = ntohl(peer_addr);
+        for (u32 i = 0; i < firewall_deny_count; i++) {
+            if (firewall_deny_ips[i] == peer_host) return false;
+        }
+        for (u32 i = 0; i < firewall_deny_cidr_count; i++) {
+            const auto& r = firewall_deny_cidrs[i];
+            if ((peer_host & r.mask) == r.net_addr) return false;
+        }
+        for (u32 i = 0; i < firewall_deny_range_count; i++) {
+            const auto& r = firewall_deny_ranges[i];
+            if (peer_host >= r.start_ip && peer_host <= r.end_ip) return false;
+        }
+        for (u32 i = 0; i < firewall_deny_port_count; i++) {
+            if (firewall_deny_ports[i] == peer_port) return false;
+        }
+        if (firewall_allow_count == 0 && firewall_allow_cidr_count == 0 &&
+            firewall_allow_range_count == 0 &&
+            firewall_allow_port_count == 0)
+            return firewall_default_allow;
+        for (u32 i = 0; i < firewall_allow_count; i++) {
+            if (firewall_allow_ips[i] == peer_host) return true;
+        }
+        for (u32 i = 0; i < firewall_allow_cidr_count; i++) {
+            const auto& r = firewall_allow_cidrs[i];
+            if ((peer_host & r.mask) == r.net_addr) return true;
+        }
+        for (u32 i = 0; i < firewall_allow_range_count; i++) {
+            const auto& r = firewall_allow_ranges[i];
+            if (peer_host >= r.start_ip && peer_host <= r.end_ip) return true;
+        }
+        for (u32 i = 0; i < firewall_allow_port_count; i++) {
+            if (firewall_allow_ports[i] == peer_port) return true;
+        }
+        return false;
+    }
     // Convenience overload for host-order IPv4 callers.
     bool firewall_allows_peer_host(u32 peer_host_addr) const {
         return firewall_allows_peer(htonl(peer_host_addr));
+    }
+    bool firewall_allows_peer_host(u32 peer_host_addr, u16 peer_port) const {
+        return firewall_allows_peer(htonl(peer_host_addr), peer_port);
     }
 
 private:

--- a/src/sim/simulate_engine.cc
+++ b/src/sim/simulate_engine.cc
@@ -759,6 +759,7 @@ static void copy_sim_connection_state(Connection& dst, const Connection& src) {
     dst.req_method = src.req_method;
     dst.req_size = src.req_size;
     dst.peer_addr = src.peer_addr;
+    dst.peer_port = src.peer_port;
     copy_char_array(dst.req_path, src.req_path);
     dst.req_path_canon = copy_req_path_canon(src, dst);
     dst.upstream_us = src.upstream_us;

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -948,6 +948,32 @@ inline i32 connect_to(u16 port) {
     return fd;
 }
 
+inline i32 connect_to_from_port(u16 server_port, u16 client_port) {
+    i32 fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) return -1;
+
+    struct sockaddr_in local_addr;
+    memset(&local_addr, 0, sizeof(local_addr));
+    local_addr.sin_family = AF_INET;
+    local_addr.sin_port = __builtin_bswap16(client_port);
+    local_addr.sin_addr.s_addr = __builtin_bswap32(0x7F000001);
+    if (bind(fd, reinterpret_cast<struct sockaddr*>(&local_addr), sizeof(local_addr)) < 0) {
+        close(fd);
+        return -1;
+    }
+
+    struct sockaddr_in remote_addr;
+    memset(&remote_addr, 0, sizeof(remote_addr));
+    remote_addr.sin_family = AF_INET;
+    remote_addr.sin_port = __builtin_bswap16(server_port);
+    remote_addr.sin_addr.s_addr = __builtin_bswap32(0x7F000001);
+    if (connect(fd, reinterpret_cast<struct sockaddr*>(&remote_addr), sizeof(remote_addr)) < 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
 inline bool send_all(i32 fd, const char* d, u32 len) {
     u32 sent = 0;
     while (sent < len) {

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -974,6 +974,28 @@ inline i32 connect_to_from_port(u16 server_port, u16 client_port) {
     return fd;
 }
 
+inline i32 reserve_local_port() {
+    i32 fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) return -1;
+    struct sockaddr_in a;
+    memset(&a, 0, sizeof(a));
+    a.sin_family = AF_INET;
+    a.sin_port = 0;  // kernel-assigned ephemeral port
+    a.sin_addr.s_addr = __builtin_bswap32(0x7F000001);
+    if (bind(fd, reinterpret_cast<struct sockaddr*>(&a), sizeof(a)) < 0) {
+        close(fd);
+        return -1;
+    }
+    socklen_t l = sizeof(a);
+    if (getsockname(fd, reinterpret_cast<struct sockaddr*>(&a), &l) < 0) {
+        close(fd);
+        return -1;
+    }
+    const i32 port = static_cast<i32>(__builtin_bswap16(a.sin_port));
+    close(fd);
+    return port;
+}
+
 inline bool send_all(i32 fd, const char* d, u32 len) {
     u32 sent = 0;
     while (sent < len) {

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -2585,6 +2585,91 @@ TEST(route, firewall_allowlist_range_localhost_real_socket) {
     destroy_real_loop(loop);
 }
 
+TEST(route, firewall_deny_localhost_source_port_real_socket) {
+    const i32 client_port = reserve_local_port();
+    REQUIRE_GT(client_port, 0);
+
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_deny_port(static_cast<u16>(client_port)));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 c = connect_to_from_port(port, static_cast<u16>(client_port));
+    REQUIRE(c >= 0);
+    send_all(c, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char buf[1024];
+    i32 n = recv_timeout(c, buf, sizeof(buf), 500);
+    CHECK_GT(n, 0);
+    CHECK(buf_contains(buf, static_cast<u32>(n), "HTTP/1.1 403 Forbidden", 22));
+    close(c);
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
+TEST(route, firewall_allowlist_source_port_real_socket) {
+    const i32 blocked_port = reserve_local_port();
+    REQUIRE_GT(blocked_port, 0);
+    i32 allowed_port = reserve_local_port();
+    for (i32 attempt = 0; attempt < 5 && allowed_port == blocked_port; attempt++) {
+        allowed_port = reserve_local_port();
+    }
+    REQUIRE_GT(allowed_port, 0);
+    REQUIRE_NE(blocked_port, allowed_port);
+
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/health", 0, 200));
+    REQUIRE(cfg.add_firewall_allow_port(static_cast<u16>(allowed_port)));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 20};
+    lt.start();
+
+    i32 blocked = connect_to_from_port(port, static_cast<u16>(blocked_port));
+    REQUIRE(blocked >= 0);
+    send_all(blocked, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char blocked_buf[1024];
+    i32 blocked_n = recv_timeout(blocked, blocked_buf, sizeof(blocked_buf), 500);
+    CHECK_GT(blocked_n, 0);
+    CHECK(buf_contains(blocked_buf, static_cast<u32>(blocked_n), "HTTP/1.1 403 Forbidden", 22));
+    close(blocked);
+
+    i32 allowed = connect_to_from_port(port, static_cast<u16>(allowed_port));
+    REQUIRE(allowed >= 0);
+    send_all(allowed, "GET /health HTTP/1.1\r\nHost: x\r\n\r\n", 33);
+    char allowed_buf[1024];
+    i32 allowed_n = recv_timeout(allowed, allowed_buf, sizeof(allowed_buf), 500);
+    CHECK_GT(allowed_n, 0);
+    CHECK(buf_contains(allowed_buf, static_cast<u32>(allowed_n), "HTTP/1.1 200 OK", 15));
+    close(allowed);
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+}
+
 TEST(route, firewall_clear_rules_reenables_localhost_real_socket) {
     RouteConfig cfg;
     REQUIRE(cfg.add_static("/health", 0, 200));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11343,6 +11343,26 @@ TEST(route_coverage, firewall_port_rule_remove_and_clear) {
     CHECK_EQ(cfg.firewall_deny_port_count, 0u);
 }
 
+TEST(route_coverage, firewall_port_rules_reject_zero_port) {
+    RouteConfig cfg;
+    CHECK(!cfg.add_firewall_allow_port(0));
+    CHECK(!cfg.add_firewall_deny_port(0));
+    CHECK_EQ(cfg.firewall_allow_port_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_port_count, 0u);
+}
+
+TEST(route_coverage, firewall_one_arg_allows_peer_ignores_port_rules) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_port(443));
+    REQUIRE(cfg.add_firewall_deny_port(22));
+
+    // Legacy one-arg overload should keep its old address-only behavior.
+    CHECK(cfg.firewall_allows_peer(htonl(0x7f000001)));
+
+    REQUIRE(cfg.add_firewall_deny_ip("127.0.0.1"));
+    CHECK(!cfg.firewall_allows_peer(htonl(0x7f000001)));
+}
+
 TEST(route_coverage, firewall_allows_peer_host_helper) {
     RouteConfig cfg;
     REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11117,6 +11117,32 @@ TEST(route_coverage, firewall_allowlist_blocks_non_members) {
     CHECK_EQ(allowed->resp_status, 200);
 }
 
+TEST(route_coverage, firewall_port_rejects_in_request_path) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_static("/ok", 0, 200));
+    REQUIRE(cfg.add_firewall_deny_port(5555));
+    const RouteConfig* active = &cfg;
+
+    SmallLoop loop;
+    loop.setup();
+    loop.config_ptr = &active;
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    c->peer_addr = htonl(0x7f000001);
+    c->peer_port = 5555;
+    c->recv_buf.reset();
+    const char req[] = "GET /ok HTTP/1.1\r\nHost: x\r\n\r\n";
+    c->recv_buf.write(reinterpret_cast<const u8*>(req), sizeof(req) - 1);
+    IoEvent rev = {c->id, static_cast<i32>(sizeof(req) - 1), 0, 0, IoEventType::Recv, 0};
+    loop.backend.inject(rev);
+    IoEvent events[8];
+    u32 n = loop.backend.wait(events, 8);
+    for (u32 i = 0; i < n; i++) loop.dispatch(events[i]);
+    CHECK_EQ(c->resp_status, 403);
+}
+
 TEST(route_coverage, firewall_cidr_allow_and_deny_rules) {
     RouteConfig cfg;
     REQUIRE(cfg.add_static("/ok", 0, 200));
@@ -11280,6 +11306,41 @@ TEST(route_coverage, firewall_deny_precedence_over_allow) {
     REQUIRE(cfg.add_firewall_deny_ip("10.1.2.3"));
     CHECK(!cfg.firewall_allows_peer(htonl(0x0a010203)));
     CHECK(cfg.firewall_allows_peer(htonl(0x0a020304)));
+}
+
+TEST(route_coverage, firewall_port_allow_and_deny_rules) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_port(443));
+    REQUIRE(cfg.add_firewall_deny_port(22));
+
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001, 443));
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001, 22));
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001, 8080));
+
+    // Deny precedence over allow for same port.
+    REQUIRE(cfg.add_firewall_allow_port(22));
+    CHECK(!cfg.firewall_allows_peer_host(0x7f000001, 22));
+}
+
+TEST(route_coverage, firewall_port_rule_remove_and_clear) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_firewall_allow_port(8080));
+    REQUIRE(cfg.add_firewall_deny_port(9000));
+
+    CHECK(cfg.remove_firewall_allow_port(8080));
+    CHECK(cfg.remove_firewall_deny_port(9000));
+    CHECK(!cfg.remove_firewall_allow_port(8080));
+    CHECK(!cfg.remove_firewall_deny_port(9000));
+
+    CHECK_EQ(cfg.firewall_allow_port_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_port_count, 0u);
+    CHECK(cfg.firewall_allows_peer_host(0x7f000001, 8080));
+
+    REQUIRE(cfg.add_firewall_allow_port(1234));
+    REQUIRE(cfg.add_firewall_deny_port(4321));
+    cfg.clear_firewall_rules();
+    CHECK_EQ(cfg.firewall_allow_port_count, 0u);
+    CHECK_EQ(cfg.firewall_deny_port_count, 0u);
 }
 
 TEST(route_coverage, firewall_allows_peer_host_helper) {


### PR DESCRIPTION
Summary\n- add firewall source-port allow/deny rule tables in RouteConfig\n- add add/remove_firewall_allow_port(u16) and add/remove_firewall_deny_port(u16) APIs\n- extend firewall evaluation to include port rules with deny precedence\n- capture peer_port at accept-time and enforce port rules in request path\n- add route_coverage tests for port rule matching/removal/runtime reject path\n- update docs/firewall.md with port APIs and evaluation order\n\nValidation\n- cmake --build build --target test_network -j8\n- ./build/tests/test_network --filter=route_coverage.firewall_port_*\n- ./build/tests/test_network --filter=route_coverage.firewall_*