### PR TITLE
runtime: add firewall ipv4 range rules

### DIFF
--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -5,7 +5,7 @@ configuration (`RouteConfig`), independent of DSL parsing.
 
 ## Scope
 
-Current support is IPv4 source-address filtering on accepted downstream
+Current support is IPv4 source-address and source-port filtering on accepted downstream
 connections.
 
 - Exact IP rules
@@ -86,8 +86,8 @@ For callers already holding network-order IPv4 (`in_addr.s_addr` style),
 `*_network_order` helper overloads convert to packed host-order internally.
 
 Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
-return `false` on cap overflow or invalid CIDR prefix.
-Adding the same exact IP or same CIDR repeatedly is idempotent (returns `true`
+return `false` on cap overflow, invalid CIDR prefix, or invalid IPv4 range.
+Adding the same exact IP, CIDR, range, or port repeatedly is idempotent (returns `true`
 without consuming additional rule slots).
 Adding the same source port repeatedly is also idempotent (returns `true`
 without consuming additional rule slots).
@@ -197,7 +197,7 @@ Current integration coverage in `tests/test_integration.cc` includes:
 - `firewall_clear_rules_reenables_localhost_real_socket`
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`
 - `firewall_remove_deny_cidr_reenables_localhost_real_socket`
-- `firewall_remove_allow_rule_restores_default_allow_real_socket`
+- `firewall_remove_allow_rule_reenables_default_allow_real_socket`
 - `firewall_remove_allow_cidr_restores_default_allow_real_socket`
 - `firewall_remove_deny_cidr_restores_allow_cidr_real_socket`
 - `firewall_remove_deny_ip_restores_allow_ip_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -197,7 +197,7 @@ Current integration coverage in `tests/test_integration.cc` includes:
 - `firewall_clear_rules_reenables_localhost_real_socket`
 - `firewall_remove_deny_rule_reenables_localhost_real_socket`
 - `firewall_remove_deny_cidr_reenables_localhost_real_socket`
-- `firewall_remove_allow_rule_reenables_default_allow_real_socket`
+- `firewall_remove_allow_rule_restores_default_allow_real_socket`
 - `firewall_remove_allow_cidr_restores_default_allow_real_socket`
 - `firewall_remove_deny_cidr_restores_allow_cidr_real_socket`
 - `firewall_remove_deny_ip_restores_allow_ip_real_socket`

--- a/docs/firewall.md
+++ b/docs/firewall.md
@@ -87,9 +87,7 @@ For callers already holding network-order IPv4 (`in_addr.s_addr` style),
 
 Each rule family currently has a fixed cap (`kMaxFirewallRules`), and add APIs
 return `false` on cap overflow, invalid CIDR prefix, or invalid IPv4 range.
-Adding the same exact IP, CIDR, range, or port repeatedly is idempotent (returns `true`
-without consuming additional rule slots).
-Adding the same source port repeatedly is also idempotent (returns `true`
+Adding the same exact IP, CIDR, range, or source port repeatedly is idempotent (returns `true`
 without consuming additional rule slots).
 Port rules reject `0` (invalid TCP/UDP port).
 Remove APIs return `true` only when a matching rule exists and is deleted.

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -187,11 +187,13 @@ struct RouteConfig {
     // Firewall rules use packed host-order u32 IPv4 values:
     //   ip = (a << 24) | (b << 16) | (c << 8) | d  for a.b.c.d
     // Connection.peer_addr is stored in network byte order; firewall_allows_peer
-    // converts it once to the packed host-order representation before evaluation.
+    // converts it once to packed host-order before evaluation.
+    // Source-port rules use Connection.peer_port captured at accept-time.
     // Evaluation order:
-    //   1) deny list (if hit => reject)
-    //   2) allow list (if non-empty => require hit)
-    //   3) default allow
+    //   1) deny exact IP / CIDR / range / port (any hit => reject)
+    //   2) allow exact IP / CIDR / range / port (if any allow rules exist:
+    //      require at least one hit)
+    //   3) default allow/deny policy (applies only when allow tables are empty)
     u32 firewall_allow_ips[kMaxFirewallRules]{};
     u32 firewall_deny_ips[kMaxFirewallRules]{};
     u16 firewall_allow_ports[kMaxFirewallRules]{};

--- a/include/rut/runtime/route_table.h
+++ b/include/rut/runtime/route_table.h
@@ -184,11 +184,11 @@ struct RouteConfig {
     UpstreamTarget upstreams[kMaxUpstreams];
     u32 upstream_count = 0;
 
-    // Firewall rules use packed host-order u32 IPv4 values:
+    // Firewall rules support source IPv4 exact, CIDR, inclusive range, and
+    // source-port checks. IP values are packed host-order u32:
     //   ip = (a << 24) | (b << 16) | (c << 8) | d  for a.b.c.d
     // Connection.peer_addr is stored in network byte order; firewall_allows_peer
-    // converts it once to packed host-order before evaluation.
-    // Source-port rules use Connection.peer_port captured at accept-time.
+    // converts it once to the packed host-order representation before evaluation.
     // Evaluation order:
     //   1) deny exact IP / CIDR / range / port (any hit => reject)
     //   2) allow exact IP / CIDR / range / port (if any allow rules exist:

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -11444,7 +11444,6 @@ TEST(route_coverage, firewall_decision_name_helper) {
     CHECK_STREQ(RouteConfig::firewall_decision_name(D::DeniedByMissingAllowMatch),
                 "denied_by_missing_allow_match");
 }
-
 TEST(route_coverage, firewall_allows_peer_host_helper) {
     RouteConfig cfg;
     REQUIRE(cfg.add_firewall_allow_cidr("10.0.0.0/8"));


### PR DESCRIPTION
## Summary
- add IPv4 firewall inclusive range rule tables (allow/deny) in RouteConfig
- add host-order, network-order, and string range helpers for add/remove operations
- include range matching in firewall decision flow while preserving deny precedence
- extend clear helpers to reset range rule tables
- update firewall docs with range APIs and synchronized coverage list
- add route_coverage tests for range allow/deny behavior, helper roundtrip, remove/clear behavior, and decision reasons
- add real-socket integration coverage for firewall range allow/deny behavior

## Validation
- find include src testing tests bench -name '*.h' -o -name '*.cc' | xargs clang-format --dry-run --Werror
- ./build/tests/test_network --filter=route_coverage.firewall_*
- ./build/tests/test_integration --filter=route.firewall_*
