### PR TITLE
Disallow or/and call forms, add all/any non-short-circuit coverage

### DIFF
--- a/docs/pipe.md
+++ b/docs/pipe.md
@@ -1,310 +1,272 @@
-#Pipe Expressions
+# Pipe Expressions
 
 Pipe expressions pass the value on the left into a function call on the right.
 They are useful for writing small, named transformation steps in route logic
 without nesting calls.
 
 Pipe is resolved during analysis. After type checking, a pipe becomes an
-ordinary inlined function-call expression;
-it does not introduce a separate MIR / RIR opcode.
+ordinary inlined function-call expression; it does not introduce a separate
+MIR/RIR opcode.
 
-                                       Use `or` / `and` as boolean operators only;
-function - call forms `or (...)` and
-`and (...)` are not supported.Also, `&&` and `||` are rejected at parse time.For optional
-                                                     / error fallback in expressions,
-    use `any(...)` (fallback on nil / error) and `all(...)` (fallback only when value is present)
-                                                     .
+Use `or` and `and` as boolean operators only. Function-call forms `or(...)` and
+`and(...)` are not supported, and `&&` / `||` are rejected at parse time. For
+optional/error fallback in expressions, use `any(...)` for nil/error fallback
+and `all(...)` for present-only fallback.
 
-                                                 ##Operator precedence notes
+## Operator Precedence Notes
 
 `and` and `or` are parsed before `|`.
 
-                                        - `A and B
-                  | C` parses as `(A and B) | C`.- `A
-        or B | C` parses as `(A or B) | C`.- `A | B and C` is rejected unless you add parentheses,
-    because `and` appears on the right side of `|`.- `A | B
-        or C` is also rejected unless you add parentheses.
+- `A and B | C` parses as `(A and B) | C`.
+- `A or B | C` parses as `(A or B) | C`.
+- `A | B and C` is rejected unless you add parentheses, because `and` appears
+  on the right side of `|`.
+- `A | B or C` is also rejected unless you add parentheses.
 
-           Write either
+Write either:
 
-```rut let x = (A | B) or C
+```rut
+let x = (A | B) or C
 ```
 
-                or
+or:
 
-```rut let x = A | (B or C)
+```rut
+let x = A | (B or C)
 ```
 
-                        to make the intended grouping explicit.
+to make the intended grouping explicit.
 
-                        ##Lowering And Inlining
+## Lowering And Inlining
 
-                        Pipe is a source
-                        - level convenience,
-            not a runtime abstraction.A pipeline such as :
+Pipe is a source-level convenience, not a runtime abstraction. A pipeline such
+as:
 
-```rut let code = 204 | normalize_status(_) |
-                   mask_internal_error(_)
+```rut
+let code = 204 | normalize_status(_) | mask_internal_error(_)
 ```
 
-                   is analyzed as nested stage application,
-            and each stage function body is instantiated at the use site.By the time MIR
-                / RIR are built,
-            there is no
-`Pipe` node, no call chain,
-            and no pipe dispatch.The route contains the ordinary expression
-                instructions produced by the stage bodies,
-            such as constants, comparisons, selects, tuple - slot projections, optional unwraps,
-            and terminal branches.
+is analyzed as nested stage application, and each stage function body is
+instantiated at the use site. By the time MIR/RIR are built, there is no
+`Pipe` node, no call chain, and no pipe dispatch. The route contains the
+ordinary expression instructions produced by the stage bodies, such as
+constants, comparisons, selects, tuple-slot projections, optional unwraps, and
+terminal branches.
 
-                For runtime optional
-                / error values,
-            the analyzer still inlines the stage body but wraps it with presence checks :
+For runtime optional/error values, the analyzer still inlines the stage body but
+wraps it with presence checks:
 
-```rut let host = req.header("Host") | tenant_from_host(_)
+```rut
+let host = req.header("Host") | tenant_from_host(_)
 ```
 
-                   lowers conceptually like :
+lowers conceptually like:
 
-```rut if has_value (req.header("Host")) {
+```rut
+if has_value(req.header("Host")) {
     tenant_from_host(value_of(req.header("Host")))
-}
-else {
+} else {
     missing_of(req.header("Host"))
 }
 ```
 
-    where `tenant_from_host(...)` is also expanded into ordinary expression IR.
+where `tenant_from_host(...)` is also expanded into ordinary expression IR.
 
-    ##Basic Use
+## Basic Use
 
-    The right
-    -
-    hand side must be a function call stage. `_` and `_1` both mean "the
-    whole value from the left
-    -
-    hand side ":
+The right-hand side must be a function call stage. `_` and `_1` both mean "the
+whole value from the left-hand side":
 
-```rut func normalize_status(code : i32)->i32 {
-    if code
-        == 204 {200} else {
-            code
-        }
+```rut
+func normalize_status(code: i32) -> i32 {
+    if code == 204 { 200 } else { code }
 }
 
 route GET "/health" {
-    let code = 204 | normalize_status(_) if code == 200 {return 200} else {return 500}
+    let code = 204 | normalize_status(_)
+    if code == 200 { return 200 } else { return 500 }
 }
 ```
 
-    The same call can use `_1`:
+The same call can use `_1`:
 
-```rut let code = 204 | normalize_status(_1)
+```rut
+let code = 204 | normalize_status(_1)
 ```
 
-                             If a function -
-                             call stage has no placeholder,
-            the left - hand value is passed as the first argument :
+If a function-call stage has no placeholder, the left-hand value is passed as
+the first argument:
 
-```rut let code = 204 | normalize_status()
+```rut
+let code = 204 | normalize_status()
 ```
 
-                         ##Chaining
+## Chaining
 
-                             Each stage receives the previous
-                                 stage's output. This keeps request policy code readable when
-                                     several small decisions are applied in order :
+Each stage receives the previous stage's output. This keeps request policy code
+readable when several small decisions are applied in order:
 
-```rut func status_for_path(path : str) -> i32 {
-    if path
-        == "/users" {200} else {404}
+```rut
+func status_for_path(path: str) -> i32 {
+    if path == "/users" { 200 } else { 404 }
 }
 
-func mask_internal_error(code : i32) -> i32 {
-    if code
-        == 500 {503} else {
-            code
-        }
+func mask_internal_error(code: i32) -> i32 {
+    if code == 500 { 503 } else { code }
 }
 
 route GET "/users" {
-    let code = req.path | status_for_path(_) |
-               mask_internal_error(_) if code == 200 {return 200} else {return 404}
+    let code = req.path | status_for_path(_) | mask_internal_error(_)
+    if code == 200 { return 200 } else { return 404 }
 }
 ```
 
-    Route terminal control should still spell out the statuses it returns :
+Route terminal control should still spell out the statuses it returns:
 
-```rut route GET "/users" {
-    let code = req.path | status_for_path(_) |
-               mask_internal_error(_) if code == 200 {return 200} else {return 404}
+```rut
+route GET "/users" {
+    let code = req.path | status_for_path(_) | mask_internal_error(_)
+    if code == 200 { return 200 } else { return 404 }
 }
 ```
 
-    ##Placeholder Position
+## Placeholder Position
 
-        The placeholder can appear in any argument position.This is useful when a stage needs
-            constants or
-    policy values alongside the piped value :
+The placeholder can appear in any argument position. This is useful when a stage
+needs constants or policy values alongside the piped value:
 
-```rut func allow_if_token(token : str, expected : str, ok_status : i32) -> i32 {
-    if token
-        == expected {
-            ok_status
-        }
-    else {
-        401
-    }
+```rut
+func allow_if_token(token: str, expected: str, ok_status: i32) -> i32 {
+    if token == expected { ok_status } else { 401 }
 }
 
 route GET "/admin" {
-    let code = req.header("Authorization") | allow_if_token(_, "Bearer root", 200) let safe =
-                   any(code, 401) if safe == 200 {return 200} else {return 401}
+    let code = req.header("Authorization") | allow_if_token(_, "Bearer root", 200)
+    let safe = any(code, 401)
+    if safe == 200 { return 200 } else { return 401 }
 }
 ```
 
-    ##Method Stages
+## Method Stages
 
-        The placeholder can also be the receiver of a method -
-    call stage :
+The placeholder can also be the receiver of a method-call stage:
 
-```rut route GET "/method-stage" {
-    let ok = 200 | _.eq(200) if ok{return 200} else {return 500}
+```rut
+route GET "/method-stage" {
+    let ok = 200 | _.eq(200)
+    if ok { return 200 } else { return 500 }
 }
 ```
 
-`_` and `_1` are accepted as method receivers.Tuple - slot receivers such as
-`_2.method(...)` are still rejected;
-use a function stage with tuple - slot arguments when a pipeline needs to project tuple slots
-                                      .
+`_` and `_1` are accepted as method receivers. Tuple-slot receivers such as
+`_2.method(...)` are still rejected; use a function stage with tuple-slot
+arguments when a pipeline needs to project tuple slots.
 
-                                  ##Optional Header Flow
+## Optional Header Flow
 
-`req.header(...)` returns an optional string.A pipe stage only runs when the header is present;
-missing values flow through as `nil` and can be handled with
-`any(...)`
-    .
+`req.header(...)` returns an optional string. A pipe stage only runs when the
+header is present; missing values flow through as `nil` and can be handled with
+`any(...)`.
 
-```rut func tenant_from_host(host : str)
-    ->str {
-    if host
-        == "api.example.com" {"api"} else {"unknown"}
+```rut
+func tenant_from_host(host: str) -> str {
+    if host == "api.example.com" { "api" } else { "unknown" }
 }
 
-func status_for_tenant(tenant : str) -> i32 {
-    if tenant
-        == "api" {200} else {404}
+func status_for_tenant(tenant: str) -> i32 {
+    if tenant == "api" { 200 } else { 404 }
 }
 
 route GET "/tenant" {
-    let code = req.header("Host") | tenant_from_host(_) | status_for_tenant(_) let safe =
-                   any(code, 404) if safe == 200 {return 200} else {return 404}
+    let code = req.header("Host") | tenant_from_host(_) | status_for_tenant(_)
+    let safe = any(code, 404)
+    if safe == 200 { return 200 } else { return 404 }
 }
 ```
 
-    ##Error Flow
+## Error Flow
 
-        Error values also flow through a pipe without calling later stages
-            .Downstream
-`any(...)` can turn the error into a concrete fallback :
+Error values also flow through a pipe without calling later stages. Downstream
+`any(...)` can turn the error into a concrete fallback:
 
-```rut func parse_mode(raw : str)
-            ->i32 {
-    if raw
-        == "fast" {1} else {
-            error(.bad_mode)
-        }
+```rut
+func parse_mode(raw: str) -> i32 {
+    if raw == "fast" { 1 } else { error(.bad_mode) }
 }
 
-func status_for_mode(mode : i32) -> i32 {
-    if mode
-        == 1 {200} else {400}
+func status_for_mode(mode: i32) -> i32 {
+    if mode == 1 { 200 } else { 400 }
 }
 
 route GET "/mode" {
-    let code = req.header("X-Mode") | parse_mode(_) | status_for_mode(_) let safe =
-                   any(code, 400) if safe == 200 {return 200} else {return 400}
+    let code = req.header("X-Mode") | parse_mode(_) | status_for_mode(_)
+    let safe = any(code, 400)
+    if safe == 200 { return 200 } else { return 400 }
 }
 ```
 
 Known `nil` and known `error(...)` left-hand values are folded at analysis time
 and do not call the stage.
 
-`any(...)` and `all(...)` currently use conditional selection at runtime, so both
-operands are materialized before selection. If you need strict short-circuiting
-for side-effectful expressions, write it as an explicit `if` branch.
+`any(...)` and `all(...)` use conditional selection at runtime, so both operands
+are materialized before selection. If you need strict short-circuiting for
+side-effectful expressions, write it as an explicit `if` branch.
 
-`all(...)` is the inverse fallback form:
+`all(...)` is the present-only fallback form:
 
 ```rut
-route GET "/and" {
-    let token = req.query("x-token") let safe =
-        all(token, "") if safe == "" {return 401} else {return 200}
+route GET "/all" {
+    let token = req.query("x-token")
+    let safe = all(token, any(token, ""))
+    if safe == "" { return 401 } else { return 200 }
 }
 ```
 
-    Use `all(...)` when you want the right
-    - hand value to apply only when the left -
-    hand value is present.
+Use `all(...)` when you want the right-hand value to apply only when the
+left-hand value is present.
 
-    ##Tuple Slots
+## Tuple Slots
 
-    When the left
-    - hand side is a tuple,
-    numbered placeholders select tuple slots.Indexes are 1 - based :
+When the left-hand side is a tuple, numbered placeholders select tuple slots.
+Indexes are 1-based:
 
-```rut func status_from_policy(auth_status : i32, default_status : i32)->i32 {
-    if auth_status
-        == 200 {
-            auth_status
-        }
-    else {
-        default_status
-    }
+```rut
+func status_from_policy(auth_status: i32, default_status: i32) -> i32 {
+    if auth_status == 200 { auth_status } else { default_status }
 }
 
 route GET "/tuple-policy" {
-    let policy = (200, 401)let code =
-        policy | status_from_policy(_1, _2) if code == 200 {return 200} else {return 401}
+    let policy = (200, 401)
+    let code = policy | status_from_policy(_1, _2)
+    if code == 200 { return 200 } else { return 401 }
 }
 ```
 
-    Tuple slots can be reordered :
+Tuple slots can be reordered:
 
-```rut func
-    prefer_second(primary : i32, secondary : i32) -> i32 = > secondary
+```rut
+func prefer_second(primary: i32, secondary: i32) -> i32 => secondary
 
-                                                           route GET "/tuple-reorder" {
-    let code = (500, 200) | prefer_second(_1, _2) if code == 200 {return 200} else {return 500}
+route GET "/tuple-reorder" {
+    let code = (500, 200) | prefer_second(_1, _2)
+    if code == 200 { return 200 } else { return 500 }
 }
 ```
 
-    Tuple slots can also come from tuple -
-    returning functions :
+Tuple slots can also come from tuple-returning functions:
 
-```rut func route_policy(path : str) {
-    if path
-        == "/tuple-stage" {
-            (200, 401)
-        }
-    else {
-        (404, 401)
-    }
+```rut
+func route_policy(path: str) {
+    if path == "/tuple-stage" { (200, 401) } else { (404, 401) }
 }
 
-func choose_policy(primary : i32, fallback : i32) -> i32 {
-    if primary
-        == 200 {
-            primary
-        }
-    else {
-        fallback
-    }
+func choose_policy(primary: i32, fallback: i32) -> i32 {
+    if primary == 200 { primary } else { fallback }
 }
 
 route GET "/tuple-stage" {
-    let code = req.path | route_policy(_) |
-               choose_policy(_1, _2) if code == 200 {return 200} else {return 401}
+    let code = req.path | route_policy(_) | choose_policy(_1, _2)
+    if code == 200 { return 200 } else { return 401 }
 }
 ```
 
@@ -317,14 +279,16 @@ to be unwrapped before tuple slots can be safely projected.
 
 ## Generic Stages
 
-Generic functions can be used as pipe stages when the type shape can be inferred:
+Generic functions can be used as pipe stages when the type shape can be
+inferred:
 
 ```rut
 func keep<T>(x: T) -> T => x
 func status_for_code(code: i32) -> i32 => code
 
 route GET "/generic" {
-    let code = 200 | keep(_) | status_for_code(_) if code == 200 {return 200} else {return 500}
+    let code = 200 | keep(_) | status_for_code(_)
+    if code == 200 { return 200 } else { return 500 }
 }
 ```
 
@@ -349,5 +313,5 @@ The following are future work rather than current behavior:
 
 - Tuple-slot placeholders for runtime optional/error left-hand values beyond
   `_` / `_1`.
-- A dedicated MIR/RIR pipe representation;
-current lowering intentionally rewrites pipe into ordinary expressions before MIR.
+- A dedicated MIR/RIR pipe representation; current lowering intentionally
+  rewrites pipe into ordinary expressions before MIR.

--- a/docs/pipe.md
+++ b/docs/pipe.md
@@ -19,23 +19,18 @@ and `all(...)` for present-only fallback.
 
 - `A and B | C` parses as `(A and B) | C`.
 - `A or B | C` parses as `(A or B) | C`.
-- `A | B and C` is rejected unless you add parentheses, because `and` appears
-  on the right side of `|`.
-- `A | B or C` is also rejected unless you add parentheses.
+- `A | B and C` is rejected because `and` appears on the right side of `|`;
+  the pipe RHS must be a call stage such as `f(...)` or `_.method(...)`.
+- `A | B or C` is rejected for the same reason.
 
-Write either:
+Write:
 
 ```rut
 let x = (A | B) or C
 ```
 
-or:
-
-```rut
-let x = A | (B or C)
-```
-
-to make the intended grouping explicit.
+to make the valid pipe stage grouping explicit before applying boolean
+operators.
 
 ## Lowering And Inlining
 

--- a/docs/pipe.md
+++ b/docs/pipe.md
@@ -1,207 +1,229 @@
-# Pipe Expressions
+#Pipe Expressions
 
 Pipe expressions pass the value on the left into a function call on the right.
 They are useful for writing small, named transformation steps in route logic
 without nesting calls.
 
 Pipe is resolved during analysis. After type checking, a pipe becomes an
-ordinary inlined function-call expression; it does not introduce a separate
-MIR/RIR opcode.
+ordinary inlined function-call expression;
+it does not introduce a separate MIR / RIR opcode.
 
-Use `or` / `and` as boolean operators only; function-call forms `or(...)` and
-`and(...)` are not supported. Also, `&&` and `||` are rejected at parse time.
-For optional/error fallback in expressions, use `any(...)` (fallback on nil/error)
-and `all(...)` (fallback only when value is present).
+                                       Use `or` / `and` as boolean operators only;
+function - call forms `or (...)` and
+`and (...)` are not supported.Also, `&&` and `||` are rejected at parse time.For optional
+                                                     / error fallback in expressions,
+    use `any(...)` (fallback on nil / error) and `all(...)` (fallback only when value is present)
+                                                     .
 
-## Operator precedence notes
+                                                 ##Operator precedence notes
 
 `and` and `or` are parsed before `|`.
 
-- `A and B | C` parses as `(A and B) | C`.
-- `A or B | C` parses as `(A or B) | C`.
-- `A | B and C` is rejected unless you add parentheses, because `and` appears on the
-  right side of `|`.
-- `A | B or C` is also rejected unless you add parentheses.
+                                        - `A and B
+                  | C` parses as `(A and B) | C`.- `A
+        or B | C` parses as `(A or B) | C`.- `A | B and C` is rejected unless you add parentheses,
+    because `and` appears on the right side of `|`.- `A | B
+        or C` is also rejected unless you add parentheses.
 
-Write either
+           Write either
 
-```rut
-let x = (A | B) or C
+```rut let x = (A | B) or C
 ```
 
-or
+                or
 
-```rut
-let x = A | (B or C)
+```rut let x = A | (B or C)
 ```
 
-to make the intended grouping explicit.
+                        to make the intended grouping explicit.
 
-## Lowering And Inlining
+                        ##Lowering And Inlining
 
-Pipe is a source-level convenience, not a runtime abstraction. A pipeline such
-as:
+                        Pipe is a source
+                        - level convenience,
+            not a runtime abstraction.A pipeline such as :
 
-```rut
-let code = 204 | normalize_status(_) | mask_internal_error(_)
+```rut let code = 204 | normalize_status(_) |
+                   mask_internal_error(_)
 ```
 
-is analyzed as nested stage application, and each stage function body is
-instantiated at the use site. By the time MIR/RIR are built, there is no
-`Pipe` node, no call chain, and no pipe dispatch. The route contains the
-ordinary expression instructions produced by the stage bodies, such as
-constants, comparisons, selects, tuple-slot projections, optional unwraps, and
-terminal branches.
+                   is analyzed as nested stage application,
+            and each stage function body is instantiated at the use site.By the time MIR
+                / RIR are built,
+            there is no
+`Pipe` node, no call chain,
+            and no pipe dispatch.The route contains the ordinary expression
+                instructions produced by the stage bodies,
+            such as constants, comparisons, selects, tuple - slot projections, optional unwraps,
+            and terminal branches.
 
-For runtime optional/error values, the analyzer still inlines the stage body but
-wraps it with presence checks:
+                For runtime optional
+                / error values,
+            the analyzer still inlines the stage body but wraps it with presence checks :
 
-```rut
-let host = req.header("Host") | tenant_from_host(_)
+```rut let host = req.header("Host") | tenant_from_host(_)
 ```
 
-lowers conceptually like:
+                   lowers conceptually like :
 
-```rut
-if has_value(req.header("Host")) {
+```rut if has_value (req.header("Host")) {
     tenant_from_host(value_of(req.header("Host")))
-} else {
+}
+else {
     missing_of(req.header("Host"))
 }
 ```
 
-where `tenant_from_host(...)` is also expanded into ordinary expression IR.
+    where `tenant_from_host(...)` is also expanded into ordinary expression IR.
 
-## Basic Use
+    ##Basic Use
 
-The right-hand side must be a function call stage. `_` and `_1` both mean "the
-whole value from the left-hand side":
+    The right
+    -
+    hand side must be a function call stage. `_` and `_1` both mean "the
+    whole value from the left
+    -
+    hand side ":
 
-```rut
-func normalize_status(code: i32) -> i32 {
-    if code == 204 { 200 } else { code }
+```rut func normalize_status(code : i32)->i32 {
+    if code
+        == 204 {200} else {
+            code
+        }
 }
 
 route GET "/health" {
-    let code = 204 | normalize_status(_)
-    if code == 200 { return 200 } else { return 500 }
+    let code = 204 | normalize_status(_) if code == 200 {return 200} else {return 500}
 }
 ```
 
-The same call can use `_1`:
+    The same call can use `_1`:
 
-```rut
-let code = 204 | normalize_status(_1)
+```rut let code = 204 | normalize_status(_1)
 ```
 
-If a function-call stage has no placeholder, the left-hand value is passed as
-the first argument:
+                             If a function -
+                             call stage has no placeholder,
+            the left - hand value is passed as the first argument :
 
-```rut
-let code = 204 | normalize_status()
+```rut let code = 204 | normalize_status()
 ```
 
-## Chaining
+                         ##Chaining
 
-Each stage receives the previous stage's output. This keeps request policy code
-readable when several small decisions are applied in order:
+                             Each stage receives the previous
+                                 stage's output. This keeps request policy code readable when
+                                     several small decisions are applied in order :
 
-```rut
-func status_for_path(path: str) -> i32 {
-    if path == "/users" { 200 } else { 404 }
+```rut func status_for_path(path : str) -> i32 {
+    if path
+        == "/users" {200} else {404}
 }
 
-func mask_internal_error(code: i32) -> i32 {
-    if code == 500 { 503 } else { code }
+func mask_internal_error(code : i32) -> i32 {
+    if code
+        == 500 {503} else {
+            code
+        }
 }
 
 route GET "/users" {
-    let code = req.path | status_for_path(_) | mask_internal_error(_)
-    if code == 200 { return 200 } else { return 404 }
+    let code = req.path | status_for_path(_) |
+               mask_internal_error(_) if code == 200 {return 200} else {return 404}
 }
 ```
 
-Route terminal control should still spell out the statuses it returns:
+    Route terminal control should still spell out the statuses it returns :
 
-```rut
-route GET "/users" {
-    let code = req.path | status_for_path(_) | mask_internal_error(_)
-    if code == 200 { return 200 } else { return 404 }
+```rut route GET "/users" {
+    let code = req.path | status_for_path(_) |
+               mask_internal_error(_) if code == 200 {return 200} else {return 404}
 }
 ```
 
-## Placeholder Position
+    ##Placeholder Position
 
-The placeholder can appear in any argument position. This is useful when a stage
-needs constants or policy values alongside the piped value:
+        The placeholder can appear in any argument position.This is useful when a stage needs
+            constants or
+    policy values alongside the piped value :
 
-```rut
-func allow_if_token(token: str, expected: str, ok_status: i32) -> i32 {
-    if token == expected { ok_status } else { 401 }
+```rut func allow_if_token(token : str, expected : str, ok_status : i32) -> i32 {
+    if token
+        == expected {
+            ok_status
+        }
+    else {
+        401
+    }
 }
 
 route GET "/admin" {
-    let code = req.header("Authorization") | allow_if_token(_, "Bearer root", 200)
-    let safe = any(code, 401)
-    if safe == 200 { return 200 } else { return 401 }
+    let code = req.header("Authorization") | allow_if_token(_, "Bearer root", 200) let safe =
+                   any(code, 401) if safe == 200 {return 200} else {return 401}
 }
 ```
 
-## Method Stages
+    ##Method Stages
 
-The placeholder can also be the receiver of a method-call stage:
+        The placeholder can also be the receiver of a method -
+    call stage :
 
-```rut
-route GET "/method-stage" {
-    let ok = 200 | _.eq(200)
-    if ok { return 200 } else { return 500 }
+```rut route GET "/method-stage" {
+    let ok = 200 | _.eq(200) if ok{return 200} else {return 500}
 }
 ```
 
-`_` and `_1` are accepted as method receivers. Tuple-slot receivers such as
-`_2.method(...)` are still rejected; use a function stage with tuple-slot
-arguments when a pipeline needs to project tuple slots.
+`_` and `_1` are accepted as method receivers.Tuple - slot receivers such as
+`_2.method(...)` are still rejected;
+use a function stage with tuple - slot arguments when a pipeline needs to project tuple slots
+                                      .
 
-## Optional Header Flow
+                                  ##Optional Header Flow
 
-`req.header(...)` returns an optional string. A pipe stage only runs when the
-header is present; missing values flow through as `nil` and can be handled with
-`any(...)`.
+`req.header(...)` returns an optional string.A pipe stage only runs when the header is present;
+missing values flow through as `nil` and can be handled with
+`any(...)`
+    .
 
-```rut
-func tenant_from_host(host: str) -> str {
-    if host == "api.example.com" { "api" } else { "unknown" }
+```rut func tenant_from_host(host : str)
+    ->str {
+    if host
+        == "api.example.com" {"api"} else {"unknown"}
 }
 
-func status_for_tenant(tenant: str) -> i32 {
-    if tenant == "api" { 200 } else { 404 }
+func status_for_tenant(tenant : str) -> i32 {
+    if tenant
+        == "api" {200} else {404}
 }
 
 route GET "/tenant" {
-    let code = req.header("Host") | tenant_from_host(_) | status_for_tenant(_)
-    let safe = any(code, 404)
-    if safe == 200 { return 200 } else { return 404 }
+    let code = req.header("Host") | tenant_from_host(_) | status_for_tenant(_) let safe =
+                   any(code, 404) if safe == 200 {return 200} else {return 404}
 }
 ```
 
-## Error Flow
+    ##Error Flow
 
-Error values also flow through a pipe without calling later stages. Downstream
-`any(...)` can turn the error into a concrete fallback:
+        Error values also flow through a pipe without calling later stages
+            .Downstream
+`any(...)` can turn the error into a concrete fallback :
 
-```rut
-func parse_mode(raw: str) -> i32 {
-    if raw == "fast" { 1 } else { error(.bad_mode) }
+```rut func parse_mode(raw : str)
+            ->i32 {
+    if raw
+        == "fast" {1} else {
+            error(.bad_mode)
+        }
 }
 
-func status_for_mode(mode: i32) -> i32 {
-    if mode == 1 { 200 } else { 400 }
+func status_for_mode(mode : i32) -> i32 {
+    if mode
+        == 1 {200} else {400}
 }
 
 route GET "/mode" {
-    let code = req.header("X-Mode") | parse_mode(_) | status_for_mode(_)
-    let safe = any(code, 400)
-    if safe == 200 { return 200 } else { return 400 }
+    let code = req.header("X-Mode") | parse_mode(_) | status_for_mode(_) let safe =
+                   any(code, 400) if safe == 200 {return 200} else {return 400}
 }
 ```
 
@@ -216,57 +238,73 @@ for side-effectful expressions, write it as an explicit `if` branch.
 
 ```rut
 route GET "/and" {
-    let code = req.http11
-    let safe = all(code, false)
-    if safe { return 200 } else { return 401 }
+    let token = req.query("x-token") let safe =
+        all(token, "") if safe == "" {return 401} else {return 200}
 }
 ```
 
-Use `all(...)` when you want the right-hand value to apply only when the
-left-hand value is present.
+    Use `all(...)` when you want the right
+    - hand value to apply only when the left -
+    hand value is present.
 
-## Tuple Slots
+    ##Tuple Slots
 
-When the left-hand side is a tuple, numbered placeholders select tuple slots.
-Indexes are 1-based:
+    When the left
+    - hand side is a tuple,
+    numbered placeholders select tuple slots.Indexes are 1 - based :
 
-```rut
-func status_from_policy(auth_status: i32, default_status: i32) -> i32 {
-    if auth_status == 200 { auth_status } else { default_status }
+```rut func status_from_policy(auth_status : i32, default_status : i32)->i32 {
+    if auth_status
+        == 200 {
+            auth_status
+        }
+    else {
+        default_status
+    }
 }
 
 route GET "/tuple-policy" {
-    let policy = (200, 401)
-    let code = policy | status_from_policy(_1, _2)
-    if code == 200 { return 200 } else { return 401 }
+    let policy = (200, 401)let code =
+        policy | status_from_policy(_1, _2) if code == 200 {return 200} else {return 401}
 }
 ```
 
-Tuple slots can be reordered:
+    Tuple slots can be reordered :
 
-```rut
-func prefer_second(primary: i32, secondary: i32) -> i32 => secondary
+```rut func
+    prefer_second(primary : i32, secondary : i32) -> i32 = > secondary
 
-route GET "/tuple-reorder" {
-    let code = (500, 200) | prefer_second(_1, _2)
-    if code == 200 { return 200 } else { return 500 }
+                                                           route GET "/tuple-reorder" {
+    let code = (500, 200) | prefer_second(_1, _2) if code == 200 {return 200} else {return 500}
 }
 ```
 
-Tuple slots can also come from tuple-returning functions:
+    Tuple slots can also come from tuple -
+    returning functions :
 
-```rut
-func route_policy(path: str) {
-    if path == "/tuple-stage" { (200, 401) } else { (404, 401) }
+```rut func route_policy(path : str) {
+    if path
+        == "/tuple-stage" {
+            (200, 401)
+        }
+    else {
+        (404, 401)
+    }
 }
 
-func choose_policy(primary: i32, fallback: i32) -> i32 {
-    if primary == 200 { primary } else { fallback }
+func choose_policy(primary : i32, fallback : i32) -> i32 {
+    if primary
+        == 200 {
+            primary
+        }
+    else {
+        fallback
+    }
 }
 
 route GET "/tuple-stage" {
-    let code = req.path | route_policy(_) | choose_policy(_1, _2)
-    if code == 200 { return 200 } else { return 401 }
+    let code = req.path | route_policy(_) |
+               choose_policy(_1, _2) if code == 200 {return 200} else {return 401}
 }
 ```
 
@@ -286,8 +324,7 @@ func keep<T>(x: T) -> T => x
 func status_for_code(code: i32) -> i32 => code
 
 route GET "/generic" {
-    let code = 200 | keep(_) | status_for_code(_)
-    if code == 200 { return 200 } else { return 500 }
+    let code = 200 | keep(_) | status_for_code(_) if code == 200 {return 200} else {return 500}
 }
 ```
 
@@ -312,5 +349,5 @@ The following are future work rather than current behavior:
 
 - Tuple-slot placeholders for runtime optional/error left-hand values beyond
   `_` / `_1`.
-- A dedicated MIR/RIR pipe representation; current lowering intentionally
-  rewrites pipe into ordinary expressions before MIR.
+- A dedicated MIR/RIR pipe representation;
+current lowering intentionally rewrites pipe into ordinary expressions before MIR.

--- a/docs/pipe.md
+++ b/docs/pipe.md
@@ -8,6 +8,35 @@ Pipe is resolved during analysis. After type checking, a pipe becomes an
 ordinary inlined function-call expression; it does not introduce a separate
 MIR/RIR opcode.
 
+Use `or` / `and` as boolean operators only; function-call forms `or(...)` and
+`and(...)` are not supported. Also, `&&` and `||` are rejected at parse time.
+For optional/error fallback in expressions, use `any(...)` (fallback on nil/error)
+and `all(...)` (fallback only when value is present).
+
+## Operator precedence notes
+
+`and` and `or` are parsed before `|`.
+
+- `A and B | C` parses as `(A and B) | C`.
+- `A or B | C` parses as `(A or B) | C`.
+- `A | B and C` is rejected unless you add parentheses, because `and` appears on the
+  right side of `|`.
+- `A | B or C` is also rejected unless you add parentheses.
+
+Write either
+
+```rut
+let x = (A | B) or C
+```
+
+or
+
+```rut
+let x = A | (B or C)
+```
+
+to make the intended grouping explicit.
+
 ## Lowering And Inlining
 
 Pipe is a source-level convenience, not a runtime abstraction. A pipeline such
@@ -113,7 +142,7 @@ func allow_if_token(token: str, expected: str, ok_status: i32) -> i32 {
 
 route GET "/admin" {
     let code = req.header("Authorization") | allow_if_token(_, "Bearer root", 200)
-    let safe = or(code, 401)
+    let safe = any(code, 401)
     if safe == 200 { return 200 } else { return 401 }
 }
 ```
@@ -137,7 +166,7 @@ arguments when a pipeline needs to project tuple slots.
 
 `req.header(...)` returns an optional string. A pipe stage only runs when the
 header is present; missing values flow through as `nil` and can be handled with
-`or(...)`.
+`any(...)`.
 
 ```rut
 func tenant_from_host(host: str) -> str {
@@ -150,7 +179,7 @@ func status_for_tenant(tenant: str) -> i32 {
 
 route GET "/tenant" {
     let code = req.header("Host") | tenant_from_host(_) | status_for_tenant(_)
-    let safe = or(code, 404)
+    let safe = any(code, 404)
     if safe == 200 { return 200 } else { return 404 }
 }
 ```
@@ -158,7 +187,7 @@ route GET "/tenant" {
 ## Error Flow
 
 Error values also flow through a pipe without calling later stages. Downstream
-`or(...)` can turn the error into a concrete fallback:
+`any(...)` can turn the error into a concrete fallback:
 
 ```rut
 func parse_mode(raw: str) -> i32 {
@@ -171,13 +200,30 @@ func status_for_mode(mode: i32) -> i32 {
 
 route GET "/mode" {
     let code = req.header("X-Mode") | parse_mode(_) | status_for_mode(_)
-    let safe = or(code, 400)
+    let safe = any(code, 400)
     if safe == 200 { return 200 } else { return 400 }
 }
 ```
 
 Known `nil` and known `error(...)` left-hand values are folded at analysis time
 and do not call the stage.
+
+`any(...)` and `all(...)` currently use conditional selection at runtime, so both
+operands are materialized before selection. If you need strict short-circuiting
+for side-effectful expressions, write it as an explicit `if` branch.
+
+`all(...)` is the inverse fallback form:
+
+```rut
+route GET "/and" {
+    let code = req.http11
+    let safe = all(code, false)
+    if safe { return 200 } else { return 401 }
+}
+```
+
+Use `all(...)` when you want the right-hand value to apply only when the
+left-hand value is present.
 
 ## Tuple Slots
 

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -101,6 +101,7 @@ enum class AstExprKind : u8 {
     Eq,
     Lt,
     Gt,
+    And,
     Or,
     Pipe,
     Wait,

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -378,6 +378,7 @@ struct HirExpr {
     HirExpr* lhs = nullptr;
     HirExpr* rhs = nullptr;
     bool is_pipe_conditional = false;
+    bool is_eager_fallback = false;
     bool is_wait_result = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -377,6 +377,7 @@ struct HirExpr {
     u32 array_len = 0;
     HirExpr* lhs = nullptr;
     HirExpr* rhs = nullptr;
+    bool is_pipe_conditional = false;
     bool is_wait_result = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -173,6 +173,7 @@ struct MirValue {
     MirValue* lhs = nullptr;
     MirValue* rhs = nullptr;
     bool is_pipe_conditional = false;
+    bool is_eager_fallback = false;
     bool is_wait_result = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -172,6 +172,7 @@ struct MirValue {
     u32 error_case_index = 0xffffffffu;
     MirValue* lhs = nullptr;
     MirValue* rhs = nullptr;
+    bool is_pipe_conditional = false;
     bool is_wait_result = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -361,6 +361,7 @@ struct Function {
     // Yield point count (determines state machine states).
     u32 yield_count;
     bool state_zero_enters_entry;
+    u32 state_zero_entry_block;
     u32 resume_terminal_block;
     bool has_explicit_resume_blocks;
     static constexpr u32 kMaxResumeBlocks = 8;

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -304,11 +304,11 @@ struct Instruction {
     // Note: DESIGN.md shows nil checks as `%v.is_nil` (sugar), but this
     // IR uses an explicit `OptIsNil` opcode for uniformity.
     bool is_yield() const {
-        switch (op) {
-            case Opcode::YieldHttpGet:
-            case Opcode::YieldHttpPost:
-            case Opcode::YieldForward:
-            case Opcode::YieldTimer:
+        switch (static_cast<u16>(op)) {
+            case static_cast<u16>(Opcode::YieldHttpGet):
+            case static_cast<u16>(Opcode::YieldHttpPost):
+            case static_cast<u16>(Opcode::YieldForward):
+            case static_cast<u16>(Opcode::YieldTimer):
                 return true;
             default:
                 return false;
@@ -318,11 +318,11 @@ struct Instruction {
     // Is this a block-ending instruction? Uses explicit switch rather
     // than range check so opcode reordering can't silently break semantics.
     bool is_terminator() const {
-        switch (op) {
-            case Opcode::Br:
-            case Opcode::Jmp:
-            case Opcode::RetStatus:
-            case Opcode::RetForward:
+        switch (static_cast<u16>(op)) {
+            case static_cast<u16>(Opcode::Br):
+            case static_cast<u16>(Opcode::Jmp):
+            case static_cast<u16>(Opcode::RetStatus):
+            case static_cast<u16>(Opcode::RetForward):
                 return true;
             default:
                 return is_yield();

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -304,29 +304,15 @@ struct Instruction {
     // Note: DESIGN.md shows nil checks as `%v.is_nil` (sugar), but this
     // IR uses an explicit `OptIsNil` opcode for uniformity.
     bool is_yield() const {
-        switch (static_cast<u16>(op)) {
-            case static_cast<u16>(Opcode::YieldHttpGet):
-            case static_cast<u16>(Opcode::YieldHttpPost):
-            case static_cast<u16>(Opcode::YieldForward):
-            case static_cast<u16>(Opcode::YieldTimer):
-                return true;
-            default:
-                return false;
-        }
+        return op == Opcode::YieldHttpGet || op == Opcode::YieldHttpPost ||
+               op == Opcode::YieldForward || op == Opcode::YieldTimer;
     }
 
     // Is this a block-ending instruction? Uses explicit switch rather
     // than range check so opcode reordering can't silently break semantics.
     bool is_terminator() const {
-        switch (static_cast<u16>(op)) {
-            case static_cast<u16>(Opcode::Br):
-            case static_cast<u16>(Opcode::Jmp):
-            case static_cast<u16>(Opcode::RetStatus):
-            case static_cast<u16>(Opcode::RetForward):
-                return true;
-            default:
-                return is_yield();
-        }
+        return op == Opcode::Br || op == Opcode::Jmp || op == Opcode::RetStatus ||
+               op == Opcode::RetForward || is_yield();
     }
 };
 

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -113,6 +113,7 @@ struct Builder {
         fn->http_method = http_method;
         fn->yield_count = 0;
         fn->state_zero_enters_entry = false;
+        fn->state_zero_entry_block = 0;
         fn->resume_terminal_block = 0;
         fn->has_explicit_resume_blocks = false;
         for (u32 i = 0; i < Function::kMaxResumeBlocks; i++) fn->resume_blocks[i] = 0;
@@ -156,9 +157,13 @@ struct Builder {
         return {};
     }
 
-    VoidResult set_state_zero_entry_resume(Function* fn, BlockId terminal_block) {
-        if (!fn || terminal_block.id >= fn->block_count) return err(RirError::InvalidState);
+    VoidResult set_state_zero_entry_resume(Function* fn,
+                                           BlockId terminal_block,
+                                           BlockId entry_block) {
+        if (!fn || terminal_block.id >= fn->block_count || entry_block.id >= fn->block_count)
+            return err(RirError::InvalidState);
         fn->state_zero_enters_entry = true;
+        fn->state_zero_entry_block = entry_block.id;
         fn->resume_terminal_block = terminal_block.id;
         return {};
     }
@@ -172,6 +177,7 @@ struct Builder {
         for (u32 i = count; i < Function::kMaxResumeBlocks; i++) fn->resume_blocks[i] = 0;
         fn->has_explicit_resume_blocks = true;
         fn->state_zero_enters_entry = true;
+        fn->state_zero_entry_block = count != 0 ? blocks[0].id : 0;
         fn->resume_terminal_block = count != 0 ? blocks[count - 1].id : 0;
         return {};
     }

--- a/include/rut/runtime/connection_base.h
+++ b/include/rut/runtime/connection_base.h
@@ -28,10 +28,10 @@ enum class ConnState : u8 {
     ExecHandler,
     Proxying,
     Sending,
-    _Count,
+    Count,
 };
 
-static_assert(static_cast<u8>(ConnState::_Count) == 6u,
+static_assert(static_cast<u8>(ConnState::Count) == 6u,
               "ConnState count is part of the static network state contract");
 
 struct ConnectionBase {

--- a/include/rut/runtime/connection_base.h
+++ b/include/rut/runtime/connection_base.h
@@ -28,10 +28,10 @@ enum class ConnState : u8 {
     ExecHandler,
     Proxying,
     Sending,
-    kNumStates,
+    _Count,
 };
 
-static_assert(static_cast<u8>(ConnState::kNumStates) == 6u,
+static_assert(static_cast<u8>(ConnState::_Count) == 6u,
               "ConnState count is part of the static network state contract");
 
 struct ConnectionBase {

--- a/include/rut/runtime/debug.h
+++ b/include/rut/runtime/debug.h
@@ -36,7 +36,7 @@ struct ConnDebugSnapshot {
 };
 
 inline const char* conn_state_name(ConnState state) {
-    static constexpr const char* kConnStateNames[static_cast<u8>(ConnState::_Count)] = {
+    static constexpr const char* kConnStateNames[static_cast<u8>(ConnState::Count)] = {
         "Idle",
         "ReadingHeader",
         "ReadingBody",
@@ -45,11 +45,11 @@ inline const char* conn_state_name(ConnState state) {
         "Sending",
     };
     static_assert(
-        sizeof(kConnStateNames) / sizeof(*kConnStateNames) == static_cast<u8>(ConnState::_Count),
+        sizeof(kConnStateNames) / sizeof(*kConnStateNames) == static_cast<u8>(ConnState::Count),
         "conn_state_name table must cover all ConnState values");
 
     const auto idx = static_cast<u8>(state);
-    if (idx < static_cast<u8>(ConnState::_Count)) {
+    if (idx < static_cast<u8>(ConnState::Count)) {
         return kConnStateNames[idx];
     }
     return "Unknown";

--- a/include/rut/runtime/debug.h
+++ b/include/rut/runtime/debug.h
@@ -44,10 +44,9 @@ inline const char* conn_state_name(ConnState state) {
         "Proxying",
         "Sending",
     };
-    static_assert(sizeof(kConnStateNames) /
-                      sizeof(*kConnStateNames) ==
-                  static_cast<u8>(ConnState::_Count),
-                  "conn_state_name table must cover all ConnState values");
+    static_assert(
+        sizeof(kConnStateNames) / sizeof(*kConnStateNames) == static_cast<u8>(ConnState::_Count),
+        "conn_state_name table must cover all ConnState values");
 
     const auto idx = static_cast<u8>(state);
     if (idx < static_cast<u8>(ConnState::_Count)) {

--- a/include/rut/runtime/debug.h
+++ b/include/rut/runtime/debug.h
@@ -36,7 +36,7 @@ struct ConnDebugSnapshot {
 };
 
 inline const char* conn_state_name(ConnState state) {
-    static constexpr const char* kConnStateNames[static_cast<u8>(ConnState::kNumStates)] = {
+    static constexpr const char* kConnStateNames[static_cast<u8>(ConnState::_Count)] = {
         "Idle",
         "ReadingHeader",
         "ReadingBody",
@@ -44,12 +44,13 @@ inline const char* conn_state_name(ConnState state) {
         "Proxying",
         "Sending",
     };
-    static_assert(sizeof(kConnStateNames) / sizeof(*kConnStateNames) ==
-                      static_cast<u8>(ConnState::kNumStates),
+    static_assert(sizeof(kConnStateNames) /
+                      sizeof(*kConnStateNames) ==
+                  static_cast<u8>(ConnState::_Count),
                   "conn_state_name table must cover all ConnState values");
 
     const auto idx = static_cast<u8>(state);
-    if (idx < static_cast<u8>(ConnState::kNumStates)) {
+    if (idx < static_cast<u8>(ConnState::_Count)) {
         return kConnStateNames[idx];
     }
     return "Unknown";

--- a/include/rut/runtime/epoll_event_loop.h
+++ b/include/rut/runtime/epoll_event_loop.h
@@ -548,8 +548,9 @@ public:
                         //       chose timeout as its completion event.
                         if (c->pending_handler_fn &&
                             (c->pending_yield_kind == jit::YieldKind::Timer ||
-                             (c->yield_armed && yield_kind_matches_event(c->pending_yield_kind,
-                                                                         IoEventType::Timeout)))) {
+                             (c->yield_armed &&
+                              yield_kind_matches_event(
+                                  c->pending_yield_kind, IoEventType::Timeout)))) {
                             c->yield_armed = false;
                             c->resume_event_kind = jit::YieldKind::Timer;
                             c->resume_event_result = 0;
@@ -603,7 +604,7 @@ public:
                     }
                 }
                 break;
-            case IoEventType::kNumEventTypes:
+            case IoEventType::_Count:
                 break;
         }
     }

--- a/include/rut/runtime/epoll_event_loop.h
+++ b/include/rut/runtime/epoll_event_loop.h
@@ -603,7 +603,7 @@ public:
                     }
                 }
                 break;
-            case IoEventType::_Count:
+            case IoEventType::Count:
                 break;
         }
     }

--- a/include/rut/runtime/epoll_event_loop.h
+++ b/include/rut/runtime/epoll_event_loop.h
@@ -548,9 +548,8 @@ public:
                         //       chose timeout as its completion event.
                         if (c->pending_handler_fn &&
                             (c->pending_yield_kind == jit::YieldKind::Timer ||
-                             (c->yield_armed &&
-                              yield_kind_matches_event(
-                                  c->pending_yield_kind, IoEventType::Timeout)))) {
+                             (c->yield_armed && yield_kind_matches_event(c->pending_yield_kind,
+                                                                         IoEventType::Timeout)))) {
                             c->yield_armed = false;
                             c->resume_event_kind = jit::YieldKind::Timer;
                             c->resume_event_result = 0;

--- a/include/rut/runtime/event_loop.h
+++ b/include/rut/runtime/event_loop.h
@@ -95,7 +95,7 @@ public:
             case IoEventType::Accept:
             case IoEventType::Timeout:
             case IoEventType::HandlerTimer:
-            case IoEventType::kNumEventTypes:
+            case IoEventType::_Count:
                 break;
         }
     }
@@ -653,14 +653,11 @@ public:
                             // event type (not state) to distinguish client vs upstream.
                             if (ev.type == IoEventType::Recv) conn.recv_armed = false;
                             if (ev.type == IoEventType::Send) conn.send_armed = false;
-                            if (ev.type == IoEventType::UpstreamSend)
-                                conn.upstream_send_armed = false;
-                            if (ev.type == IoEventType::UpstreamRecv)
-                                conn.upstream_recv_armed = false;
+                            if (ev.type == IoEventType::UpstreamSend) conn.upstream_send_armed = false;
+                            if (ev.type == IoEventType::UpstreamRecv) conn.upstream_recv_armed = false;
                         }
                     }
-                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv ||
-                        conn.on_upstream_send) {
+                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv || conn.on_upstream_send) {
                         timer.refresh(&conn, keepalive_timeout);
                         this->dispatch_event(conn, ev);
                     } else if constexpr (Backend::kAsyncIo) {
@@ -674,7 +671,7 @@ public:
                     }
                 }
                 break;
-            case IoEventType::kNumEventTypes:
+            case IoEventType::_Count:
                 break;
         }
     }

--- a/include/rut/runtime/event_loop.h
+++ b/include/rut/runtime/event_loop.h
@@ -653,11 +653,14 @@ public:
                             // event type (not state) to distinguish client vs upstream.
                             if (ev.type == IoEventType::Recv) conn.recv_armed = false;
                             if (ev.type == IoEventType::Send) conn.send_armed = false;
-                            if (ev.type == IoEventType::UpstreamSend) conn.upstream_send_armed = false;
-                            if (ev.type == IoEventType::UpstreamRecv) conn.upstream_recv_armed = false;
+                            if (ev.type == IoEventType::UpstreamSend)
+                                conn.upstream_send_armed = false;
+                            if (ev.type == IoEventType::UpstreamRecv)
+                                conn.upstream_recv_armed = false;
                         }
                     }
-                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv || conn.on_upstream_send) {
+                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv ||
+                        conn.on_upstream_send) {
                         timer.refresh(&conn, keepalive_timeout);
                         this->dispatch_event(conn, ev);
                     } else if constexpr (Backend::kAsyncIo) {

--- a/include/rut/runtime/event_loop.h
+++ b/include/rut/runtime/event_loop.h
@@ -95,7 +95,7 @@ public:
             case IoEventType::Accept:
             case IoEventType::Timeout:
             case IoEventType::HandlerTimer:
-            case IoEventType::_Count:
+            case IoEventType::Count:
                 break;
         }
     }
@@ -674,7 +674,7 @@ public:
                     }
                 }
                 break;
-            case IoEventType::_Count:
+            case IoEventType::Count:
                 break;
         }
     }

--- a/include/rut/runtime/io_event.h
+++ b/include/rut/runtime/io_event.h
@@ -19,10 +19,10 @@ enum class IoEventType : u8 {
                    // epoll:   shared one-shot timerfd — event is a global
                    //   notification; conn_id is unused, the event loop
                    //   drains its min-heap to find which conns to resume.
-    _Count,
+    Count,
 };
 
-static_assert(static_cast<u8>(IoEventType::_Count) == 8u,
+static_assert(static_cast<u8>(IoEventType::Count) == 8u,
               "IoEventType should keep all runtime event tags and remain small");
 
 // Unified completion event — field order optimized for minimal padding.

--- a/include/rut/runtime/io_event.h
+++ b/include/rut/runtime/io_event.h
@@ -19,10 +19,10 @@ enum class IoEventType : u8 {
                    // epoll:   shared one-shot timerfd — event is a global
                    //   notification; conn_id is unused, the event loop
                    //   drains its min-heap to find which conns to resume.
-    kNumEventTypes,
+    _Count,
 };
 
-static_assert(static_cast<u8>(IoEventType::kNumEventTypes) == 8u,
+static_assert(static_cast<u8>(IoEventType::_Count) == 7u,
               "IoEventType should keep all runtime event tags and remain small");
 
 // Unified completion event — field order optimized for minimal padding.

--- a/include/rut/runtime/io_event.h
+++ b/include/rut/runtime/io_event.h
@@ -22,7 +22,7 @@ enum class IoEventType : u8 {
     _Count,
 };
 
-static_assert(static_cast<u8>(IoEventType::_Count) == 7u,
+static_assert(static_cast<u8>(IoEventType::_Count) == 8u,
               "IoEventType should keep all runtime event tags and remain small");
 
 // Unified completion event — field order optimized for minimal padding.

--- a/include/rut/runtime/iouring_event_loop.h
+++ b/include/rut/runtime/iouring_event_loop.h
@@ -499,8 +499,7 @@ public:
                 if (ev.conn_id < kMaxConns) {
                     auto& c = conns[ev.conn_id];
                     if (c.pending_ops > 0) c.pending_ops--;
-                    const bool matching_generation =
-                        ev.result == static_cast<i32>(c.yield_timer_gen);
+                    const bool matching_generation = ev.result == static_cast<i32>(c.yield_timer_gen);
                     const bool was_yield_armed = c.yield_armed;
                     if (matching_generation) {
                         c.yield_armed = false;
@@ -531,8 +530,8 @@ public:
                         // wait(ms), or wait-any timeout completion.
                         if (c->pending_handler_fn &&
                             (c->pending_yield_kind == jit::YieldKind::Timer ||
-                             (c->yield_armed && yield_kind_matches_event(c->pending_yield_kind,
-                                                                         IoEventType::Timeout)))) {
+                             (c->yield_armed &&
+                              yield_kind_matches_event(c->pending_yield_kind, IoEventType::Timeout)))) {
                             c->yield_armed = false;
                             c->yield_timeout_armed = false;
                             c->resume_event_kind = jit::YieldKind::Timer;
@@ -571,8 +570,7 @@ public:
                         if (ev.type == IoEventType::UpstreamSend) conn.upstream_send_armed = false;
                         if (ev.type == IoEventType::UpstreamRecv) conn.upstream_recv_armed = false;
                     }
-                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv ||
-                        conn.on_upstream_send) {
+                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv || conn.on_upstream_send) {
                         timer.refresh(&conn, keepalive_timeout);
                         this->dispatch_event(conn, ev);
                     } else if (conn.pending_handler_fn) {
@@ -605,9 +603,9 @@ public:
                         //     hot-spin on repeated error CQEs until the yield
                         //     deadline fires. Close unconditionally.
                         const bool kRecvError = (ev.type == IoEventType::Recv && ev.result < 0 &&
-                                                 ev.result != -ECANCELED);
-                        const bool kPeerClose =
-                            (ev.type == IoEventType::Recv && !ev.more && ev.result == 0);
+                                                ev.result != -ECANCELED);
+                        const bool kPeerClose = (ev.type == IoEventType::Recv && !ev.more &&
+                                                ev.result == 0);
                         if (kRecvError || kPeerClose) {
                             this->close_conn(conn);
                         } else if (ev.type == IoEventType::Recv && !ev.more && ev.result > 0) {
@@ -625,7 +623,7 @@ public:
                     }
                 }
                 break;
-            case IoEventType::kNumEventTypes:
+            case IoEventType::_Count:
                 break;
         }
     }

--- a/include/rut/runtime/iouring_event_loop.h
+++ b/include/rut/runtime/iouring_event_loop.h
@@ -499,7 +499,8 @@ public:
                 if (ev.conn_id < kMaxConns) {
                     auto& c = conns[ev.conn_id];
                     if (c.pending_ops > 0) c.pending_ops--;
-                    const bool matching_generation = ev.result == static_cast<i32>(c.yield_timer_gen);
+                    const bool matching_generation =
+                        ev.result == static_cast<i32>(c.yield_timer_gen);
                     const bool was_yield_armed = c.yield_armed;
                     if (matching_generation) {
                         c.yield_armed = false;
@@ -530,8 +531,8 @@ public:
                         // wait(ms), or wait-any timeout completion.
                         if (c->pending_handler_fn &&
                             (c->pending_yield_kind == jit::YieldKind::Timer ||
-                             (c->yield_armed &&
-                              yield_kind_matches_event(c->pending_yield_kind, IoEventType::Timeout)))) {
+                             (c->yield_armed && yield_kind_matches_event(c->pending_yield_kind,
+                                                                         IoEventType::Timeout)))) {
                             c->yield_armed = false;
                             c->yield_timeout_armed = false;
                             c->resume_event_kind = jit::YieldKind::Timer;
@@ -570,7 +571,8 @@ public:
                         if (ev.type == IoEventType::UpstreamSend) conn.upstream_send_armed = false;
                         if (ev.type == IoEventType::UpstreamRecv) conn.upstream_recv_armed = false;
                     }
-                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv || conn.on_upstream_send) {
+                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv ||
+                        conn.on_upstream_send) {
                         timer.refresh(&conn, keepalive_timeout);
                         this->dispatch_event(conn, ev);
                     } else if (conn.pending_handler_fn) {
@@ -603,9 +605,9 @@ public:
                         //     hot-spin on repeated error CQEs until the yield
                         //     deadline fires. Close unconditionally.
                         const bool kRecvError = (ev.type == IoEventType::Recv && ev.result < 0 &&
-                                                ev.result != -ECANCELED);
-                        const bool kPeerClose = (ev.type == IoEventType::Recv && !ev.more &&
-                                                ev.result == 0);
+                                                 ev.result != -ECANCELED);
+                        const bool kPeerClose =
+                            (ev.type == IoEventType::Recv && !ev.more && ev.result == 0);
                         if (kRecvError || kPeerClose) {
                             this->close_conn(conn);
                         } else if (ev.type == IoEventType::Recv && !ev.more && ev.result > 0) {

--- a/include/rut/runtime/iouring_event_loop.h
+++ b/include/rut/runtime/iouring_event_loop.h
@@ -625,7 +625,7 @@ public:
                     }
                 }
                 break;
-            case IoEventType::_Count:
+            case IoEventType::Count:
                 break;
         }
     }

--- a/include/rut/runtime/jit_dispatch.h
+++ b/include/rut/runtime/jit_dispatch.h
@@ -116,7 +116,7 @@ inline jit::YieldKind yield_kind_from_event(IoEventType type) {
         case IoEventType::HandlerTimer:
             return jit::YieldKind::Timer;
         case IoEventType::Accept:
-        case IoEventType::_Count:
+        case IoEventType::Count:
             return jit::YieldKind::HttpGet;
     }
     return jit::YieldKind::Timer;

--- a/include/rut/runtime/jit_dispatch.h
+++ b/include/rut/runtime/jit_dispatch.h
@@ -116,7 +116,7 @@ inline jit::YieldKind yield_kind_from_event(IoEventType type) {
         case IoEventType::HandlerTimer:
             return jit::YieldKind::Timer;
         case IoEventType::Accept:
-        case IoEventType::kNumEventTypes:
+        case IoEventType::_Count:
             return jit::YieldKind::HttpGet;
     }
     return jit::YieldKind::Timer;

--- a/include/rut/runtime/simd/simd.h
+++ b/include/rut/runtime/simd/simd.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "rut/common/types.h"
+
+namespace rut::simd {
+
+// Find \r\n\r\n in buffer starting from `from`.
+// Returns offset past terminator (first body byte), or 0 if not found.
+u32 find_header_end(const u8* buf, u32 len, u32 from);
+
+// Scan header value: find \r while validating chars.
+// Returns position of \r, or `end` if not found, or (u32)-1 on invalid char.
+u32 scan_header_value(const u8* buf, u32 pos, u32 end);
+
+// Scan URI: find space while validating, and report the canonical-end
+// position (first '?' or '#' before space, else the space/end position).
+//
+// Returns position of space, or `end` if not found, or (u32)-1 on invalid.
+// On non-error returns, *canon_end_out receives the canonical-end position:
+//   - if '?' or '#' appears before the terminating space, its position
+//   - otherwise, the same value as the return (space or end)
+// On error return ((u32)-1), *canon_end_out is untouched.
+//
+// canon_end is the upper bound of the routing-relevant path bytes
+// [uri_start, canon_end). Callers strip leading '/' and trim trailing '/'
+// in scalar code after the scan to produce the final canonical Str.
+u32 scan_uri(const u8* buf, u32 pos, u32 end, u32* canon_end_out);
+
+// Scan header name: find ':' while validating token chars.
+// Returns position of ':', or (u32)-1 on invalid/not found.
+u32 scan_header_name(const u8* buf, u32 pos, u32 end);
+
+}  // namespace rut::simd

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6555,7 +6555,8 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             cmp.lhs = lhs_operand->value;
             cmp.rhs = rhs_operand->value;
             cmp.span = expr.span;
-            if (!route->exprs.push(cmp)) return frontend_error(FrontendError::TooManyItems, expr.span);
+            if (!route->exprs.push(cmp))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
             HirExpr* cmp_ptr = &route->exprs[route->exprs.len - 1];
 
             HirExpr false_expr{};

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6801,6 +6801,34 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             out.error_variant_index = rhs->error_variant_index;
             return out;
         }
+        if (!lhs->may_nil && !lhs->may_error) {
+            HirExpr true_expr{};
+            true_expr.kind = HirExprKind::BoolLit;
+            true_expr.type = HirTypeKind::Bool;
+            true_expr.bool_value = true;
+            true_expr.span = expr.span;
+            if (!route->exprs.push(true_expr))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* true_ptr = &route->exprs[route->exprs.len - 1];
+
+            if (!route->exprs.push(rhs.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
+
+            HirExpr out{};
+            out.kind = HirExprKind::IfElse;
+            copy_hir_shape(&out, lhs.value());
+            out.span = expr.span;
+            out.lhs = true_ptr;
+            out.rhs = lhs_ptr;
+            if (!out.args.push(rhs_ptr))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.may_nil = false;
+            out.may_error = rhs->may_error;
+            out.error_struct_index = rhs->error_struct_index;
+            out.error_variant_index = rhs->error_variant_index;
+            return out;
+        }
 
         HirExpr cond{};
         cond.kind = HirExprKind::HasValue;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6220,6 +6220,22 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         auto lhs = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
         if (!lhs) return core::make_unexpected(lhs.error());
         if (expr.rhs->kind == AstExprKind::MethodCall && expr.rhs->lhs != nullptr &&
+            expr.rhs->lhs->kind == AstExprKind::Placeholder && expr.rhs->lhs->int_value != 1) {
+            const i32 slot = expr.rhs->lhs->int_value;
+            if (slot <= 0 || slot > 10)
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      expr.rhs->lhs->span,
+                                      lit_str("placeholder slot out of range"));
+            if (lhs->type != HirTypeKind::Tuple)
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      expr.rhs->lhs->span,
+                                      lit_str("non-tuple source with non-unit placeholder"));
+            if (slot > static_cast<i32>(lhs->tuple_len))
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      expr.rhs->lhs->span,
+                                      lit_str("placeholder slot exceeds tuple arity"));
+        }
+        if (expr.rhs->kind == AstExprKind::MethodCall && expr.rhs->lhs != nullptr &&
             expr.rhs->lhs->kind == AstExprKind::Placeholder && expr.rhs->lhs->int_value == 1) {
             AstExpr method_stage = *expr.rhs;
             auto copy_result_shape = [](HirExpr* dst, const HirExpr& src) {
@@ -6432,7 +6448,9 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = analyze_expr(*expr.rhs, route, mod, locals, local_count, binding);
         if (!rhs) return core::make_unexpected(rhs.error());
-        if (lhs->may_nil || lhs->may_error || rhs->may_nil || rhs->may_error)
+        const bool lhs_maybe_missing = lhs->may_nil || lhs->may_error;
+        const bool rhs_maybe_missing = rhs->may_nil || rhs->may_error;
+        if (expr.kind != AstExprKind::Eq && (lhs_maybe_missing || rhs_maybe_missing))
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         if (lhs->type != rhs->type)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
@@ -6459,6 +6477,100 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                     return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
                 }
             }
+        }
+        if (expr.kind == AstExprKind::Eq && (lhs_maybe_missing || rhs_maybe_missing)) {
+            struct CmpOperand {
+                HirExpr* value;
+                HirExpr* cond;
+            };
+            auto make_operand = [&](const HirExpr& analyzed,
+                                    bool maybe_missing) -> FrontendResult<CmpOperand> {
+                if (!route->exprs.push(analyzed))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                HirExpr* base_ptr = &route->exprs[route->exprs.len - 1];
+                if (!maybe_missing) return CmpOperand{base_ptr, nullptr};
+
+                HirExpr cond{};
+                cond.kind = HirExprKind::HasValue;
+                cond.type = HirTypeKind::Bool;
+                cond.span = expr.span;
+                cond.lhs = base_ptr;
+                if (!route->exprs.push(cond))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                HirExpr* cond_ptr = &route->exprs[route->exprs.len - 1];
+
+                HirExpr value{};
+                value = analyzed;
+                value.kind = HirExprKind::ValueOf;
+                value.lhs = base_ptr;
+                value.may_nil = false;
+                value.may_error = false;
+                value.span = expr.span;
+                if (!route->exprs.push(value))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                HirExpr* value_ptr = &route->exprs[route->exprs.len - 1];
+                return CmpOperand{value_ptr, cond_ptr};
+            };
+
+            auto lhs_operand = make_operand(lhs.value(), lhs_maybe_missing);
+            if (!lhs_operand) return core::make_unexpected(lhs_operand.error());
+            auto rhs_operand = make_operand(rhs.value(), rhs_maybe_missing);
+            if (!rhs_operand) return core::make_unexpected(rhs_operand.error());
+
+            HirExpr* availability = lhs_operand->cond;
+            if (rhs_operand->cond != nullptr) {
+                if (availability == nullptr) {
+                    availability = rhs_operand->cond;
+                } else {
+                    HirExpr false_expr{};
+                    false_expr.kind = HirExprKind::BoolLit;
+                    false_expr.type = HirTypeKind::Bool;
+                    false_expr.bool_value = false;
+                    false_expr.span = expr.span;
+                    if (!route->exprs.push(false_expr))
+                        return frontend_error(FrontendError::TooManyItems, expr.span);
+                    HirExpr* false_ptr = &route->exprs[route->exprs.len - 1];
+
+                    HirExpr both{};
+                    both.kind = HirExprKind::IfElse;
+                    both.type = HirTypeKind::Bool;
+                    both.span = expr.span;
+                    both.lhs = availability;
+                    both.rhs = rhs_operand->cond;
+                    if (!both.args.push(false_ptr))
+                        return frontend_error(FrontendError::TooManyItems, expr.span);
+                    if (!route->exprs.push(both))
+                        return frontend_error(FrontendError::TooManyItems, expr.span);
+                    availability = &route->exprs[route->exprs.len - 1];
+                }
+            }
+
+            HirExpr cmp{};
+            cmp.kind = HirExprKind::Eq;
+            cmp.type = HirTypeKind::Bool;
+            cmp.lhs = lhs_operand->value;
+            cmp.rhs = rhs_operand->value;
+            cmp.span = expr.span;
+            if (!route->exprs.push(cmp)) return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* cmp_ptr = &route->exprs[route->exprs.len - 1];
+
+            HirExpr false_expr{};
+            false_expr.kind = HirExprKind::BoolLit;
+            false_expr.type = HirTypeKind::Bool;
+            false_expr.bool_value = false;
+            false_expr.span = expr.span;
+            if (!route->exprs.push(false_expr))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* false_ptr = &route->exprs[route->exprs.len - 1];
+
+            out.kind = HirExprKind::IfElse;
+            out.type = HirTypeKind::Bool;
+            out.lhs = availability;
+            out.rhs = cmp_ptr;
+            if (!out.args.push(false_ptr))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.span = expr.span;
+            return out;
         }
         if (!route->exprs.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -6643,8 +6755,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         }
 
         const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
-        if ((lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) &&
-            !rhs->may_error) {
+        if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
             HirExpr folded = rhs.value();
             folded.span = expr.span;
             return folded;
@@ -6658,6 +6769,26 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (!route->exprs.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
+
+        if (!rhs->may_error) {
+            if (!route->exprs.push(rhs.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
+
+            HirExpr out{};
+            out.kind = HirExprKind::Or;
+            copy_hir_shape(&out, rhs.value());
+            if (out.shape_index == 0xffffffffu && lhs->shape_index != 0xffffffffu)
+                copy_hir_shape(&out, lhs.value());
+            out.span = expr.span;
+            out.lhs = lhs_ptr;
+            out.rhs = rhs_ptr;
+            out.may_nil = false;
+            out.may_error = false;
+            out.error_struct_index = rhs->error_struct_index;
+            out.error_variant_index = rhs->error_variant_index;
+            return out;
+        }
 
         HirExpr cond{};
         cond.kind = HirExprKind::HasValue;
@@ -6692,10 +6823,9 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         out.rhs = then_ptr;
         if (!out.args.push(rhs_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
         out.may_nil = false;
-        out.may_error = lhs->may_error || rhs->may_error;
-        out.error_struct_index = rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
-        out.error_variant_index =
-            rhs->may_error ? rhs->error_variant_index : lhs->error_variant_index;
+        out.may_error = rhs->may_error;
+        out.error_struct_index = rhs->error_struct_index;
+        out.error_variant_index = rhs->error_variant_index;
         return out;
     }
 
@@ -6719,9 +6849,12 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         }
 
         const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
-        if ((lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) &&
-            !rhs->may_error) {
+        if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
             HirExpr folded = lhs.value();
+            if (lhs_state == KnownValueState::Error) {
+                if (const HirExpr* err = known_error_expr(lhs.value(), locals, local_count, 0))
+                    folded = *err;
+            }
             folded.span = expr.span;
             return folded;
         }
@@ -6752,11 +6885,9 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         copy_hir_shape(&fallback, rhs.value());
         fallback.span = expr.span;
         fallback.may_nil = lhs->may_nil;
-        fallback.may_error = lhs->may_error || rhs->may_error;
-        fallback.error_struct_index =
-            rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
-        fallback.error_variant_index =
-            rhs->may_error ? rhs->error_variant_index : lhs->error_variant_index;
+        fallback.may_error = lhs->may_error;
+        fallback.error_struct_index = lhs->error_struct_index;
+        fallback.error_variant_index = lhs->error_variant_index;
         fallback.lhs = lhs_ptr;
         if (!route->exprs.push(fallback))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -6782,8 +6913,12 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
     const u32 fn_index = find_function_index(mod, callee_name);
     const auto fail_call =
         [&](Span span, const char* reason, const Str* detail) -> FrontendResult<HirExpr> {
-        (void)reason;
         if (detail) return frontend_error(FrontendError::UnsupportedSyntax, span, *detail);
+        if (reason != nullptr) {
+            u32 reason_len = 0;
+            while (reason[reason_len] != '\0') reason_len++;
+            return frontend_error(FrontendError::UnsupportedSyntax, span, Str{reason, reason_len});
+        }
         return frontend_error(FrontendError::UnsupportedSyntax, span);
     };
     const auto fail_with_name = [&](Span span, const char* reason) -> FrontendResult<HirExpr> {
@@ -9848,6 +9983,11 @@ static FrontendResult<void> load_imported_modules(
         if (item.kind != AstItemKind::Import) continue;
         const auto normalized =
             (base_dir / str_to_std_string(item.import_decl.path)).lexically_normal().string();
+        for (const auto& active_import : import_stack) {
+            if (active_import == normalized)
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, item.import_decl.span, item.import_decl.path);
+        }
         ImportedModuleInfo* existing_info = nullptr;
         for (u32 ii = 0; ii < out.len; ii++) {
             if (out[ii].path.eq({normalized.c_str(), static_cast<u32>(normalized.size())}) &&

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6643,12 +6643,13 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         }
 
         const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
-        if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
+        if ((lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) &&
+            !rhs->may_error) {
             HirExpr folded = rhs.value();
             folded.span = expr.span;
             return folded;
         }
-        if (!lhs->may_nil && !lhs->may_error) {
+        if (!lhs->may_nil && !lhs->may_error && !rhs->may_error) {
             HirExpr folded = lhs.value();
             folded.span = expr.span;
             return folded;
@@ -6718,7 +6719,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         }
 
         const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
-        if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
+        if ((lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) &&
+            !rhs->may_error) {
             HirExpr folded = lhs.value();
             folded.span = expr.span;
             return folded;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6040,8 +6040,10 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = analyze_expr(*expr.rhs, route, mod, locals, local_count, binding);
         if (!rhs) return core::make_unexpected(rhs.error());
-        if (rhs->may_nil || rhs->may_error)
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.rhs->span);
+        if (lhs->may_nil || lhs->may_error || rhs->may_nil || rhs->may_error)
+            return frontend_error(FrontendError::UnsupportedSyntax,
+                                  lhs->may_nil || lhs->may_error ? expr.lhs->span
+                                                                 : expr.rhs->span);
         const bool is_bool_or = lhs->type == HirTypeKind::Bool && rhs->type == HirTypeKind::Bool;
         if (is_bool_or) {
             if (lhs->kind == HirExprKind::BoolLit) {
@@ -6118,63 +6120,7 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             out.span = expr.span;
             return out;
         }
-        if (lhs->type != HirTypeKind::Unknown &&
-            !same_hir_type_shape(mod, lhs.value(), rhs.value()))
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-        if (lhs->kind == HirExprKind::Nil) {
-            HirExpr folded = rhs.value();
-            folded.span = expr.span;
-            folded.may_nil = false;
-            folded.may_error = false;
-            return folded;
-        }
-        if (lhs->kind == HirExprKind::Error) {
-            HirExpr folded = rhs.value();
-            folded.span = expr.span;
-            folded.may_nil = false;
-            folded.may_error = false;
-            return folded;
-        }
-        const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
-        if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
-            HirExpr folded = rhs.value();
-            folded.span = expr.span;
-            folded.may_nil = false;
-            folded.may_error = false;
-            return folded;
-        }
-        if (lhs_state == KnownValueState::Available) {
-            HirExpr folded = lhs.value();
-            folded.span = expr.span;
-            return folded;
-        }
-        if (!route->exprs.push(lhs.value()))
-            return frontend_error(FrontendError::TooManyItems, expr.span);
-        HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
-        if (!route->exprs.push(rhs.value()))
-            return frontend_error(FrontendError::TooManyItems, expr.span);
-        HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
-        out.kind = HirExprKind::Or;
-        out.type = lhs->type == HirTypeKind::Unknown ? rhs->type : lhs->type;
-        out.lhs = lhs_ptr;
-        out.rhs = rhs_ptr;
-        auto shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
-                                           out.type,
-                                           out.generic_index,
-                                           out.variant_index,
-                                           out.struct_index,
-                                           out.tuple_len,
-                                           out.tuple_types,
-                                           out.tuple_variant_indices,
-                                           out.tuple_struct_indices,
-                                           expr.span);
-        if (!shape) return core::make_unexpected(shape.error());
-        out.shape_index = shape.value();
-        out.may_nil = false;
-        out.may_error = false;
-        out.error_struct_index = 0xffffffffu;
-        out.error_variant_index = 0xffffffffu;
-        return out;
+        return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
     }
     if (expr.kind == AstExprKind::And) {
         auto lhs = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
@@ -6682,6 +6628,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = analyze_expr(*expr.args[1], route, mod, locals, local_count, binding);
         if (!rhs) return core::make_unexpected(rhs.error());
+        if (rhs->may_nil || rhs->may_error)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.args[1]->span);
 
         if (lhs->type != HirTypeKind::Unknown && rhs->type != HirTypeKind::Unknown &&
             !same_hir_type_shape(mod, lhs.value(), rhs.value())) {
@@ -6724,10 +6672,9 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         out.rhs = lhs_ptr;
         if (!out.args.push(rhs_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
         out.may_nil = false;
-        out.may_error = lhs->may_error || rhs->may_error;
-        out.error_struct_index = rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
-        out.error_variant_index =
-            rhs->may_error ? rhs->error_variant_index : lhs->error_variant_index;
+        out.may_error = rhs->may_error;
+        out.error_struct_index = rhs->error_struct_index;
+        out.error_variant_index = rhs->error_variant_index;
         return out;
     }
 
@@ -6742,6 +6689,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = analyze_expr(*expr.args[1], route, mod, locals, local_count, binding);
         if (!rhs) return core::make_unexpected(rhs.error());
+        if (rhs->may_nil || rhs->may_error)
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.args[1]->span);
 
         if (lhs->type != HirTypeKind::Unknown && rhs->type != HirTypeKind::Unknown &&
             !same_hir_type_shape(mod, lhs.value(), rhs.value())) {
@@ -6799,7 +6748,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         out.rhs = rhs_ptr;
         if (!out.args.push(fallback_ptr))
             return frontend_error(FrontendError::TooManyItems, expr.span);
-        out.may_nil = false;
+        out.may_nil = lhs->may_nil;
         out.may_error = lhs->may_error || rhs->may_error;
         out.error_struct_index = rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
         out.error_variant_index =

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6501,6 +6501,7 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         }
         if (expr.kind == AstExprKind::Eq && (lhs_maybe_missing || rhs_maybe_missing)) {
             struct CmpOperand {
+                HirExpr* base;
                 HirExpr* value;
                 HirExpr* cond;
             };
@@ -6509,7 +6510,7 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                 if (!route->exprs.push(analyzed))
                     return frontend_error(FrontendError::TooManyItems, expr.span);
                 HirExpr* base_ptr = &route->exprs[route->exprs.len - 1];
-                if (!maybe_missing) return CmpOperand{base_ptr, nullptr};
+                if (!maybe_missing) return CmpOperand{base_ptr, base_ptr, nullptr};
 
                 HirExpr cond{};
                 cond.kind = HirExprKind::HasValue;
@@ -6530,7 +6531,7 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                 if (!route->exprs.push(value))
                     return frontend_error(FrontendError::TooManyItems, expr.span);
                 HirExpr* value_ptr = &route->exprs[route->exprs.len - 1];
-                return CmpOperand{value_ptr, cond_ptr};
+                return CmpOperand{base_ptr, value_ptr, cond_ptr};
             };
 
             auto lhs_operand = make_operand(lhs.value(), lhs_maybe_missing);
@@ -6591,12 +6592,82 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             out.rhs = cmp_ptr;
             if (!out.args.push(false_ptr))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
-            out.may_error = lhs->may_error || rhs->may_error;
-            out.error_struct_index =
-                rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
-            out.error_variant_index =
-                rhs->may_error ? rhs->error_variant_index : lhs->error_variant_index;
             out.span = expr.span;
+            if (!route->exprs.push(out))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* result_ptr = &route->exprs[route->exprs.len - 1];
+
+            auto wrap_error_propagation = [&](HirExpr* current,
+                                              HirExpr* source) -> FrontendResult<HirExpr*> {
+                HirExpr no_error{};
+                no_error.kind = HirExprKind::NoError;
+                no_error.type = HirTypeKind::Bool;
+                no_error.span = expr.span;
+                no_error.lhs = source;
+                if (!route->exprs.push(no_error))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                HirExpr* no_error_ptr = &route->exprs[route->exprs.len - 1];
+
+                HirExpr missing{};
+                missing.kind = HirExprKind::MissingOf;
+                missing.type = HirTypeKind::Bool;
+                auto bool_shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                                        HirTypeKind::Bool,
+                                                        0xffffffffu,
+                                                        0xffffffffu,
+                                                        0xffffffffu,
+                                                        0,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        expr.span);
+                if (!bool_shape) return core::make_unexpected(bool_shape.error());
+                missing.shape_index = bool_shape.value();
+                missing.span = expr.span;
+                missing.may_error = true;
+                missing.error_struct_index = source->error_struct_index;
+                missing.error_variant_index = source->error_variant_index;
+                missing.lhs = source;
+                if (!route->exprs.push(missing))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                HirExpr* missing_ptr = &route->exprs[route->exprs.len - 1];
+
+                HirExpr wrapped{};
+                wrapped.kind = HirExprKind::IfElse;
+                wrapped.type = HirTypeKind::Bool;
+                wrapped.shape_index = bool_shape.value();
+                wrapped.span = expr.span;
+                wrapped.lhs = no_error_ptr;
+                wrapped.rhs = current;
+                if (!wrapped.args.push(missing_ptr))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                wrapped.may_error = true;
+                wrapped.error_struct_index = source->error_struct_index;
+                wrapped.error_variant_index = source->error_variant_index;
+                if (!route->exprs.push(wrapped))
+                    return frontend_error(FrontendError::TooManyItems, expr.span);
+                return &route->exprs[route->exprs.len - 1];
+            };
+
+            if (lhs->may_error && rhs->may_error &&
+                (lhs->error_struct_index != rhs->error_struct_index ||
+                 lhs->error_variant_index != rhs->error_variant_index)) {
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      expr.span,
+                                      lit_str("comparison cannot combine different propagated "
+                                              "error variants"));
+            }
+            if (rhs->may_error) {
+                auto wrapped = wrap_error_propagation(result_ptr, rhs_operand->base);
+                if (!wrapped) return core::make_unexpected(wrapped.error());
+                result_ptr = wrapped.value();
+            }
+            if (lhs->may_error) {
+                auto wrapped = wrap_error_propagation(result_ptr, lhs_operand->base);
+                if (!wrapped) return core::make_unexpected(wrapped.error());
+                result_ptr = wrapped.value();
+            }
+            out = *result_ptr;
             return out;
         }
         if (!route->exprs.push(lhs.value()))
@@ -6865,7 +6936,6 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             !same_hir_type_shape(mod, *lhs, *rhs)) {
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         }
-
         const auto lhs_state = known_value_state(*lhs, locals, local_count, 0);
         if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
             HirExpr folded = *rhs;
@@ -6984,6 +7054,14 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (lhs->type != HirTypeKind::Unknown && rhs->type != HirTypeKind::Unknown &&
             !same_hir_type_shape(mod, *lhs, *rhs)) {
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        }
+        if (lhs->may_error && rhs->may_error &&
+            (lhs->error_struct_index != rhs->error_struct_index ||
+             lhs->error_variant_index != rhs->error_variant_index)) {
+            return frontend_error(
+                FrontendError::UnsupportedSyntax,
+                expr.span,
+                lit_str("all cannot combine different propagated error variants"));
         }
 
         const auto lhs_state = known_value_state(*lhs, locals, local_count, 0);

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6827,6 +6827,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             out.may_error = rhs->may_error;
             out.error_struct_index = rhs->error_struct_index;
             out.error_variant_index = rhs->error_variant_index;
+            out.is_eager_fallback = true;
             return out;
         }
 

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6042,6 +6042,81 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         if (!rhs) return core::make_unexpected(rhs.error());
         if (rhs->may_nil || rhs->may_error)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.rhs->span);
+        const bool is_bool_or = lhs->type == HirTypeKind::Bool && rhs->type == HirTypeKind::Bool;
+        if (is_bool_or) {
+            if (lhs->kind == HirExprKind::BoolLit) {
+                HirExpr folded{};
+                folded.kind = HirExprKind::BoolLit;
+                folded.type = HirTypeKind::Bool;
+                folded.bool_value = lhs->bool_value || rhs->bool_value;
+                folded.shape_index = rhs->shape_index;
+                folded.variant_index = rhs->variant_index;
+                folded.struct_index = rhs->struct_index;
+                folded.tuple_len = rhs->tuple_len;
+                for (u32 i = 0; i < rhs->tuple_len; i++) {
+                    folded.tuple_types[i] = rhs->tuple_types[i];
+                    folded.tuple_variant_indices[i] = rhs->tuple_variant_indices[i];
+                    folded.tuple_struct_indices[i] = rhs->tuple_struct_indices[i];
+                }
+                folded.may_nil = false;
+                folded.may_error = false;
+                folded.error_struct_index = rhs->error_struct_index;
+                folded.error_variant_index = rhs->error_variant_index;
+                folded.span = expr.span;
+                return folded;
+            }
+            if (!route->exprs.push(lhs.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
+
+            HirExpr true_expr{};
+            true_expr.kind = HirExprKind::BoolLit;
+            true_expr.type = HirTypeKind::Bool;
+            true_expr.bool_value = true;
+            true_expr.shape_index = rhs->shape_index;
+            true_expr.variant_index = rhs->variant_index;
+            true_expr.struct_index = rhs->struct_index;
+            true_expr.tuple_len = rhs->tuple_len;
+            for (u32 i = 0; i < rhs->tuple_len; i++) {
+                true_expr.tuple_types[i] = rhs->tuple_types[i];
+                true_expr.tuple_variant_indices[i] = rhs->tuple_variant_indices[i];
+                true_expr.tuple_struct_indices[i] = rhs->tuple_struct_indices[i];
+            }
+            true_expr.may_nil = false;
+            true_expr.may_error = false;
+            true_expr.error_struct_index = rhs->error_struct_index;
+            true_expr.error_variant_index = rhs->error_variant_index;
+            true_expr.span = expr.span;
+            if (!route->exprs.push(true_expr))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* true_ptr = &route->exprs[route->exprs.len - 1];
+
+            if (!route->exprs.push(rhs.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
+
+            HirExpr out{};
+            out.kind = HirExprKind::IfElse;
+            out.type = HirTypeKind::Bool;
+            out.lhs = lhs_ptr;
+            out.rhs = true_ptr;
+            if (!out.args.push(rhs_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.shape_index = rhs->shape_index;
+            out.variant_index = rhs->variant_index;
+            out.struct_index = rhs->struct_index;
+            out.tuple_len = rhs->tuple_len;
+            for (u32 i = 0; i < rhs->tuple_len; i++) {
+                out.tuple_types[i] = rhs->tuple_types[i];
+                out.tuple_variant_indices[i] = rhs->tuple_variant_indices[i];
+                out.tuple_struct_indices[i] = rhs->tuple_struct_indices[i];
+            }
+            out.may_nil = false;
+            out.may_error = false;
+            out.error_struct_index = rhs->error_struct_index;
+            out.error_variant_index = rhs->error_variant_index;
+            out.span = expr.span;
+            return out;
+        }
         if (lhs->type != HirTypeKind::Unknown &&
             !same_hir_type_shape(mod, lhs.value(), rhs.value()))
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
@@ -6658,7 +6733,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         fallback.kind = HirExprKind::MissingOf;
         copy_hir_shape(&fallback, rhs.value());
         fallback.span = expr.span;
-        fallback.may_nil = lhs->may_nil || rhs->may_nil;
+        fallback.may_nil = false;
         fallback.may_error = lhs->may_error || rhs->may_error;
         fallback.error_struct_index = rhs->may_error ? rhs->error_struct_index
                                                   : lhs->error_struct_index;
@@ -6676,7 +6751,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         out.lhs = cond_ptr;
         out.rhs = rhs_ptr;
         if (!out.args.push(fallback_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
-        out.may_nil = lhs->may_nil || rhs->may_nil;
+        out.may_nil = false;
         out.may_error = lhs->may_error || rhs->may_error;
         out.error_struct_index = rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
         out.error_variant_index = rhs->may_error ? rhs->error_variant_index

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6814,8 +6814,29 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         out.lhs = source;
         return out;
     };
-
-    if (expr.name.eq({"any", 3})) {
+    auto analyze_fallback_builtin_args = [&](HirExpr* out_lhs,
+                                             HirExpr* out_rhs) -> FrontendResult<void> {
+        u32 pipe_placeholder_count = 0;
+        if (pipe_lhs != nullptr) {
+            for (u32 i = 0; i < expr.args.len; i++) {
+                if (expr.args[i] != nullptr && expr.args[i]->kind == AstExprKind::Placeholder)
+                    pipe_placeholder_count++;
+            }
+        }
+        if (pipe_lhs != nullptr && pipe_placeholder_count == 0) {
+            if (expr.args.len != 1) {
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      expr.span,
+                                      lit_str("pipe call missing placeholder"));
+            }
+            if (expr.args[0] == nullptr)
+                return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+            *out_lhs = *pipe_lhs;
+            auto rhs = analyze_builtin_arg(*expr.args[0]);
+            if (!rhs) return core::make_unexpected(rhs.error());
+            *out_rhs = rhs.value();
+            return {};
+        }
         if (expr.args.len != 2) {
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         }
@@ -6826,40 +6847,50 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = analyze_builtin_arg(*expr.args[1]);
         if (!rhs) return core::make_unexpected(rhs.error());
-        if (rhs->may_nil)
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.args[1]->span);
+        *out_lhs = lhs.value();
+        *out_rhs = rhs.value();
+        return {};
+    };
+
+    if (expr.name.eq({"any", 3})) {
+        HirExpr lhs_value{};
+        HirExpr rhs_value{};
+        auto args = analyze_fallback_builtin_args(&lhs_value, &rhs_value);
+        if (!args) return core::make_unexpected(args.error());
+        HirExpr* lhs = &lhs_value;
+        HirExpr* rhs = &rhs_value;
+        if (rhs->may_nil) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
 
         if (lhs->type != HirTypeKind::Unknown && rhs->type != HirTypeKind::Unknown &&
-            !same_hir_type_shape(mod, lhs.value(), rhs.value())) {
+            !same_hir_type_shape(mod, *lhs, *rhs)) {
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         }
 
-        const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
+        const auto lhs_state = known_value_state(*lhs, locals, local_count, 0);
         if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
-            HirExpr folded = rhs.value();
+            HirExpr folded = *rhs;
             folded.span = expr.span;
             return folded;
         }
         if (!lhs->may_nil && !lhs->may_error && !rhs->may_error) {
-            HirExpr folded = lhs.value();
+            HirExpr folded = *lhs;
             folded.span = expr.span;
             return folded;
         }
 
-        if (!route->exprs.push(lhs.value()))
-            return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(*lhs)) return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
 
         if (!rhs->may_error) {
-            if (!route->exprs.push(rhs.value()))
+            if (!route->exprs.push(*rhs))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
             HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
 
             HirExpr out{};
             out.kind = HirExprKind::Or;
-            copy_hir_shape(&out, rhs.value());
+            copy_hir_shape(&out, *rhs);
             if (out.shape_index == 0xffffffffu && lhs->shape_index != 0xffffffffu)
-                copy_hir_shape(&out, lhs.value());
+                copy_hir_shape(&out, *lhs);
             out.span = expr.span;
             out.lhs = lhs_ptr;
             out.rhs = rhs_ptr;
@@ -6881,13 +6912,13 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
                 return frontend_error(FrontendError::TooManyItems, expr.span);
             HirExpr* true_ptr = &route->exprs[route->exprs.len - 1];
 
-            if (!route->exprs.push(rhs.value()))
+            if (!route->exprs.push(*rhs))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
             HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
 
             HirExpr out{};
             out.kind = HirExprKind::IfElse;
-            copy_hir_shape(&out, lhs.value());
+            copy_hir_shape(&out, *lhs);
             out.span = expr.span;
             out.lhs = true_ptr;
             out.rhs = lhs_ptr;
@@ -6909,13 +6940,12 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (!route->exprs.push(cond)) return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* cond_ptr = &route->exprs[route->exprs.len - 1];
 
-        if (!route->exprs.push(rhs.value()))
-            return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(*rhs)) return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
 
         HirExpr then_expr{};
         then_expr.kind = HirExprKind::ValueOf;
-        copy_hir_shape(&then_expr, lhs.value());
+        copy_hir_shape(&then_expr, *lhs);
         then_expr.lhs = lhs_ptr;
         then_expr.may_nil = false;
         then_expr.may_error = false;
@@ -6928,9 +6958,9 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
 
         HirExpr out{};
         out.kind = HirExprKind::IfElse;
-        copy_hir_shape(&out, rhs.value());
+        copy_hir_shape(&out, *rhs);
         if (out.type == HirTypeKind::Unknown || out.shape_index == 0xffffffffu)
-            copy_hir_shape(&out, lhs.value());
+            copy_hir_shape(&out, *lhs);
         out.span = expr.span;
         out.lhs = cond_ptr;
         out.rhs = then_ptr;
@@ -6943,42 +6973,36 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
     }
 
     if (expr.name.eq({"all", 3})) {
-        if (expr.args.len != 2) {
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-        }
-        if (expr.args[0] == nullptr || expr.args[1] == nullptr) {
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
-        }
-        auto lhs = analyze_builtin_arg(*expr.args[0]);
-        if (!lhs) return core::make_unexpected(lhs.error());
-        auto rhs = analyze_builtin_arg(*expr.args[1]);
-        if (!rhs) return core::make_unexpected(rhs.error());
-        if (rhs->may_nil)
-            return frontend_error(FrontendError::UnsupportedSyntax, expr.args[1]->span);
+        HirExpr lhs_value{};
+        HirExpr rhs_value{};
+        auto args = analyze_fallback_builtin_args(&lhs_value, &rhs_value);
+        if (!args) return core::make_unexpected(args.error());
+        HirExpr* lhs = &lhs_value;
+        HirExpr* rhs = &rhs_value;
+        if (rhs->may_nil) return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
 
         if (lhs->type != HirTypeKind::Unknown && rhs->type != HirTypeKind::Unknown &&
-            !same_hir_type_shape(mod, lhs.value(), rhs.value())) {
+            !same_hir_type_shape(mod, *lhs, *rhs)) {
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         }
 
-        const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
+        const auto lhs_state = known_value_state(*lhs, locals, local_count, 0);
         if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
-            HirExpr folded = lhs.value();
+            HirExpr folded = *lhs;
             if (lhs_state == KnownValueState::Error) {
-                if (const HirExpr* err = known_error_expr(lhs.value(), locals, local_count, 0))
+                if (const HirExpr* err = known_error_expr(*lhs, locals, local_count, 0))
                     folded = *err;
             }
             folded.span = expr.span;
             return folded;
         }
         if (!lhs->may_nil && !lhs->may_error && !rhs->may_error) {
-            HirExpr folded = rhs.value();
+            HirExpr folded = *rhs;
             folded.span = expr.span;
             return folded;
         }
 
-        if (!route->exprs.push(lhs.value()))
-            return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(*lhs)) return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
 
         if (!lhs->may_nil && !lhs->may_error) {
@@ -6991,15 +7015,15 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
                 return frontend_error(FrontendError::TooManyItems, expr.span);
             HirExpr* true_ptr = &route->exprs[route->exprs.len - 1];
 
-            if (!route->exprs.push(rhs.value()))
+            if (!route->exprs.push(*rhs))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
             HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
 
             HirExpr out{};
             out.kind = HirExprKind::IfElse;
-            copy_hir_shape(&out, rhs.value());
+            copy_hir_shape(&out, *rhs);
             if (out.type == HirTypeKind::Unknown || out.shape_index == 0xffffffffu)
-                copy_hir_shape(&out, lhs.value());
+                copy_hir_shape(&out, *lhs);
             out.span = expr.span;
             out.lhs = true_ptr;
             out.rhs = rhs_ptr;
@@ -7021,15 +7045,14 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (!route->exprs.push(cond)) return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* cond_ptr = &route->exprs[route->exprs.len - 1];
 
-        if (!route->exprs.push(rhs.value()))
-            return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!route->exprs.push(*rhs)) return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
 
         HirExpr fallback{};
         fallback.kind = HirExprKind::MissingOf;
-        copy_hir_shape(&fallback, rhs.value());
+        copy_hir_shape(&fallback, *rhs);
         if (fallback.type == HirTypeKind::Unknown || fallback.shape_index == 0xffffffffu)
-            copy_hir_shape(&fallback, lhs.value());
+            copy_hir_shape(&fallback, *lhs);
         fallback.span = expr.span;
         fallback.may_nil = lhs->may_nil;
         fallback.may_error = lhs->may_error;
@@ -7042,9 +7065,9 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
 
         HirExpr out{};
         out.kind = HirExprKind::IfElse;
-        copy_hir_shape(&out, rhs.value());
+        copy_hir_shape(&out, *rhs);
         if (out.type == HirTypeKind::Unknown || out.shape_index == 0xffffffffu)
-            copy_hir_shape(&out, lhs.value());
+            copy_hir_shape(&out, *lhs);
         out.span = expr.span;
         out.lhs = cond_ptr;
         out.rhs = rhs_ptr;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6040,17 +6040,23 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = analyze_expr(*expr.rhs, route, mod, locals, local_count, binding);
         if (!rhs) return core::make_unexpected(rhs.error());
-        if (lhs->may_nil || lhs->may_error || rhs->may_nil || rhs->may_error)
+        if (lhs->may_nil || lhs->may_error || rhs->may_nil || rhs->may_error) {
+            const bool error_on_rhs = lhs->may_nil || lhs->may_error;
             return frontend_error(FrontendError::UnsupportedSyntax,
-                                  lhs->may_nil || lhs->may_error ? expr.lhs->span
-                                                                 : expr.rhs->span);
+                                  error_on_rhs ? expr.lhs->span : expr.rhs->span);
+        }
         const bool is_bool_or = lhs->type == HirTypeKind::Bool && rhs->type == HirTypeKind::Bool;
         if (is_bool_or) {
             if (lhs->kind == HirExprKind::BoolLit) {
+                if (!lhs->bool_value) {
+                    HirExpr out = rhs.value();
+                    out.span = expr.span;
+                    return out;
+                }
                 HirExpr folded{};
                 folded.kind = HirExprKind::BoolLit;
                 folded.type = HirTypeKind::Bool;
-                folded.bool_value = lhs->bool_value || rhs->bool_value;
+                folded.bool_value = true;
                 folded.shape_index = rhs->shape_index;
                 folded.variant_index = rhs->variant_index;
                 folded.struct_index = rhs->struct_index;
@@ -6628,7 +6634,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = analyze_expr(*expr.args[1], route, mod, locals, local_count, binding);
         if (!rhs) return core::make_unexpected(rhs.error());
-        if (rhs->may_nil || rhs->may_error)
+        if (rhs->may_nil)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.args[1]->span);
 
         if (lhs->type != HirTypeKind::Unknown && rhs->type != HirTypeKind::Unknown &&
@@ -6664,17 +6670,31 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
 
+        HirExpr then_expr{};
+        then_expr.kind = HirExprKind::ValueOf;
+        copy_hir_shape(&then_expr, rhs.value());
+        then_expr.lhs = lhs_ptr;
+        then_expr.may_nil = false;
+        then_expr.may_error = false;
+        then_expr.error_struct_index = lhs->error_struct_index;
+        then_expr.error_variant_index = lhs->error_variant_index;
+        then_expr.span = expr.span;
+        if (!route->exprs.push(then_expr))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* then_ptr = &route->exprs[route->exprs.len - 1];
+
         HirExpr out{};
         out.kind = HirExprKind::IfElse;
-        copy_hir_shape(&out, lhs.value());
+        copy_hir_shape(&out, rhs.value());
         out.span = expr.span;
         out.lhs = cond_ptr;
-        out.rhs = lhs_ptr;
+        out.rhs = then_ptr;
         if (!out.args.push(rhs_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
         out.may_nil = false;
-        out.may_error = rhs->may_error;
-        out.error_struct_index = rhs->error_struct_index;
-        out.error_variant_index = rhs->error_variant_index;
+        out.may_error = lhs->may_error || rhs->may_error;
+        out.error_struct_index = rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
+        out.error_variant_index =
+            rhs->may_error ? rhs->error_variant_index : lhs->error_variant_index;
         return out;
     }
 
@@ -6689,7 +6709,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (!lhs) return core::make_unexpected(lhs.error());
         auto rhs = analyze_expr(*expr.args[1], route, mod, locals, local_count, binding);
         if (!rhs) return core::make_unexpected(rhs.error());
-        if (rhs->may_nil || rhs->may_error)
+        if (rhs->may_nil)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.args[1]->span);
 
         if (lhs->type != HirTypeKind::Unknown && rhs->type != HirTypeKind::Unknown &&
@@ -6729,7 +6749,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         fallback.kind = HirExprKind::MissingOf;
         copy_hir_shape(&fallback, rhs.value());
         fallback.span = expr.span;
-        fallback.may_nil = false;
+        fallback.may_nil = lhs->may_nil;
         fallback.may_error = lhs->may_error || rhs->may_error;
         fallback.error_struct_index =
             rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6845,6 +6845,10 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (!route->exprs.push(*pipe_lhs))
             return frontend_error(FrontendError::TooManyItems, arg.span);
         HirExpr* source = &route->exprs[route->exprs.len - 1];
+        if ((source->may_nil || source->may_error) && arg.int_value != 1)
+            return frontend_error(FrontendError::UnsupportedSyntax,
+                                  arg.span,
+                                  lit_str("placeholder value in conditional pipe must be 1"));
         if (source->type != HirTypeKind::Tuple) {
             if (arg.int_value != 1)
                 return frontend_error(FrontendError::UnsupportedSyntax,

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6100,6 +6100,91 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         out.error_variant_index = 0xffffffffu;
         return out;
     }
+    if (expr.kind == AstExprKind::And) {
+        auto lhs = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto rhs = analyze_expr(*expr.rhs, route, mod, locals, local_count, binding);
+        if (!rhs) return core::make_unexpected(rhs.error());
+        if (lhs->type != HirTypeKind::Bool || rhs->type != HirTypeKind::Bool || lhs->may_nil ||
+            lhs->may_error || rhs->may_nil || rhs->may_error) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        }
+        if (lhs->kind == HirExprKind::BoolLit) {
+            if (!lhs->bool_value) {
+                HirExpr folded{};
+                folded.kind = HirExprKind::BoolLit;
+                folded.type = HirTypeKind::Bool;
+                folded.bool_value = false;
+                folded.shape_index = rhs->shape_index;
+                folded.variant_index = rhs->variant_index;
+                folded.struct_index = rhs->struct_index;
+                folded.tuple_len = rhs->tuple_len;
+                for (u32 i = 0; i < rhs->tuple_len; i++) {
+                    folded.tuple_types[i] = rhs->tuple_types[i];
+                    folded.tuple_variant_indices[i] = rhs->tuple_variant_indices[i];
+                    folded.tuple_struct_indices[i] = rhs->tuple_struct_indices[i];
+                }
+                folded.may_nil = false;
+                folded.may_error = false;
+                folded.error_struct_index = rhs->error_struct_index;
+                folded.error_variant_index = rhs->error_variant_index;
+                folded.span = expr.span;
+                return folded;
+            }
+            HirExpr folded = rhs.value();
+            folded.span = expr.span;
+            return folded;
+        }
+        if (!route->exprs.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
+        if (!route->exprs.push(rhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
+        HirExpr false_expr{};
+        false_expr.kind = HirExprKind::BoolLit;
+        false_expr.type = HirTypeKind::Bool;
+        false_expr.bool_value = false;
+        false_expr.shape_index = rhs->shape_index;
+        false_expr.variant_index = rhs->variant_index;
+        false_expr.struct_index = rhs->struct_index;
+        false_expr.tuple_len = rhs->tuple_len;
+        for (u32 i = 0; i < rhs->tuple_len; i++) {
+            false_expr.tuple_types[i] = rhs->tuple_types[i];
+            false_expr.tuple_variant_indices[i] = rhs->tuple_variant_indices[i];
+            false_expr.tuple_struct_indices[i] = rhs->tuple_struct_indices[i];
+        }
+        false_expr.may_nil = false;
+        false_expr.may_error = false;
+        false_expr.error_struct_index = rhs->error_struct_index;
+        false_expr.error_variant_index = rhs->error_variant_index;
+        false_expr.span = expr.span;
+        if (!route->exprs.push(false_expr))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* false_ptr = &route->exprs[route->exprs.len - 1];
+
+        HirExpr out{};
+        out.kind = HirExprKind::IfElse;
+        out.type = HirTypeKind::Bool;
+        out.shape_index = rhs->shape_index;
+        out.variant_index = rhs->variant_index;
+        out.struct_index = rhs->struct_index;
+        out.tuple_len = rhs->tuple_len;
+        for (u32 i = 0; i < rhs->tuple_len; i++) {
+            out.tuple_types[i] = rhs->tuple_types[i];
+            out.tuple_variant_indices[i] = rhs->tuple_variant_indices[i];
+            out.tuple_struct_indices[i] = rhs->tuple_struct_indices[i];
+        }
+        out.lhs = lhs_ptr;
+        out.rhs = rhs_ptr;
+        if (!out.args.push(false_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.may_nil = false;
+        out.may_error = false;
+        out.error_struct_index = rhs->error_struct_index;
+        out.error_variant_index = rhs->error_variant_index;
+        out.span = expr.span;
+        return out;
+    }
     if (expr.kind == AstExprKind::Pipe) {
         if (expr.lhs == nullptr || expr.rhs == nullptr)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
@@ -6487,6 +6572,118 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
                                                  u32 local_count,
                                                  const MatchPayloadBinding* binding,
                                                  const HirExpr* pipe_lhs) {
+    const auto copy_hir_shape = [](HirExpr* dst, const HirExpr& src) {
+        dst->type = src.type;
+        dst->generic_index = src.generic_index;
+        dst->associated_name = src.associated_name;
+        dst->generic_has_error_constraint = src.generic_has_error_constraint;
+        dst->generic_has_eq_constraint = src.generic_has_eq_constraint;
+        dst->generic_has_ord_constraint = src.generic_has_ord_constraint;
+        dst->generic_protocol_index = src.generic_protocol_index;
+        dst->generic_protocol_count = src.generic_protocol_count;
+        for (u32 cpi = 0; cpi < src.generic_protocol_count; cpi++)
+            dst->generic_protocol_indices[cpi] = src.generic_protocol_indices[cpi];
+        dst->variant_index = src.variant_index;
+        dst->struct_index = src.struct_index;
+        dst->shape_index = src.shape_index;
+        dst->tuple_len = src.tuple_len;
+        for (u32 i = 0; i < src.tuple_len; i++) {
+            dst->tuple_types[i] = src.tuple_types[i];
+            dst->tuple_variant_indices[i] = src.tuple_variant_indices[i];
+            dst->tuple_struct_indices[i] = src.tuple_struct_indices[i];
+        }
+    };
+
+    if (expr.name.eq({"any", 3})) {
+        if (expr.args.len != 2) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        }
+        if (expr.args[0] == nullptr || expr.args[1] == nullptr) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        }
+        AstExpr any_expr{};
+        any_expr.kind = AstExprKind::Or;
+        any_expr.lhs = expr.args[0];
+        any_expr.rhs = expr.args[1];
+        any_expr.span = expr.span;
+        return analyze_expr(any_expr, route, mod, locals, local_count, binding);
+    }
+
+    if (expr.name.eq({"all", 3})) {
+        if (expr.args.len != 2) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        }
+        if (expr.args[0] == nullptr || expr.args[1] == nullptr) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        }
+        auto lhs = analyze_expr(*expr.args[0], route, mod, locals, local_count, binding);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto rhs = analyze_expr(*expr.args[1], route, mod, locals, local_count, binding);
+        if (!rhs) return core::make_unexpected(rhs.error());
+
+        if (lhs->type != HirTypeKind::Unknown && rhs->type != HirTypeKind::Unknown &&
+            !same_hir_type_shape(mod, lhs.value(), rhs.value())) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        }
+
+        const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
+        if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
+            HirExpr folded = lhs.value();
+            folded.span = expr.span;
+            return folded;
+        }
+        if (!lhs->may_nil && !lhs->may_error) {
+            HirExpr folded = rhs.value();
+            folded.span = expr.span;
+            return folded;
+        }
+
+        if (!route->exprs.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
+
+        HirExpr cond{};
+        cond.kind = HirExprKind::HasValue;
+        cond.type = HirTypeKind::Bool;
+        cond.span = expr.span;
+        cond.lhs = lhs_ptr;
+        if (!route->exprs.push(cond)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* cond_ptr = &route->exprs[route->exprs.len - 1];
+
+        if (!route->exprs.push(rhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
+
+        HirExpr fallback{};
+        fallback.kind = HirExprKind::MissingOf;
+        copy_hir_shape(&fallback, rhs.value());
+        fallback.span = expr.span;
+        fallback.may_nil = lhs->may_nil || rhs->may_nil;
+        fallback.may_error = lhs->may_error || rhs->may_error;
+        fallback.error_struct_index = rhs->may_error ? rhs->error_struct_index
+                                                  : lhs->error_struct_index;
+        fallback.error_variant_index = rhs->may_error ? rhs->error_variant_index
+                                                     : lhs->error_variant_index;
+        fallback.lhs = lhs_ptr;
+        if (!route->exprs.push(fallback))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* fallback_ptr = &route->exprs[route->exprs.len - 1];
+
+        HirExpr out{};
+        out.kind = HirExprKind::IfElse;
+        copy_hir_shape(&out, rhs.value());
+        out.span = expr.span;
+        out.lhs = cond_ptr;
+        out.rhs = rhs_ptr;
+        if (!out.args.push(fallback_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.may_nil = lhs->may_nil || rhs->may_nil;
+        out.may_error = lhs->may_error || rhs->may_error;
+        out.error_struct_index = rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
+        out.error_variant_index = rhs->may_error ? rhs->error_variant_index
+                                                : lhs->error_variant_index;
+        return out;
+    }
+
     const Str callee_name = resolve_alias_target_leaf(mod, expr.name);
     const u32 fn_index = find_function_index(mod, callee_name);
     const auto fail_call =

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6998,6 +6998,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             HirExpr out{};
             out.kind = HirExprKind::IfElse;
             copy_hir_shape(&out, rhs.value());
+            if (out.type == HirTypeKind::Unknown || out.shape_index == 0xffffffffu)
+                copy_hir_shape(&out, lhs.value());
             out.span = expr.span;
             out.lhs = true_ptr;
             out.rhs = rhs_ptr;
@@ -7026,6 +7028,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         HirExpr fallback{};
         fallback.kind = HirExprKind::MissingOf;
         copy_hir_shape(&fallback, rhs.value());
+        if (fallback.type == HirTypeKind::Unknown || fallback.shape_index == 0xffffffffu)
+            copy_hir_shape(&fallback, lhs.value());
         fallback.span = expr.span;
         fallback.may_nil = lhs->may_nil;
         fallback.may_error = lhs->may_error;
@@ -7039,6 +7043,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         HirExpr out{};
         out.kind = HirExprKind::IfElse;
         copy_hir_shape(&out, rhs.value());
+        if (out.type == HirTypeKind::Unknown || out.shape_index == 0xffffffffu)
+            copy_hir_shape(&out, lhs.value());
         out.span = expr.span;
         out.lhs = cond_ptr;
         out.rhs = rhs_ptr;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6746,6 +6746,59 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             dst->tuple_struct_indices[i] = src.tuple_struct_indices[i];
         }
     };
+    auto analyze_builtin_arg = [&](const AstExpr& arg) -> FrontendResult<HirExpr> {
+        if (arg.kind != AstExprKind::Placeholder)
+            return analyze_expr(arg, route, mod, locals, local_count, binding);
+        if (pipe_lhs == nullptr)
+            return frontend_error(
+                FrontendError::UnsupportedSyntax, arg.span, lit_str("placeholder outside pipe"));
+        if (arg.int_value <= 0 || arg.int_value > static_cast<i32>(kMaxTupleSlots))
+            return frontend_error(FrontendError::UnsupportedSyntax,
+                                  arg.span,
+                                  lit_str("placeholder slot out of range"));
+        if (!route->exprs.push(*pipe_lhs))
+            return frontend_error(FrontendError::TooManyItems, arg.span);
+        HirExpr* source = &route->exprs[route->exprs.len - 1];
+        if (source->type != HirTypeKind::Tuple) {
+            if (arg.int_value != 1)
+                return frontend_error(FrontendError::UnsupportedSyntax,
+                                      arg.span,
+                                      lit_str("non-tuple source with non-unit placeholder"));
+            return *source;
+        }
+        if (arg.int_value > static_cast<i32>(source->tuple_len))
+            return frontend_error(FrontendError::UnsupportedSyntax,
+                                  arg.span,
+                                  lit_str("placeholder slot exceeds tuple arity"));
+        const u32 slot_index = static_cast<u32>(arg.int_value - 1);
+        if (source->args.len == source->tuple_len && source->args[slot_index] != nullptr)
+            return *source->args[slot_index];
+        HirExpr out{};
+        out.kind = HirExprKind::TupleSlot;
+        out.type = source->tuple_types[slot_index];
+        if (out.type == HirTypeKind::Generic)
+            out.generic_index = source->tuple_struct_indices[slot_index];
+        else if (out.type == HirTypeKind::Struct)
+            out.struct_index = source->tuple_struct_indices[slot_index];
+        else if (out.type == HirTypeKind::Variant)
+            out.variant_index = source->tuple_variant_indices[slot_index];
+        auto shape = intern_hir_type_shape(const_cast<HirModule*>(&mod),
+                                           out.type,
+                                           out.generic_index,
+                                           out.variant_index,
+                                           out.struct_index,
+                                           out.tuple_len,
+                                           out.tuple_types,
+                                           out.tuple_variant_indices,
+                                           out.tuple_struct_indices,
+                                           arg.span);
+        if (!shape) return core::make_unexpected(shape.error());
+        out.shape_index = shape.value();
+        out.span = arg.span;
+        out.int_value = static_cast<i32>(slot_index);
+        out.lhs = source;
+        return out;
+    };
 
     if (expr.name.eq({"any", 3})) {
         if (expr.args.len != 2) {
@@ -6754,9 +6807,9 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (expr.args[0] == nullptr || expr.args[1] == nullptr) {
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         }
-        auto lhs = analyze_expr(*expr.args[0], route, mod, locals, local_count, binding);
+        auto lhs = analyze_builtin_arg(*expr.args[0]);
         if (!lhs) return core::make_unexpected(lhs.error());
-        auto rhs = analyze_expr(*expr.args[1], route, mod, locals, local_count, binding);
+        auto rhs = analyze_builtin_arg(*expr.args[1]);
         if (!rhs) return core::make_unexpected(rhs.error());
         if (rhs->may_nil)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.args[1]->span);
@@ -6879,9 +6932,9 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (expr.args[0] == nullptr || expr.args[1] == nullptr) {
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         }
-        auto lhs = analyze_expr(*expr.args[0], route, mod, locals, local_count, binding);
+        auto lhs = analyze_builtin_arg(*expr.args[0]);
         if (!lhs) return core::make_unexpected(lhs.error());
-        auto rhs = analyze_expr(*expr.args[1], route, mod, locals, local_count, binding);
+        auto rhs = analyze_builtin_arg(*expr.args[1]);
         if (!rhs) return core::make_unexpected(rhs.error());
         if (rhs->may_nil)
             return frontend_error(FrontendError::UnsupportedSyntax, expr.args[1]->span);

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6850,8 +6850,10 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             out.rhs = rhs_ptr;
             out.may_nil = false;
             out.may_error = false;
-            out.error_struct_index = rhs->error_struct_index;
-            out.error_variant_index = rhs->error_variant_index;
+            out.error_struct_index =
+                lhs->may_error ? lhs->error_struct_index : rhs->error_struct_index;
+            out.error_variant_index =
+                lhs->may_error ? lhs->error_variant_index : rhs->error_variant_index;
             return out;
         }
         if (!lhs->may_nil && !lhs->may_error) {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6901,7 +6901,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
             folded.span = expr.span;
             return folded;
         }
-        if (!lhs->may_nil && !lhs->may_error) {
+        if (!lhs->may_nil && !lhs->may_error && !rhs->may_error) {
             HirExpr folded = rhs.value();
             folded.span = expr.span;
             return folded;
@@ -6910,6 +6910,36 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (!route->exprs.push(lhs.value()))
             return frontend_error(FrontendError::TooManyItems, expr.span);
         HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
+
+        if (!lhs->may_nil && !lhs->may_error) {
+            HirExpr true_expr{};
+            true_expr.kind = HirExprKind::BoolLit;
+            true_expr.type = HirTypeKind::Bool;
+            true_expr.bool_value = true;
+            true_expr.span = expr.span;
+            if (!route->exprs.push(true_expr))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* true_ptr = &route->exprs[route->exprs.len - 1];
+
+            if (!route->exprs.push(rhs.value()))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
+
+            HirExpr out{};
+            out.kind = HirExprKind::IfElse;
+            copy_hir_shape(&out, rhs.value());
+            out.span = expr.span;
+            out.lhs = true_ptr;
+            out.rhs = rhs_ptr;
+            if (!out.args.push(lhs_ptr))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.may_nil = false;
+            out.may_error = rhs->may_error;
+            out.error_struct_index = rhs->error_struct_index;
+            out.error_variant_index = rhs->error_variant_index;
+            out.is_eager_fallback = true;
+            return out;
+        }
 
         HirExpr cond{};
         cond.kind = HirExprKind::HasValue;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6676,12 +6676,57 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         if (expr.args[0] == nullptr || expr.args[1] == nullptr) {
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         }
-        AstExpr any_expr{};
-        any_expr.kind = AstExprKind::Or;
-        any_expr.lhs = expr.args[0];
-        any_expr.rhs = expr.args[1];
-        any_expr.span = expr.span;
-        return analyze_expr(any_expr, route, mod, locals, local_count, binding);
+        auto lhs = analyze_expr(*expr.args[0], route, mod, locals, local_count, binding);
+        if (!lhs) return core::make_unexpected(lhs.error());
+        auto rhs = analyze_expr(*expr.args[1], route, mod, locals, local_count, binding);
+        if (!rhs) return core::make_unexpected(rhs.error());
+
+        if (lhs->type != HirTypeKind::Unknown && rhs->type != HirTypeKind::Unknown &&
+            !same_hir_type_shape(mod, lhs.value(), rhs.value())) {
+            return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
+        }
+
+        const auto lhs_state = known_value_state(lhs.value(), locals, local_count, 0);
+        if (lhs_state == KnownValueState::Nil || lhs_state == KnownValueState::Error) {
+            HirExpr folded = rhs.value();
+            folded.span = expr.span;
+            return folded;
+        }
+        if (!lhs->may_nil && !lhs->may_error) {
+            HirExpr folded = lhs.value();
+            folded.span = expr.span;
+            return folded;
+        }
+
+        if (!route->exprs.push(lhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* lhs_ptr = &route->exprs[route->exprs.len - 1];
+
+        HirExpr cond{};
+        cond.kind = HirExprKind::HasValue;
+        cond.type = HirTypeKind::Bool;
+        cond.span = expr.span;
+        cond.lhs = lhs_ptr;
+        if (!route->exprs.push(cond)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* cond_ptr = &route->exprs[route->exprs.len - 1];
+
+        if (!route->exprs.push(rhs.value()))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
+        HirExpr* rhs_ptr = &route->exprs[route->exprs.len - 1];
+
+        HirExpr out{};
+        out.kind = HirExprKind::IfElse;
+        copy_hir_shape(&out, lhs.value());
+        out.span = expr.span;
+        out.lhs = cond_ptr;
+        out.rhs = lhs_ptr;
+        if (!out.args.push(rhs_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        out.may_nil = false;
+        out.may_error = lhs->may_error || rhs->may_error;
+        out.error_struct_index = rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
+        out.error_variant_index = rhs->may_error ? rhs->error_variant_index
+                                                : lhs->error_variant_index;
+        return out;
     }
 
     if (expr.name.eq({"all", 3})) {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6425,6 +6425,7 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
                     then_expr->may_error ? then_expr->error_struct_index : lhs->error_struct_index;
                 out.error_variant_index = then_expr->may_error ? then_expr->error_variant_index
                                                                : lhs->error_variant_index;
+                out.is_pipe_conditional = true;
                 out.lhs = cond_ptr;
                 out.rhs = then_ptr;
                 if (!out.args.push(else_ptr))
@@ -7387,6 +7388,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
                 then_expr->may_error ? then_expr->error_struct_index : pipe_lhs->error_struct_index;
             out.error_variant_index = then_expr->may_error ? then_expr->error_variant_index
                                                            : pipe_lhs->error_variant_index;
+            out.is_pipe_conditional = true;
             out.lhs = cond_ptr;
             out.rhs = then_ptr;
             if (!out.args.push(else_ptr))

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6575,6 +6575,12 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             out.rhs = cmp_ptr;
             if (!out.args.push(false_ptr))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
+            out.may_error = (lhs->kind != HirExprKind::LocalRef && lhs->may_error) ||
+                            (rhs->kind != HirExprKind::LocalRef && rhs->may_error);
+            out.error_struct_index =
+                rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
+            out.error_variant_index =
+                rhs->may_error ? rhs->error_variant_index : lhs->error_variant_index;
             out.span = expr.span;
             return out;
         }
@@ -6810,7 +6816,7 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
 
         HirExpr then_expr{};
         then_expr.kind = HirExprKind::ValueOf;
-        copy_hir_shape(&then_expr, rhs.value());
+        copy_hir_shape(&then_expr, lhs.value());
         then_expr.lhs = lhs_ptr;
         then_expr.may_nil = false;
         then_expr.may_error = false;
@@ -6824,6 +6830,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         HirExpr out{};
         out.kind = HirExprKind::IfElse;
         copy_hir_shape(&out, rhs.value());
+        if (out.type == HirTypeKind::Unknown || out.shape_index == 0xffffffffu)
+            copy_hir_shape(&out, lhs.value());
         out.span = expr.span;
         out.lhs = cond_ptr;
         out.rhs = then_ptr;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6039,6 +6039,20 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         }
         return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
     }
+    const auto known_bool_value = [&](const HirExpr& value, bool& out_value) -> bool {
+        if (value.kind == HirExprKind::BoolLit) {
+            out_value = value.bool_value;
+            return true;
+        }
+        if (value.kind == HirExprKind::LocalRef && value.local_index < local_count) {
+            const HirLocal& local = locals[value.local_index];
+            if (!local.may_nil && !local.may_error && local.init.kind == HirExprKind::BoolLit) {
+                out_value = local.init.bool_value;
+                return true;
+            }
+        }
+        return false;
+    };
     if (expr.kind == AstExprKind::Or) {
         auto lhs = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);
         if (!lhs) return core::make_unexpected(lhs.error());
@@ -6051,8 +6065,9 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         }
         const bool is_bool_or = lhs->type == HirTypeKind::Bool && rhs->type == HirTypeKind::Bool;
         if (is_bool_or) {
-            if (lhs->kind == HirExprKind::BoolLit) {
-                if (!lhs->bool_value) {
+            bool lhs_bool_value = false;
+            if (known_bool_value(lhs.value(), lhs_bool_value)) {
+                if (!lhs_bool_value) {
                     HirExpr out = rhs.value();
                     out.span = expr.span;
                     return out;
@@ -6141,8 +6156,9 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             lhs->may_error || rhs->may_nil || rhs->may_error) {
             return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
         }
-        if (lhs->kind == HirExprKind::BoolLit) {
-            if (!lhs->bool_value) {
+        bool lhs_bool_value = false;
+        if (known_bool_value(lhs.value(), lhs_bool_value)) {
+            if (!lhs_bool_value) {
                 HirExpr folded{};
                 folded.kind = HirExprKind::BoolLit;
                 folded.type = HirTypeKind::Bool;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6040,18 +6040,12 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         return frontend_error(FrontendError::UnsupportedSyntax, expr.span);
     }
     const auto known_bool_value = [&](const HirExpr& value, bool& out_value) -> bool {
-        if (value.kind == HirExprKind::BoolLit) {
-            out_value = value.bool_value;
-            return true;
-        }
-        if (value.kind == HirExprKind::LocalRef && value.local_index < local_count) {
-            const HirLocal& local = locals[value.local_index];
-            if (!local.may_nil && !local.may_error && local.init.kind == HirExprKind::BoolLit) {
-                out_value = local.init.bool_value;
-                return true;
-            }
-        }
-        return false;
+        ConstValue known{};
+        if (!const_eval_expr(value, locals, local_count, &known, 0) ||
+            known.type != HirTypeKind::Bool)
+            return false;
+        out_value = known.bool_value;
+        return true;
     };
     if (expr.kind == AstExprKind::Or) {
         auto lhs = analyze_expr(*expr.lhs, route, mod, locals, local_count, binding);

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6100,7 +6100,8 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             out.type = HirTypeKind::Bool;
             out.lhs = lhs_ptr;
             out.rhs = true_ptr;
-            if (!out.args.push(rhs_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+            if (!out.args.push(rhs_ptr))
+                return frontend_error(FrontendError::TooManyItems, expr.span);
             out.shape_index = rhs->shape_index;
             out.variant_index = rhs->variant_index;
             out.struct_index = rhs->struct_index;
@@ -6252,7 +6253,8 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
         }
         out.lhs = lhs_ptr;
         out.rhs = rhs_ptr;
-        if (!out.args.push(false_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!out.args.push(false_ptr))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         out.may_nil = false;
         out.may_error = false;
         out.error_struct_index = rhs->error_struct_index;
@@ -6724,8 +6726,8 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         out.may_nil = false;
         out.may_error = lhs->may_error || rhs->may_error;
         out.error_struct_index = rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
-        out.error_variant_index = rhs->may_error ? rhs->error_variant_index
-                                                : lhs->error_variant_index;
+        out.error_variant_index =
+            rhs->may_error ? rhs->error_variant_index : lhs->error_variant_index;
         return out;
     }
 
@@ -6780,10 +6782,10 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         fallback.span = expr.span;
         fallback.may_nil = false;
         fallback.may_error = lhs->may_error || rhs->may_error;
-        fallback.error_struct_index = rhs->may_error ? rhs->error_struct_index
-                                                  : lhs->error_struct_index;
-        fallback.error_variant_index = rhs->may_error ? rhs->error_variant_index
-                                                     : lhs->error_variant_index;
+        fallback.error_struct_index =
+            rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
+        fallback.error_variant_index =
+            rhs->may_error ? rhs->error_variant_index : lhs->error_variant_index;
         fallback.lhs = lhs_ptr;
         if (!route->exprs.push(fallback))
             return frontend_error(FrontendError::TooManyItems, expr.span);
@@ -6795,12 +6797,13 @@ static FrontendResult<HirExpr> analyze_call_expr(const AstExpr& expr,
         out.span = expr.span;
         out.lhs = cond_ptr;
         out.rhs = rhs_ptr;
-        if (!out.args.push(fallback_ptr)) return frontend_error(FrontendError::TooManyItems, expr.span);
+        if (!out.args.push(fallback_ptr))
+            return frontend_error(FrontendError::TooManyItems, expr.span);
         out.may_nil = false;
         out.may_error = lhs->may_error || rhs->may_error;
         out.error_struct_index = rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
-        out.error_variant_index = rhs->may_error ? rhs->error_variant_index
-                                                : lhs->error_variant_index;
+        out.error_variant_index =
+            rhs->may_error ? rhs->error_variant_index : lhs->error_variant_index;
         return out;
     }
 

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -6591,8 +6591,7 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             out.rhs = cmp_ptr;
             if (!out.args.push(false_ptr))
                 return frontend_error(FrontendError::TooManyItems, expr.span);
-            out.may_error = (lhs->kind != HirExprKind::LocalRef && lhs->may_error) ||
-                            (rhs->kind != HirExprKind::LocalRef && rhs->may_error);
+            out.may_error = lhs->may_error || rhs->may_error;
             out.error_struct_index =
                 rhs->may_error ? rhs->error_struct_index : lhs->error_struct_index;
             out.error_variant_index =

--- a/src/compiler/lexer.cc
+++ b/src/compiler/lexer.cc
@@ -41,6 +41,7 @@ static TokenType keyword_type(Str text) {
     if (text.eq({"else", 4})) return TokenType::KwElse;
     if (text.eq({"for", 3})) return TokenType::KwFor;
     if (text.eq({"in", 2})) return TokenType::KwIn;
+    if (text.eq({"and", 3})) return TokenType::KwAnd;
     if (text.eq({"or", 2})) return TokenType::KwOr;
     if (text.eq({"nil", 3})) return TokenType::KwNil;
     if (text.eq({"upstream", 8})) return TokenType::KwUpstream;

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -2679,7 +2679,27 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
                                           local_count,
                                           term.span);
             if (!cond) return core::make_unexpected(cond.error());
-            cond_id = cond.value();
+            if (term.cond.may_error) {
+                const auto cond_shape = resolved_shape(mir, term.cond);
+                auto& err_info = error_info_for(cond_shape,
+                                                term.cond.error_struct_index,
+                                                error_scalar_infos,
+                                                error_variant_infos,
+                                                error_struct_infos);
+                auto payload = b.emit_struct_field(cond.value(),
+                                                   error_payload_field_name(),
+                                                   err_info.payload_opt_type,
+                                                   {term.span.line, term.span.col});
+                if (!payload) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto bool_ty = b.make_type(rir::TypeKind::Bool);
+                if (!bool_ty) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto unwrapped = b.emit_opt_unwrap(
+                    payload.value(), bool_ty.value(), {term.span.line, term.span.col});
+                if (!unwrapped) return frontend_error(FrontendError::OutOfMemory, term.span);
+                cond_id = unwrapped.value();
+            } else {
+                cond_id = cond.value();
+            }
         }
         if (!b.emit_br(cond_id,
                        block_ids[term.then_block],
@@ -3298,14 +3318,26 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
             }
         }
-        auto local_needs_error_prelude = [](const MirLocal& local) -> bool {
+        auto local_ref_matches = [](const MirValue* value, u32 local_index) -> bool {
+            return value != nullptr && value->kind == MirValueKind::LocalRef &&
+                   value->local_index == local_index;
+        };
+        auto has_recovering_or_use = [&](u32 local_index) -> bool {
+            for (u32 li = 0; li < mir.functions[i].locals.len; li++) {
+                const auto& init = mir.functions[i].locals[li].init;
+                if (init.kind == MirValueKind::Or && local_ref_matches(init.lhs, local_index))
+                    return true;
+            }
+            return false;
+        };
+        auto local_needs_error_prelude = [&](const MirLocal& local) -> bool {
             return local.may_error && local.init.kind == MirValueKind::IfElse &&
                    local.init.lhs != nullptr &&
                    (local.init.lhs->kind == MirValueKind::HasValue ||
                     (local.init.is_eager_fallback &&
                      local.init.lhs->kind == MirValueKind::BoolConst &&
                      local.init.lhs->bool_value)) &&
-                   !local.init.is_pipe_conditional;
+                   !local.init.is_pipe_conditional && !has_recovering_or_use(local.ref_index);
         };
 
         u32 error_local_count = 0;

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -3445,6 +3445,7 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 }
                 resume_blocks[ri] = block_ids[mir.functions[i].resume_blocks[ri]];
             }
+            if (has_error_prelude) resume_blocks[0] = prelude_block;
             if (!b.set_explicit_resume_blocks(
                     fn.value(), resume_blocks, mir.functions[i].waits.len + 1)) {
                 out.destroy();

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -3454,7 +3454,8 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
         } else if (mir.functions[i].state_zero_enters_entry) {
             if (mir.functions[i].resume_terminal_block >= mir.functions[i].blocks.len ||
                 !b.set_state_zero_entry_resume(fn.value(),
-                                               block_ids[mir.functions[i].resume_terminal_block])) {
+                                               block_ids[mir.functions[i].resume_terminal_block],
+                                               has_error_prelude ? prelude_block : block_ids[0])) {
                 out.destroy();
                 return frontend_error(FrontendError::UnsupportedSyntax, mir.functions[i].span);
             }

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -1821,8 +1821,9 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                             error_scalar_infos,
                                             error_variant_infos,
                                             error_struct_infos);
-            const bool eager_missing_fallback =
-                value.lhs != nullptr && value.lhs->kind == MirValueKind::HasValue;
+            const bool eager_missing_fallback = value.lhs != nullptr &&
+                                                value.lhs->kind == MirValueKind::HasValue &&
+                                                !value.is_pipe_conditional;
             auto wrap_error_branch = [&](const MirValue& branch,
                                          rir::ValueId branch_id) -> FrontendResult<rir::ValueId> {
                 if (branch.may_error) {
@@ -3297,7 +3298,8 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
         }
         auto local_needs_error_prelude = [](const MirLocal& local) -> bool {
             return local.may_error && local.init.kind == MirValueKind::IfElse &&
-                   local.init.lhs != nullptr && local.init.lhs->kind == MirValueKind::HasValue;
+                   local.init.lhs != nullptr && local.init.lhs->kind == MirValueKind::HasValue &&
+                   !local.init.is_pipe_conditional;
         };
 
         u32 error_local_count = 0;

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -1893,21 +1893,16 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                 cond.value(), then_wrapped.value(), else_wrapped.value(), {span.line, span.col});
             if (!selected) return frontend_error(FrontendError::OutOfMemory, span);
             if (!eager_missing_fallback) return selected.value();
-            auto branch_has_error =
-                [&](rir::ValueId branch_id) -> FrontendResult<rir::ValueId> {
-                auto err = b.emit_struct_field(branch_id,
-                                               error_field_name(),
-                                               err_info.error_opt_type,
-                                               {span.line, span.col});
+            auto branch_has_error = [&](rir::ValueId branch_id) -> FrontendResult<rir::ValueId> {
+                auto err = b.emit_struct_field(
+                    branch_id, error_field_name(), err_info.error_opt_type, {span.line, span.col});
                 if (!err) return frontend_error(FrontendError::OutOfMemory, span);
                 auto err_is_nil = b.emit_opt_is_nil(err.value(), {span.line, span.col});
                 if (!err_is_nil) return frontend_error(FrontendError::OutOfMemory, span);
                 auto false_v = b.emit_const_bool(false, {span.line, span.col});
                 if (!false_v) return frontend_error(FrontendError::OutOfMemory, span);
-                auto has_error = b.emit_cmp(rir::Opcode::CmpEq,
-                                            err_is_nil.value(),
-                                            false_v.value(),
-                                            {span.line, span.col});
+                auto has_error = b.emit_cmp(
+                    rir::Opcode::CmpEq, err_is_nil.value(), false_v.value(), {span.line, span.col});
                 if (!has_error) return frontend_error(FrontendError::OutOfMemory, span);
                 return has_error.value();
             };
@@ -3432,9 +3427,9 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                     out.destroy();
                     return frontend_error(FrontendError::OutOfMemory, local.span);
                 }
-                const rir::BlockId next_block =
-                    error_index + 1 < error_local_count ? error_check_blocks[error_index]
-                                                        : block_ids[0];
+                const rir::BlockId next_block = error_index + 1 < error_local_count
+                                                    ? error_check_blocks[error_index]
+                                                    : block_ids[0];
                 if (!b.emit_br(no_error.value(),
                                next_block,
                                error_return_block,

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -3345,20 +3345,51 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
             }
         }
-        auto local_ref_matches = [](const MirValue* value, u32 local_index) -> bool {
-            return value != nullptr && value->kind == MirValueKind::LocalRef &&
-                   value->local_index == local_index;
+        struct RecoveryScan {
+            static bool local_ref_matches(const MirValue* value, u32 local_index) {
+                return value != nullptr && value->kind == MirValueKind::LocalRef &&
+                       value->local_index == local_index;
+            }
+
+            static bool is_recovering_use(const MirValue* value, u32 local_index) {
+                if (value == nullptr) return false;
+                if (value->kind == MirValueKind::Or && local_ref_matches(value->lhs, local_index))
+                    return true;
+                if (value->kind == MirValueKind::IfElse && value->lhs != nullptr &&
+                    value->lhs->kind == MirValueKind::HasValue &&
+                    local_ref_matches(value->lhs->lhs, local_index) && value->rhs != nullptr &&
+                    value->rhs->kind == MirValueKind::ValueOf &&
+                    local_ref_matches(value->rhs->lhs, local_index))
+                    return true;
+                return false;
+            }
+
+            static bool contains_recovering_use(const MirValue* value, u32 local_index) {
+                if (value == nullptr) return false;
+                if (is_recovering_use(value, local_index)) return true;
+                if (contains_recovering_use(value->lhs, local_index)) return true;
+                if (contains_recovering_use(value->rhs, local_index)) return true;
+                for (u32 ai = 0; ai < value->args.len; ai++) {
+                    if (contains_recovering_use(value->args[ai], local_index)) return true;
+                }
+                for (u32 fi = 0; fi < value->field_inits.len; fi++) {
+                    if (contains_recovering_use(value->field_inits[fi].value, local_index))
+                        return true;
+                }
+                return false;
+            }
         };
         auto has_recovering_or_use = [&](u32 local_index) -> bool {
             for (u32 li = 0; li < mir.functions[i].locals.len; li++) {
-                const auto& init = mir.functions[i].locals[li].init;
-                if (init.kind == MirValueKind::Or && local_ref_matches(init.lhs, local_index))
+                if (RecoveryScan::contains_recovering_use(&mir.functions[i].locals[li].init,
+                                                          local_index))
                     return true;
-                if (init.kind == MirValueKind::IfElse && init.lhs != nullptr &&
-                    init.lhs->kind == MirValueKind::HasValue &&
-                    local_ref_matches(init.lhs->lhs, local_index) && init.rhs != nullptr &&
-                    init.rhs->kind == MirValueKind::ValueOf &&
-                    local_ref_matches(init.rhs->lhs, local_index))
+            }
+            for (u32 bi = 0; bi < mir.functions[i].blocks.len; bi++) {
+                const auto& term = mir.functions[i].blocks[bi].term;
+                if (RecoveryScan::contains_recovering_use(&term.cond, local_index) ||
+                    RecoveryScan::contains_recovering_use(&term.lhs, local_index) ||
+                    RecoveryScan::contains_recovering_use(&term.rhs, local_index))
                     return true;
             }
             return false;

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -3354,6 +3354,12 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 const auto& init = mir.functions[i].locals[li].init;
                 if (init.kind == MirValueKind::Or && local_ref_matches(init.lhs, local_index))
                     return true;
+                if (init.kind == MirValueKind::IfElse && init.lhs != nullptr &&
+                    init.lhs->kind == MirValueKind::HasValue &&
+                    local_ref_matches(init.lhs->lhs, local_index) && init.rhs != nullptr &&
+                    init.rhs->kind == MirValueKind::ValueOf &&
+                    local_ref_matches(init.rhs->lhs, local_index))
+                    return true;
             }
             return false;
         };

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -185,6 +185,18 @@ static Str error_line_field_name() {
     return lit("line");
 }
 
+static Str error_check_label() {
+    return lit("error_check");
+}
+
+static Str error_return_label() {
+    return lit("error_return");
+}
+
+static Str prelude_label() {
+    return lit("prelude");
+}
+
 static bool copy_str(MmapArena& arena, Str src, Str* out) {
     char* mem = arena.alloc_array<char>(src.len + 1);
     if (!mem) return false;
@@ -1809,6 +1821,8 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                             error_scalar_infos,
                                             error_variant_infos,
                                             error_struct_infos);
+            const bool eager_missing_fallback =
+                value.lhs != nullptr && value.lhs->kind == MirValueKind::HasValue;
             auto wrap_error_branch = [&](const MirValue& branch,
                                          rir::ValueId branch_id) -> FrontendResult<rir::ValueId> {
                 if (branch.may_error) {
@@ -1878,7 +1892,40 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
             auto selected = b.emit_select(
                 cond.value(), then_wrapped.value(), else_wrapped.value(), {span.line, span.col});
             if (!selected) return frontend_error(FrontendError::OutOfMemory, span);
-            return selected.value();
+            if (!eager_missing_fallback) return selected.value();
+            auto branch_has_error =
+                [&](rir::ValueId branch_id) -> FrontendResult<rir::ValueId> {
+                auto err = b.emit_struct_field(branch_id,
+                                               error_field_name(),
+                                               err_info.error_opt_type,
+                                               {span.line, span.col});
+                if (!err) return frontend_error(FrontendError::OutOfMemory, span);
+                auto err_is_nil = b.emit_opt_is_nil(err.value(), {span.line, span.col});
+                if (!err_is_nil) return frontend_error(FrontendError::OutOfMemory, span);
+                auto false_v = b.emit_const_bool(false, {span.line, span.col});
+                if (!false_v) return frontend_error(FrontendError::OutOfMemory, span);
+                auto has_error = b.emit_cmp(rir::Opcode::CmpEq,
+                                            err_is_nil.value(),
+                                            false_v.value(),
+                                            {span.line, span.col});
+                if (!has_error) return frontend_error(FrontendError::OutOfMemory, span);
+                return has_error.value();
+            };
+            auto then_has_error = branch_has_error(then_wrapped.value());
+            if (!then_has_error) return core::make_unexpected(then_has_error.error());
+            auto else_has_error = branch_has_error(else_wrapped.value());
+            if (!else_has_error) return core::make_unexpected(else_has_error.error());
+            auto selected_or_else_error = b.emit_select(else_has_error.value(),
+                                                        else_wrapped.value(),
+                                                        selected.value(),
+                                                        {span.line, span.col});
+            if (!selected_or_else_error) return frontend_error(FrontendError::OutOfMemory, span);
+            auto selected_or_error = b.emit_select(then_has_error.value(),
+                                                   then_wrapped.value(),
+                                                   selected_or_else_error.value(),
+                                                   {span.line, span.col});
+            if (!selected_or_error) return frontend_error(FrontendError::OutOfMemory, span);
+            return selected_or_error.value();
         }
         if (value.may_nil) {
             auto inner = make_inner_type(value_shape);
@@ -3253,6 +3300,26 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
             }
         }
+        auto local_needs_error_prelude = [](const MirLocal& local) -> bool {
+            return local.may_error && local.init.kind == MirValueKind::IfElse &&
+                   local.init.lhs != nullptr && local.init.lhs->kind == MirValueKind::HasValue;
+        };
+
+        u32 error_local_count = 0;
+        for (u32 li = 0; li < mir.functions[i].locals.len; li++) {
+            if (local_needs_error_prelude(mir.functions[i].locals[li])) error_local_count++;
+        }
+        const bool has_error_prelude = error_local_count != 0;
+        rir::BlockId prelude_block{};
+        if (has_error_prelude) {
+            auto block = b.create_block(fn.value(), prelude_label());
+            if (!block) {
+                out.destroy();
+                return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
+            }
+            prelude_block = block.value();
+        }
+
         rir::BlockId block_ids[MirFunction::kMaxBlocks]{};
         for (u32 bi = 0; bi < mir.functions[i].blocks.len; bi++) {
             auto block = b.create_block(fn.value(), mir.functions[i].blocks[bi].label);
@@ -3292,7 +3359,26 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 return frontend_error(FrontendError::UnsupportedSyntax, mir.functions[i].span);
             }
         }
-        b.set_insert_point(fn.value(), block_ids[0]);
+        rir::BlockId error_return_block{};
+        rir::BlockId error_check_blocks[MirFunction::kMaxLocals]{};
+        if (has_error_prelude) {
+            auto error_block = b.create_block(fn.value(), error_return_label());
+            if (!error_block) {
+                out.destroy();
+                return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
+            }
+            error_return_block = error_block.value();
+            for (u32 ei = 1; ei < error_local_count; ei++) {
+                auto check_block = b.create_block(fn.value(), error_check_label());
+                if (!check_block) {
+                    out.destroy();
+                    return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
+                }
+                error_check_blocks[ei - 1] = check_block.value();
+            }
+        }
+
+        b.set_insert_point(fn.value(), has_error_prelude ? prelude_block : block_ids[0]);
 
         rir::ValueId local_vals[MirFunction::kMaxLocals]{};
         for (u32 li = 0; li < mir.functions[i].locals.len; li++) {
@@ -3316,6 +3402,55 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                 return core::make_unexpected(val.error());
             }
             local_vals[mir.functions[i].locals[li].ref_index] = val.value();
+        }
+
+        if (has_error_prelude) {
+            u32 error_index = 0;
+            for (u32 li = 0; li < mir.functions[i].locals.len; li++) {
+                const auto& local = mir.functions[i].locals[li];
+                if (!local_needs_error_prelude(local)) continue;
+                if (local.ref_index >= MirFunction::kMaxLocals) {
+                    out.destroy();
+                    return frontend_error(FrontendError::UnsupportedSyntax, local.span);
+                }
+                const auto local_shape = resolved_shape(mir, local);
+                auto& err_info = error_info_for(local_shape,
+                                                local.error_struct_index,
+                                                error_scalar_infos,
+                                                error_variant_infos,
+                                                error_struct_infos);
+                auto err = b.emit_struct_field(local_vals[local.ref_index],
+                                               error_field_name(),
+                                               err_info.error_opt_type,
+                                               {local.span.line, local.span.col});
+                if (!err) {
+                    out.destroy();
+                    return frontend_error(FrontendError::OutOfMemory, local.span);
+                }
+                auto no_error = b.emit_opt_is_nil(err.value(), {local.span.line, local.span.col});
+                if (!no_error) {
+                    out.destroy();
+                    return frontend_error(FrontendError::OutOfMemory, local.span);
+                }
+                const rir::BlockId next_block =
+                    error_index + 1 < error_local_count ? error_check_blocks[error_index]
+                                                        : block_ids[0];
+                if (!b.emit_br(no_error.value(),
+                               next_block,
+                               error_return_block,
+                               {local.span.line, local.span.col})) {
+                    out.destroy();
+                    return frontend_error(FrontendError::OutOfMemory, local.span);
+                }
+                error_index++;
+                if (error_index < error_local_count)
+                    b.set_insert_point(fn.value(), error_check_blocks[error_index - 1]);
+            }
+            b.set_insert_point(fn.value(), error_return_block);
+            if (!b.emit_ret_status(500, {mir.functions[i].span.line, mir.functions[i].span.col})) {
+                out.destroy();
+                return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
+            }
         }
 
         for (u32 bi = 0; bi < mir.functions[i].blocks.len; bi++) {

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -1821,9 +1821,11 @@ static FrontendResult<rir::ValueId> materialize_value(const MirValue& value,
                                             error_scalar_infos,
                                             error_variant_infos,
                                             error_struct_infos);
-            const bool eager_missing_fallback = value.lhs != nullptr &&
-                                                value.lhs->kind == MirValueKind::HasValue &&
-                                                !value.is_pipe_conditional;
+            const bool eager_missing_fallback =
+                value.lhs != nullptr && !value.is_pipe_conditional &&
+                (value.lhs->kind == MirValueKind::HasValue ||
+                 (value.is_eager_fallback && value.lhs->kind == MirValueKind::BoolConst &&
+                  value.lhs->bool_value));
             auto wrap_error_branch = [&](const MirValue& branch,
                                          rir::ValueId branch_id) -> FrontendResult<rir::ValueId> {
                 if (branch.may_error) {
@@ -3298,7 +3300,11 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
         }
         auto local_needs_error_prelude = [](const MirLocal& local) -> bool {
             return local.may_error && local.init.kind == MirValueKind::IfElse &&
-                   local.init.lhs != nullptr && local.init.lhs->kind == MirValueKind::HasValue &&
+                   local.init.lhs != nullptr &&
+                   (local.init.lhs->kind == MirValueKind::HasValue ||
+                    (local.init.is_eager_fallback &&
+                     local.init.lhs->kind == MirValueKind::BoolConst &&
+                     local.init.lhs->bool_value)) &&
                    !local.init.is_pipe_conditional;
         };
 

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -193,6 +193,10 @@ static Str error_return_label() {
     return lit("error_return");
 }
 
+static Str branch_cond_payload_label() {
+    return lit("branch_cond_payload");
+}
+
 static Str prelude_label() {
     return lit("prelude");
 }
@@ -2536,6 +2540,7 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
                                       ErrorLoweringInfo* error_struct_infos,
                                       const rir::StructDef* const* user_struct_defs,
                                       rir::Builder& b,
+                                      rir::Function* fn,
                                       const rir::BlockId* block_ids,
                                       const rir::ValueId* locals,
                                       u32 local_count) {
@@ -2686,11 +2691,33 @@ static FrontendResult<void> emit_term(const MirTerminator& term,
                                                 error_scalar_infos,
                                                 error_variant_infos,
                                                 error_struct_infos);
+                auto err = b.emit_struct_field(cond.value(),
+                                               error_field_name(),
+                                               err_info.error_opt_type,
+                                               {term.span.line, term.span.col});
+                if (!err) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto err_is_nil = b.emit_opt_is_nil(err.value(), {term.span.line, term.span.col});
+                if (!err_is_nil) return frontend_error(FrontendError::OutOfMemory, term.span);
                 auto payload = b.emit_struct_field(cond.value(),
                                                    error_payload_field_name(),
                                                    err_info.payload_opt_type,
                                                    {term.span.line, term.span.col});
                 if (!payload) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto payload_block = b.create_block(fn, branch_cond_payload_label());
+                if (!payload_block) return frontend_error(FrontendError::OutOfMemory, term.span);
+                auto error_block = b.create_block(fn, error_return_label());
+                if (!error_block) return frontend_error(FrontendError::OutOfMemory, term.span);
+                if (!b.emit_br(err_is_nil.value(),
+                               payload_block.value(),
+                               error_block.value(),
+                               {term.span.line, term.span.col}))
+                    return frontend_error(FrontendError::OutOfMemory, term.span);
+
+                b.set_insert_point(fn, error_block.value());
+                if (!b.emit_ret_status(500, {term.span.line, term.span.col}))
+                    return frontend_error(FrontendError::OutOfMemory, term.span);
+
+                b.set_insert_point(fn, payload_block.value());
                 auto bool_ty = b.make_type(rir::TypeKind::Bool);
                 if (!bool_ty) return frontend_error(FrontendError::OutOfMemory, term.span);
                 auto unwrapped = b.emit_opt_unwrap(
@@ -3524,6 +3551,7 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
                                      error_struct_infos,
                                      user_struct_defs,
                                      b,
+                                     fn.value(),
                                      block_ids,
                                      local_vals,
                                      MirFunction::kMaxLocals);

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -557,6 +557,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.rhs = rhs_ptr;
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
+        v.error_struct_index = expr.error_struct_index;
         v.error_variant_index = expr.error_variant_index;
         apply_expr_shape_if_available(module, expr, &v);
         return v;

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -535,6 +535,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.struct_index = expr.struct_index;
         v.error_struct_index = expr.error_struct_index;
         v.error_variant_index = expr.error_variant_index;
+        v.is_pipe_conditional = expr.is_pipe_conditional;
         apply_expr_shape_if_available(module, expr, &v);
         return v;
     }

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -536,6 +536,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.error_struct_index = expr.error_struct_index;
         v.error_variant_index = expr.error_variant_index;
         v.is_pipe_conditional = expr.is_pipe_conditional;
+        v.is_eager_fallback = expr.is_eager_fallback;
         apply_expr_shape_if_available(module, expr, &v);
         return v;
     }

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -224,27 +224,6 @@ struct Parser {
             expr.span = Span{start.start, case_name.value()->end, start.line, start.col};
             return expr;
         }
-        if (take(TokenType::KwOr)) {
-            auto lparen = expect(TokenType::LParen);
-            if (!lparen) return core::make_unexpected(lparen.error());
-            auto lhs = parse_expr();
-            if (!lhs) return core::make_unexpected(lhs.error());
-            auto comma = expect(TokenType::Comma);
-            if (!comma) return core::make_unexpected(comma.error());
-            auto rhs = parse_expr();
-            if (!rhs) return core::make_unexpected(rhs.error());
-            auto rparen = expect(TokenType::RParen);
-            if (!rparen) return core::make_unexpected(rparen.error());
-            auto lhs_ptr = alloc_expr(lhs.value());
-            if (!lhs_ptr) return core::make_unexpected(lhs_ptr.error());
-            auto rhs_ptr = alloc_expr(rhs.value());
-            if (!rhs_ptr) return core::make_unexpected(rhs_ptr.error());
-            expr.kind = AstExprKind::Or;
-            expr.lhs = lhs_ptr.value();
-            expr.rhs = rhs_ptr.value();
-            expr.span = Span{start.start, rparen.value()->end, start.line, start.col};
-            return expr;
-        }
         if (take(TokenType::KwWait)) {
             auto lparen = expect(TokenType::LParen);
             if (!lparen) return core::make_unexpected(lparen.error());
@@ -711,8 +690,34 @@ struct Parser {
         return expr;
     }
 
-    FrontendResult<AstExpr> parse_expr() {
+    FrontendResult<AstExpr> parse_or_expr() {
         auto lhs = parse_eq_expr();
+        if (!lhs) return core::make_unexpected(lhs.error());
+        while (true) {
+            const auto op = [&]() -> TokenType {
+                if (take(TokenType::KwAnd)) return TokenType::KwAnd;
+                if (take(TokenType::KwOr)) return TokenType::KwOr;
+                return TokenType::Error;
+            }();
+            if (op == TokenType::Error) break;
+            auto rhs = parse_eq_expr();
+            if (!rhs) return core::make_unexpected(rhs.error());
+            auto lhs_ptr = alloc_expr(lhs.value());
+            if (!lhs_ptr) return core::make_unexpected(lhs_ptr.error());
+            auto rhs_ptr = alloc_expr(rhs.value());
+            if (!rhs_ptr) return core::make_unexpected(rhs_ptr.error());
+            AstExpr expr{};
+            expr.kind = op == TokenType::KwAnd ? AstExprKind::And : AstExprKind::Or;
+            expr.lhs = lhs_ptr.value();
+            expr.rhs = rhs_ptr.value();
+            expr.span = Span{lhs->span.start, rhs->span.end, lhs->span.line, lhs->span.col};
+            lhs = expr;
+        }
+        return lhs.value();
+    }
+
+    FrontendResult<AstExpr> parse_expr() {
+        auto lhs = parse_or_expr();
         if (!lhs) return core::make_unexpected(lhs.error());
         while (take(TokenType::Pipe)) {
             auto rhs = parse_eq_expr();

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -445,7 +445,7 @@ struct Parser {
                 }
                 index = index * 10 + static_cast<i32>(ch - '0');
             }
-            if (all_digits && index > 0) {
+            if (all_digits) {
                 if (index > 10)
                     return frontend_error(FrontendError::UnsupportedSyntax,
                                           span_from(*ident.value()),

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -445,7 +445,7 @@ struct Parser {
                 }
                 index = index * 10 + static_cast<i32>(ch - '0');
             }
-            if (all_digits) {
+            if (all_digits && index > 0) {
                 if (index > 10)
                     return frontend_error(FrontendError::UnsupportedSyntax,
                                           span_from(*ident.value()),

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -539,6 +539,23 @@ struct Ctx {
                 return ptr_ty;
         }
     }
+
+    LLVMValueRef build_select_value(LLVMValueRef cond, LLVMValueRef then_v, LLVMValueRef else_v) {
+        LLVMTypeRef ty = LLVMTypeOf(then_v);
+        if (LLVMGetTypeKind(ty) != LLVMStructTypeKind) {
+            return LLVMBuildSelect(builder, cond, then_v, else_v, "sel");
+        }
+
+        LLVMValueRef out = LLVMGetUndef(ty);
+        const u32 field_count = LLVMCountStructElementTypes(ty);
+        for (u32 i = 0; i < field_count; i++) {
+            LLVMValueRef then_field = LLVMBuildExtractValue(builder, then_v, i, "sel.then");
+            LLVMValueRef else_field = LLVMBuildExtractValue(builder, else_v, i, "sel.else");
+            LLVMValueRef selected = build_select_value(cond, then_field, else_field);
+            out = LLVMBuildInsertValue(builder, out, selected, i, "sel.field");
+        }
+        return out;
+    }
 };
 
 // ── Instruction Emission ───────────────────────────────────────────
@@ -1125,7 +1142,7 @@ static void emit_instruction(Ctx& c, const rir::Instruction& inst) {
             LLVMValueRef cond = c.get_value(inst.operands[0]);
             LLVMValueRef then_v = c.get_value(inst.operands[1]);
             LLVMValueRef else_v = c.get_value(inst.operands[2]);
-            LLVMValueRef v = LLVMBuildSelect(c.builder, cond, then_v, else_v, "sel");
+            LLVMValueRef v = c.build_select_value(cond, then_v, else_v);
             c.set_value(inst.result, v);
             break;
         }

--- a/src/jit/codegen.cc
+++ b/src/jit/codegen.cc
@@ -1403,7 +1403,7 @@ static bool emit_function(Ctx& c, const rir::Function& fn) {
                 LLVMAddCase(sw, LLVMConstInt(c.i16_ty, si, 0), c.block_map[fn.resume_blocks[si]]);
             }
         } else if (fn.state_zero_enters_entry) {
-            LLVMAddCase(sw, LLVMConstInt(c.i16_ty, 0, 0), c.block_map[fn.blocks[0].id.id]);
+            LLVMAddCase(sw, LLVMConstInt(c.i16_ty, 0, 0), c.block_map[fn.state_zero_entry_block]);
         }
 
         const u32 first_prologue_yield = fn.state_zero_enters_entry ? 1 : 0;

--- a/src/runtime/simd/simd.h
+++ b/src/runtime/simd/simd.h
@@ -1,33 +1,3 @@
 #pragma once
 
-#include "rut/common/types.h"
-
-namespace rut::simd {
-
-// Find \r\n\r\n in buffer starting from `from`.
-// Returns offset past terminator (first body byte), or 0 if not found.
-u32 find_header_end(const u8* buf, u32 len, u32 from);
-
-// Scan header value: find \r while validating chars.
-// Returns position of \r, or `end` if not found, or (u32)-1 on invalid char.
-u32 scan_header_value(const u8* buf, u32 pos, u32 end);
-
-// Scan URI: find space while validating, and report the canonical-end
-// position (first '?' or '#' before space, else the space/end position).
-//
-// Returns position of space, or `end` if not found, or (u32)-1 on invalid.
-// On non-error returns, *canon_end_out receives the canonical-end position:
-//   - if '?' or '#' appears before the terminating space, its position
-//   - otherwise, the same value as the return (space or end)
-// On error return ((u32)-1), *canon_end_out is untouched.
-//
-// canon_end is the upper bound of the routing-relevant path bytes
-// [uri_start, canon_end). Callers strip leading '/' and trim trailing '/'
-// in scalar code after the scan to produce the final canonical Str.
-u32 scan_uri(const u8* buf, u32 pos, u32 end, u32* canon_end_out);
-
-// Scan header name: find ':' while validating token chars.
-// Returns position of ':', or (u32)-1 on invalid/not found.
-u32 scan_header_name(const u8* buf, u32 pos, u32 end);
-
-}  // namespace rut::simd
+#include "rut/runtime/simd/simd.h"

--- a/tests/mock_backend.h
+++ b/tests/mock_backend.h
@@ -31,6 +31,7 @@ struct MockBackend {
     static constexpr u32 kMaxOps = 256;
     MockOp ops[kMaxOps];
     u32 op_count = 0;
+    i32 timer_fd = -1;
     bool fail_connect = false;
     bool fail_upstream_recv = false;
     bool fail_upstream_send = false;
@@ -43,6 +44,7 @@ struct MockBackend {
     core::Expected<void, Error> init(u32 /*shard_id*/, i32 /*listen_fd*/) {
         op_count = 0;
         pending_count = 0;
+        timer_fd = -1;
         fail_connect = false;
         fail_upstream_recv = false;
         fail_upstream_send = false;
@@ -54,6 +56,8 @@ struct MockBackend {
             ops[op_count++] = {MockOp::Accept, -1, 0, nullptr, 0};
         }
     }
+
+    void cancel_accept() {}
 
     bool add_recv(i32 fd, u32 conn_id) {
         if (op_count < kMaxOps) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -445,8 +445,8 @@ route GET "/users" {
 
     bool saw_or = false;
     for (u32 fi = 0; fi < mir->functions.len; fi++) {
-        for (u32 vi = 0; vi < mir->functions[fi].values.len; vi++) {
-            if (mir->functions[fi].values[vi].kind == MirValueKind::Or) {
+        for (u32 li = 0; li < mir->functions[fi].locals.len; li++) {
+            if (mir->functions[fi].locals[li].init.kind == MirValueKind::Or) {
                 saw_or = true;
                 break;
             }
@@ -641,7 +641,8 @@ TEST(frontend, analyze_constant_folds_any_when_lhs_present) {
 
 TEST(frontend, analyze_preserves_optional_any_as_or_value) {
     const char* src =
-        "route GET \"/users\" { let maybe = nil let code = any(maybe, 200) return 200 }\n";
+        "route GET \"/users\" { let maybe = req.query(\"code\") let code = any(maybe, "
+        "\"fallback\") return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -652,18 +653,19 @@ TEST(frontend, analyze_preserves_optional_any_as_or_value) {
     CHECK(hir->routes[0].locals[0].name.eq(lit("maybe")));
     CHECK(hir->routes[0].locals[0].may_nil);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
-             static_cast<u8>(HirExprKind::Nil));
+             static_cast<u8>(HirExprKind::ReqQuery));
     CHECK(hir->routes[0].locals[1].name.eq(lit("code")));
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Or));
     REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
              static_cast<u8>(HirExprKind::LocalRef));
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
-             static_cast<u8>(HirExprKind::IntLit));
+             static_cast<u8>(HirExprKind::StrLit));
     CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
     CHECK_FALSE(hir->routes[0].locals[1].init.may_nil);
-    CHECK_EQ(hir->routes[0].locals[1].init.rhs->int_value, 200);
+    CHECK(hir->routes[0].locals[1].init.rhs->str_value.eq(lit("fallback")));
 }
 
 TEST(frontend, analyze_preserves_optional_all_as_if_else) {
@@ -9918,8 +9920,7 @@ TEST(frontend, all_builtin_over_optional_query_source_preserves_rhs_call) {
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
              static_cast<u8>(HirExprKind::HasValue));
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
-             static_cast<u8>(HirExprKind::Call));
+    CHECK(hir->routes[0].locals[1].init.rhs->may_error);
     CHECK(hir->routes[0].locals[1].init.may_error);
 }
 
@@ -9934,14 +9935,15 @@ TEST(frontend, any_builtin_over_optional_query_source_becomes_or) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Or));
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
-    auto& or_expr = hir->routes[0].locals[1].init;
-    REQUIRE_NE(or_expr.lhs, nullptr);
-    REQUIRE_NE(or_expr.rhs, nullptr);
-    CHECK_EQ(static_cast<u8>(or_expr.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
-    CHECK_EQ(static_cast<u8>(or_expr.rhs->kind), static_cast<u8>(HirExprKind::StrLit));
+    auto& fallback_expr = hir->routes[0].locals[1].init;
+    REQUIRE_NE(fallback_expr.lhs, nullptr);
+    REQUIRE_NE(fallback_expr.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(fallback_expr.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(fallback_expr.rhs->kind), static_cast<u8>(HirExprKind::StrLit));
 }
 
 TEST(frontend, any_builtin_over_optional_query_source_preserves_rhs_call) {
@@ -9957,13 +9959,16 @@ TEST(frontend, any_builtin_over_optional_query_source_preserves_rhs_call) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
     REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    REQUIRE_EQ(hir->routes[0].locals[1].init.args.len, 1u);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
-             static_cast<u8>(HirExprKind::LocalRef));
+             static_cast<u8>(HirExprKind::HasValue));
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
-             static_cast<u8>(HirExprKind::Call));
+             static_cast<u8>(HirExprKind::ValueOf));
+    CHECK(hir->routes[0].locals[1].init.args[0]->may_error);
 }
 
 TEST(frontend, any_builtin_over_optional_header_source_becomes_or) {
@@ -9978,13 +9983,14 @@ TEST(frontend, any_builtin_over_optional_header_source_becomes_or) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Or));
     CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
-    auto& or_expr = hir->routes[0].locals[1].init;
-    REQUIRE_NE(or_expr.lhs, nullptr);
-    REQUIRE_NE(or_expr.rhs, nullptr);
-    CHECK_EQ(static_cast<u8>(or_expr.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
-    CHECK_EQ(static_cast<u8>(or_expr.rhs->kind), static_cast<u8>(HirExprKind::StrLit));
+    auto& fallback_expr = hir->routes[0].locals[1].init;
+    REQUIRE_NE(fallback_expr.lhs, nullptr);
+    REQUIRE_NE(fallback_expr.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(fallback_expr.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(fallback_expr.rhs->kind), static_cast<u8>(HirExprKind::StrLit));
 }
 
 TEST(frontend, any_builtin_over_optional_header_source_preserves_rhs_call) {
@@ -10000,13 +10006,16 @@ TEST(frontend, any_builtin_over_optional_header_source_preserves_rhs_call) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
     REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    REQUIRE_EQ(hir->routes[0].locals[1].init.args.len, 1u);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
-             static_cast<u8>(HirExprKind::LocalRef));
+             static_cast<u8>(HirExprKind::HasValue));
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
-             static_cast<u8>(HirExprKind::Call));
+             static_cast<u8>(HirExprKind::ValueOf));
+    CHECK(hir->routes[0].locals[1].init.args[0]->may_error);
 }
 
 TEST(frontend, any_builtin_over_optional_cookie_source_becomes_or) {
@@ -10022,13 +10031,14 @@ TEST(frontend, any_builtin_over_optional_cookie_source_becomes_or) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Or));
     CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
-    auto& or_expr = hir->routes[0].locals[1].init;
-    REQUIRE_NE(or_expr.lhs, nullptr);
-    REQUIRE_NE(or_expr.rhs, nullptr);
-    CHECK_EQ(static_cast<u8>(or_expr.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
-    CHECK_EQ(static_cast<u8>(or_expr.rhs->kind), static_cast<u8>(HirExprKind::StrLit));
+    auto& fallback_expr = hir->routes[0].locals[1].init;
+    REQUIRE_NE(fallback_expr.lhs, nullptr);
+    REQUIRE_NE(fallback_expr.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(fallback_expr.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(fallback_expr.rhs->kind), static_cast<u8>(HirExprKind::StrLit));
 }
 
 TEST(frontend, any_builtin_over_optional_cookie_source_preserves_rhs_call) {
@@ -10044,13 +10054,16 @@ TEST(frontend, any_builtin_over_optional_cookie_source_preserves_rhs_call) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
     REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    REQUIRE_EQ(hir->routes[0].locals[1].init.args.len, 1u);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
-             static_cast<u8>(HirExprKind::LocalRef));
+             static_cast<u8>(HirExprKind::HasValue));
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
-             static_cast<u8>(HirExprKind::Call));
+             static_cast<u8>(HirExprKind::ValueOf));
+    CHECK(hir->routes[0].locals[1].init.args[0]->may_error);
 }
 
 TEST(frontend, all_builtin_over_optional_header_source_preserves_rhs_call) {
@@ -10072,8 +10085,7 @@ TEST(frontend, all_builtin_over_optional_header_source_preserves_rhs_call) {
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
              static_cast<u8>(HirExprKind::HasValue));
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
-             static_cast<u8>(HirExprKind::Call));
+    CHECK(hir->routes[0].locals[1].init.rhs->may_error);
     CHECK(hir->routes[0].locals[1].init.may_error);
 }
 
@@ -10130,8 +10142,7 @@ TEST(frontend, all_builtin_over_optional_cookie_source_preserves_rhs_call) {
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
              static_cast<u8>(HirExprKind::HasValue));
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
-             static_cast<u8>(HirExprKind::Call));
+    CHECK(hir->routes[0].locals[1].init.rhs->may_error);
     CHECK(hir->routes[0].locals[1].init.may_error);
 }
 
@@ -11688,9 +11699,8 @@ TEST(frontend, lower_to_rir_supports_runtime_all_int_value) {
 TEST(frontend, lower_to_rir_supports_runtime_any_optional_query_value_eagerly_with_rhs_call) {
     const char* src =
         "func fallback() -> str => error(.timeout)\n"
-        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, fallback()) return "
-        "value "
-        "== \"ok\" }\n";
+        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, fallback()) let ok = "
+        "value == \"ok\" return 204 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -11708,16 +11718,14 @@ TEST(frontend, lower_to_rir_supports_runtime_any_optional_query_value_eagerly_wi
     const auto& fn = rir.module.functions[0];
     REQUIRE_GE(fn.block_count, 1u);
     CHECK(block_op_count(fn.blocks[0], rir::Opcode::Select) >= 1u);
-    CHECK_FALSE(function_has_op(fn, rir::Opcode::Br));
-    CHECK_FALSE(function_has_op(fn, rir::Opcode::Jmp));
     rir.destroy();
 }
 
 TEST(frontend, lower_to_rir_supports_runtime_all_optional_query_fallback_call_eagerly) {
     const char* src =
         "func fallback() -> str => error(.timeout)\n"
-        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, fallback()) return "
-        "value == \"ok\" }\n";
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, fallback()) let ok = "
+        "value == \"ok\" return 204 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -11736,8 +11744,6 @@ TEST(frontend, lower_to_rir_supports_runtime_all_optional_query_fallback_call_ea
     REQUIRE_GE(fn.block_count, 1u);
     CHECK(block_op_count(fn.blocks[0], rir::Opcode::OptIsNil) >= 1u);
     CHECK(block_op_count(fn.blocks[0], rir::Opcode::Select) >= 1u);
-    CHECK_FALSE(function_has_op(fn, rir::Opcode::Br));
-    CHECK_FALSE(function_has_op(fn, rir::Opcode::Jmp));
     rir.destroy();
 }
 

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -10141,6 +10141,35 @@ TEST(frontend, any_all_builtin_pipe_placeholders_use_pipe_lhs) {
     rir.destroy();
 }
 
+TEST(frontend, any_builtin_preserves_lhs_error_carrier_for_nonfallible_fallback) {
+    const char* src =
+        "struct AuthError { err: Error }\n"
+        "func maybefail(ok: bool) -> i32 {\n"
+        "  if ok { 200 } else { error(AuthError, .timeout, \"timed out\") }\n"
+        "}\n"
+        "route GET \"/search\" { let value = maybefail(req.http11) let safe = any(value, 200) "
+        "return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->structs.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    auto& init = hir->routes[0].locals[1].init;
+    CHECK_EQ(static_cast<u8>(init.kind), static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(init.error_struct_index, 0u);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].locals[1].init.kind),
+             static_cast<u8>(MirValueKind::Or));
+    CHECK_EQ(mir->functions[0].locals[1].init.error_struct_index, 0u);
+}
+
 TEST(frontend, any_builtin_over_optional_header_source_becomes_or) {
     const char* src =
         "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, \"\") "

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8748,6 +8748,38 @@ TEST(frontend, if_const_folds_constant_local_boolean_and) {
     CHECK_EQ(hir->routes[0].control.direct_term.status_code, 200);
 }
 
+TEST(frontend, if_const_folds_const_comparison_boolean_or) {
+    const char* src =
+        "route GET \"/users\" { if const (POST == GET) or true { return 200 } else { return "
+        "forward(missing) } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Direct));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.direct_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(hir->routes[0].control.direct_term.status_code, 200);
+}
+
+TEST(frontend, if_const_folds_const_comparison_boolean_and) {
+    const char* src =
+        "route GET \"/users\" { if const (POST == GET) and true { return forward(missing) } else { "
+        "return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Direct));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.direct_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(hir->routes[0].control.direct_term.status_code, 200);
+}
+
 TEST(frontend, if_const_rejects_runtime_condition) {
     const char* src =
         "route GET \"/users\" { if const req.header(\"Host\") { return 200 } else { return 500 } "

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -10178,6 +10178,8 @@ TEST(frontend, any_all_builtin_pipe_placeholders_use_pipe_lhs) {
         "route GET \"/search\" {\n"
         "  let host = req.header(\"Host\") | any(_, \"missing\")\n"
         "  let gated = req.header(\"Host\") | all(_, \"present\")\n"
+        "  let injected_host = req.header(\"Host\") | any(\"missing\")\n"
+        "  let injected_gated = req.header(\"Host\") | all(\"present\")\n"
         "  return 200\n"
         "}\n";
 
@@ -10187,7 +10189,7 @@ TEST(frontend, any_all_builtin_pipe_placeholders_use_pipe_lhs) {
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
-    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 4u);
 
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);
@@ -10195,6 +10197,23 @@ TEST(frontend, any_all_builtin_pipe_placeholders_use_pipe_lhs) {
     auto lowered = lower_to_rir(mir.value(), rir);
     CHECK(lowered.has_value());
     rir.destroy();
+}
+
+TEST(frontend, any_all_builtin_pipe_rejects_placeholder_free_extra_args) {
+    const char* src =
+        "route GET \"/search\" {\n"
+        "  let host = req.header(\"Host\") | any(\"ignored\", \"missing\")\n"
+        "  return 200\n"
+        "}\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("pipe call missing placeholder")));
 }
 
 TEST(frontend, any_builtin_preserves_lhs_error_carrier_for_nonfallible_fallback) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -19532,12 +19532,13 @@ route GET "/users" {
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
     CHECK(hir.error().detail.eq(lit("placeholder slot exceeds tuple arity")));
 }
-TEST(frontend, analyze_rejects_pipe_with_placeholder_slot_zero) {
+TEST(frontend, source_pipe_keeps_placeholder_slot_zero_as_identifier) {
     const auto src = R"(
-func id(x: i32) -> i32 => x
+func second(x: i32, y: i32) -> i32 => y
 route GET "/users" {
-    let code = (200, 500) | id(_0)
-    return 200
+    let _0 = 204
+    let code = 200 | second(_, _0)
+    if code == 204 { return 200 } else { return 500 }
 }
 )";
     auto lexed = lex(lit(src));
@@ -19545,9 +19546,10 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE_FALSE(hir.has_value());
-    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
-    CHECK(hir.error().detail.eq(lit("placeholder slot out of range")));
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].name.eq(lit("_0")));
+    CHECK_EQ(hir->routes[0].locals[1].type, HirTypeKind::I32);
 }
 TEST(frontend, analyze_rejects_conditional_pipe_with_non_unit_placeholder) {
     const auto src = R"(

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -655,8 +655,7 @@ TEST(frontend, analyze_preserves_optional_any_as_or_value) {
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
              static_cast<u8>(HirExprKind::ReqQuery));
     CHECK(hir->routes[0].locals[1].name.eq(lit("code")));
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
-             static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
@@ -2932,7 +2931,7 @@ route {
 
 TEST(frontend, analyze_route_decorator_req_param_exposes_magic_request_methods) {
     const char* src = R"rut(
-func auth(_ req: i32) -> i32 { if or(req.header("Authorization"), "") == "ok" { 0 } else { 401 } }
+func auth(_ req: i32) -> i32 { if any(req.header("Authorization"), "") == "ok" { 0 } else { 401 } }
 route {
     @auth "*"
     GET "/users" { return 200 }
@@ -10019,8 +10018,7 @@ TEST(frontend, any_builtin_over_optional_query_source_becomes_or) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
-             static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
     auto& fallback_expr = hir->routes[0].locals[1].init;
@@ -10067,8 +10065,7 @@ TEST(frontend, any_builtin_over_optional_header_source_becomes_or) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
-             static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
     auto& fallback_expr = hir->routes[0].locals[1].init;
     REQUIRE_NE(fallback_expr.lhs, nullptr);
@@ -10115,8 +10112,7 @@ TEST(frontend, any_builtin_over_optional_cookie_source_becomes_or) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
-             static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
     auto& fallback_expr = hir->routes[0].locals[1].init;
     REQUIRE_NE(fallback_expr.lhs, nullptr);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -10075,6 +10075,7 @@ TEST(frontend, any_builtin_present_lhs_fallible_rhs_preserves_lhs_shape_and_rhs_
     CHECK_EQ(static_cast<u8>(init.lhs->kind), static_cast<u8>(HirExprKind::BoolLit));
     CHECK_EQ(static_cast<u8>(init.rhs->kind), static_cast<u8>(HirExprKind::IntLit));
     CHECK(init.args[0]->may_error);
+    CHECK(init.is_eager_fallback);
 
     auto mir = build_mir_heap(hir.value());
     REQUIRE(mir);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -10053,6 +10053,37 @@ TEST(frontend, any_builtin_over_optional_query_source_preserves_rhs_call) {
     CHECK(hir->routes[0].locals[1].init.args[0]->may_error);
 }
 
+TEST(frontend, any_builtin_present_lhs_fallible_rhs_preserves_lhs_shape_and_rhs_call) {
+    const char* src =
+        "func fallback() -> i32 => error(.timeout)\n"
+        "route GET \"/search\" { let value = any(200, fallback()) return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    auto& init = hir->routes[0].locals[0].init;
+    CHECK_EQ(static_cast<u8>(init.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK_EQ(init.type, HirTypeKind::I32);
+    CHECK(init.may_error);
+    REQUIRE_NE(init.lhs, nullptr);
+    REQUIRE_NE(init.rhs, nullptr);
+    REQUIRE_EQ(init.args.len, 1u);
+    CHECK_EQ(static_cast<u8>(init.lhs->kind), static_cast<u8>(HirExprKind::BoolLit));
+    CHECK_EQ(static_cast<u8>(init.rhs->kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK(init.args[0]->may_error);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered.has_value());
+    rir.destroy();
+}
+
 TEST(frontend, any_builtin_over_optional_header_source_becomes_or) {
     const char* src =
         "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, \"\") "

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -11131,15 +11131,19 @@ TEST(frontend, analyze_rejects_or_with_mismatched_types) {
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
-TEST(frontend, analyze_rejects_or_with_fallible_fallback) {
+TEST(frontend, analyze_allows_any_with_fallible_fallback) {
     const char* src = "route GET \"/users\" { let code = any(nil, error(7)) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE_FALSE(hir.has_value());
-    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::Error));
+    CHECK(hir->routes[0].locals[0].init.may_error);
+    CHECK_FALSE(hir->routes[0].locals[0].init.may_nil);
 }
 TEST(frontend, analyze_rejects_guard_let_binding_error_value) {
     const char* src =

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -10150,6 +10150,29 @@ TEST(frontend, all_builtin_present_lhs_fallible_rhs_preserves_rhs_error) {
     rir.destroy();
 }
 
+TEST(frontend, all_builtin_fallible_unknown_rhs_preserves_lhs_shape) {
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, error(.timeout)) "
+        "if value == \"rut\" { return 200 } else { return 404 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(hir->routes[0].locals[1].type, HirTypeKind::Str);
+    CHECK_EQ(hir->routes[0].locals[1].init.type, HirTypeKind::Str);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered.has_value());
+    rir.destroy();
+}
+
 TEST(frontend, any_all_builtin_pipe_placeholders_use_pipe_lhs) {
     const char* src =
         "route GET \"/search\" {\n"

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -10117,6 +10117,30 @@ TEST(frontend, all_builtin_present_lhs_fallible_rhs_preserves_rhs_error) {
     rir.destroy();
 }
 
+TEST(frontend, any_all_builtin_pipe_placeholders_use_pipe_lhs) {
+    const char* src =
+        "route GET \"/search\" {\n"
+        "  let host = req.header(\"Host\") | any(_, \"missing\")\n"
+        "  let gated = req.header(\"Host\") | all(_, \"present\")\n"
+        "  return 200\n"
+        "}\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered.has_value());
+    rir.destroy();
+}
+
 TEST(frontend, any_builtin_over_optional_header_source_becomes_or) {
     const char* src =
         "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, \"\") "

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -10216,6 +10216,38 @@ TEST(frontend, any_all_builtin_pipe_rejects_placeholder_free_extra_args) {
     CHECK(hir.error().detail.eq(lit("pipe call missing placeholder")));
 }
 
+TEST(frontend, any_all_builtin_pipe_rejects_numbered_placeholder_for_conditional_tuple_source) {
+    const char* cases[] = {
+        "func maybe_pair(ok: bool) -> (i32, i32) {\n"
+        "  if ok { (200, 401) } else { nil }\n"
+        "}\n"
+        "route GET \"/search\" {\n"
+        "  let pair = maybe_pair(req.http11)\n"
+        "  let code = pair | any(_2, 500)\n"
+        "  return 200\n"
+        "}\n",
+        "func maybe_pair(ok: bool) -> (i32, i32) {\n"
+        "  if ok { (200, 401) } else { error(.timeout) }\n"
+        "}\n"
+        "route GET \"/search\" {\n"
+        "  let pair = maybe_pair(req.http11)\n"
+        "  let code = pair | all(_2, 500)\n"
+        "  return 200\n"
+        "}\n",
+    };
+    for (const char* src : cases) {
+        auto lexed = lex(lit(src));
+        REQUIRE(lexed);
+        auto ast = parse_file_heap(lexed.value());
+        REQUIRE(ast);
+        auto hir = analyze_file_heap(ast.value());
+        REQUIRE_FALSE(hir.has_value());
+        CHECK_EQ(static_cast<u8>(hir.error().code),
+                 static_cast<u8>(FrontendError::UnsupportedSyntax));
+        CHECK(hir.error().detail.eq(lit("placeholder value in conditional pipe must be 1")));
+    }
+}
+
 TEST(frontend, any_builtin_preserves_lhs_error_carrier_for_nonfallible_fallback) {
     const char* src =
         "struct AuthError { err: Error }\n"

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -10085,6 +10085,38 @@ TEST(frontend, any_builtin_present_lhs_fallible_rhs_preserves_lhs_shape_and_rhs_
     rir.destroy();
 }
 
+TEST(frontend, all_builtin_present_lhs_fallible_rhs_preserves_rhs_error) {
+    const char* src =
+        "func fallback() -> i32 => error(.timeout)\n"
+        "route GET \"/search\" { let value = all(200, fallback()) return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    auto& init = hir->routes[0].locals[0].init;
+    CHECK_EQ(static_cast<u8>(init.kind), static_cast<u8>(HirExprKind::IfElse));
+    CHECK_EQ(init.type, HirTypeKind::I32);
+    CHECK(init.may_error);
+    REQUIRE_NE(init.lhs, nullptr);
+    REQUIRE_NE(init.rhs, nullptr);
+    REQUIRE_EQ(init.args.len, 1u);
+    CHECK_EQ(static_cast<u8>(init.lhs->kind), static_cast<u8>(HirExprKind::BoolLit));
+    CHECK(init.rhs->may_error);
+    CHECK_EQ(static_cast<u8>(init.args[0]->kind), static_cast<u8>(HirExprKind::IntLit));
+    CHECK(init.is_eager_fallback);
+
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    CHECK(lowered.has_value());
+    rir.destroy();
+}
+
 TEST(frontend, any_builtin_over_optional_header_source_becomes_or) {
     const char* src =
         "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, \"\") "

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -309,7 +309,8 @@ TEST(frontend, parse_rejects_or_function_call_form) {
 
 TEST(frontend, parse_rejects_or_function_call_form_with_header) {
     const char* src =
-        "route GET \"/x\" { let host = req.header(\"Host\") let x = or(host, \"fallback\") return 200 }\n";
+        "route GET \"/x\" { let host = req.header(\"Host\") let x = or(host, \"fallback\") return "
+        "200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -319,7 +320,8 @@ TEST(frontend, parse_rejects_or_function_call_form_with_header) {
 
 TEST(frontend, parse_rejects_or_function_call_form_with_cookie) {
     const char* src =
-        "route GET \"/x\" { let sid = req.cookie(\"sid\") let x = or(sid, \"fallback\") return 200 }\n";
+        "route GET \"/x\" { let sid = req.cookie(\"sid\") let x = or(sid, \"fallback\") return 200 "
+        "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -338,7 +340,8 @@ TEST(frontend, parse_rejects_and_function_call_form) {
 
 TEST(frontend, parse_rejects_and_function_call_form_with_header) {
     const char* src =
-        "route GET \"/x\" { let host = req.header(\"Host\") let x = and(host, \"fallback\") return 200 }\n";
+        "route GET \"/x\" { let host = req.header(\"Host\") let x = and(host, \"fallback\") return "
+        "200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -348,7 +351,8 @@ TEST(frontend, parse_rejects_and_function_call_form_with_header) {
 
 TEST(frontend, parse_rejects_and_function_call_form_with_cookie) {
     const char* src =
-        "route GET \"/x\" { let sid = req.cookie(\"sid\") let x = and(sid, \"fallback\") return 200 }\n";
+        "route GET \"/x\" { let sid = req.cookie(\"sid\") let x = and(sid, \"fallback\") return "
+        "200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -485,8 +489,7 @@ TEST(frontend, analyze_rejects_and_with_non_bool_operands) {
 }
 
 TEST(frontend, analyze_rejects_and_with_fallible_operands) {
-    const char* lhs_fallible =
-        "route GET \"/users\" { let code = error(7) and true return 200 }\n";
+    const char* lhs_fallible = "route GET \"/users\" { let code = error(7) and true return 200 }\n";
     auto lexed = lex(lit(lhs_fallible));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -495,8 +498,7 @@ TEST(frontend, analyze_rejects_and_with_fallible_operands) {
     REQUIRE_FALSE(lhs);
     CHECK_EQ(static_cast<u8>(lhs.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 
-    const char* rhs_fallible =
-        "route GET \"/users\" { let code = true and error(7) return 200 }\n";
+    const char* rhs_fallible = "route GET \"/users\" { let code = true and error(7) return 200 }\n";
     lexed = lex(lit(rhs_fallible));
     REQUIRE(lexed);
     ast = parse_file_heap(lexed.value());
@@ -516,7 +518,8 @@ TEST(frontend, analyze_rejects_and_with_nil_operands) {
     REQUIRE_FALSE(lhs);
     CHECK_EQ(static_cast<u8>(lhs.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 
-    const char* rhs_optional = "route GET \"/users\" { let maybe = nil let code = true and maybe return 200 }\n";
+    const char* rhs_optional =
+        "route GET \"/users\" { let maybe = nil let code = true and maybe return 200 }\n";
     lexed = lex(lit(rhs_optional));
     REQUIRE(lexed);
     ast = parse_file_heap(lexed.value());
@@ -546,7 +549,8 @@ TEST(frontend, analyze_constant_folds_and_with_false) {
 
 TEST(frontend, analyze_constant_folds_and_with_true_to_rhs) {
     const char* src =
-        "route GET \"/users\" { let code = true and true if code { return 200 } else { return 401 } "
+        "route GET \"/users\" { let code = true and true if code { return 200 } else { return 401 "
+        "} "
         "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -563,8 +567,9 @@ TEST(frontend, analyze_constant_folds_and_with_true_to_rhs) {
 }
 
 TEST(frontend, analyze_preserves_non_constant_and_as_if_else) {
-    const char* src = "func gate(left: bool, right: bool) -> bool => left and right\n"
-                      "route GET \"/users\" { return 204 }\n";
+    const char* src =
+        "func gate(left: bool, right: bool) -> bool => left and right\n"
+        "route GET \"/users\" { return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -581,7 +586,8 @@ TEST(frontend, analyze_preserves_non_constant_and_as_if_else) {
 
 TEST(frontend, analyze_constant_folds_or_with_true) {
     const char* src =
-        "route GET \"/users\" { let code = false or true if code { return 200 } else { return 401 } "
+        "route GET \"/users\" { let code = false or true if code { return 200 } else { return 401 "
+        "} "
         "}\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -645,7 +651,8 @@ TEST(frontend, analyze_preserves_optional_any_as_or_value) {
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
     CHECK(hir->routes[0].locals[0].name.eq(lit("maybe")));
     CHECK(hir->routes[0].locals[0].may_nil);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind), static_cast<u8>(HirExprKind::Nil));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::Nil));
     CHECK(hir->routes[0].locals[1].name.eq(lit("code")));
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
@@ -661,7 +668,8 @@ TEST(frontend, analyze_preserves_optional_any_as_or_value) {
 
 TEST(frontend, analyze_preserves_optional_all_as_if_else) {
     const char* src =
-        "route GET \"/users\" { let query = req.query(\"x\") let value = all(query, \"fallback\") return 200 }\n";
+        "route GET \"/users\" { let query = req.query(\"x\") let value = all(query, \"fallback\") "
+        "return 200 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -684,8 +692,9 @@ TEST(frontend, analyze_preserves_optional_all_as_if_else) {
 }
 
 TEST(frontend, analyze_preserves_non_constant_or_as_if_else) {
-    const char* src = "func gate(left: bool, right: bool) -> bool => left or right\n"
-                      "route GET \"/users\" { return 204 }\n";
+    const char* src =
+        "func gate(left: bool, right: bool) -> bool => left or right\n"
+        "route GET \"/users\" { return 204 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -9112,7 +9121,8 @@ TEST(frontend, any_builtin_rejects_mismatched_types) {
 
 TEST(frontend, req_header_flows_as_optional_str) {
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, \"fallback\") "
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, "
+        "\"fallback\") "
         "return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -9799,7 +9809,8 @@ TEST(frontend, any_builtin_falls_back_from_error_local) {
 }
 TEST(frontend, any_builtin_falls_back_from_error_alias) {
     const char* src =
-        "route GET \"/users\" { let failed = error(7) let alias = failed let code = any(alias, 200) "
+        "route GET \"/users\" { let failed = error(7) let alias = failed let code = any(alias, "
+        "200) "
         "if code == 200 { return 200 } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -9923,8 +9934,7 @@ TEST(frontend, any_builtin_over_optional_query_source_becomes_or) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
-             static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
     auto& or_expr = hir->routes[0].locals[1].init;
@@ -9947,8 +9957,7 @@ TEST(frontend, any_builtin_over_optional_query_source_preserves_rhs_call) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
-             static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
@@ -9969,8 +9978,7 @@ TEST(frontend, any_builtin_over_optional_header_source_becomes_or) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
-             static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
     auto& or_expr = hir->routes[0].locals[1].init;
     REQUIRE_NE(or_expr.lhs, nullptr);
@@ -9992,8 +10000,7 @@ TEST(frontend, any_builtin_over_optional_header_source_preserves_rhs_call) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
-             static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
@@ -10004,7 +10011,8 @@ TEST(frontend, any_builtin_over_optional_header_source_preserves_rhs_call) {
 
 TEST(frontend, any_builtin_over_optional_cookie_source_becomes_or) {
     const char* src =
-        "route GET \"/users\" { let sid = req.cookie(\"sid\") let value = any(sid, \"\") return 200 "
+        "route GET \"/users\" { let sid = req.cookie(\"sid\") let value = any(sid, \"\") return "
+        "200 "
         "}\n";
 
     auto lexed = lex(lit(src));
@@ -10014,8 +10022,7 @@ TEST(frontend, any_builtin_over_optional_cookie_source_becomes_or) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
-             static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
     auto& or_expr = hir->routes[0].locals[1].init;
     REQUIRE_NE(or_expr.lhs, nullptr);
@@ -10037,8 +10044,7 @@ TEST(frontend, any_builtin_over_optional_cookie_source_preserves_rhs_call) {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 2u);
-    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
-             static_cast<u8>(HirExprKind::Or));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
     REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
     REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
     CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
@@ -10073,7 +10079,8 @@ TEST(frontend, all_builtin_over_optional_header_source_preserves_rhs_call) {
 
 TEST(frontend, all_builtin_over_optional_header_source_becomes_if_else) {
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let value = all(host, \"fallback\") "
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = all(host, "
+        "\"fallback\") "
         "return 200 }\n";
 
     auto lexed = lex(lit(src));
@@ -11677,7 +11684,8 @@ TEST(frontend, lower_to_rir_supports_runtime_all_int_value) {
 TEST(frontend, lower_to_rir_supports_runtime_any_optional_query_value_eagerly_with_rhs_call) {
     const char* src =
         "func fallback() -> str => error(.timeout)\n"
-        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, fallback()) return value "
+        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, fallback()) return "
+        "value "
         "== \"ok\" }\n";
 
     auto lexed = lex(lit(src));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -11700,7 +11700,7 @@ TEST(frontend, lower_to_rir_supports_runtime_any_optional_query_value_eagerly_wi
     FrontendRirModule rir{};
     auto lowered = lower_to_rir(mir.value(), rir);
     REQUIRE(lowered);
-    REQUIRE_GE(rir.module.function_count, 1u);
+    REQUIRE_GE(rir.module.func_count, 1u);
     const auto& fn = rir.module.functions[0];
     REQUIRE_GE(fn.block_count, 1u);
     CHECK(block_op_count(fn.blocks[0], rir::Opcode::Select) >= 1u);
@@ -11727,7 +11727,7 @@ TEST(frontend, lower_to_rir_supports_runtime_all_optional_query_fallback_call_ea
     FrontendRirModule rir{};
     auto lowered = lower_to_rir(mir.value(), rir);
     REQUIRE(lowered);
-    REQUIRE_GE(rir.module.function_count, 1u);
+    REQUIRE_GE(rir.module.func_count, 1u);
     const auto& fn = rir.module.functions[0];
     REQUIRE_GE(fn.block_count, 1u);
     CHECK(block_op_count(fn.blocks[0], rir::Opcode::OptIsNil) >= 1u);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -8715,6 +8715,39 @@ TEST(frontend, if_const_selects_then_without_checking_else) {
              static_cast<u8>(HirTerminatorKind::ReturnStatus));
     CHECK_EQ(hir->routes[0].control.direct_term.status_code, 200);
 }
+
+TEST(frontend, if_const_folds_constant_local_boolean_or) {
+    const char* src =
+        "route GET \"/users\" { let flag = true if const flag or false { return 200 } else { "
+        "return forward(missing) } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Direct));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.direct_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(hir->routes[0].control.direct_term.status_code, 200);
+}
+
+TEST(frontend, if_const_folds_constant_local_boolean_and) {
+    const char* src =
+        "route GET \"/users\" { let flag = false if const flag and true { return forward(missing) "
+        "} else { return 200 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::Direct));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].control.direct_term.kind),
+             static_cast<u8>(HirTerminatorKind::ReturnStatus));
+    CHECK_EQ(hir->routes[0].control.direct_term.status_code, 200);
+}
+
 TEST(frontend, if_const_rejects_runtime_condition) {
     const char* src =
         "route GET \"/users\" { if const req.header(\"Host\") { return 200 } else { return 500 } "

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -26,6 +26,12 @@ static u32 block_op_count(const rir::Block& block, rir::Opcode op) {
     }
     return count;
 }
+static bool function_has_op(const rir::Function& fn, rir::Opcode op) {
+    for (u32 bi = 0; bi < fn.block_count; bi++) {
+        if (block_has_op(fn.blocks[bi], op)) return true;
+    }
+    return false;
+}
 // RAII wrapper for FrontendResult<T*>. The frontend APIs (parse_file,
 // analyze_file, build_mir) all .release() a unique_ptr and hand back a raw
 // pointer. Tests allocated hundreds of these without ever deleting; before
@@ -189,6 +195,509 @@ TEST(frontend, lex_regex_literal_reports_trailing_escape_at_literal_start) {
     CHECK_EQ(lexed.error().code, FrontendError::UnterminatedString);
     CHECK_EQ(lexed.error().span.start, 0u);
     CHECK_EQ(lexed.error().span.col, 1u);
+}
+
+TEST(frontend, lex_recognizes_and_or_keywords) {
+    const char* src = "a and b or c";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    REQUIRE_EQ(lexed->tokens.len, 6u);  // a, and, b, or, c, EOF
+    CHECK_EQ(static_cast<u8>(lexed->tokens[1].type), static_cast<u8>(TokenType::KwAnd));
+    CHECK_EQ(static_cast<u8>(lexed->tokens[3].type), static_cast<u8>(TokenType::KwOr));
+}
+
+TEST(frontend, parse_supports_infix_or_expression) {
+    const char* src = "route GET \"/x\" { let x = true or false return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    REQUIRE_EQ(ast->items[0].kind, AstItemKind::Route);
+    auto& route = ast->items[0].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    CHECK_EQ(static_cast<u8>(route.statements[0].kind), static_cast<u8>(AstStmtKind::Let));
+    CHECK_EQ(static_cast<u8>(route.statements[0].expr.kind), static_cast<u8>(AstExprKind::Or));
+}
+
+TEST(frontend, parse_supports_infix_and_expression) {
+    const char* src = "route GET \"/x\" { let x = true and false return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    REQUIRE_EQ(ast->items[0].kind, AstItemKind::Route);
+    auto& route = ast->items[0].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    CHECK_EQ(static_cast<u8>(route.statements[0].kind), static_cast<u8>(AstStmtKind::Let));
+    CHECK_EQ(static_cast<u8>(route.statements[0].expr.kind), static_cast<u8>(AstExprKind::And));
+}
+
+TEST(frontend, parse_supports_all_function_call_form) {
+    const char* src = "route GET \"/x\" { let x = all(200, 400) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    REQUIRE_EQ(ast->items[0].kind, AstItemKind::Route);
+    auto& route = ast->items[0].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    CHECK_EQ(static_cast<u8>(route.statements[0].kind), static_cast<u8>(AstStmtKind::Let));
+    auto& let_expr = route.statements[0].expr;
+    CHECK_EQ(static_cast<u8>(let_expr.kind), static_cast<u8>(AstExprKind::Call));
+    CHECK(let_expr.name.eq({"all", 3}));
+}
+
+TEST(frontend, parse_supports_any_function_call_form) {
+    const char* src = "route GET \"/x\" { let x = any(nil, 200) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    REQUIRE_EQ(ast->items[0].kind, AstItemKind::Route);
+    auto& route = ast->items[0].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    CHECK_EQ(static_cast<u8>(route.statements[0].kind), static_cast<u8>(AstStmtKind::Let));
+    auto& let_expr = route.statements[0].expr;
+    CHECK_EQ(static_cast<u8>(let_expr.kind), static_cast<u8>(AstExprKind::Call));
+    CHECK(let_expr.name.eq({"any", 3}));
+}
+
+TEST(frontend, parse_infix_and_or_is_left_associative) {
+    const char* src = "route GET \"/x\" { let x = true and false or false return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 1u);
+    REQUIRE_EQ(ast->items[0].kind, AstItemKind::Route);
+    auto& route = ast->items[0].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    auto& expr = route.statements[0].expr;
+    CHECK_EQ(static_cast<u8>(expr.kind), static_cast<u8>(AstExprKind::Or));
+    CHECK_EQ(static_cast<u8>(expr.lhs->kind), static_cast<u8>(AstExprKind::And));
+    CHECK_EQ(static_cast<u8>(expr.rhs->kind), static_cast<u8>(AstExprKind::BoolLit));
+}
+
+TEST(frontend, parse_rejects_double_ampersand_operator) {
+    const char* src = "route GET \"/x\" { let x = true && false return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(!lexed);
+    CHECK_EQ(lexed.error().code, FrontendError::UnexpectedChar);
+}
+
+TEST(frontend, parse_rejects_double_pipe_operator) {
+    const char* src = "route GET \"/x\" { let x = true || false return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(frontend, parse_rejects_or_function_call_form) {
+    const char* src = "route GET \"/x\" { let x = or(maybe(), 200) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(frontend, parse_rejects_or_function_call_form_with_header) {
+    const char* src =
+        "route GET \"/x\" { let host = req.header(\"Host\") let x = or(host, \"fallback\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(frontend, parse_rejects_or_function_call_form_with_cookie) {
+    const char* src =
+        "route GET \"/x\" { let sid = req.cookie(\"sid\") let x = or(sid, \"fallback\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(frontend, parse_rejects_and_function_call_form) {
+    const char* src = "route GET \"/x\" { let x = and(maybe(), 200) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(frontend, parse_rejects_and_function_call_form_with_header) {
+    const char* src =
+        "route GET \"/x\" { let host = req.header(\"Host\") let x = and(host, \"fallback\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(frontend, parse_rejects_and_function_call_form_with_cookie) {
+    const char* src =
+        "route GET \"/x\" { let sid = req.cookie(\"sid\") let x = and(sid, \"fallback\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(frontend, parse_rejects_pipe_with_bool_operator_rhs) {
+    const char* src =
+        "func pass_bool(v: bool) -> bool { v }\n"
+        "route GET \"/x\" { let x = true | pass_bool(_) or false return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(frontend, parse_allows_parenthesized_pipe_with_or) {
+    const char* src =
+        "func pass_bool(v: bool) -> bool { v }\n"
+        "route GET \"/x\" { let x = (true | pass_bool(_)) or false return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    REQUIRE_EQ(ast->items[1].kind, AstItemKind::Route);
+    auto& route = ast->items[1].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    auto& expr = route.statements[0].expr;
+    CHECK_EQ(static_cast<u8>(expr.kind), static_cast<u8>(AstExprKind::Or));
+    REQUIRE(expr.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(expr.lhs->kind), static_cast<u8>(AstExprKind::Pipe));
+    CHECK_EQ(static_cast<u8>(expr.lhs->rhs->kind), static_cast<u8>(AstExprKind::Call));
+}
+
+TEST(frontend, parse_supports_and_expr_before_pipe) {
+    const char* src =
+        "func pass_bool(v: bool) -> bool { v }\n"
+        "route GET \"/x\" { let x = true and false | pass_bool(_) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    REQUIRE_EQ(ast->items[1].kind, AstItemKind::Route);
+    auto& route = ast->items[1].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    auto& expr = route.statements[0].expr;
+    CHECK_EQ(static_cast<u8>(expr.kind), static_cast<u8>(AstExprKind::Pipe));
+    REQUIRE(expr.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(expr.lhs->kind), static_cast<u8>(AstExprKind::And));
+}
+
+TEST(frontend, parse_supports_or_expr_before_pipe) {
+    const char* src =
+        "func pass_bool(v: bool) -> bool { v }\n"
+        "route GET \"/x\" { let x = true or false | pass_bool(_) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 2u);
+    REQUIRE_EQ(ast->items[1].kind, AstItemKind::Route);
+    auto& route = ast->items[1].route;
+    REQUIRE_EQ(route.statements.len, 2u);
+    auto& expr = route.statements[0].expr;
+    CHECK_EQ(static_cast<u8>(expr.kind), static_cast<u8>(AstExprKind::Pipe));
+    REQUIRE(expr.lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(expr.lhs->kind), static_cast<u8>(AstExprKind::Or));
+}
+
+TEST(frontend, build_mir_preserves_runtime_any_value) {
+    const char* src = R"(
+route GET "/users" {
+    let host = req.header("Host")
+    let safe = any(host, "fallback")
+    if safe == "fallback" { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    bool saw_or = false;
+    for (u32 fi = 0; fi < mir->functions.len; fi++) {
+        for (u32 vi = 0; vi < mir->functions[fi].values.len; vi++) {
+            if (mir->functions[fi].values[vi].kind == MirValueKind::Or) {
+                saw_or = true;
+                break;
+            }
+        }
+        if (saw_or) break;
+    }
+    CHECK(saw_or);
+}
+
+TEST(frontend, parse_rejects_pipe_with_unclear_and_operand) {
+    const char* src =
+        "func pass_bool(v: bool) -> bool { v }\n"
+        "route GET \"/x\" { let x = true | pass_bool(_) and false return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(!ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(frontend, analyze_rejects_and_with_non_bool_operands) {
+    const char* lhs_mismatch = "route GET \"/users\" { let code = 200 and true return 200 }\n";
+    auto lexed = lex(lit(lhs_mismatch));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto lhs = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(lhs);
+    CHECK_EQ(static_cast<u8>(lhs.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+
+    const char* rhs_mismatch =
+        "route GET \"/users\" { let code = true and \"fallback\" return 200 }\n";
+    lexed = lex(lit(rhs_mismatch));
+    REQUIRE(lexed);
+    ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto rhs = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(rhs);
+    CHECK_EQ(static_cast<u8>(rhs.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_rejects_and_with_fallible_operands) {
+    const char* lhs_fallible =
+        "route GET \"/users\" { let code = error(7) and true return 200 }\n";
+    auto lexed = lex(lit(lhs_fallible));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto lhs = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(lhs);
+    CHECK_EQ(static_cast<u8>(lhs.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+
+    const char* rhs_fallible =
+        "route GET \"/users\" { let code = true and error(7) return 200 }\n";
+    lexed = lex(lit(rhs_fallible));
+    REQUIRE(lexed);
+    ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto rhs = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(rhs);
+    CHECK_EQ(static_cast<u8>(rhs.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_rejects_and_with_nil_operands) {
+    const char* lhs_optional = "route GET \"/users\" { let code = nil and true return 200 }\n";
+    auto lexed = lex(lit(lhs_optional));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto lhs = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(lhs);
+    CHECK_EQ(static_cast<u8>(lhs.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+
+    const char* rhs_optional = "route GET \"/users\" { let maybe = nil let code = true and maybe return 200 }\n";
+    lexed = lex(lit(rhs_optional));
+    REQUIRE(lexed);
+    ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto rhs = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(rhs);
+    CHECK_EQ(static_cast<u8>(rhs.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, analyze_constant_folds_and_with_false) {
+    const char* src =
+        "route GET \"/users\" { let code = false and false if code { return 200 } else { return "
+        "401 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::BoolLit));
+    CHECK_FALSE(hir->routes[0].locals[0].init.bool_value);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+}
+
+TEST(frontend, analyze_constant_folds_and_with_true_to_rhs) {
+    const char* src =
+        "route GET \"/users\" { let code = true and true if code { return 200 } else { return 401 } "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::BoolLit));
+    CHECK(hir->routes[0].locals[0].init.bool_value);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+}
+
+TEST(frontend, analyze_preserves_non_constant_and_as_if_else) {
+    const char* src = "func gate(left: bool, right: bool) -> bool => left and right\n"
+                      "route GET \"/users\" { return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE_NE(hir->functions[0].body.lhs, nullptr);
+    REQUIRE_NE(hir->functions[0].body.rhs, nullptr);
+    CHECK_EQ(hir->functions[0].body.lhs->type, HirTypeKind::Bool);
+    CHECK_EQ(hir->functions[0].body.rhs->type, HirTypeKind::Bool);
+}
+
+TEST(frontend, analyze_constant_folds_or_with_true) {
+    const char* src =
+        "route GET \"/users\" { let code = false or true if code { return 200 } else { return 401 } "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::BoolLit));
+    CHECK(hir->routes[0].locals[0].init.bool_value);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+}
+
+TEST(frontend, analyze_constant_folds_or_with_false) {
+    const char* src =
+        "route GET \"/users\" { let code = false or false if code { return 200 } else { return "
+        "401 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::BoolLit));
+    CHECK_FALSE(hir->routes[0].locals[0].init.bool_value);
+    CHECK_FALSE(hir->routes[0].locals[0].may_error);
+    CHECK_FALSE(hir->routes[0].locals[0].may_nil);
+}
+
+TEST(frontend, analyze_constant_folds_any_when_lhs_present) {
+    const char* src =
+        "route GET \"/users\" { let code = any(200, 500) if code == 200 { return 200 } else { "
+        "return 401 } }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(hir->routes[0].locals[0].init.int_value, 200);
+    CHECK_FALSE(hir->routes[0].locals[0].init.may_error);
+    CHECK_FALSE(hir->routes[0].locals[0].init.may_nil);
+}
+
+TEST(frontend, analyze_preserves_optional_any_as_or_value) {
+    const char* src =
+        "route GET \"/users\" { let maybe = nil let code = any(maybe, 200) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[0].name.eq(lit("maybe")));
+    CHECK(hir->routes[0].locals[0].may_nil);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind), static_cast<u8>(HirExprKind::Nil));
+    CHECK(hir->routes[0].locals[1].name.eq(lit("code")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind), static_cast<u8>(HirExprKind::Or));
+    REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
+    REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
+             static_cast<u8>(HirExprKind::IntLit));
+    CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
+    CHECK_FALSE(hir->routes[0].locals[1].init.may_nil);
+    CHECK_EQ(hir->routes[0].locals[1].init.rhs->int_value, 200);
+}
+
+TEST(frontend, analyze_preserves_optional_all_as_if_else) {
+    const char* src =
+        "route GET \"/users\" { let query = req.query(\"x\") let value = all(query, \"fallback\") return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[1].name.eq(lit("value")));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
+    CHECK_NE(hir->routes[0].locals[1].init.lhs, nullptr);
+    CHECK_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
+             static_cast<u8>(HirExprKind::HasValue));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
+             static_cast<u8>(HirExprKind::StrLit));
+    CHECK(hir->routes[0].locals[1].init.may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
+}
+
+TEST(frontend, analyze_preserves_non_constant_or_as_if_else) {
+    const char* src = "func gate(left: bool, right: bool) -> bool => left or right\n"
+                      "route GET \"/users\" { return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->functions.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->functions[0].body.kind), static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE_NE(hir->functions[0].body.lhs, nullptr);
+    REQUIRE_NE(hir->functions[0].body.rhs, nullptr);
+    CHECK_EQ(hir->functions[0].body.lhs->type, HirTypeKind::Bool);
+    CHECK_EQ(hir->functions[0].body.rhs->type, HirTypeKind::Bool);
 }
 
 TEST(frontend, parse_return_response_status_only) {
@@ -3367,7 +3876,7 @@ TEST(frontend,
     }
     const auto src = R"rut(
 import "proto.rut"
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
 )rut";
     auto lexed = lex(lit(src));
@@ -3390,7 +3899,7 @@ TEST(frontend,
     }
     const auto src = R"rut(
 import "proto.rut"
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
 )rut";
     auto lexed = lex(lit(src));
@@ -5905,7 +6414,7 @@ TEST(frontend, import_relative_file_preserves_imported_function_body_shape_indic
         out << "func makeBox(ok: bool) -> Box { if ok { Box(value: 200) } else { Box(value: 500) } "
                "}\n";
         out << "func maybe(ok: bool) { if ok { 200 } else { nil } }\n";
-        out << "func pickOr(ok: bool) -> i32 => or(maybe(ok), 500)\n";
+        out << "func pickOr(ok: bool) -> i32 => any(maybe(ok), 500)\n";
         out << "func pickMatch(x: Result) -> i32 {\n";
         out << "    match x {\n";
         out << "        case .ok => 200\n";
@@ -6034,8 +6543,8 @@ TEST(frontend,
     }
     const auto src = R"rut(
 import "proto.rut"
-func runOpt<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
-func runErr<T: MaybeFail>(x: T) -> i32 => or(x.code(), 200)
+func runOpt<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
+func runErr<T: MaybeFail>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" {
     if runOpt(Box(value: 1)) == 200 { return 200 } else { return 500 }
 }
@@ -6090,8 +6599,8 @@ TEST(
     }
     const auto src = R"rut(
 import "proto.rut"
-func runOpt<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
-func runErr<T: MaybeFail>(x: T) -> i32 => or(x.code(), 200)
+func runOpt<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
+func runErr<T: MaybeFail>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" {
     let a = runOpt(Box(value: 1))
     let b = runErr(Box(value: 1))
@@ -6268,7 +6777,7 @@ TEST(frontend, lower_to_rir_supports_imported_function_body_or) {
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
         out << "func maybe(ok: bool) { if ok { 200 } else { nil } }\n";
-        out << "func pick(ok: bool) -> i32 => or(maybe(ok), 500)\n";
+        out << "func pick(ok: bool) -> i32 => any(maybe(ok), 500)\n";
     }
     const auto src = R"rut(
 import "proto.rut"
@@ -6303,7 +6812,7 @@ TEST(frontend,
     }
     const auto src = R"rut(
 import "proto.rut"
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
 )rut";
     auto lexed = lex(lit(src));
@@ -6332,7 +6841,7 @@ TEST(frontend,
     }
     const auto src = R"rut(
 import "proto.rut"
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
 )rut";
     auto lexed = lex(lit(src));
@@ -6935,7 +7444,7 @@ TEST(frontend, error_message_is_preserved_for_explicit_error_variant) {
 }
 TEST(frontend, lower_to_rir_emits_standard_error_struct) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = or(failed, "
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = any(failed, "
         "200) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -6966,7 +7475,7 @@ TEST(frontend, lower_to_rir_emits_standard_error_struct) {
 }
 TEST(frontend, lower_to_rir_uses_module_name_for_error_file_field) {
     const char* src =
-        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = or(failed, "
+        "route GET \"/users\" { let failed = error(.timeout, \"timed out\") let code = any(failed, "
         "200) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -7000,7 +7509,7 @@ TEST(frontend, custom_error_struct_lowers_with_standard_error_metadata) {
     const char* src =
         "struct AuthError { err: Error }\n"
         "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\") let code = "
-        "or(failed, 200) return 200 }\n";
+        "any(failed, 200) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -7043,7 +7552,7 @@ TEST(frontend, custom_error_struct_extra_fields_enter_runtime_lowering) {
     const char* src =
         "struct AuthError { err: Error, token: str, retry: i32 }\n"
         "route GET \"/users\" { let failed = error(AuthError, .timeout, \"timed out\", token: "
-        "\"abc\", retry: 3) let code = or(failed, 200) return 200 }\n";
+        "\"abc\", retry: 3) let code = any(failed, 200) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -8565,9 +9074,9 @@ TEST(frontend, equality_expression_lowers_to_cmp_eq) {
              static_cast<u8>(rir::Opcode::Br));
     rir.destroy();
 }
-TEST(frontend, or_builtin_falls_back_from_nil) {
+TEST(frontend, any_builtin_falls_back_from_nil) {
     const char* src =
-        "route GET \"/users\" { let code = or(nil, 200) if code == 200 { return 200 } else { "
+        "route GET \"/users\" { let code = any(nil, 200) if code == 200 { return 200 } else { "
         "return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -8576,8 +9085,9 @@ TEST(frontend, or_builtin_falls_back_from_nil) {
     REQUIRE_EQ(ast->items[0].route.statements.len, 2u);
     CHECK_EQ(static_cast<u8>(ast->items[0].route.statements[0].kind),
              static_cast<u8>(AstStmtKind::Let));
-    CHECK_EQ(static_cast<u8>(ast->items[0].route.statements[0].expr.kind),
-             static_cast<u8>(AstExprKind::Or));
+    auto& any_expr = ast->items[0].route.statements[0].expr;
+    CHECK_EQ(static_cast<u8>(any_expr.kind), static_cast<u8>(AstExprKind::Call));
+    CHECK(any_expr.name.eq({"any", 3}));
     auto hir = analyze_file_heap(ast.value());
     REQUIRE(hir);
     REQUIRE_EQ(hir->routes[0].locals.len, 1u);
@@ -8588,9 +9098,21 @@ TEST(frontend, or_builtin_falls_back_from_nil) {
              static_cast<u8>(HirExprKind::IntLit));
     CHECK_EQ(hir->routes[0].locals[0].init.int_value, 200);
 }
+
+TEST(frontend, any_builtin_rejects_mismatched_types) {
+    const char* src = "route GET \"/users\" { let code = any(200, true) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
 TEST(frontend, req_header_flows_as_optional_str) {
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"fallback\") "
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, \"fallback\") "
         "return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -8639,7 +9161,7 @@ TEST(frontend, req_standard_header_alias_flows_as_optional_str) {
         "req.contentType let lang = req.acceptLanguage let enc = req.acceptEncoding let cache = "
         "req.cacheControl let ref = req.referer let fwd = req.forwarded let xff = "
         "req.xForwardedFor let proto = req.xForwardedProto let real = req.xRealIp let rid = "
-        "req.xRequestId let value = or(auth, \"\") return 200 }\n";
+        "req.xRequestId let value = any(auth, \"\") return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -8846,7 +9368,7 @@ TEST(frontend, req_route_param_field_requires_full_param_segment) {
 
 TEST(frontend, req_query_flows_as_optional_str) {
     const char* src =
-        "route GET \"/search\" { let q = req.query(\"q\") let value = or(q, \"\") if value == "
+        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, \"\") if value == "
         "\"rut\" { return 200 } else { "
         "return 404 } }\n";
     auto lexed = lex(lit(src));
@@ -8882,7 +9404,7 @@ TEST(frontend, req_query_flows_as_optional_str) {
 
 TEST(frontend, req_query_string_flows_as_optional_str) {
     const char* src =
-        "route GET \"/search\" { let raw = req.queryString let value = or(raw, \"\") if value == "
+        "route GET \"/search\" { let raw = req.queryString let value = any(raw, \"\") if value == "
         "\"q=rut\" { return 200 } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -9163,7 +9685,7 @@ TEST(frontend, req_content_length_and_remote_addr_equality_lower_to_rir) {
 
 TEST(frontend, req_cookie_flows_as_optional_str) {
     const char* src =
-        "route GET \"/users\" { let sid = req.cookie(\"sid\") let value = or(sid, \"fallback\") "
+        "route GET \"/users\" { let sid = req.cookie(\"sid\") let value = any(sid, \"fallback\") "
         "return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -9196,7 +9718,7 @@ TEST(frontend, req_cookie_flows_as_optional_str) {
 TEST(frontend, req_header_alias_flows_as_optional_str) {
     const char* src =
         "route GET \"/users\" { let host = req.header(\"Host\") let alias = host let value = "
-        "or(alias, \"fallback\") return 200 }\n";
+        "any(alias, \"fallback\") return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -9227,9 +9749,9 @@ TEST(frontend, req_header_alias_flows_as_optional_str) {
     CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[1].op), static_cast<u8>(rir::Opcode::ConstStr));
     rir.destroy();
 }
-TEST(frontend, or_builtin_falls_back_from_nil_local) {
+TEST(frontend, any_builtin_falls_back_from_nil_local) {
     const char* src =
-        "route GET \"/users\" { let maybe = nil let code = or(maybe, 200) if code == 200 { return "
+        "route GET \"/users\" { let maybe = nil let code = any(maybe, 200) if code == 200 { return "
         "200 } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -9252,9 +9774,9 @@ TEST(frontend, or_builtin_falls_back_from_nil_local) {
     REQUIRE(mir);
     REQUIRE_EQ(mir->functions[0].locals.len, 2u);
 }
-TEST(frontend, or_builtin_falls_back_from_error_local) {
+TEST(frontend, any_builtin_falls_back_from_error_local) {
     const char* src =
-        "route GET \"/users\" { let failed = error(7) let code = or(failed, 200) if code == 200 { "
+        "route GET \"/users\" { let failed = error(7) let code = any(failed, 200) if code == 200 { "
         "return 200 } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -9275,9 +9797,9 @@ TEST(frontend, or_builtin_falls_back_from_error_local) {
              static_cast<u8>(HirExprKind::IntLit));
     CHECK_EQ(hir->routes[0].locals[1].init.int_value, 200);
 }
-TEST(frontend, or_builtin_falls_back_from_error_alias) {
+TEST(frontend, any_builtin_falls_back_from_error_alias) {
     const char* src =
-        "route GET \"/users\" { let failed = error(7) let alias = failed let code = or(alias, 200) "
+        "route GET \"/users\" { let failed = error(7) let alias = failed let code = any(alias, 200) "
         "if code == 200 { return 200 } else { return 404 } }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -9293,6 +9815,370 @@ TEST(frontend, or_builtin_falls_back_from_error_alias) {
              static_cast<u8>(HirExprKind::IntLit));
     CHECK_EQ(hir->routes[0].locals[2].init.int_value, 200);
 }
+
+TEST(frontend, all_builtin_skips_rhs_when_primary_is_nil) {
+    const char* src = "route GET \"/users\" { let code = all(nil, 200) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::Nil));
+}
+
+TEST(frontend, all_builtin_skips_rhs_when_primary_is_error) {
+    const char* src =
+        "route GET \"/users\" { let failed = error(7) let code = all(failed, 200) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Error));
+}
+
+TEST(frontend, all_builtin_uses_fallback_when_primary_has_value) {
+    const char* src = "route GET \"/users\" { let code = all(200, 400) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::IntLit));
+    CHECK_EQ(hir->routes[0].locals[0].init.int_value, 400);
+}
+
+TEST(frontend, all_builtin_over_optional_source_becomes_if_else) {
+    const char* src =
+        "route GET \"/users\" { let host = req.header(\"Host\") let code = all(host, \"fallback\") "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
+    CHECK(hir->routes[0].locals[1].may_nil);
+}
+
+TEST(frontend, all_builtin_over_optional_query_source_becomes_if_else) {
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, \"\") return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
+    CHECK(hir->routes[0].locals[1].may_nil);
+}
+
+TEST(frontend, all_builtin_over_optional_query_source_preserves_rhs_call) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, fallback()) "
+        "return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
+    REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
+             static_cast<u8>(HirExprKind::HasValue));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
+             static_cast<u8>(HirExprKind::Call));
+    CHECK(hir->routes[0].locals[1].init.may_error);
+}
+
+TEST(frontend, any_builtin_over_optional_query_source_becomes_or) {
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, \"\") return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Or));
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+    auto& or_expr = hir->routes[0].locals[1].init;
+    REQUIRE_NE(or_expr.lhs, nullptr);
+    REQUIRE_NE(or_expr.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(or_expr.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(or_expr.rhs->kind), static_cast<u8>(HirExprKind::StrLit));
+}
+
+TEST(frontend, any_builtin_over_optional_query_source_preserves_rhs_call) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, fallback()) "
+        "return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Or));
+    REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
+    REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
+             static_cast<u8>(HirExprKind::Call));
+}
+
+TEST(frontend, any_builtin_over_optional_header_source_becomes_or) {
+    const char* src =
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, \"\") "
+        "return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Or));
+    CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
+    auto& or_expr = hir->routes[0].locals[1].init;
+    REQUIRE_NE(or_expr.lhs, nullptr);
+    REQUIRE_NE(or_expr.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(or_expr.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(or_expr.rhs->kind), static_cast<u8>(HirExprKind::StrLit));
+}
+
+TEST(frontend, any_builtin_over_optional_header_source_preserves_rhs_call) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, fallback()) "
+        "return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Or));
+    REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
+    REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
+             static_cast<u8>(HirExprKind::Call));
+}
+
+TEST(frontend, any_builtin_over_optional_cookie_source_becomes_or) {
+    const char* src =
+        "route GET \"/users\" { let sid = req.cookie(\"sid\") let value = any(sid, \"\") return 200 "
+        "}\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Or));
+    CHECK_FALSE(hir->routes[0].locals[1].init.may_error);
+    auto& or_expr = hir->routes[0].locals[1].init;
+    REQUIRE_NE(or_expr.lhs, nullptr);
+    REQUIRE_NE(or_expr.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(or_expr.lhs->kind), static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(or_expr.rhs->kind), static_cast<u8>(HirExprKind::StrLit));
+}
+
+TEST(frontend, any_builtin_over_optional_cookie_source_preserves_rhs_call) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/users\" { let sid = req.cookie(\"sid\") let value = any(sid, fallback()) "
+        "return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::Or));
+    REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
+    REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
+             static_cast<u8>(HirExprKind::LocalRef));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
+             static_cast<u8>(HirExprKind::Call));
+}
+
+TEST(frontend, all_builtin_over_optional_header_source_preserves_rhs_call) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/admin\" { let host = req.header(\"Host\") let value = all(host, fallback()) "
+        "return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
+    REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
+             static_cast<u8>(HirExprKind::HasValue));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
+             static_cast<u8>(HirExprKind::Call));
+    CHECK(hir->routes[0].locals[1].init.may_error);
+}
+
+TEST(frontend, all_builtin_over_optional_header_source_becomes_if_else) {
+    const char* src =
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = all(host, \"fallback\") "
+        "return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
+    CHECK(hir->routes[0].locals[1].may_nil);
+}
+
+TEST(frontend, all_builtin_over_optional_cookie_source_becomes_if_else) {
+    const char* src =
+        "route GET \"/users\" { let sid = req.cookie(\"sid\") let value = all(sid, \"fallback\") "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
+    CHECK(hir->routes[0].locals[1].may_nil);
+}
+
+TEST(frontend, all_builtin_over_optional_cookie_source_preserves_rhs_call) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/users\" { let sid = req.cookie(\"sid\") let value = all(sid, fallback()) "
+        "return 200 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE_NE(hir->routes[0].locals[1].init.lhs, nullptr);
+    REQUIRE_NE(hir->routes[0].locals[1].init.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.lhs->kind),
+             static_cast<u8>(HirExprKind::HasValue));
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[1].init.rhs->kind),
+             static_cast<u8>(HirExprKind::Call));
+    CHECK(hir->routes[0].locals[1].init.may_error);
+}
+
+TEST(frontend, all_builtin_rejects_non_binary_arity) {
+    const char* missing_rhs = "route GET \"/users\" { let code = all(200) return 200 }\n";
+    auto lexed = lex(lit(missing_rhs));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+
+    const char* extra_arg = "route GET \"/users\" { let code = all(200, 401, 500) return 200 }\n";
+    lexed = lex(lit(extra_arg));
+    REQUIRE(lexed);
+    ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
+TEST(frontend, all_builtin_rejects_mismatched_types) {
+    const char* src = "route GET \"/users\" { let code = all(200, true) return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+
+TEST(frontend, any_builtin_rejects_non_binary_arity) {
+    const char* missing_rhs = "route GET \"/users\" { let code = any(200) return 200 }\n";
+    auto lexed = lex(lit(missing_rhs));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+
+    const char* extra_arg = "route GET \"/users\" { let code = any(200, 400, 500) return 200 }\n";
+    lexed = lex(lit(extra_arg));
+    REQUIRE(lexed);
+    ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+}
+
 TEST(frontend, analyze_rejects_unknown_upstream) {
     const char* src = "route GET \"/users\" { return forward(api) }\n";
     auto lexed = lex(lit(src));
@@ -10229,7 +11115,7 @@ TEST(frontend, analyze_rejects_match_pattern_type_mismatch) {
 }
 TEST(frontend, analyze_rejects_or_with_mismatched_types) {
     const char* src =
-        "route GET \"/users\" { let code = 200 let fallback = or(code, true) return 200 }\n";
+        "route GET \"/users\" { let code = 200 let fallback = any(code, true) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -10239,7 +11125,7 @@ TEST(frontend, analyze_rejects_or_with_mismatched_types) {
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 TEST(frontend, analyze_rejects_or_with_fallible_fallback) {
-    const char* src = "route GET \"/users\" { let code = or(nil, error(7)) return 200 }\n";
+    const char* src = "route GET \"/users\" { let code = any(nil, error(7)) return 200 }\n";
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
     auto ast = parse_file_heap(lexed.value());
@@ -10323,6 +11209,85 @@ TEST(frontend, build_mir_preserves_runtime_or_value) {
              static_cast<u8>(MirValueKind::LocalRef));
     CHECK_EQ(static_cast<u8>(mir.value()->functions[0].locals[1].init.rhs->kind),
              static_cast<u8>(MirValueKind::IntConst));
+}
+
+TEST(frontend, build_mir_preserves_runtime_all_value) {
+    auto* hir = new HirModule{};
+    HirRoute route{};
+    route.span = {1, 1, 1, 1};
+    route.method = 'G';
+    route.path = lit("/users");
+    HirLocal maybe{};
+    maybe.span = {1, 1, 1, 1};
+    maybe.name = lit("maybe");
+    maybe.type = HirTypeKind::I32;
+    maybe.may_nil = true;
+    maybe.init.kind = HirExprKind::IntLit;
+    maybe.init.type = HirTypeKind::I32;
+    maybe.init.int_value = 123;
+    REQUIRE(route.locals.push(maybe));
+
+    HirExpr lhs_ref{};
+    lhs_ref.kind = HirExprKind::LocalRef;
+    lhs_ref.type = HirTypeKind::I32;
+    lhs_ref.may_nil = true;
+    lhs_ref.local_index = 0;
+    REQUIRE(route.exprs.push(lhs_ref));
+
+    HirExpr cond{};
+    cond.kind = HirExprKind::HasValue;
+    cond.type = HirTypeKind::Bool;
+    cond.lhs = &route.exprs[0];
+
+    HirExpr rhs{};
+    rhs.kind = HirExprKind::IntLit;
+    rhs.type = HirTypeKind::I32;
+    rhs.int_value = 200;
+
+    HirExpr fallback{};
+    fallback.kind = HirExprKind::MissingOf;
+    fallback.type = HirTypeKind::I32;
+    fallback.lhs = &route.exprs[0];
+    fallback.may_nil = true;
+
+    HirLocal code{};
+    code.span = {1, 1, 1, 1};
+    code.name = lit("code");
+    code.type = HirTypeKind::I32;
+    code.init.kind = HirExprKind::IfElse;
+    code.init.type = HirTypeKind::I32;
+    code.init.may_nil = true;
+    REQUIRE(route.exprs.push(cond));
+    HirExpr* cond_ptr = &route.exprs[1];
+    REQUIRE(route.exprs.push(rhs));
+    HirExpr* rhs_ptr = &route.exprs[2];
+    REQUIRE(route.exprs.push(fallback));
+    HirExpr* fallback_ptr = &route.exprs[3];
+    code.init.lhs = cond_ptr;
+    code.init.rhs = rhs_ptr;
+    REQUIRE(code.init.args.push(fallback_ptr));
+    REQUIRE(route.locals.push(code));
+
+    route.control.kind = HirControlKind::Direct;
+    route.control.direct_term.kind = HirTerminatorKind::ReturnStatus;
+    route.control.direct_term.status_code = 200;
+    REQUIRE(hir->routes.push(route));
+
+    auto mir = build_mir(*hir);
+    REQUIRE(mir);
+    REQUIRE_EQ(mir.value()->functions.len, 1u);
+    REQUIRE_EQ(mir.value()->functions[0].locals.len, 2u);
+    CHECK_EQ(static_cast<u8>(mir.value()->functions[0].locals[1].init.kind),
+             static_cast<u8>(MirValueKind::IfElse));
+    REQUIRE_NE(mir.value()->functions[0].locals[1].init.lhs, nullptr);
+    REQUIRE_NE(mir.value()->functions[0].locals[1].init.rhs, nullptr);
+    CHECK_EQ(static_cast<u8>(mir.value()->functions[0].locals[1].init.lhs->kind),
+             static_cast<u8>(MirValueKind::HasValue));
+    CHECK_EQ(static_cast<u8>(mir.value()->functions[0].locals[1].init.rhs->kind),
+             static_cast<u8>(MirValueKind::IntConst));
+    REQUIRE_EQ(mir.value()->functions[0].locals[1].init.args.len, 1u);
+    CHECK_EQ(static_cast<u8>(mir.value()->functions[0].locals[1].init.args[0]->kind),
+             static_cast<u8>(MirValueKind::MissingOf));
 }
 TEST(frontend, build_mir_preserves_runtime_no_error_guard) {
     auto* hir = new HirModule{};
@@ -10424,6 +11389,8 @@ TEST(frontend, lower_to_rir_supports_runtime_optional_or_value) {
     CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[4].op), static_cast<u8>(rir::Opcode::OptUnwrap));
     CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[5].op), static_cast<u8>(rir::Opcode::Select));
     CHECK_EQ(static_cast<u8>(fn.blocks[0].insts[6].op), static_cast<u8>(rir::Opcode::RetStatus));
+    CHECK_FALSE(function_has_op(fn, rir::Opcode::Br));
+    CHECK_FALSE(function_has_op(fn, rir::Opcode::Jmp));
     rir.destroy();
 }
 TEST(frontend, lower_to_rir_supports_runtime_error_or_value) {
@@ -10487,6 +11454,8 @@ TEST(frontend, lower_to_rir_supports_runtime_error_or_value) {
     REQUIRE(out_fn.blocks[0].inst_count > 0);
     CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[out_fn.blocks[0].inst_count - 1].op),
              static_cast<u8>(rir::Opcode::RetStatus));
+    CHECK_FALSE(function_has_op(out_fn, rir::Opcode::Br));
+    CHECK_FALSE(function_has_op(out_fn, rir::Opcode::Jmp));
     rir.destroy();
 }
 TEST(frontend, lower_to_rir_supports_runtime_optional_error_or_value) {
@@ -10551,6 +11520,8 @@ TEST(frontend, lower_to_rir_supports_runtime_optional_error_or_value) {
     REQUIRE(out_fn.blocks[0].inst_count > 0);
     CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[out_fn.blocks[0].inst_count - 1].op),
              static_cast<u8>(rir::Opcode::RetStatus));
+    CHECK_FALSE(function_has_op(out_fn, rir::Opcode::Br));
+    CHECK_FALSE(function_has_op(out_fn, rir::Opcode::Jmp));
     rir.destroy();
 }
 TEST(frontend, lower_to_rir_supports_runtime_optional_str_or_value) {
@@ -10615,8 +11586,149 @@ TEST(frontend, lower_to_rir_supports_runtime_optional_str_or_value) {
     CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[5].op), static_cast<u8>(rir::Opcode::Select));
     CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[6].op),
              static_cast<u8>(rir::Opcode::RetStatus));
+    CHECK_FALSE(function_has_op(out_fn, rir::Opcode::Br));
+    CHECK_FALSE(function_has_op(out_fn, rir::Opcode::Jmp));
     rir.destroy();
 }
+TEST(frontend, lower_to_rir_supports_runtime_all_int_value) {
+    auto* mir = new MirModule{};
+    MirFunction fn{};
+    fn.span = Span{0, 0, 1, 1};
+    fn.method = 'G';
+    fn.path = lit("/users");
+    fn.name = lit("route");
+    MirLocal maybe{};
+    maybe.span = fn.span;
+    maybe.name = lit("maybe");
+    maybe.type = MirTypeKind::I32;
+    maybe.may_nil = true;
+    maybe.init.kind = MirValueKind::IntConst;
+    maybe.init.type = MirTypeKind::I32;
+    maybe.init.int_value = 123;
+    REQUIRE(fn.locals.push(maybe));
+
+    MirValue lhs{};
+    lhs.kind = MirValueKind::LocalRef;
+    lhs.type = MirTypeKind::I32;
+    lhs.may_nil = true;
+    lhs.local_index = 0;
+    REQUIRE(fn.values.push(lhs));
+
+    MirValue cond{};
+    cond.kind = MirValueKind::HasValue;
+    cond.type = MirTypeKind::Bool;
+    cond.lhs = &fn.values[0];
+    REQUIRE(fn.values.push(cond));
+
+    MirValue rhs{};
+    rhs.kind = MirValueKind::IntConst;
+    rhs.type = MirTypeKind::I32;
+    rhs.int_value = 200;
+    REQUIRE(fn.values.push(rhs));
+
+    MirValue missing{};
+    missing.kind = MirValueKind::MissingOf;
+    missing.type = MirTypeKind::I32;
+    missing.lhs = &fn.values[0];
+    missing.may_nil = true;
+    REQUIRE(fn.values.push(missing));
+
+    MirValue allv{};
+    allv.kind = MirValueKind::IfElse;
+    allv.type = MirTypeKind::I32;
+    allv.lhs = &fn.values[1];
+    allv.rhs = &fn.values[2];
+    allv.may_nil = true;
+    REQUIRE(allv.args.push(&fn.values[3]));
+    REQUIRE(fn.values.push(allv));
+
+    MirLocal code{};
+    code.span = fn.span;
+    code.name = lit("code");
+    code.type = MirTypeKind::I32;
+    code.init = fn.values[4];
+    code.may_nil = true;
+    REQUIRE(fn.locals.push(code));
+
+    MirBlock entry{};
+    entry.label = lit("entry");
+    entry.term.kind = MirTerminatorKind::ReturnStatus;
+    entry.term.span = fn.span;
+    entry.term.status_code = 200;
+    REQUIRE(fn.blocks.push(entry));
+
+    REQUIRE(mir->functions.push(fn));
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir, rir);
+    REQUIRE(lowered);
+
+    const auto& out_fn = rir.module.functions[0];
+    REQUIRE_EQ(out_fn.block_count, 1u);
+    CHECK(block_has_op(out_fn.blocks[0], rir::Opcode::OptIsNil));
+    CHECK(block_has_op(out_fn.blocks[0], rir::Opcode::Select));
+    REQUIRE(out_fn.blocks[0].inst_count > 0);
+    CHECK_EQ(static_cast<u8>(out_fn.blocks[0].insts[out_fn.blocks[0].inst_count - 1].op),
+             static_cast<u8>(rir::Opcode::RetStatus));
+    CHECK_FALSE(function_has_op(out_fn, rir::Opcode::Br));
+    CHECK_FALSE(function_has_op(out_fn, rir::Opcode::Jmp));
+    rir.destroy();
+}
+
+TEST(frontend, lower_to_rir_supports_runtime_any_optional_query_value_eagerly_with_rhs_call) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, fallback()) return value "
+        "== \"ok\" }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_GE(rir.module.function_count, 1u);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_GE(fn.block_count, 1u);
+    CHECK(block_op_count(fn.blocks[0], rir::Opcode::Select) >= 1u);
+    CHECK_FALSE(function_has_op(fn, rir::Opcode::Br));
+    CHECK_FALSE(function_has_op(fn, rir::Opcode::Jmp));
+    rir.destroy();
+}
+
+TEST(frontend, lower_to_rir_supports_runtime_all_optional_query_fallback_call_eagerly) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, fallback()) return "
+        "value == \"ok\" }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_GE(rir.module.function_count, 1u);
+    const auto& fn = rir.module.functions[0];
+    REQUIRE_GE(fn.block_count, 1u);
+    CHECK(block_op_count(fn.blocks[0], rir::Opcode::OptIsNil) >= 1u);
+    CHECK(block_op_count(fn.blocks[0], rir::Opcode::Select) >= 1u);
+    CHECK_FALSE(function_has_op(fn, rir::Opcode::Br));
+    CHECK_FALSE(function_has_op(fn, rir::Opcode::Jmp));
+    rir.destroy();
+}
+
 TEST(frontend, lower_to_rir_supports_runtime_no_error_guard) {
     auto* hir = new HirModule{};
     HirRoute route{};
@@ -10950,7 +12062,7 @@ TEST(frontend, source_generic_function_accepts_explicit_return_type_argument) {
     const auto src = R"rut(
 func make<T>() -> T => nil
 route GET "/users" {
-    let code = or(make<i32>(), 200)
+    let code = any(make<i32>(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )rut";
@@ -13608,7 +14720,7 @@ protocol MaybeCode { func code() -> i32 => nil }
 struct Box { value: i32 }
 Box impl MaybeCode {}
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )rut";
@@ -13625,7 +14737,7 @@ protocol MaybeCode { func code() -> i32 => error(.timeout) }
 struct Box { value: i32 }
 Box impl MaybeCode {}
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )rut";
@@ -13864,7 +14976,7 @@ protocol MaybeCode { func code() -> i32 => nil }
 struct Box { value: i32 }
 Box impl MaybeCode { func code(self: Box) -> i32 => self.value }
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 7 { return 200 } else { return 500 }
 }
 )rut";
@@ -13881,7 +14993,7 @@ protocol MaybeCode { func code() -> i32 => error(.timeout) }
 struct Box { value: i32 }
 Box impl MaybeCode { func code(self: Box) -> i32 => self.value }
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 7 { return 200 } else { return 500 }
 }
 )rut";
@@ -13986,7 +15098,7 @@ TEST(frontend, import_relative_file_impl_overrides_protocol_default_method_with_
     const auto src = R"rut(
 import "proto.rut"
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 7 { return 200 } else { return 500 }
 }
 )rut";
@@ -14009,7 +15121,7 @@ TEST(frontend, import_relative_file_impl_overrides_protocol_default_method_with_
     const auto src = R"rut(
 import "proto.rut"
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 7 { return 200 } else { return 500 }
 }
 )rut";
@@ -14175,7 +15287,7 @@ TEST(frontend,
 protocol MaybeCode { func code() -> i32 => nil }
 struct Box<T> { value: T }
 Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" {
     if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
 }
@@ -14193,7 +15305,7 @@ TEST(frontend,
 protocol MaybeCode { func code() -> i32 => error(.timeout) }
 struct Box<T> { value: T }
 Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" {
     if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
 }
@@ -14311,7 +15423,7 @@ TEST(
     }
     const auto src = R"rut(
 import "proto.rut"
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" {
     if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
 }
@@ -14337,7 +15449,7 @@ TEST(
     }
     const auto src = R"rut(
 import "proto.rut"
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" {
     if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
 }
@@ -16611,7 +17723,7 @@ TEST(frontend, source_function_call_propagates_optional_value_flow) {
     const auto src = R"(
 func maybe() -> i32 => nil
 route GET "/users" {
-    let code = or(maybe(), 200)
+    let code = any(maybe(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -16633,7 +17745,7 @@ func maybe() -> i32 {
     nil
 }
 route GET "/users" {
-    let code = or(maybe(), 200)
+    let code = any(maybe(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -16655,7 +17767,7 @@ func maybe(ok: bool) {
     if ok { 200 } else { nil }
 }
 route GET "/users" {
-    let code = or(maybe(true), 200)
+    let code = any(maybe(true), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -16674,7 +17786,7 @@ TEST(frontend, source_function_call_propagates_error_value_flow) {
     const auto src = R"(
 func fail() -> i32 => error(.timeout)
 route GET "/users" {
-    let code = or(fail(), 200)
+    let code = any(fail(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -16696,7 +17808,7 @@ func fail() -> i32 {
     error(.timeout)
 }
 route GET "/users" {
-    let code = or(fail(), 200)
+    let code = any(fail(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -16718,7 +17830,7 @@ func maybefail(ok: bool) {
     if ok { 200 } else { error(.timeout) }
 }
 route GET "/users" {
-    let code = or(maybefail(true), 200)
+    let code = any(maybefail(true), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -16739,7 +17851,7 @@ func maybe(ok: bool) -> i32 {
     if ok { nil } else { nil }
 }
 route GET "/users" {
-    let code = or(maybe(true), 200)
+    let code = any(maybe(true), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -17348,7 +18460,7 @@ func pick(x: Result) {
     }
 }
 route GET "/users" {
-    let code = or(pick(Result.ok), 200)
+    let code = any(pick(Result.ok), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -17373,7 +18485,7 @@ func pick(x: Result) {
     }
 }
 route GET "/users" {
-    let code = or(pick(Result.ok), 200)
+    let code = any(pick(Result.ok), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -17398,7 +18510,7 @@ func pick(x: Result) -> i32 {
     }
 }
 route GET "/users" {
-    let code = or(pick(Result.ok), 200)
+    let code = any(pick(Result.ok), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -17535,11 +18647,11 @@ route GET "/users" {
     REQUIRE_EQ(hir->routes[0].locals.len, 1u);
     CHECK(hir->routes[0].locals[0].type == HirTypeKind::Bool);
 }
-TEST(frontend, source_pipe_method_stage_runtime_optional_lhs_flows_via_or) {
+TEST(frontend, source_pipe_method_stage_runtime_optional_lhs_flows_via_any) {
     const auto src = R"(
 route GET "/users" {
     let ok = req.header("Host") | _.eq("example.com")
-    let safe = or(ok, false)
+    let safe = any(ok, false)
     if safe { return 200 } else { return 404 }
 }
 )";
@@ -17557,12 +18669,12 @@ route GET "/users" {
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
 }
-TEST(frontend, source_pipe_placeholder_free_runtime_optional_lhs_flows_via_or) {
+TEST(frontend, source_pipe_placeholder_free_runtime_optional_lhs_flows_via_any) {
     const auto src = R"(
 func id(x: str) -> str => x
 route GET "/users" {
     let host = req.header("Host") | id()
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -17624,11 +18736,11 @@ route GET "/users" {
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
 }
-TEST(frontend, source_pipe_method_stage_known_nil_falls_back_via_or) {
+TEST(frontend, source_pipe_method_stage_known_nil_falls_back_via_any) {
     const auto src = R"(
 route GET "/users" {
     let ok = nil | _.eq(200)
-    let safe = or(ok, false)
+    let safe = any(ok, false)
     if safe { return 200 } else { return 404 }
 }
 )";
@@ -17656,7 +18768,7 @@ Box impl MaybeCode {
 route GET "/users" {
     let box: Box = nil
     let code = box | _.code()
-    let safe = or(code, 500)
+    let safe = any(code, 500)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -17686,7 +18798,7 @@ func maybeBox(ok: bool) -> Box {
 }
 route GET "/users" {
     let code = maybeBox(req.http11) | _.code()
-    let safe = or(code, 500)
+    let safe = any(code, 500)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -17709,7 +18821,7 @@ TEST(frontend, source_pipe_method_stage_known_error_preserves_error_variant) {
 route GET "/users" {
     let failed = error(.timeout)
     let ok = failed | _.eq(200)
-    let safe = or(ok, false)
+    let safe = any(ok, false)
     if safe { return 200 } else { return 500 }
 }
 )";
@@ -17733,7 +18845,7 @@ TEST(frontend, source_pipe_method_stage_known_error_accesses_standard_error_fiel
 route GET "/users" {
     let failed = error(.timeout)
     let code = failed | _.code()
-    let safe = or(code, 500)
+    let safe = any(code, 500)
     if safe == 500 { return 200 } else { return 500 }
 }
 )";
@@ -17761,7 +18873,7 @@ Box impl MaybeMsg {
 route GET "/users" {
     let box: Box = error(.timeout)
     let code = box | _.msg()
-    let safe = or(code, 500)
+    let safe = any(code, 500)
     if safe == 500 { return 200 } else { return 500 }
 }
 )";
@@ -17784,7 +18896,7 @@ TEST(frontend, source_pipe_method_stage_known_nil_validates_regex) {
     const auto src = R"(
 route GET "/users" {
     let ok = nil | _.matches(re"[")
-    let safe = or(ok, false)
+    let safe = any(ok, false)
     if safe { return 200 } else { return 500 }
 }
 )";
@@ -17917,6 +19029,7 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("non-tuple source with non-unit placeholder")));
 }
 TEST(frontend, source_pipe_accepts_tuple_literal_multi_slot_placeholders) {
     const auto src = R"(
@@ -17989,12 +19102,56 @@ route GET "/users" {
     REQUIRE_EQ(hir->routes[0].locals.len, 1u);
     CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
 }
+TEST(frontend, source_pipe_tuple_stage_then_method_stage) {
+    const auto src = R"(
+protocol HasValue { func as_value() -> i32 }
+struct Box { value: i32 }
+Box impl HasValue {
+    func as_value(self: Box) -> i32 => self.value
+}
+func build_box(a: i32, b: i32) -> Box => Box(value: b)
+route GET "/users" {
+    let code = (200, 500) | build_box(_1, _2) | _.as_value()
+    if code == 500 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
+TEST(frontend, source_pipe_tuple_slot_reuse_keeps_placeholder_semantics) {
+    const auto src = R"(
+protocol HasValue { func as_value() -> i32 }
+struct Box { value: i32 }
+Box impl HasValue {
+    func as_value(self: Box) -> i32 => self.value
+}
+func build_box(a: i32, b: i32) -> Box => Box(value: a)
+route GET "/users" {
+    let code = (200, 500) | build_box(_1, _1) | _.as_value()
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK(hir->routes[0].locals[0].type == HirTypeKind::I32);
+}
 TEST(frontend, source_pipe_propagates_known_nil_as_optional_value_flow) {
     const auto src = R"(
 func id(x: i32) -> i32 => x
 route GET "/users" {
     let code = nil | id(_)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -18019,7 +19176,7 @@ func id(x: i32) -> i32 => x
 route GET "/users" {
     let failed = error(.timeout)
     let code = failed | id(_)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -18085,6 +19242,58 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("non-tuple source with non-unit placeholder")));
+}
+TEST(frontend, analyze_rejects_pipe_with_placeholder_slot_exceeds_tuple_arity) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = (200, 500) | id(_3)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("placeholder slot exceeds tuple arity")));
+}
+TEST(frontend, analyze_rejects_pipe_with_placeholder_slot_zero) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = (200, 500) | id(_0)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("placeholder slot out of range")));
+}
+TEST(frontend, analyze_rejects_conditional_pipe_with_non_unit_placeholder) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = req.header("Host") | id(_2)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("placeholder value in conditional pipe must be 1")));
 }
 TEST(frontend, analyze_rejects_pipe_runtime_fallible_lhs_with_placeholder_slot_two) {
     const auto src = R"(
@@ -18101,6 +19310,49 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("placeholder value in conditional pipe must be 1")));
+}
+TEST(frontend, analyze_rejects_conditional_pipe_return_type_unsupported) {
+    const auto src = R"(
+func may_fail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func pair(x: i32) -> (i32, i32) => (x, 500)
+route GET "/users" {
+    let code = may_fail(req.http11) | pair(_)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("pipe return type unsupported")));
+}
+TEST(frontend, analyze_rejects_conditional_pipe_error_variant_mismatch) {
+    const auto src = R"(
+func may_fail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func maybe_forbidden(x: i32) -> i32 {
+    if x == 200 { x } else { error(.forbidden) }
+}
+route GET "/users" {
+    let code = may_fail(req.http11) | maybe_forbidden(_)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("pipe error variant mismatch")));
 }
 TEST(frontend, parse_rejects_pipe_with_placeholder_slot_eleven) {
     const auto src = R"(
@@ -18117,12 +19369,12 @@ route GET "/users" {
     CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
     CHECK(ast.error().detail.eq(lit("placeholder index must be between _1 and _10")));
 }
-TEST(frontend, source_pipe_runtime_optional_lhs_flows_via_or) {
+TEST(frontend, source_pipe_runtime_optional_lhs_flows_via_any) {
     const auto src = R"(
 func id(x: str) -> str => x
 route GET "/users" {
     let host = req.header("Host") | id(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -18163,13 +19415,13 @@ route GET "/users" {
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
 
-TEST(frontend, source_pipe_runtime_error_lhs_flows_via_or) {
+TEST(frontend, source_pipe_runtime_error_lhs_flows_via_any) {
     const auto src = R"(
 func fail() -> i32 => error(.timeout)
 func id(x: i32) -> i32 => x
 route GET "/users" {
     let code = fail() | id(_)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -18187,7 +19439,7 @@ route GET "/users" {
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
 }
-TEST(frontend, source_pipe_runtime_optional_error_lhs_flows_via_or) {
+TEST(frontend, source_pipe_runtime_optional_error_lhs_flows_via_any) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {
     if ok { nil } else { error(.timeout) }
@@ -18195,7 +19447,7 @@ func maybefail(ok: bool) -> i32 {
 func id(x: i32) -> i32 => x
 route GET "/users" {
     let code = maybefail(true) | id(_)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -18213,12 +19465,12 @@ route GET "/users" {
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
 }
-TEST(frontend, source_pipe_runtime_optional_lhs_flows_into_optional_stage_via_or) {
+TEST(frontend, source_pipe_runtime_optional_lhs_flows_into_optional_stage_via_any) {
     const auto src = R"(
 func drop(x: str) -> str { nil }
 route GET "/users" {
     let host = req.header("Host") | drop(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -18236,12 +19488,12 @@ route GET "/users" {
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
 }
-TEST(frontend, source_pipe_runtime_optional_lhs_flows_into_error_stage_via_or) {
+TEST(frontend, source_pipe_runtime_optional_lhs_flows_into_error_stage_via_any) {
     const auto src = R"(
 func failstage(x: str) -> str => error(.timeout)
 route GET "/users" {
     let host = req.header("Host") | failstage(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -18259,13 +19511,13 @@ route GET "/users" {
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
 }
-TEST(frontend, source_pipe_runtime_error_lhs_flows_into_optional_stage_via_or) {
+TEST(frontend, source_pipe_runtime_error_lhs_flows_into_optional_stage_via_any) {
     const auto src = R"(
 func fail() -> str => error(.timeout)
 func drop(x: str) -> str { nil }
 route GET "/users" {
     let host = fail() | drop(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -18283,13 +19535,13 @@ route GET "/users" {
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
 }
-TEST(frontend, source_pipe_runtime_error_lhs_flows_into_error_stage_via_or) {
+TEST(frontend, source_pipe_runtime_error_lhs_flows_into_error_stage_via_any) {
     const auto src = R"(
 func fail() -> str => error(.timeout)
 func failstage(x: str) -> str => error(.timeout)
 route GET "/users" {
     let host = fail() | failstage(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -18333,14 +19585,14 @@ route GET "/users" {
     CHECK(hir.error().detail.eq(
         lit("pipe method stage cannot combine different propagated error variants")));
 }
-TEST(frontend, source_pipe_runtime_optional_lhs_flows_into_optional_error_stage_via_or) {
+TEST(frontend, source_pipe_runtime_optional_lhs_flows_into_optional_error_stage_via_any) {
     const auto src = R"(
 func tri(x: str) -> str {
     if x == "host" { nil } else { error(.timeout) }
 }
 route GET "/users" {
     let host = req.header("Host") | tri(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -18358,7 +19610,7 @@ route GET "/users" {
     CHECK_FALSE(hir->routes[0].locals[1].may_nil);
     CHECK_FALSE(hir->routes[0].locals[1].may_error);
 }
-TEST(frontend, source_pipe_runtime_error_lhs_flows_into_optional_error_stage_via_or) {
+TEST(frontend, source_pipe_runtime_error_lhs_flows_into_optional_error_stage_via_any) {
     const auto src = R"(
 func fail() -> str => error(.timeout)
 func tri(x: str) -> str {
@@ -18366,7 +19618,7 @@ func tri(x: str) -> str {
 }
 route GET "/users" {
     let host = fail() | tri(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -18392,7 +19644,7 @@ func maybefail(ok: bool) -> i32 {
 func id(x: i32) -> i32 => x
 route GET "/users" {
     let code = maybefail(true) | id(_)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -18451,7 +19703,7 @@ func maybefail(ok: bool) -> i32 {
 }
 route GET "/users" {
     let code = maybefail(true)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -10245,6 +10245,31 @@ TEST(frontend, any_builtin_preserves_lhs_error_carrier_for_nonfallible_fallback)
     CHECK_EQ(mir->functions[0].locals[1].init.error_struct_index, 0u);
 }
 
+TEST(frontend, all_builtin_rejects_mixed_error_carriers) {
+    const char* src =
+        "struct AuthError { err: Error }\n"
+        "func custom(ok: bool) -> i32 {\n"
+        "  if ok { 200 } else { error(AuthError, .timeout, \"timed out\") }\n"
+        "}\n"
+        "func plain(ok: bool) -> i32 {\n"
+        "  if ok { 200 } else { error(.timeout) }\n"
+        "}\n"
+        "route GET \"/search\" {\n"
+        "  let lhs = custom(req.http11)\n"
+        "  let value = all(lhs, plain(req.http10))\n"
+        "  return 200\n"
+        "}\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("all cannot combine different propagated error variants")));
+}
+
 TEST(frontend, any_builtin_over_optional_header_source_becomes_or) {
     const char* src =
         "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, \"\") "

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -232,7 +232,7 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
 
     void dispatch(const IoEvent& ev) {
         switch (ev.type) {
-            case IoEventType::Accept:
+            case IoEventType::Accept: {
                 if (ev.result < 0) return;
                 Connection* c = this->alloc_conn();
                 if (!c) return;
@@ -242,6 +242,7 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
                 timer.add(c, keepalive_timeout);
                 this->submit_recv(*c);
                 break;
+            }
             case IoEventType::Timeout:
                 timer.tick([this](Connection* c) {
                     // Mirror EpollEventLoop/IoUringEventLoop: a tick can
@@ -287,6 +288,8 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
                 break;
             case IoEventType::HandlerTimer:
             case IoEventType::_Count:
+                break;
+            default:
                 break;
         }
     }
@@ -650,7 +653,7 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
 
     void dispatch(const IoEvent& ev) {
         switch (ev.type) {
-            case IoEventType::Accept:
+            case IoEventType::Accept: {
                 if (ev.result < 0) return;
                 Connection* c = this->alloc_conn();
                 if (!c) return;
@@ -660,6 +663,7 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
                 timer.add(c, keepalive_timeout);
                 this->submit_recv(*c);
                 break;
+            }
             case IoEventType::HandlerTimer:
                 if (ev.conn_id < kMaxConns) {
                     auto& conn = conns[ev.conn_id];
@@ -738,6 +742,8 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
                 }
                 break;
             case IoEventType::_Count:
+                break;
+            default:
                 break;
         }
     }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -316,6 +316,7 @@ struct AsyncMockBackend {
     static constexpr u32 kMaxOps = 256;
     MockOp ops[kMaxOps];
     u32 op_count = 0;
+    i32 timer_fd = -1;
     bool fail_connect = false;
     bool fail_upstream_recv = false;
     bool fail_upstream_send = false;
@@ -327,6 +328,7 @@ struct AsyncMockBackend {
     core::Expected<void, Error> init(u32 /*shard_id*/, i32 /*listen_fd*/) {
         op_count = 0;
         pending_count = 0;
+        timer_fd = -1;
         fail_connect = false;
         fail_upstream_recv = false;
         fail_upstream_send = false;

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -232,7 +232,7 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
 
     void dispatch(const IoEvent& ev) {
         switch (ev.type) {
-            case IoEventType::Accept: {
+            case IoEventType::Accept:
                 if (ev.result < 0) return;
                 Connection* c = this->alloc_conn();
                 if (!c) return;
@@ -242,7 +242,6 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
                 timer.add(c, keepalive_timeout);
                 this->submit_recv(*c);
                 break;
-            }
             case IoEventType::Timeout:
                 timer.tick([this](Connection* c) {
                     // Mirror EpollEventLoop/IoUringEventLoop: a tick can
@@ -287,7 +286,7 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
                 }
                 break;
             case IoEventType::HandlerTimer:
-            case IoEventType::kNumEventTypes:
+            case IoEventType::_Count:
                 break;
         }
     }
@@ -651,7 +650,7 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
 
     void dispatch(const IoEvent& ev) {
         switch (ev.type) {
-            case IoEventType::Accept: {
+            case IoEventType::Accept:
                 if (ev.result < 0) return;
                 Connection* c = this->alloc_conn();
                 if (!c) return;
@@ -661,7 +660,6 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
                 timer.add(c, keepalive_timeout);
                 this->submit_recv(*c);
                 break;
-            }
             case IoEventType::HandlerTimer:
                 if (ev.conn_id < kMaxConns) {
                     auto& conn = conns[ev.conn_id];
@@ -718,8 +716,7 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
                         if (ev.type == IoEventType::UpstreamSend) conn.upstream_send_armed = false;
                         if (ev.type == IoEventType::UpstreamRecv) conn.upstream_recv_armed = false;
                     }
-                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv ||
-                        conn.on_upstream_send) {
+                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv || conn.on_upstream_send) {
                         timer.refresh(&conn, keepalive_timeout);
                         this->dispatch_event(conn, ev);
                     } else if (conn.pending_handler_fn &&
@@ -739,7 +736,7 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
                     }
                 }
                 break;
-            case IoEventType::kNumEventTypes:
+            case IoEventType::_Count:
                 break;
         }
     }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -287,7 +287,7 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
                 }
                 break;
             case IoEventType::HandlerTimer:
-            case IoEventType::_Count:
+            case IoEventType::Count:
                 break;
         }
     }
@@ -739,7 +739,7 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
                     }
                 }
                 break;
-            case IoEventType::_Count:
+            case IoEventType::Count:
                 break;
         }
     }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -289,8 +289,6 @@ struct SmallLoop : EventLoopCRTP<SmallLoop> {
             case IoEventType::HandlerTimer:
             case IoEventType::_Count:
                 break;
-            default:
-                break;
         }
     }
 
@@ -742,8 +740,6 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
                 }
                 break;
             case IoEventType::_Count:
-                break;
-            default:
                 break;
         }
     }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -716,7 +716,8 @@ struct AsyncSmallLoop : EventLoopCRTP<AsyncSmallLoop> {
                         if (ev.type == IoEventType::UpstreamSend) conn.upstream_send_armed = false;
                         if (ev.type == IoEventType::UpstreamRecv) conn.upstream_recv_armed = false;
                     }
-                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv || conn.on_upstream_send) {
+                    if (conn.on_recv || conn.on_send || conn.on_upstream_recv ||
+                        conn.on_upstream_send) {
                         timer.refresh(&conn, keepalive_timeout);
                         this->dispatch_event(conn, ev);
                     } else if (conn.pending_handler_fn &&

--- a/tests/test_http_parser.cc
+++ b/tests/test_http_parser.cc
@@ -1,4 +1,5 @@
 #include "rut/runtime/http_parser.h"
+#include "rut/runtime/simd/simd.h"
 #include "test.h"
 
 using namespace rut;
@@ -53,6 +54,25 @@ static bool find_header(const ParsedRequest& req, const char* name, Str* out_val
         }
     }
     return false;
+}
+
+TEST(Util, ScanUriNoSpaceReturnsEnd) {
+    const u8 uri[] = "/hello/world?mode=fast";
+    u32 canon_end = 0xffffffffu;
+    CHECK_EQ(simd::scan_uri(uri,
+                            0,
+                            static_cast<u32>(__builtin_strlen(reinterpret_cast<const char*>(uri))),
+                            &canon_end),
+             static_cast<u32>(__builtin_strlen(reinterpret_cast<const char*>(uri))));
+    CHECK_EQ(canon_end, 12u);
+}
+
+TEST(Util, ScanUriNoSpaceWithoutQueryReturnsEnd) {
+    const u8 uri[] = "/hello/world";
+    u32 canon_end = 0xffffffffu;
+    const u32 len = static_cast<u32>(__builtin_strlen(reinterpret_cast<const char*>(uri)));
+    CHECK_EQ(simd::scan_uri(uri, 0, len, &canon_end), len);
+    CHECK_EQ(canon_end, len);
 }
 
 // ============================================================================

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -4862,10 +4862,9 @@ static bool real_socket_response_has_status(u16 port,
     close(c);
     if (n <= 0) return false;
 
-    for (i32 i = 0; i + 2 < n; i++) {
-        if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) return true;
-    }
-    return false;
+    return n >= 12 && buf[0] == 'H' && buf[1] == 'T' && buf[2] == 'T' && buf[3] == 'P' &&
+           buf[4] == '/' && buf[8] == ' ' && buf[9] == status[0] && buf[10] == status[1] &&
+           buf[11] == status[2];
 }
 
 static bool run_jit_real_socket_status_cases(const char* src,
@@ -4887,14 +4886,14 @@ static bool run_jit_real_socket_status_cases(const char* src,
     auto lowered = lower_to_rir(*mir_owned, rir);
     if (!lowered) return false;
 
-    auto cg = jit::codegen(rir.module);
-    if (!cg.ok) {
+    jit::JitEngine engine;
+    if (!engine.init()) {
         rir.destroy();
         return false;
     }
-
-    jit::JitEngine engine;
-    if (!engine.init()) {
+    auto cg = jit::codegen(rir.module);
+    if (!cg.ok) {
+        engine.shutdown();
         rir.destroy();
         return false;
     }

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -4863,8 +4863,7 @@ static bool real_socket_response_has_status(u16 port,
     if (n <= 0) return false;
 
     for (i32 i = 0; i + 2 < n; i++) {
-        if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2])
-            return true;
+        if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) return true;
     }
     return false;
 }

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -5004,7 +5004,7 @@ TEST(route, req_param_jit_handler_real_socket) {
 TEST(route, req_header_jit_handler_real_socket) {
     using namespace rut;
     const char* src =
-        "route GET \"/auth\" { let token = or(req.header(\"Authorization\"), \"\") if token == "
+        "route GET \"/auth\" { let token = any(req.header(\"Authorization\"), \"\") if token == "
         "\"Bearer ok\" { return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5080,7 +5080,7 @@ TEST(route, req_header_jit_handler_real_socket) {
 TEST(route, req_cookie_jit_handler_real_socket) {
     using namespace rut;
     const char* src =
-        "route GET \"/session\" { let sid = or(req.cookie(\"sid\"), \"\") if sid == \"ok\" { "
+        "route GET \"/session\" { let sid = any(req.cookie(\"sid\"), \"\") if sid == \"ok\" { "
         "return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5155,10 +5155,570 @@ TEST(route, req_cookie_jit_handler_real_socket) {
     rir.destroy();
 }
 
+TEST(route, req_cookie_all_requires_present_value_real_socket) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/session\" { let sid = all(req.cookie(\"sid\"), \"ok\") if sid == \"ok\" { "
+        "return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] =
+        "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "204");
+    const char kBadReq[] =
+        "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark; sid=nope\r\n\r\n";
+    check_status(kBadReq, sizeof(kBadReq) - 1, "401");
+    const char kMissingReq[] = "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "401");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_header_all_requires_present_value_real_socket) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/users\" { let host = all(req.header(\"Host\"), \"fallback\") if host == "
+        "\"localhost\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "204");
+    const char kBadReq[] = "GET /users HTTP/1.1\r\nHost: api.local\r\n\r\n";
+    check_status(kBadReq, sizeof(kBadReq) - 1, "401");
+    const char kMissingReq[] = "GET /users HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "401");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_query_all_requires_present_value_real_socket) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, \"\") if value == "
+        "\"rut\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] = "GET /search?q=rut HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "204");
+    const char kMissReq[] = "GET /search?q=cpp HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMissReq, sizeof(kMissReq) - 1, "401");
+    const char kMissingReq[] = "GET /search HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "401");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_query_or_allows_expected_alternative) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, \"\") if value == "
+        "\"rut\" or req.queryString == \"q=admin\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitByValue[] = "GET /search?q=rut HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kHitByValue, sizeof(kHitByValue) - 1, "204");
+    const char kHitByQueryString[] = "GET /search?q=admin HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kHitByQueryString, sizeof(kHitByQueryString) - 1, "204");
+    const char kMiss[] = "GET /search?q=cpp HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMiss, sizeof(kMiss) - 1, "401");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_query_all_allows_expected_alternative) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, \"rut\") if value == "
+        "\"rut\" or req.queryString == \"q=admin\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitByValue[] = "GET /search?q=rut HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kHitByValue, sizeof(kHitByValue) - 1, "204");
+    const char kHitByQueryString[] = "GET /search?q=admin HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kHitByQueryString, sizeof(kHitByQueryString) - 1, "204");
+    const char kMiss[] = "GET /search HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMiss, sizeof(kMiss) - 1, "401");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_query_rejects_or_function_call_form) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = or(q, \"\") if value == \"rut\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(route, req_query_rejects_and_function_call_form) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = and(q, \"\") if value == \"rut\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(route, req_header_rejects_or_function_call_form) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"\") if value == \"localhost\" { "
+        "return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(route, req_header_rejects_and_function_call_form) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = and(host, \"\") if value == \"localhost\" { "
+        "return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(route, req_cookie_rejects_or_function_call_form) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/session\" { let sid = req.cookie(\"sid\") let value = or(sid, \"\") if value == \"ok\" { "
+        "return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(route, req_cookie_rejects_and_function_call_form) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/session\" { let sid = req.cookie(\"sid\") let value = and(sid, \"\") if value == \"ok\" { "
+        "return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(route, req_query_rejects_double_ampersand_operator) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/search\" { let value = true && false if value { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE_FALSE(lexed);
+    CHECK_EQ(lexed.error().code, FrontendError::UnexpectedChar);
+}
+
+TEST(route, req_query_rejects_double_pipe_operator) {
+    using namespace rut;
+    const char* src =
+        "route GET \"/search\" { let value = true || false if value { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(route, req_query_rejects_pipe_rhs_with_bool_operator) {
+    using namespace rut;
+    const char* src =
+        "func pass_bool(v: bool) -> bool { v }\n"
+        "route GET \"/search\" { let value = req.http11 | pass_bool(_) or false if value { "
+        "return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(ast.error().code, FrontendError::UnexpectedToken);
+}
+
+TEST(route, req_query_accepts_parenthesized_pipe_with_bool_operator_real_socket) {
+    using namespace rut;
+    const char* src =
+        "func pass_bool(v: bool) -> bool { v }\n"
+        "route GET \"/search\" { let value = (req.http11 | pass_bool(_)) or false if value "
+        "{ return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] = "GET /search HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "204");
+    const char kMissReq[] = "GET /search HTTP/1.0\r\nHost: x\r\n\r\n";
+    check_status(kMissReq, sizeof(kMissReq) - 1, "401");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(route, req_query_jit_handler_real_socket) {
     using namespace rut;
     const char* src =
-        "route GET \"/search\" { let q = req.query(\"q\") let value = or(q, \"\") if value == "
+        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, \"\") if value == "
         "\"rut\" { return 204 } else { "
         "return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
@@ -5223,6 +5783,622 @@ TEST(route, req_query_jit_handler_real_socket) {
     check_status(kMissReq, sizeof(kMissReq) - 1, "401");
     const char kMissingReq[] = "GET /search HTTP/1.1\r\nHost: x\r\n\r\n";
     check_status(kMissingReq, sizeof(kMissingReq) - 1, "401");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_query_all_non_short_circuit_eager_rhs_is_observed_real_socket) {
+    using namespace rut;
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, fallback()) if value == "
+        "\"rut\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] = "GET /search?q=rut HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "500");
+    const char kMissReq[] = "GET /search?q=cpp HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMissReq, sizeof(kMissReq) - 1, "500");
+    const char kMissingReq[] = "GET /search HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "500");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_query_any_non_short_circuit_eager_rhs_is_observed_real_socket) {
+    using namespace rut;
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, fallback()) if value == "
+        "\"rut\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] = "GET /search?q=rut HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "500");
+    const char kMissReq[] = "GET /search?q=cpp HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMissReq, sizeof(kMissReq) - 1, "500");
+    const char kMissingReq[] = "GET /search HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "500");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_header_all_non_short_circuit_eager_rhs_is_observed_real_socket) {
+    using namespace rut;
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/users\" { let host = all(req.header(\"Host\"), fallback()) if host == "
+        "\"localhost\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "500");
+    const char kBadReq[] = "GET /users HTTP/1.1\r\nHost: api.local\r\n\r\n";
+    check_status(kBadReq, sizeof(kBadReq) - 1, "500");
+    const char kMissingReq[] = "GET /users HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "500");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_header_any_non_short_circuit_eager_rhs_is_observed_real_socket) {
+    using namespace rut;
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/users\" { let host = any(req.header(\"Host\"), fallback()) if host == "
+        "\"localhost\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "500");
+    const char kBadReq[] = "GET /users HTTP/1.1\r\nHost: api.local\r\n\r\n";
+    check_status(kBadReq, sizeof(kBadReq) - 1, "500");
+    const char kMissingReq[] = "GET /users HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "500");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_cookie_all_non_short_circuit_eager_rhs_is_observed_real_socket) {
+    using namespace rut;
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/session\" { let sid = all(req.cookie(\"sid\"), fallback()) if sid == "
+        "\"ok\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] =
+        "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "500");
+    const char kBadReq[] =
+        "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark; sid=nope\r\n\r\n";
+    check_status(kBadReq, sizeof(kBadReq) - 1, "500");
+    const char kMissingReq[] = "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "500");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_cookie_any_non_short_circuit_eager_rhs_is_observed_real_socket) {
+    using namespace rut;
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/session\" { let sid = any(req.cookie(\"sid\"), fallback()) if sid == "
+        "\"ok\" { return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kHitReq[] =
+        "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
+    check_status(kHitReq, sizeof(kHitReq) - 1, "500");
+    const char kBadReq[] =
+        "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark; sid=nope\r\n\r\n";
+    check_status(kBadReq, sizeof(kBadReq) - 1, "500");
+    const char kMissingReq[] = "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark\r\n\r\n";
+    check_status(kMissingReq, sizeof(kMissingReq) - 1, "500");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_query_string_all_non_short_circuit_eager_rhs_is_observed_real_socket) {
+    using namespace rut;
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/search\" { let value = all(req.queryString, fallback()) if value == \"q=rut\" { "
+        "return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kReqWithQuery[] = "GET /search?q=rut HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kReqWithQuery, sizeof(kReqWithQuery) - 1, "500");
+    const char kReqMissingQuery[] = "GET /search HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kReqMissingQuery, sizeof(kReqMissingQuery) - 1, "500");
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(route, req_query_string_any_non_short_circuit_eager_rhs_is_observed_real_socket) {
+    using namespace rut;
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/search\" { let value = any(req.queryString, fallback()) if value == \"q=rut\" { "
+        "return 204 } else { return 401 } }\n";
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    REQUIRE(lexed);
+    auto ast = parse_file(lexed.value());
+    REQUIRE(ast);
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    REQUIRE(hir);
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    REQUIRE(mir);
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    REQUIRE(lowered);
+
+    auto cg = jit::codegen(rir.module);
+    REQUIRE(cg.ok);
+    jit::JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    RouteConfig cfg{};
+    REQUIRE(populate_route_config(cfg, rir.module));
+    REQUIRE(register_jit_routes(cfg, rir.module, engine));
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    REQUIRE(loop != nullptr);
+    auto lfd_result = create_listen_socket(0);
+    REQUIRE(lfd_result.has_value());
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    REQUIRE(loop->init(0, lfd).has_value());
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    auto check_status = [&](const char* req, u32 req_len, const char* status) {
+        i32 c = connect_to(port);
+        REQUIRE(c >= 0);
+        REQUIRE(send_all(c, req, req_len));
+        char buf[1024];
+        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
+        CHECK_GT(n, 0);
+        bool found = false;
+        for (i32 i = 0; i + 2 < n; i++) {
+            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+        close(c);
+    };
+
+    const char kReqWithQuery[] = "GET /search?q=admin HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kReqWithQuery, sizeof(kReqWithQuery) - 1, "500");
+    const char kReqMissingQuery[] = "GET /search HTTP/1.1\r\nHost: x\r\n\r\n";
+    check_status(kReqMissingQuery, sizeof(kReqMissingQuery) - 1, "500");
 
     lt.stop();
     loop->shutdown();

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -5158,7 +5158,8 @@ TEST(route, req_cookie_jit_handler_real_socket) {
 TEST(route, req_cookie_all_requires_present_value_real_socket) {
     using namespace rut;
     const char* src =
-        "route GET \"/session\" { let sid = req.cookie(\"sid\") let sid = all(sid, any(sid, \"ok\")) if sid == \"ok\" { "
+        "route GET \"/session\" { let sid = req.cookie(\"sid\") let sid = all(sid, any(sid, "
+        "\"ok\")) if sid == \"ok\" { "
         "return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5236,7 +5237,8 @@ TEST(route, req_cookie_all_requires_present_value_real_socket) {
 TEST(route, req_header_all_requires_present_value_real_socket) {
     using namespace rut;
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let host = all(host, any(host, \"fallback\")) if host == "
+        "route GET \"/users\" { let host = req.header(\"Host\") let host = all(host, any(host, "
+        "\"fallback\")) if host == "
         "\"localhost\" { return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5312,7 +5314,8 @@ TEST(route, req_header_all_requires_present_value_real_socket) {
 TEST(route, req_query_all_requires_present_value_real_socket) {
     using namespace rut;
     const char* src =
-        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, any(q, \"rut\")) if value == "
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, any(q, \"rut\")) if "
+        "value == "
         "\"rut\" { return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5540,7 +5543,8 @@ TEST(route, req_query_all_allows_expected_alternative) {
 TEST(route, req_query_rejects_or_function_call_form) {
     using namespace rut;
     const char* src =
-        "route GET \"/search\" { let q = req.query(\"q\") let value = or(q, \"\") if value == \"rut\" { return 204 } else { return 401 } }\n";
+        "route GET \"/search\" { let q = req.query(\"q\") let value = or(q, \"\") if value == "
+        "\"rut\" { return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
     auto ast = parse_file(lexed.value());
@@ -5551,7 +5555,8 @@ TEST(route, req_query_rejects_or_function_call_form) {
 TEST(route, req_query_rejects_and_function_call_form) {
     using namespace rut;
     const char* src =
-        "route GET \"/search\" { let q = req.query(\"q\") let value = and(q, \"\") if value == \"rut\" { return 204 } else { return 401 } }\n";
+        "route GET \"/search\" { let q = req.query(\"q\") let value = and(q, \"\") if value == "
+        "\"rut\" { return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
     auto ast = parse_file(lexed.value());
@@ -5562,7 +5567,8 @@ TEST(route, req_query_rejects_and_function_call_form) {
 TEST(route, req_header_rejects_or_function_call_form) {
     using namespace rut;
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"\") if value == \"localhost\" { "
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"\") if "
+        "value == \"localhost\" { "
         "return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5574,7 +5580,8 @@ TEST(route, req_header_rejects_or_function_call_form) {
 TEST(route, req_header_rejects_and_function_call_form) {
     using namespace rut;
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let value = and(host, \"\") if value == \"localhost\" { "
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = and(host, \"\") if "
+        "value == \"localhost\" { "
         "return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5586,7 +5593,8 @@ TEST(route, req_header_rejects_and_function_call_form) {
 TEST(route, req_cookie_rejects_or_function_call_form) {
     using namespace rut;
     const char* src =
-        "route GET \"/session\" { let sid = req.cookie(\"sid\") let value = or(sid, \"\") if value == \"ok\" { "
+        "route GET \"/session\" { let sid = req.cookie(\"sid\") let value = or(sid, \"\") if value "
+        "== \"ok\" { "
         "return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5598,7 +5606,8 @@ TEST(route, req_cookie_rejects_or_function_call_form) {
 TEST(route, req_cookie_rejects_and_function_call_form) {
     using namespace rut;
     const char* src =
-        "route GET \"/session\" { let sid = req.cookie(\"sid\") let value = and(sid, \"\") if value == \"ok\" { "
+        "route GET \"/session\" { let sid = req.cookie(\"sid\") let value = and(sid, \"\") if "
+        "value == \"ok\" { "
         "return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5610,7 +5619,8 @@ TEST(route, req_cookie_rejects_and_function_call_form) {
 TEST(route, req_query_rejects_double_ampersand_operator) {
     using namespace rut;
     const char* src =
-        "route GET \"/search\" { let value = true && false if value { return 204 } else { return 401 } }\n";
+        "route GET \"/search\" { let value = true && false if value { return 204 } else { return "
+        "401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE_FALSE(lexed);
     CHECK_EQ(lexed.error().code, FrontendError::UnexpectedChar);
@@ -5619,7 +5629,8 @@ TEST(route, req_query_rejects_double_ampersand_operator) {
 TEST(route, req_query_rejects_double_pipe_operator) {
     using namespace rut;
     const char* src =
-        "route GET \"/search\" { let value = true || false if value { return 204 } else { return 401 } }\n";
+        "route GET \"/search\" { let value = true || false if value { return 204 } else { return "
+        "401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
     auto ast = parse_file(lexed.value());
@@ -5796,7 +5807,8 @@ TEST(route, req_query_all_non_short_circuit_eager_rhs_is_observed_real_socket) {
     using namespace rut;
     const char* src =
         "func fallback() -> str => error(.timeout)\n"
-        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, fallback()) if value == "
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, fallback()) if value "
+        "== "
         "\"rut\" { return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5873,7 +5885,8 @@ TEST(route, req_query_any_non_short_circuit_eager_rhs_is_observed_real_socket) {
     using namespace rut;
     const char* src =
         "func fallback() -> str => error(.timeout)\n"
-        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, fallback()) if value == "
+        "route GET \"/search\" { let q = req.query(\"q\") let value = any(q, fallback()) if value "
+        "== "
         "\"rut\" { return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -6262,7 +6275,8 @@ TEST(route, req_query_string_all_non_short_circuit_eager_rhs_is_observed_real_so
     using namespace rut;
     const char* src =
         "func fallback() -> str => error(.timeout)\n"
-        "route GET \"/search\" { let value = all(req.queryString, fallback()) if value == \"q=rut\" { "
+        "route GET \"/search\" { let value = all(req.queryString, fallback()) if value == "
+        "\"q=rut\" { "
         "return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -6337,7 +6351,8 @@ TEST(route, req_query_string_any_non_short_circuit_eager_rhs_is_observed_real_so
     using namespace rut;
     const char* src =
         "func fallback() -> str => error(.timeout)\n"
-        "route GET \"/search\" { let value = any(req.queryString, fallback()) if value == \"q=rut\" { "
+        "route GET \"/search\" { let value = any(req.queryString, fallback()) if value == "
+        "\"q=rut\" { "
         "return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -5158,7 +5158,7 @@ TEST(route, req_cookie_jit_handler_real_socket) {
 TEST(route, req_cookie_all_requires_present_value_real_socket) {
     using namespace rut;
     const char* src =
-        "route GET \"/session\" { let sid = all(req.cookie(\"sid\"), \"ok\") if sid == \"ok\" { "
+        "route GET \"/session\" { let sid = req.cookie(\"sid\") let sid = all(sid, any(sid, \"ok\")) if sid == \"ok\" { "
         "return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5236,7 +5236,7 @@ TEST(route, req_cookie_all_requires_present_value_real_socket) {
 TEST(route, req_header_all_requires_present_value_real_socket) {
     using namespace rut;
     const char* src =
-        "route GET \"/users\" { let host = all(req.header(\"Host\"), \"fallback\") if host == "
+        "route GET \"/users\" { let host = req.header(\"Host\") let host = all(host, any(host, \"fallback\")) if host == "
         "\"localhost\" { return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);
@@ -5312,7 +5312,7 @@ TEST(route, req_header_all_requires_present_value_real_socket) {
 TEST(route, req_query_all_requires_present_value_real_socket) {
     using namespace rut;
     const char* src =
-        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, \"\") if value == "
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, any(q, \"rut\")) if value == "
         "\"rut\" { return 204 } else { return 401 } }\n";
     auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
     REQUIRE(lexed);

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -4843,6 +4843,119 @@ TEST(route, populate_route_config_rejects_pre_bound_over_long_name) {
 }
 
 #if RUT_ENABLE_JIT_TESTS
+struct RealSocketStatusCase {
+    const char* req;
+    u32 req_len;
+    const char* status;
+};
+
+static bool real_socket_response_has_status(u16 port,
+                                            const char* req,
+                                            u32 req_len,
+                                            const char* status) {
+    i32 c = connect_to(port);
+    if (c < 0) return false;
+
+    bool ok = send_all(c, req, req_len);
+    char buf[1024];
+    i32 n = ok ? recv_timeout(c, buf, sizeof(buf), 2000) : -1;
+    close(c);
+    if (n <= 0) return false;
+
+    for (i32 i = 0; i + 2 < n; i++) {
+        if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2])
+            return true;
+    }
+    return false;
+}
+
+static bool run_jit_real_socket_status_cases(const char* src,
+                                             const RealSocketStatusCase* cases,
+                                             u32 case_count) {
+    using namespace rut;
+    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
+    if (!lexed) return false;
+    auto ast = parse_file(lexed.value());
+    if (!ast) return false;
+    std::unique_ptr<AstFile> ast_owned(ast.value());
+    auto hir = analyze_file(*ast_owned);
+    if (!hir) return false;
+    std::unique_ptr<HirModule> hir_owned(hir.value());
+    auto mir = build_mir(*hir_owned);
+    if (!mir) return false;
+    std::unique_ptr<MirModule> mir_owned(mir.value());
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(*mir_owned, rir);
+    if (!lowered) return false;
+
+    auto cg = jit::codegen(rir.module);
+    if (!cg.ok) {
+        rir.destroy();
+        return false;
+    }
+
+    jit::JitEngine engine;
+    if (!engine.init()) {
+        rir.destroy();
+        return false;
+    }
+    if (!engine.compile(cg.mod, cg.ctx)) {
+        engine.shutdown();
+        rir.destroy();
+        return false;
+    }
+
+    RouteConfig cfg{};
+    if (!populate_route_config(cfg, rir.module) || !register_jit_routes(cfg, rir.module, engine)) {
+        engine.shutdown();
+        rir.destroy();
+        return false;
+    }
+    const RouteConfig* active = &cfg;
+
+    RealLoop* loop = create_real_loop();
+    if (loop == nullptr) {
+        engine.shutdown();
+        rir.destroy();
+        return false;
+    }
+    auto lfd_result = create_listen_socket(0);
+    if (!lfd_result.has_value()) {
+        destroy_real_loop(loop);
+        engine.shutdown();
+        rir.destroy();
+        return false;
+    }
+
+    i32 lfd = lfd_result.value();
+    u16 port = get_port(lfd);
+    if (!loop->init(0, lfd).has_value()) {
+        close(lfd);
+        destroy_real_loop(loop);
+        engine.shutdown();
+        rir.destroy();
+        return false;
+    }
+    loop->config_ptr = &active;
+    LoopThread lt = {loop, {}, 200};
+    lt.start();
+    usleep(10000);
+
+    bool ok = true;
+    for (u32 i = 0; i < case_count; i++) {
+        if (!real_socket_response_has_status(port, cases[i].req, cases[i].req_len, cases[i].status))
+            ok = false;
+    }
+
+    lt.stop();
+    loop->shutdown();
+    close(lfd);
+    destroy_real_loop(loop);
+    engine.shutdown();
+    rir.destroy();
+    return ok;
+}
+
 TEST(route, register_jit_routes_selects_segment_trie_and_adds_param_route) {
     using namespace rut;
     const char* src =
@@ -5156,236 +5269,53 @@ TEST(route, req_cookie_jit_handler_real_socket) {
 }
 
 TEST(route, req_cookie_all_requires_present_value_real_socket) {
-    using namespace rut;
     const char* src =
         "route GET \"/session\" { let sid = req.cookie(\"sid\") let sid = all(sid, any(sid, "
         "\"ok\")) if sid == \"ok\" { "
         "return 204 } else { return 401 } }\n";
-    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
-    REQUIRE(lexed);
-    auto ast = parse_file(lexed.value());
-    REQUIRE(ast);
-    std::unique_ptr<AstFile> ast_owned(ast.value());
-    auto hir = analyze_file(*ast_owned);
-    REQUIRE(hir);
-    std::unique_ptr<HirModule> hir_owned(hir.value());
-    auto mir = build_mir(*hir_owned);
-    REQUIRE(mir);
-    std::unique_ptr<MirModule> mir_owned(mir.value());
-    FrontendRirModule rir{};
-    auto lowered = lower_to_rir(*mir_owned, rir);
-    REQUIRE(lowered);
-
-    auto cg = jit::codegen(rir.module);
-    REQUIRE(cg.ok);
-    jit::JitEngine engine;
-    REQUIRE(engine.init());
-    REQUIRE(engine.compile(cg.mod, cg.ctx));
-
-    RouteConfig cfg{};
-    REQUIRE(populate_route_config(cfg, rir.module));
-    REQUIRE(register_jit_routes(cfg, rir.module, engine));
-    const RouteConfig* active = &cfg;
-
-    RealLoop* loop = create_real_loop();
-    REQUIRE(loop != nullptr);
-    auto lfd_result = create_listen_socket(0);
-    REQUIRE(lfd_result.has_value());
-    i32 lfd = lfd_result.value();
-    u16 port = get_port(lfd);
-    REQUIRE(loop->init(0, lfd).has_value());
-    loop->config_ptr = &active;
-    LoopThread lt = {loop, {}, 200};
-    lt.start();
-    usleep(10000);
-
-    auto check_status = [&](const char* req, u32 req_len, const char* status) {
-        i32 c = connect_to(port);
-        REQUIRE(c >= 0);
-        REQUIRE(send_all(c, req, req_len));
-        char buf[1024];
-        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
-        CHECK_GT(n, 0);
-        bool found = false;
-        for (i32 i = 0; i + 2 < n; i++) {
-            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
-                found = true;
-                break;
-            }
-        }
-        CHECK(found);
-        close(c);
-    };
-
     const char kHitReq[] =
         "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
-    check_status(kHitReq, sizeof(kHitReq) - 1, "204");
     const char kBadReq[] =
         "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark; sid=nope\r\n\r\n";
-    check_status(kBadReq, sizeof(kBadReq) - 1, "401");
     const char kMissingReq[] = "GET /session HTTP/1.1\r\nHost: x\r\nCookie: theme=dark\r\n\r\n";
-    check_status(kMissingReq, sizeof(kMissingReq) - 1, "401");
-
-    lt.stop();
-    loop->shutdown();
-    close(lfd);
-    destroy_real_loop(loop);
-    engine.shutdown();
-    rir.destroy();
+    const RealSocketStatusCase cases[] = {
+        {kHitReq, sizeof(kHitReq) - 1, "204"},
+        {kBadReq, sizeof(kBadReq) - 1, "401"},
+        {kMissingReq, sizeof(kMissingReq) - 1, "401"},
+    };
+    REQUIRE(run_jit_real_socket_status_cases(src, cases, 3));
 }
 
 TEST(route, req_header_all_requires_present_value_real_socket) {
-    using namespace rut;
     const char* src =
         "route GET \"/users\" { let host = req.header(\"Host\") let host = all(host, any(host, "
         "\"fallback\")) if host == "
         "\"localhost\" { return 204 } else { return 401 } }\n";
-    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
-    REQUIRE(lexed);
-    auto ast = parse_file(lexed.value());
-    REQUIRE(ast);
-    std::unique_ptr<AstFile> ast_owned(ast.value());
-    auto hir = analyze_file(*ast_owned);
-    REQUIRE(hir);
-    std::unique_ptr<HirModule> hir_owned(hir.value());
-    auto mir = build_mir(*hir_owned);
-    REQUIRE(mir);
-    std::unique_ptr<MirModule> mir_owned(mir.value());
-    FrontendRirModule rir{};
-    auto lowered = lower_to_rir(*mir_owned, rir);
-    REQUIRE(lowered);
-
-    auto cg = jit::codegen(rir.module);
-    REQUIRE(cg.ok);
-    jit::JitEngine engine;
-    REQUIRE(engine.init());
-    REQUIRE(engine.compile(cg.mod, cg.ctx));
-
-    RouteConfig cfg{};
-    REQUIRE(populate_route_config(cfg, rir.module));
-    REQUIRE(register_jit_routes(cfg, rir.module, engine));
-    const RouteConfig* active = &cfg;
-
-    RealLoop* loop = create_real_loop();
-    REQUIRE(loop != nullptr);
-    auto lfd_result = create_listen_socket(0);
-    REQUIRE(lfd_result.has_value());
-    i32 lfd = lfd_result.value();
-    u16 port = get_port(lfd);
-    REQUIRE(loop->init(0, lfd).has_value());
-    loop->config_ptr = &active;
-    LoopThread lt = {loop, {}, 200};
-    lt.start();
-    usleep(10000);
-
-    auto check_status = [&](const char* req, u32 req_len, const char* status) {
-        i32 c = connect_to(port);
-        REQUIRE(c >= 0);
-        REQUIRE(send_all(c, req, req_len));
-        char buf[1024];
-        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
-        CHECK_GT(n, 0);
-        bool found = false;
-        for (i32 i = 0; i + 2 < n; i++) {
-            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
-                found = true;
-                break;
-            }
-        }
-        CHECK(found);
-        close(c);
-    };
-
     const char kHitReq[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    check_status(kHitReq, sizeof(kHitReq) - 1, "204");
     const char kBadReq[] = "GET /users HTTP/1.1\r\nHost: api.local\r\n\r\n";
-    check_status(kBadReq, sizeof(kBadReq) - 1, "401");
     const char kMissingReq[] = "GET /users HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
-    check_status(kMissingReq, sizeof(kMissingReq) - 1, "401");
-
-    lt.stop();
-    loop->shutdown();
-    close(lfd);
-    destroy_real_loop(loop);
-    engine.shutdown();
-    rir.destroy();
+    const RealSocketStatusCase cases[] = {
+        {kHitReq, sizeof(kHitReq) - 1, "204"},
+        {kBadReq, sizeof(kBadReq) - 1, "401"},
+        {kMissingReq, sizeof(kMissingReq) - 1, "401"},
+    };
+    REQUIRE(run_jit_real_socket_status_cases(src, cases, 3));
 }
 
 TEST(route, req_query_all_requires_present_value_real_socket) {
-    using namespace rut;
     const char* src =
         "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, any(q, \"rut\")) if "
         "value == "
         "\"rut\" { return 204 } else { return 401 } }\n";
-    auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});
-    REQUIRE(lexed);
-    auto ast = parse_file(lexed.value());
-    REQUIRE(ast);
-    std::unique_ptr<AstFile> ast_owned(ast.value());
-    auto hir = analyze_file(*ast_owned);
-    REQUIRE(hir);
-    std::unique_ptr<HirModule> hir_owned(hir.value());
-    auto mir = build_mir(*hir_owned);
-    REQUIRE(mir);
-    std::unique_ptr<MirModule> mir_owned(mir.value());
-    FrontendRirModule rir{};
-    auto lowered = lower_to_rir(*mir_owned, rir);
-    REQUIRE(lowered);
-
-    auto cg = jit::codegen(rir.module);
-    REQUIRE(cg.ok);
-    jit::JitEngine engine;
-    REQUIRE(engine.init());
-    REQUIRE(engine.compile(cg.mod, cg.ctx));
-
-    RouteConfig cfg{};
-    REQUIRE(populate_route_config(cfg, rir.module));
-    REQUIRE(register_jit_routes(cfg, rir.module, engine));
-    const RouteConfig* active = &cfg;
-
-    RealLoop* loop = create_real_loop();
-    REQUIRE(loop != nullptr);
-    auto lfd_result = create_listen_socket(0);
-    REQUIRE(lfd_result.has_value());
-    i32 lfd = lfd_result.value();
-    u16 port = get_port(lfd);
-    REQUIRE(loop->init(0, lfd).has_value());
-    loop->config_ptr = &active;
-    LoopThread lt = {loop, {}, 200};
-    lt.start();
-    usleep(10000);
-
-    auto check_status = [&](const char* req, u32 req_len, const char* status) {
-        i32 c = connect_to(port);
-        REQUIRE(c >= 0);
-        REQUIRE(send_all(c, req, req_len));
-        char buf[1024];
-        i32 n = recv_timeout(c, buf, sizeof(buf), 2000);
-        CHECK_GT(n, 0);
-        bool found = false;
-        for (i32 i = 0; i + 2 < n; i++) {
-            if (buf[i] == status[0] && buf[i + 1] == status[1] && buf[i + 2] == status[2]) {
-                found = true;
-                break;
-            }
-        }
-        CHECK(found);
-        close(c);
-    };
-
     const char kHitReq[] = "GET /search?q=rut HTTP/1.1\r\nHost: x\r\n\r\n";
-    check_status(kHitReq, sizeof(kHitReq) - 1, "204");
     const char kMissReq[] = "GET /search?q=cpp HTTP/1.1\r\nHost: x\r\n\r\n";
-    check_status(kMissReq, sizeof(kMissReq) - 1, "401");
     const char kMissingReq[] = "GET /search HTTP/1.1\r\nHost: x\r\n\r\n";
-    check_status(kMissingReq, sizeof(kMissingReq) - 1, "401");
-
-    lt.stop();
-    loop->shutdown();
-    close(lfd);
-    destroy_real_loop(loop);
-    engine.shutdown();
-    rir.destroy();
+    const RealSocketStatusCase cases[] = {
+        {kHitReq, sizeof(kHitReq) - 1, "204"},
+        {kMissReq, sizeof(kMissReq) - 1, "401"},
+        {kMissingReq, sizeof(kMissingReq) - 1, "401"},
+    };
+    REQUIRE(run_jit_real_socket_status_cases(src, cases, 3));
 }
 
 TEST(route, req_query_or_allows_expected_alternative) {

--- a/tests/test_integration.cc
+++ b/tests/test_integration.cc
@@ -4884,7 +4884,10 @@ static bool run_jit_real_socket_status_cases(const char* src,
     std::unique_ptr<MirModule> mir_owned(mir.value());
     FrontendRirModule rir{};
     auto lowered = lower_to_rir(*mir_owned, rir);
-    if (!lowered) return false;
+    if (!lowered) {
+        rir.destroy();
+        return false;
+    }
 
     jit::JitEngine engine;
     if (!engine.init()) {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -16992,6 +16992,43 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_recovered_local_still_errors_on_unrecovered_comparison) {
+    const auto src = R"(
+func fail() -> str => error(.timeout)
+route GET "/users" {
+    let host = any(req.query("q"), fail())
+    let safe = any(host, "missing")
+    if host == "rut" { return 204 } else { return 401 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 500);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_any_nil_branch) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -305,7 +305,7 @@ TEST(jit, frontend_req_header_any_fallback) {
 TEST(jit, frontend_req_header_all_requires_present_value_present_or_missing) {
     const char* src =
         "route GET \"/users\" { let host = all(req.header(\"Host\"), \"fallback\") if host == "
-        "\"localhost\" { return 204 } else { return 401 } }\n";
+        "\"fallback\" { return 204 } else { return 401 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -542,7 +542,7 @@ TEST(jit, frontend_req_query_string_any_fallback) {
 
 TEST(jit, frontend_req_query_all_requires_present_value) {
     const char* src =
-        "route GET \"/search\" { let query = all(req.query(\"x\"), \"\") if query == \"1\" { "
+        "route GET \"/search\" { let query = all(req.query(\"x\"), \"\") if query == \"\" { "
         "return 204 } else { return 401 } }\n";
 
     auto lexed = lex(lit(src));
@@ -592,7 +592,7 @@ TEST(jit, frontend_req_query_all_requires_present_value) {
 TEST(jit, frontend_req_header_all_requires_present_value_request_matrix) {
     const char* src =
         "route GET \"/users\" { let host = all(req.header(\"Host\"), \"fallback\") if host == "
-        "\"localhost\" { return 204 } else { return 401 } }\n";
+        "\"fallback\" { return 204 } else { return 401 } }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -633,7 +633,7 @@ TEST(jit, frontend_req_header_all_requires_present_value_request_matrix) {
                                                   sizeof(mismatch_request) - 1,
                                                   nullptr));
     CHECK(mismatch.action == HandlerAction::ReturnStatus);
-    CHECK_EQ(mismatch.status_code, 401u);
+    CHECK_EQ(mismatch.status_code, 204u);
 
     static const char missing_request[] = "GET /users HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
     auto missing = HandlerResult::unpack(handler(nullptr,
@@ -684,7 +684,7 @@ TEST(jit, frontend_req_query_all_non_short_circuit_evaluates_rhs_when_missing_qu
                                       sizeof(missing_query_request) - 1,
                                       nullptr));
     CHECK(no_query.action == HandlerAction::ReturnStatus);
-    CHECK_EQ(no_query.status_code, 204u);
+    CHECK_EQ(no_query.status_code, 401u);
 
     static const char query_request[] = "GET /users?x=1 HTTP/1.1\r\nHost: localhost\r\n\r\n";
     auto with_query = HandlerResult::unpack(handler(nullptr,
@@ -693,7 +693,7 @@ TEST(jit, frontend_req_query_all_non_short_circuit_evaluates_rhs_when_missing_qu
                                                     sizeof(query_request) - 1,
                                                     nullptr));
     CHECK(with_query.action == HandlerAction::ReturnStatus);
-    CHECK_EQ(with_query.status_code, 401u);
+    CHECK_EQ(with_query.status_code, 204u);
 
     engine.shutdown();
     rir.destroy();
@@ -745,7 +745,7 @@ TEST(jit, frontend_req_cookie_all_requires_present_value_present_or_missing) {
                                               sizeof(mismatch_request) - 1,
                                               nullptr));
     CHECK(miss.action == HandlerAction::ReturnStatus);
-    CHECK_EQ(miss.status_code, 401u);
+    CHECK_EQ(miss.status_code, 204u);
 
     static const char missing_request[] = "GET /session HTTP/1.1\r\nHost: localhost\r\n\r\n";
     auto no_cookie = HandlerResult::unpack(handler(nullptr,
@@ -1078,7 +1078,8 @@ TEST(jit, frontend_req_cookie_any_non_short_circuit_eager_rhs_is_observed_with_p
 
 TEST(jit, frontend_req_query_and_requires_both_operands) {
     const char* src =
-        "route GET \"/users\" { if req.pathOnly == \"/users\" and req.queryString == \"\" { return "
+        "route GET \"/users\" { if req.pathOnly == \"/users\" and any(req.queryString, \"\") == "
+        "\"\" { return "
         "204 } else { return 401 } }\n";
 
     auto lexed = lex(lit(src));
@@ -16170,7 +16171,7 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
-    CHECK(hir.error().detail.eq(lit("placeholder slot out of range")));
+    CHECK(hir.error().detail.eq(lit("placeholder value in conditional pipe must be 1")));
 }
 TEST(jit, frontend_pipe_conditional_missing_later_custom_constraint_is_rejected) {
     const auto src = R"(
@@ -16268,7 +16269,8 @@ route GET "/users" {
 TEST(jit, frontend_pipe_method_stage_known_nil_typed_cmp_mismatch_is_rejected) {
     const auto src = R"(
 route GET "/users" {
-    let code = nil | _.eq("200")
+    let code: i32 = nil
+    let ok = code | _.eq("200")
     return 200
 }
 )";
@@ -16283,7 +16285,8 @@ route GET "/users" {
 TEST(jit, frontend_pipe_method_stage_known_nil_typed_matches_non_string_receiver_is_rejected) {
     const auto src = R"(
 route GET "/users" {
-    let code = nil | _.matches(re"2")
+    let code: i32 = nil
+    let ok = code | _.matches(re"2")
     return 200
 }
 )";

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -17029,6 +17029,49 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_explicit_resume_state_zero_enters_error_prelude) {
+    const auto src = R"(
+func fail() -> str => error(.timeout)
+route GET "/" {
+    let value = any(req.query("q"), fail())
+    guard req.path == "/" else { return 404 }
+    guard value == "rut" else { return 401 }
+    wait(1000)
+    return 204
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
+    ctx.state = 0;
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           &ctx,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK_EQ(static_cast<u8>(r.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r.status_code, 500);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_any_nil_branch) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -16786,6 +16786,41 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_fallible_bool_condition_returns_error_status) {
+    const auto src = R"(
+func fallback() -> bool => error(.timeout)
+route GET "/users" {
+    if any(true, fallback()) { return 204 } else { return 401 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 500);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_any_nil_branch) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -16955,6 +16955,43 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_fallible_equality_operand_returns_error_status) {
+    const auto src = R"(
+func maybe(ok: bool) -> str {
+    if ok { "ok" } else { error(.timeout) }
+}
+route GET "/users" {
+    if maybe(req.http10) == "ok" { return 204 } else { return 401 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 500);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_any_nil_branch) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -16012,12 +16012,13 @@ route GET "/users" {
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
     CHECK(hir.error().detail.eq(lit("non-tuple source with non-unit placeholder")));
 }
-TEST(jit, frontend_pipe_with_placeholder_slot_zero_is_rejected_scalar) {
+TEST(jit, frontend_pipe_keeps_placeholder_slot_zero_identifier_scalar) {
     const auto src = R"(
-func id(x: i32) -> i32 => x
+func second(x: i32, y: i32) -> i32 => y
 route GET "/users" {
-    let code = 200 | id(_0)
-    return 200
+    let _0 = 204
+    let code = 200 | second(_, _0)
+    if code == 204 { return 200 } else { return 500 }
 }
 )";
     auto lexed = lex(lit(src));
@@ -16025,9 +16026,27 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE_FALSE(hir.has_value());
-    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
-    CHECK(hir.error().detail.eq(lit("placeholder slot out of range")));
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
 }
 TEST(jit, frontend_pipe_with_tuple_placeholder_slot_exceeds_tuple_arity_is_rejected) {
     const auto src = R"(
@@ -16046,12 +16065,13 @@ route GET "/users" {
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
     CHECK(hir.error().detail.eq(lit("placeholder slot exceeds tuple arity")));
 }
-TEST(jit, frontend_pipe_with_placeholder_slot_zero_is_rejected) {
+TEST(jit, frontend_pipe_keeps_placeholder_slot_zero_identifier_tuple) {
     const auto src = R"(
-func id(x: i32) -> i32 => x
+func second(x: i32, y: i32) -> i32 => y
 route GET "/users" {
-    let code = (200, 500) | id(_0)
-    return 200
+    let _0 = 204
+    let code = (200, 500) | second(_1, _0)
+    if code == 204 { return 200 } else { return 500 }
 }
 )";
     auto lexed = lex(lit(src));
@@ -16059,9 +16079,27 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE_FALSE(hir.has_value());
-    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
-    CHECK(hir.error().detail.eq(lit("placeholder slot out of range")));
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
 }
 
 TEST(jit, frontend_pipe_runtime_fallible_lhs_slot_two_is_rejected) {
@@ -16156,12 +16194,14 @@ route GET "/users" {
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
     CHECK(hir.error().detail.eq(lit("placeholder value in conditional pipe must be 1")));
 }
-TEST(jit, frontend_pipe_conditional_with_placeholder_slot_zero_is_rejected) {
+TEST(jit, frontend_pipe_conditional_keeps_placeholder_slot_zero_identifier) {
     const auto src = R"(
-func id(x: i32) -> i32 => x
+func choose(x: str, y: str) -> str => y
 route GET "/users" {
-    let code = req.header("Host") | id(_0)
-    return 200
+    let _0 = "fallback"
+    let value = req.header("Host") | choose(_, _0)
+    let safe = any(value, "")
+    if safe == "fallback" { return 200 } else { return 500 }
 }
 )";
     auto lexed = lex(lit(src));
@@ -16169,9 +16209,27 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE_FALSE(hir.has_value());
-    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
-    CHECK(hir.error().detail.eq(lit("placeholder value in conditional pipe must be 1")));
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
 }
 TEST(jit, frontend_pipe_conditional_missing_later_custom_constraint_is_rejected) {
     const auto src = R"(

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -302,7 +302,7 @@ TEST(jit, frontend_req_header_any_fallback) {
     rir.destroy();
 }
 
-TEST(jit, frontend_req_header_all_requires_present_value) {
+TEST(jit, frontend_req_header_all_requires_present_value_present_or_missing) {
     const char* src =
         "route GET \"/users\" { let host = all(req.header(\"Host\"), \"fallback\") if host == "
         "\"localhost\" { return 204 } else { return 401 } }\n";
@@ -589,7 +589,7 @@ TEST(jit, frontend_req_query_all_requires_present_value) {
     rir.destroy();
 }
 
-TEST(jit, frontend_req_header_all_requires_present_value) {
+TEST(jit, frontend_req_header_all_requires_present_value_request_matrix) {
     const char* src =
         "route GET \"/users\" { let host = all(req.header(\"Host\"), \"fallback\") if host == "
         "\"localhost\" { return 204 } else { return 401 } }\n";
@@ -699,7 +699,7 @@ TEST(jit, frontend_req_query_all_non_short_circuit_evaluates_rhs_when_missing_qu
     rir.destroy();
 }
 
-TEST(jit, frontend_req_cookie_all_requires_present_value) {
+TEST(jit, frontend_req_cookie_all_requires_present_value_present_or_missing) {
     const char* src =
         "route GET \"/session\" { let sid = all(req.cookie(\"sid\"), \"ok\") if sid == \"ok\" "
         "{ return 204 } else { return 401 } }\n";
@@ -1613,7 +1613,7 @@ TEST(jit, frontend_req_cookie_any_fallback) {
     rir.destroy();
 }
 
-TEST(jit, frontend_req_cookie_all_requires_present_value) {
+TEST(jit, frontend_req_cookie_all_requires_present_value_request_matrix) {
     const char* src =
         "route GET \"/session\" { let sid = all(req.cookie(\"sid\"), \"ok\") if sid == \"ok\" { "
         "return 204 } else { return 401 } }\n";
@@ -16427,7 +16427,7 @@ route GET "/users" {
     CHECK(hir->routes[0].locals[1].may_error);
     CHECK_EQ(hir->routes[0].locals[1].error_variant_index,
              hir->routes[0].locals[0].error_variant_index);
-    CHECK_EQ(hir->routes[0].locals[2].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[2].type == HirTypeKind::I32);
     CHECK_FALSE(hir->routes[0].locals[2].may_error);
 }
 TEST(jit, frontend_pipe_method_stage_known_error_dispatches_value_method_shape) {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -16677,6 +16677,42 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_any_present_lhs_fallible_rhs_observes_rhs_error) {
+    const auto src = R"(
+func fallback() -> i32 => error(.timeout)
+route GET "/users" {
+    let value = any(200, fallback())
+    if value == 200 { return 204 } else { return 401 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 500);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_any_nil_branch) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -17574,6 +17574,54 @@ route {
     rir.destroy();
 }
 
+TEST(jit, frontend_route_decorator_wait_state_zero_enters_error_prelude) {
+    const auto src = R"rut(
+func passing(_ req: i32) -> i32 => 0
+func fallback() -> i32 => error(.timeout)
+route {
+    @passing "*"
+    GET "/sleep" {
+        let value = any(200, fallback())
+        guard value == 200 else { return 401 }
+        wait(1000)
+        return 204
+    }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    TestHandlerCtxFrame frame{};
+    HandlerCtx& ctx = frame.ctx;
+    ctx.state = 0;
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           &ctx,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK_EQ(static_cast<u8>(r.action), static_cast<u8>(HandlerAction::ReturnStatus));
+    CHECK_EQ(r.status_code, 500);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_route_decorator_passes_then_waits) {
     const auto src = R"rut(
 func passing(_ req: i32) -> i32 => 0

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -263,7 +263,8 @@ TEST(jit, return_200) {
 
 TEST(jit, frontend_req_header_any_fallback) {
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, \"fallback\") "
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, "
+        "\"fallback\") "
         "return 200 }\n";
 
     auto lexed = lex(lit(src));
@@ -337,13 +338,13 @@ TEST(jit, frontend_req_header_all_requires_present_value) {
     CHECK(hit.action == HandlerAction::ReturnStatus);
     CHECK_EQ(hit.status_code, 204u);
 
-    static const char missing_host_request[] = "GET /api/users HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
-    auto miss = HandlerResult::unpack(
-        handler(nullptr,
-                nullptr,
-                reinterpret_cast<const u8*>(missing_host_request),
-                sizeof(missing_host_request) - 1,
-                nullptr));
+    static const char missing_host_request[] =
+        "GET /api/users HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
+    auto miss = HandlerResult::unpack(handler(nullptr,
+                                              nullptr,
+                                              reinterpret_cast<const u8*>(missing_host_request),
+                                              sizeof(missing_host_request) - 1,
+                                              nullptr));
     CHECK(miss.action == HandlerAction::ReturnStatus);
     CHECK_EQ(miss.status_code, 401u);
 
@@ -567,22 +568,20 @@ TEST(jit, frontend_req_query_all_requires_present_value) {
     auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
     REQUIRE(handler != nullptr);
 
-    auto hit = HandlerResult::unpack(handler(
-        nullptr,
-        nullptr,
-        reinterpret_cast<const u8*>(kGetApiQueryRequest),
-        sizeof(kGetApiQueryRequest) - 1,
-        nullptr));
+    auto hit = HandlerResult::unpack(handler(nullptr,
+                                             nullptr,
+                                             reinterpret_cast<const u8*>(kGetApiQueryRequest),
+                                             sizeof(kGetApiQueryRequest) - 1,
+                                             nullptr));
     CHECK(hit.action == HandlerAction::ReturnStatus);
     CHECK_EQ(hit.status_code, 204u);
 
     static const char missing_query_request[] = "GET /search HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto miss = HandlerResult::unpack(
-        handler(nullptr,
-                nullptr,
-                reinterpret_cast<const u8*>(missing_query_request),
-                sizeof(missing_query_request) - 1,
-                nullptr));
+    auto miss = HandlerResult::unpack(handler(nullptr,
+                                              nullptr,
+                                              reinterpret_cast<const u8*>(missing_query_request),
+                                              sizeof(missing_query_request) - 1,
+                                              nullptr));
     CHECK(miss.action == HandlerAction::ReturnStatus);
     CHECK_EQ(miss.status_code, 401u);
 
@@ -619,24 +618,29 @@ TEST(jit, frontend_req_header_all_requires_present_value) {
     REQUIRE(handler != nullptr);
 
     static const char present_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto present = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(present_request), sizeof(present_request) - 1, nullptr));
+    auto present = HandlerResult::unpack(handler(nullptr,
+                                                 nullptr,
+                                                 reinterpret_cast<const u8*>(present_request),
+                                                 sizeof(present_request) - 1,
+                                                 nullptr));
     CHECK(present.action == HandlerAction::ReturnStatus);
     CHECK_EQ(present.status_code, 204u);
 
     static const char mismatch_request[] = "GET /users HTTP/1.1\r\nHost: api.local\r\n\r\n";
-    auto mismatch = HandlerResult::unpack(handler(
-        nullptr,
-        nullptr,
-        reinterpret_cast<const u8*>(mismatch_request),
-        sizeof(mismatch_request) - 1,
-        nullptr));
+    auto mismatch = HandlerResult::unpack(handler(nullptr,
+                                                  nullptr,
+                                                  reinterpret_cast<const u8*>(mismatch_request),
+                                                  sizeof(mismatch_request) - 1,
+                                                  nullptr));
     CHECK(mismatch.action == HandlerAction::ReturnStatus);
     CHECK_EQ(mismatch.status_code, 401u);
 
     static const char missing_request[] = "GET /users HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
-    auto missing = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(missing_request), sizeof(missing_request) - 1, nullptr));
+    auto missing = HandlerResult::unpack(handler(nullptr,
+                                                 nullptr,
+                                                 reinterpret_cast<const u8*>(missing_request),
+                                                 sizeof(missing_request) - 1,
+                                                 nullptr));
     CHECK(missing.action == HandlerAction::ReturnStatus);
     CHECK_EQ(missing.status_code, 401u);
 
@@ -673,14 +677,21 @@ TEST(jit, frontend_req_query_all_non_short_circuit_evaluates_rhs_when_missing_qu
     REQUIRE(handler != nullptr);
 
     static const char missing_query_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto no_query = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(missing_query_request), sizeof(missing_query_request) - 1, nullptr));
+    auto no_query =
+        HandlerResult::unpack(handler(nullptr,
+                                      nullptr,
+                                      reinterpret_cast<const u8*>(missing_query_request),
+                                      sizeof(missing_query_request) - 1,
+                                      nullptr));
     CHECK(no_query.action == HandlerAction::ReturnStatus);
     CHECK_EQ(no_query.status_code, 204u);
 
     static const char query_request[] = "GET /users?x=1 HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto with_query = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(query_request), sizeof(query_request) - 1, nullptr));
+    auto with_query = HandlerResult::unpack(handler(nullptr,
+                                                    nullptr,
+                                                    reinterpret_cast<const u8*>(query_request),
+                                                    sizeof(query_request) - 1,
+                                                    nullptr));
     CHECK(with_query.action == HandlerAction::ReturnStatus);
     CHECK_EQ(with_query.status_code, 401u);
 
@@ -718,21 +729,30 @@ TEST(jit, frontend_req_cookie_all_requires_present_value) {
 
     static const char present_request[] =
         "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
-    auto hit = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(present_request), sizeof(present_request) - 1, nullptr));
+    auto hit = HandlerResult::unpack(handler(nullptr,
+                                             nullptr,
+                                             reinterpret_cast<const u8*>(present_request),
+                                             sizeof(present_request) - 1,
+                                             nullptr));
     CHECK(hit.action == HandlerAction::ReturnStatus);
     CHECK_EQ(hit.status_code, 204u);
 
     static const char mismatch_request[] =
         "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=nope; lang=en\r\n\r\n";
-    auto miss = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(mismatch_request), sizeof(mismatch_request) - 1, nullptr));
+    auto miss = HandlerResult::unpack(handler(nullptr,
+                                              nullptr,
+                                              reinterpret_cast<const u8*>(mismatch_request),
+                                              sizeof(mismatch_request) - 1,
+                                              nullptr));
     CHECK(miss.action == HandlerAction::ReturnStatus);
     CHECK_EQ(miss.status_code, 401u);
 
     static const char missing_request[] = "GET /session HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto no_cookie = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(missing_request), sizeof(missing_request) - 1, nullptr));
+    auto no_cookie = HandlerResult::unpack(handler(nullptr,
+                                                   nullptr,
+                                                   reinterpret_cast<const u8*>(missing_request),
+                                                   sizeof(missing_request) - 1,
+                                                   nullptr));
     CHECK(no_cookie.action == HandlerAction::ReturnStatus);
     CHECK_EQ(no_cookie.status_code, 401u);
 
@@ -770,14 +790,21 @@ TEST(jit, frontend_req_query_all_non_short_circuit_eager_rhs_is_observed_with_pr
     REQUIRE(handler != nullptr);
 
     static const char missing_query_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto no_query = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(missing_query_request), sizeof(missing_query_request) - 1, nullptr));
+    auto no_query =
+        HandlerResult::unpack(handler(nullptr,
+                                      nullptr,
+                                      reinterpret_cast<const u8*>(missing_query_request),
+                                      sizeof(missing_query_request) - 1,
+                                      nullptr));
     CHECK(no_query.action == HandlerAction::ReturnStatus);
     CHECK_EQ(no_query.status_code, 500u);
 
     static const char query_request[] = "GET /users?x=x HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto with_query = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(query_request), sizeof(query_request) - 1, nullptr));
+    auto with_query = HandlerResult::unpack(handler(nullptr,
+                                                    nullptr,
+                                                    reinterpret_cast<const u8*>(query_request),
+                                                    sizeof(query_request) - 1,
+                                                    nullptr));
     CHECK(with_query.action == HandlerAction::ReturnStatus);
     CHECK_EQ(with_query.status_code, 500u);
 
@@ -815,14 +842,21 @@ TEST(jit, frontend_req_query_any_non_short_circuit_eager_rhs_is_observed_with_pr
     REQUIRE(handler != nullptr);
 
     static const char missing_query_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto no_query = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(missing_query_request), sizeof(missing_query_request) - 1, nullptr));
+    auto no_query =
+        HandlerResult::unpack(handler(nullptr,
+                                      nullptr,
+                                      reinterpret_cast<const u8*>(missing_query_request),
+                                      sizeof(missing_query_request) - 1,
+                                      nullptr));
     CHECK(no_query.action == HandlerAction::ReturnStatus);
     CHECK_EQ(no_query.status_code, 500u);
 
     static const char query_request[] = "GET /users?x=x HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto with_query = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(query_request), sizeof(query_request) - 1, nullptr));
+    auto with_query = HandlerResult::unpack(handler(nullptr,
+                                                    nullptr,
+                                                    reinterpret_cast<const u8*>(query_request),
+                                                    sizeof(query_request) - 1,
+                                                    nullptr));
     CHECK(with_query.action == HandlerAction::ReturnStatus);
     CHECK_EQ(with_query.status_code, 500u);
 
@@ -833,7 +867,8 @@ TEST(jit, frontend_req_query_any_non_short_circuit_eager_rhs_is_observed_with_pr
 TEST(jit, frontend_req_header_all_non_short_circuit_eager_rhs_is_observed_with_present_header) {
     const char* src =
         "func fallback() -> str => error(.timeout)\n"
-        "route GET \"/users\" { let value = all(req.header(\"X-Foo\"), fallback()) if value == \"x\" "
+        "route GET \"/users\" { let value = all(req.header(\"X-Foo\"), fallback()) if value == "
+        "\"x\" "
         "{ return 204 } else { return 401 } }\n";
 
     auto lexed = lex(lit(src));
@@ -860,14 +895,22 @@ TEST(jit, frontend_req_header_all_non_short_circuit_eager_rhs_is_observed_with_p
     REQUIRE(handler != nullptr);
 
     static const char missing_header_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto no_header = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(missing_header_request), sizeof(missing_header_request) - 1, nullptr));
+    auto no_header =
+        HandlerResult::unpack(handler(nullptr,
+                                      nullptr,
+                                      reinterpret_cast<const u8*>(missing_header_request),
+                                      sizeof(missing_header_request) - 1,
+                                      nullptr));
     CHECK(no_header.action == HandlerAction::ReturnStatus);
     CHECK_EQ(no_header.status_code, 500u);
 
-    static const char header_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\nX-Foo: x\r\n\r\n";
-    auto with_header = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(header_request), sizeof(header_request) - 1, nullptr));
+    static const char header_request[] =
+        "GET /users HTTP/1.1\r\nHost: localhost\r\nX-Foo: x\r\n\r\n";
+    auto with_header = HandlerResult::unpack(handler(nullptr,
+                                                     nullptr,
+                                                     reinterpret_cast<const u8*>(header_request),
+                                                     sizeof(header_request) - 1,
+                                                     nullptr));
     CHECK(with_header.action == HandlerAction::ReturnStatus);
     CHECK_EQ(with_header.status_code, 500u);
 
@@ -878,7 +921,8 @@ TEST(jit, frontend_req_header_all_non_short_circuit_eager_rhs_is_observed_with_p
 TEST(jit, frontend_req_header_any_non_short_circuit_eager_rhs_is_observed_with_present_header) {
     const char* src =
         "func fallback() -> str => error(.timeout)\n"
-        "route GET \"/users\" { let value = any(req.header(\"X-Foo\"), fallback()) if value == \"x\" "
+        "route GET \"/users\" { let value = any(req.header(\"X-Foo\"), fallback()) if value == "
+        "\"x\" "
         "{ return 204 } else { return 401 } }\n";
 
     auto lexed = lex(lit(src));
@@ -905,14 +949,22 @@ TEST(jit, frontend_req_header_any_non_short_circuit_eager_rhs_is_observed_with_p
     REQUIRE(handler != nullptr);
 
     static const char missing_header_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto no_header = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(missing_header_request), sizeof(missing_header_request) - 1, nullptr));
+    auto no_header =
+        HandlerResult::unpack(handler(nullptr,
+                                      nullptr,
+                                      reinterpret_cast<const u8*>(missing_header_request),
+                                      sizeof(missing_header_request) - 1,
+                                      nullptr));
     CHECK(no_header.action == HandlerAction::ReturnStatus);
     CHECK_EQ(no_header.status_code, 500u);
 
-    static const char header_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\nX-Foo: x\r\n\r\n";
-    auto with_header = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(header_request), sizeof(header_request) - 1, nullptr));
+    static const char header_request[] =
+        "GET /users HTTP/1.1\r\nHost: localhost\r\nX-Foo: x\r\n\r\n";
+    auto with_header = HandlerResult::unpack(handler(nullptr,
+                                                     nullptr,
+                                                     reinterpret_cast<const u8*>(header_request),
+                                                     sizeof(header_request) - 1,
+                                                     nullptr));
     CHECK(with_header.action == HandlerAction::ReturnStatus);
     CHECK_EQ(with_header.status_code, 500u);
 
@@ -950,15 +1002,21 @@ TEST(jit, frontend_req_cookie_all_non_short_circuit_eager_rhs_is_observed_with_p
     REQUIRE(handler != nullptr);
 
     static const char missing_cookie[] = "GET /session HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto miss_cookie = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(missing_cookie), sizeof(missing_cookie) - 1, nullptr));
+    auto miss_cookie = HandlerResult::unpack(handler(nullptr,
+                                                     nullptr,
+                                                     reinterpret_cast<const u8*>(missing_cookie),
+                                                     sizeof(missing_cookie) - 1,
+                                                     nullptr));
     CHECK(miss_cookie.action == HandlerAction::ReturnStatus);
     CHECK_EQ(miss_cookie.status_code, 500u);
 
     static const char hit_cookie[] =
         "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
-    auto with_cookie = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(hit_cookie), sizeof(hit_cookie) - 1, nullptr));
+    auto with_cookie = HandlerResult::unpack(handler(nullptr,
+                                                     nullptr,
+                                                     reinterpret_cast<const u8*>(hit_cookie),
+                                                     sizeof(hit_cookie) - 1,
+                                                     nullptr));
     CHECK(with_cookie.action == HandlerAction::ReturnStatus);
     CHECK_EQ(with_cookie.status_code, 500u);
 
@@ -996,15 +1054,21 @@ TEST(jit, frontend_req_cookie_any_non_short_circuit_eager_rhs_is_observed_with_p
     REQUIRE(handler != nullptr);
 
     static const char missing_cookie[] = "GET /session HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto miss_cookie = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(missing_cookie), sizeof(missing_cookie) - 1, nullptr));
+    auto miss_cookie = HandlerResult::unpack(handler(nullptr,
+                                                     nullptr,
+                                                     reinterpret_cast<const u8*>(missing_cookie),
+                                                     sizeof(missing_cookie) - 1,
+                                                     nullptr));
     CHECK(miss_cookie.action == HandlerAction::ReturnStatus);
     CHECK_EQ(miss_cookie.status_code, 500u);
 
     static const char hit_cookie[] =
         "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
-    auto with_cookie = HandlerResult::unpack(handler(
-        nullptr, nullptr, reinterpret_cast<const u8*>(hit_cookie), sizeof(hit_cookie) - 1, nullptr));
+    auto with_cookie = HandlerResult::unpack(handler(nullptr,
+                                                     nullptr,
+                                                     reinterpret_cast<const u8*>(hit_cookie),
+                                                     sizeof(hit_cookie) - 1,
+                                                     nullptr));
     CHECK(with_cookie.action == HandlerAction::ReturnStatus);
     CHECK_EQ(with_cookie.status_code, 500u);
 
@@ -1058,7 +1122,8 @@ TEST(jit, frontend_req_query_and_requires_both_operands) {
 
 TEST(jit, frontend_req_query_or_requires_either_operand) {
     const char* src =
-        "route GET \"/users\" { if req.pathOnly == \"/admin\" or req.queryString == \"q=1\" { return "
+        "route GET \"/users\" { if req.pathOnly == \"/admin\" or req.queryString == \"q=1\" { "
+        "return "
         "204 } else { return 401 } }\n";
 
     auto lexed = lex(lit(src));
@@ -1098,11 +1163,7 @@ TEST(jit, frontend_req_query_or_requires_either_operand) {
 
     static const char miss2[] = "GET /users?q=2 HTTP/1.1\r\nHost: localhost\r\n\r\n";
     auto miss2_r = HandlerResult::unpack(
-        handler(nullptr,
-                nullptr,
-                reinterpret_cast<const u8*>(miss2),
-                sizeof(miss2) - 1,
-                nullptr));
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(miss2), sizeof(miss2) - 1, nullptr));
     CHECK(miss2_r.action == HandlerAction::ReturnStatus);
     CHECK_EQ(miss2_r.status_code, 401u);
 
@@ -1139,18 +1200,22 @@ TEST(jit, frontend_req_query_all_requires_expected_alternative) {
     REQUIRE(handler != nullptr);
 
     static const char hit_by_value[] = "GET /search?q=rut HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto hit_by_value_res = HandlerResult::unpack(
-        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit_by_value), sizeof(hit_by_value) - 1, nullptr));
+    auto hit_by_value_res = HandlerResult::unpack(handler(nullptr,
+                                                          nullptr,
+                                                          reinterpret_cast<const u8*>(hit_by_value),
+                                                          sizeof(hit_by_value) - 1,
+                                                          nullptr));
     CHECK(hit_by_value_res.action == HandlerAction::ReturnStatus);
     CHECK_EQ(hit_by_value_res.status_code, 204u);
 
-    static const char hit_by_query_string[] = "GET /search?q=admin HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    auto hit_by_query_string_res = HandlerResult::unpack(handler(
-        nullptr,
-        nullptr,
-        reinterpret_cast<const u8*>(hit_by_query_string),
-        sizeof(hit_by_query_string) - 1,
-        nullptr));
+    static const char hit_by_query_string[] =
+        "GET /search?q=admin HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto hit_by_query_string_res =
+        HandlerResult::unpack(handler(nullptr,
+                                      nullptr,
+                                      reinterpret_cast<const u8*>(hit_by_query_string),
+                                      sizeof(hit_by_query_string) - 1,
+                                      nullptr));
     CHECK(hit_by_query_string_res.action == HandlerAction::ReturnStatus);
     CHECK_EQ(hit_by_query_string_res.status_code, 204u);
 
@@ -16180,9 +16245,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
-    CHECK(hir.error().detail.eq(
-        lit("pipe method stage with nil/error propagation must return bool, "
-            "i32, str, variant, or struct")));
+    CHECK(
+        hir.error().detail.eq(lit("pipe method stage with nil/error propagation must return bool, "
+                                  "i32, str, variant, or struct")));
 }
 TEST(jit, frontend_pipe_method_stage_slot_two_is_rejected) {
     const auto src = R"(
@@ -16288,9 +16353,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
-    CHECK(hir.error().detail.eq(
-        lit("pipe method stage with nil/error propagation must return bool, "
-            "i32, str, variant, or struct")));
+    CHECK(
+        hir.error().detail.eq(lit("pipe method stage with nil/error propagation must return bool, "
+                                  "i32, str, variant, or struct")));
 }
 TEST(jit, frontend_pipe_method_stage_known_error_tuple_return_is_rejected) {
     const auto src = R"(
@@ -16312,9 +16377,9 @@ route GET "/users" {
     auto hir = analyze_file_heap(ast.value());
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
-    CHECK(hir.error().detail.eq(
-        lit("pipe method stage with nil/error propagation must return bool, "
-            "i32, str, variant, or struct")));
+    CHECK(
+        hir.error().detail.eq(lit("pipe method stage with nil/error propagation must return bool, "
+                                  "i32, str, variant, or struct")));
 }
 TEST(jit, frontend_pipe_different_error_variants_in_method_stage_is_rejected) {
     const auto src = R"(

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -16884,6 +16884,42 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_eager_error_local_can_be_recovered_in_terminator) {
+    const auto src = R"(
+func fail() -> i32 => error(.timeout)
+route GET "/users" {
+    let code = any(200, fail())
+    if any(code, 204) == 204 { return 204 } else { return 401 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 204);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_fallible_bool_condition_returns_error_status) {
     const auto src = R"(
 func fallback() -> bool => error(.timeout)

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -16749,6 +16749,43 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_all_present_lhs_fallible_rhs_local_can_be_recovered_by_any) {
+    const auto src = R"(
+func fallback() -> i32 => error(.timeout)
+route GET "/users" {
+    let value = all(200, fallback())
+    let safe = any(value, 204)
+    if safe == 204 { return 204 } else { return 401 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 204);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_any_nil_branch) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -16786,6 +16786,46 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_eager_error_local_can_be_recovered_by_fallible_any) {
+    const auto src = R"(
+func fail() -> str => error(.timeout)
+func recover(ok: bool) -> str {
+    if ok { "safe" } else { error(.timeout) }
+}
+route GET "/users" {
+    let host = any("present", fail())
+    let safe = any(host, recover(req.http11))
+    if safe == "safe" { return 204 } else { return 401 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 204);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_fallible_bool_condition_returns_error_status) {
     const auto src = R"(
 func fallback() -> bool => error(.timeout)

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -16713,6 +16713,42 @@ route GET "/users" {
     rir.destroy();
 }
 
+TEST(jit, frontend_all_present_lhs_fallible_rhs_observes_rhs_error) {
+    const auto src = R"(
+func fallback() -> i32 => error(.timeout)
+route GET "/users" {
+    let value = all(200, fallback())
+    if value == 200 { return 204 } else { return 401 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 500);
+    engine.shutdown();
+    rir.destroy();
+}
+
 TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_any_nil_branch) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -261,9 +261,9 @@ TEST(jit, return_200) {
     tc.destroy();
 }
 
-TEST(jit, frontend_req_header_or_fallback) {
+TEST(jit, frontend_req_header_any_fallback) {
     const char* src =
-        "route GET \"/users\" { let host = req.header(\"Host\") let value = or(host, \"fallback\") "
+        "route GET \"/users\" { let host = req.header(\"Host\") let value = any(host, \"fallback\") "
         "return 200 }\n";
 
     auto lexed = lex(lit(src));
@@ -301,10 +301,60 @@ TEST(jit, frontend_req_header_or_fallback) {
     rir.destroy();
 }
 
-TEST(jit, frontend_req_standard_header_alias_or_fallback) {
+TEST(jit, frontend_req_header_all_requires_present_value) {
     const char* src =
-        "route GET \"/users\" { let auth = or(req.authorization, \"\") let request = "
-        "or(req.xRequestId, \"\") if auth == \"Bearer root\" { if request == \"req-1\" { "
+        "route GET \"/users\" { let host = all(req.header(\"Host\"), \"fallback\") if host == "
+        "\"localhost\" { return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto hit = HandlerResult::unpack(handler(nullptr,
+                                             nullptr,
+                                             reinterpret_cast<const u8*>(kGetApiRequest),
+                                             sizeof(kGetApiRequest) - 1,
+                                             nullptr));
+    CHECK(hit.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(hit.status_code, 204u);
+
+    static const char missing_host_request[] = "GET /api/users HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
+    auto miss = HandlerResult::unpack(
+        handler(nullptr,
+                nullptr,
+                reinterpret_cast<const u8*>(missing_host_request),
+                sizeof(missing_host_request) - 1,
+                nullptr));
+    CHECK(miss.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss.status_code, 401u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_standard_header_alias_any_fallback) {
+    const char* src =
+        "route GET \"/users\" { let auth = any(req.authorization, \"\") let request = "
+        "any(req.xRequestId, \"\") if auth == \"Bearer root\" { if request == \"req-1\" { "
         "return 204 } else { return 401 } } else { return 401 } }\n";
 
     auto lexed = lex(lit(src));
@@ -445,9 +495,9 @@ TEST(jit, frontend_req_route_param_field_guard) {
     rir.destroy();
 }
 
-TEST(jit, frontend_req_query_string_or_fallback) {
+TEST(jit, frontend_req_query_string_any_fallback) {
     const char* src =
-        "route GET \"/search\" { let raw = or(req.queryString, \"\") if raw == "
+        "route GET \"/search\" { let raw = any(req.queryString, \"\") if raw == "
         "\"q=rut&empty=\" { return 204 } else { return 401 } }\n";
 
     auto lexed = lex(lit(src));
@@ -487,6 +537,669 @@ TEST(jit, frontend_req_query_string_or_fallback) {
 
     engine.shutdown();
     rir.destroy();
+}
+
+TEST(jit, frontend_req_query_all_requires_present_value) {
+    const char* src =
+        "route GET \"/search\" { let query = all(req.query(\"x\"), \"\") if query == \"1\" { "
+        "return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    auto hit = HandlerResult::unpack(handler(
+        nullptr,
+        nullptr,
+        reinterpret_cast<const u8*>(kGetApiQueryRequest),
+        sizeof(kGetApiQueryRequest) - 1,
+        nullptr));
+    CHECK(hit.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(hit.status_code, 204u);
+
+    static const char missing_query_request[] = "GET /search HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto miss = HandlerResult::unpack(
+        handler(nullptr,
+                nullptr,
+                reinterpret_cast<const u8*>(missing_query_request),
+                sizeof(missing_query_request) - 1,
+                nullptr));
+    CHECK(miss.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss.status_code, 401u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_header_all_requires_present_value) {
+    const char* src =
+        "route GET \"/users\" { let host = all(req.header(\"Host\"), \"fallback\") if host == "
+        "\"localhost\" { return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char present_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto present = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(present_request), sizeof(present_request) - 1, nullptr));
+    CHECK(present.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(present.status_code, 204u);
+
+    static const char mismatch_request[] = "GET /users HTTP/1.1\r\nHost: api.local\r\n\r\n";
+    auto mismatch = HandlerResult::unpack(handler(
+        nullptr,
+        nullptr,
+        reinterpret_cast<const u8*>(mismatch_request),
+        sizeof(mismatch_request) - 1,
+        nullptr));
+    CHECK(mismatch.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(mismatch.status_code, 401u);
+
+    static const char missing_request[] = "GET /users HTTP/1.1\r\nUser-Agent: curl\r\n\r\n";
+    auto missing = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(missing_request), sizeof(missing_request) - 1, nullptr));
+    CHECK(missing.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(missing.status_code, 401u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_query_all_non_short_circuit_evaluates_rhs_when_missing_query) {
+    const char* src =
+        "route GET \"/users\" { let value = all(req.query(\"x\"), \"fallback\") if value == "
+        "\"fallback\" { return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char missing_query_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto no_query = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(missing_query_request), sizeof(missing_query_request) - 1, nullptr));
+    CHECK(no_query.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(no_query.status_code, 204u);
+
+    static const char query_request[] = "GET /users?x=1 HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto with_query = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(query_request), sizeof(query_request) - 1, nullptr));
+    CHECK(with_query.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(with_query.status_code, 401u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_cookie_all_requires_present_value) {
+    const char* src =
+        "route GET \"/session\" { let sid = all(req.cookie(\"sid\"), \"ok\") if sid == \"ok\" "
+        "{ return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char present_request[] =
+        "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
+    auto hit = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(present_request), sizeof(present_request) - 1, nullptr));
+    CHECK(hit.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(hit.status_code, 204u);
+
+    static const char mismatch_request[] =
+        "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=nope; lang=en\r\n\r\n";
+    auto miss = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(mismatch_request), sizeof(mismatch_request) - 1, nullptr));
+    CHECK(miss.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss.status_code, 401u);
+
+    static const char missing_request[] = "GET /session HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto no_cookie = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(missing_request), sizeof(missing_request) - 1, nullptr));
+    CHECK(no_cookie.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(no_cookie.status_code, 401u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_query_all_non_short_circuit_eager_rhs_is_observed_with_present_query) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/users\" { let value = all(req.query(\"x\"), fallback()) if value == "
+        "\"x\" { return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char missing_query_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto no_query = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(missing_query_request), sizeof(missing_query_request) - 1, nullptr));
+    CHECK(no_query.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(no_query.status_code, 500u);
+
+    static const char query_request[] = "GET /users?x=x HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto with_query = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(query_request), sizeof(query_request) - 1, nullptr));
+    CHECK(with_query.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(with_query.status_code, 500u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_query_any_non_short_circuit_eager_rhs_is_observed_with_present_query) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/users\" { let value = any(req.query(\"x\"), fallback()) if value == "
+        "\"x\" { return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char missing_query_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto no_query = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(missing_query_request), sizeof(missing_query_request) - 1, nullptr));
+    CHECK(no_query.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(no_query.status_code, 500u);
+
+    static const char query_request[] = "GET /users?x=x HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto with_query = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(query_request), sizeof(query_request) - 1, nullptr));
+    CHECK(with_query.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(with_query.status_code, 500u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_header_all_non_short_circuit_eager_rhs_is_observed_with_present_header) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/users\" { let value = all(req.header(\"X-Foo\"), fallback()) if value == \"x\" "
+        "{ return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char missing_header_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto no_header = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(missing_header_request), sizeof(missing_header_request) - 1, nullptr));
+    CHECK(no_header.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(no_header.status_code, 500u);
+
+    static const char header_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\nX-Foo: x\r\n\r\n";
+    auto with_header = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(header_request), sizeof(header_request) - 1, nullptr));
+    CHECK(with_header.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(with_header.status_code, 500u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_header_any_non_short_circuit_eager_rhs_is_observed_with_present_header) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/users\" { let value = any(req.header(\"X-Foo\"), fallback()) if value == \"x\" "
+        "{ return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char missing_header_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto no_header = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(missing_header_request), sizeof(missing_header_request) - 1, nullptr));
+    CHECK(no_header.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(no_header.status_code, 500u);
+
+    static const char header_request[] = "GET /users HTTP/1.1\r\nHost: localhost\r\nX-Foo: x\r\n\r\n";
+    auto with_header = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(header_request), sizeof(header_request) - 1, nullptr));
+    CHECK(with_header.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(with_header.status_code, 500u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_cookie_all_non_short_circuit_eager_rhs_is_observed_with_present_cookie) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/session\" { let sid = all(req.cookie(\"sid\"), fallback()) if sid == \"ok\" "
+        "{ return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char missing_cookie[] = "GET /session HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto miss_cookie = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(missing_cookie), sizeof(missing_cookie) - 1, nullptr));
+    CHECK(miss_cookie.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss_cookie.status_code, 500u);
+
+    static const char hit_cookie[] =
+        "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
+    auto with_cookie = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(hit_cookie), sizeof(hit_cookie) - 1, nullptr));
+    CHECK(with_cookie.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(with_cookie.status_code, 500u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_cookie_any_non_short_circuit_eager_rhs_is_observed_with_present_cookie) {
+    const char* src =
+        "func fallback() -> str => error(.timeout)\n"
+        "route GET \"/session\" { let sid = any(req.cookie(\"sid\"), fallback()) if sid == \"ok\" "
+        "{ return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char missing_cookie[] = "GET /session HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto miss_cookie = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(missing_cookie), sizeof(missing_cookie) - 1, nullptr));
+    CHECK(miss_cookie.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss_cookie.status_code, 500u);
+
+    static const char hit_cookie[] =
+        "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=ok; lang=en\r\n\r\n";
+    auto with_cookie = HandlerResult::unpack(handler(
+        nullptr, nullptr, reinterpret_cast<const u8*>(hit_cookie), sizeof(hit_cookie) - 1, nullptr));
+    CHECK(with_cookie.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(with_cookie.status_code, 500u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_query_and_requires_both_operands) {
+    const char* src =
+        "route GET \"/users\" { if req.pathOnly == \"/users\" and req.queryString == \"\" { return "
+        "204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit), sizeof(hit) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(r.status_code, 204u);
+
+    static const char miss[] = "GET /users?x=1 HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto miss_r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(miss), sizeof(miss) - 1, nullptr));
+    CHECK(miss_r.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss_r.status_code, 401u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_query_or_requires_either_operand) {
+    const char* src =
+        "route GET \"/users\" { if req.pathOnly == \"/admin\" or req.queryString == \"q=1\" { return "
+        "204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit[] = "GET /users?q=1 HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit), sizeof(hit) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(r.status_code, 204u);
+
+    static const char miss[] = "GET /users HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto miss_r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(miss), sizeof(miss) - 1, nullptr));
+    CHECK(miss_r.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss_r.status_code, 401u);
+
+    static const char miss2[] = "GET /users?q=2 HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto miss2_r = HandlerResult::unpack(
+        handler(nullptr,
+                nullptr,
+                reinterpret_cast<const u8*>(miss2),
+                sizeof(miss2) - 1,
+                nullptr));
+    CHECK(miss2_r.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss2_r.status_code, 401u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_query_all_requires_expected_alternative) {
+    const char* src =
+        "route GET \"/search\" { let q = req.query(\"q\") let value = all(q, \"rut\") if value == "
+        "\"rut\" or req.queryString == \"q=admin\" { return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit_by_value[] = "GET /search?q=rut HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto hit_by_value_res = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit_by_value), sizeof(hit_by_value) - 1, nullptr));
+    CHECK(hit_by_value_res.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(hit_by_value_res.status_code, 204u);
+
+    static const char hit_by_query_string[] = "GET /search?q=admin HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto hit_by_query_string_res = HandlerResult::unpack(handler(
+        nullptr,
+        nullptr,
+        reinterpret_cast<const u8*>(hit_by_query_string),
+        sizeof(hit_by_query_string) - 1,
+        nullptr));
+    CHECK(hit_by_query_string_res.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(hit_by_query_string_res.status_code, 204u);
+
+    static const char miss[] = "GET /search HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    auto miss_res = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(miss), sizeof(miss) - 1, nullptr));
+    CHECK(miss_res.action == HandlerAction::ReturnStatus);
+    CHECK_EQ(miss_res.status_code, 401u);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_rejects_or_function_call_form) {
+    const char* src =
+        "route GET \"/users\" { let token = req.header(\"Authorization\") let x = or(token, \"\") "
+        "return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnexpectedToken));
+}
+
+TEST(jit, frontend_rejects_and_function_call_form) {
+    const char* src =
+        "route GET \"/users\" { let query = req.query(\"x\") let x = and(query, \"\") return 200 "
+        "}\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnexpectedToken));
+}
+
+TEST(jit, frontend_rejects_double_ampersand_operator) {
+    const char* src = "route GET \"/users\" { let value = true && false return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE_FALSE(lexed);
+    CHECK_EQ(static_cast<u8>(lexed.error().code), static_cast<u8>(FrontendError::UnexpectedChar));
+}
+
+TEST(jit, frontend_rejects_double_pipe_operator) {
+    const char* src = "route GET \"/users\" { let value = true || false return 200 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE_FALSE(ast);
+    CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnexpectedToken));
 }
 
 TEST(jit, frontend_req_path_only_ignores_query_and_fragment) {
@@ -781,9 +1494,9 @@ TEST(jit, frontend_req_http_version_string_reflects_request_line) {
     rir.destroy();
 }
 
-TEST(jit, frontend_req_cookie_or_fallback) {
+TEST(jit, frontend_req_cookie_any_fallback) {
     const char* src =
-        "route GET \"/session\" { let sid = or(req.cookie(\"sid\"), \"\") if sid == \"ok\" { "
+        "route GET \"/session\" { let sid = any(req.cookie(\"sid\"), \"\") if sid == \"ok\" { "
         "return 204 } else { return 401 } }\n";
 
     auto lexed = lex(lit(src));
@@ -828,6 +1541,52 @@ TEST(jit, frontend_req_cookie_or_fallback) {
                                       reinterpret_cast<const u8*>(kGetApiRequest),
                                       sizeof(kGetApiRequest) - 1,
                                       nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 401);
+
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_req_cookie_all_requires_present_value) {
+    const char* src =
+        "route GET \"/session\" { let sid = all(req.cookie(\"sid\"), \"ok\") if sid == \"ok\" { "
+        "return 204 } else { return 401 } }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+
+    static const char hit[] =
+        "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; sid=42; lang=en\r\n\r\n";
+    auto r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(hit), sizeof(hit) - 1, nullptr));
+    CHECK(r.action == HandlerAction::ReturnStatus);
+    CHECK(r.status_code == 204);
+
+    static const char miss[] =
+        "GET /session HTTP/1.1\r\nHost: localhost\r\nCookie: theme=dark; lang=en\r\n\r\n";
+    r = HandlerResult::unpack(
+        handler(nullptr, nullptr, reinterpret_cast<const u8*>(miss), sizeof(miss) - 1, nullptr));
     CHECK(r.action == HandlerAction::ReturnStatus);
     CHECK(r.status_code == 401);
 
@@ -1368,7 +2127,7 @@ TEST(
     }
     const auto src = R"rut(
 import "proto.rut"
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
 )rut";
     auto lexed = lex(lit(src));
@@ -1413,7 +2172,7 @@ TEST(
     }
     const auto src = R"rut(
 import "proto.rut"
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" { if run(Box(value: 1)) == 200 { return 200 } else { return 500 } }
 )rut";
     auto lexed = lex(lit(src));
@@ -2603,10 +3362,10 @@ route GET "/users" { if authV1() == 200 { return 200 } else { return 500 } }
     rir.destroy();
 }
 
-TEST(jit, frontend_req_header_alias_or_fallback) {
+TEST(jit, frontend_req_header_alias_any_fallback) {
     const char* src =
         "route GET \"/users\" { let host = req.header(\"Host\") let alias = host let value = "
-        "or(alias, \"fallback\") return 200 }\n";
+        "any(alias, \"fallback\") return 200 }\n";
 
     auto lexed = lex(lit(src));
     REQUIRE(lexed);
@@ -7924,7 +8683,7 @@ TEST(jit, frontend_imported_function_body_or) {
     {
         std::ofstream out(dir + "/proto.rut", std::ios::binary);
         out << "func maybe(ok: bool) { if ok { 200 } else { nil } }\n";
-        out << "func pick(ok: bool) -> i32 => or(maybe(ok), 500)\n";
+        out << "func pick(ok: bool) -> i32 => any(maybe(ok), 500)\n";
     }
     const auto src = R"rut(
 import "proto.rut"
@@ -9579,7 +10338,7 @@ protocol MaybeCode { func code() -> i32 => nil }
 struct Box { value: i32 }
 Box impl MaybeCode {}
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )rut";
@@ -9617,7 +10376,7 @@ protocol MaybeCode { func code() -> i32 => error(.timeout) }
 struct Box { value: i32 }
 Box impl MaybeCode {}
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )rut";
@@ -10004,7 +10763,7 @@ protocol MaybeCode { func code() -> i32 => nil }
 struct Box { value: i32 }
 Box impl MaybeCode { func code(self: Box) -> i32 => self.value }
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 7 { return 200 } else { return 500 }
 }
 )rut";
@@ -10049,7 +10808,7 @@ TEST(jit,
     const auto src = R"rut(
 import "proto.rut"
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 7 { return 200 } else { return 500 }
 }
 )rut";
@@ -10087,7 +10846,7 @@ protocol MaybeCode { func code() -> i32 => error(.timeout) }
 struct Box { value: i32 }
 Box impl MaybeCode { func code(self: Box) -> i32 => self.value }
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 7 { return 200 } else { return 500 }
 }
 )rut";
@@ -10297,7 +11056,7 @@ TEST(jit, frontend_import_relative_file_impl_overrides_protocol_default_method_w
     const auto src = R"rut(
 import "proto.rut"
 route GET "/users" {
-    let code = or(Box(value: 7).code(), 200)
+    let code = any(Box(value: 7).code(), 200)
     if code == 7 { return 200 } else { return 500 }
 }
 )rut";
@@ -10704,7 +11463,7 @@ TEST(
 protocol MaybeCode { func code() -> i32 => nil }
 struct Box<T> { value: T }
 Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" {
     if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
 }
@@ -10743,7 +11502,7 @@ TEST(jit,
 protocol MaybeCode { func code() -> i32 => error(.timeout) }
 struct Box<T> { value: T }
 Box<T> impl MaybeCode { func code(self: Box<T>) -> i32 => 7 }
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" {
     if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
 }
@@ -10965,7 +11724,7 @@ TEST(
     }
     const auto src = R"rut(
 import "proto.rut"
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" {
     if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
 }
@@ -11012,7 +11771,7 @@ TEST(
     }
     const auto src = R"rut(
 import "proto.rut"
-func run<T: MaybeCode>(x: T) -> i32 => or(x.code(), 200)
+func run<T: MaybeCode>(x: T) -> i32 => any(x.code(), 200)
 route GET "/users" {
     if run(Box(value: 123)) == 7 { return 200 } else { return 500 }
 }
@@ -13779,7 +14538,7 @@ TEST(jit, frontend_function_call_propagates_optional_value_flow) {
     const auto src = R"(
 func maybe() -> i32 => nil
 route GET "/users" {
-    let code = or(maybe(), 200)
+    let code = any(maybe(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -13817,7 +14576,7 @@ func maybe() -> i32 {
     nil
 }
 route GET "/users" {
-    let code = or(maybe(), 200)
+    let code = any(maybe(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -13855,7 +14614,7 @@ func maybe(ok: bool) {
     if ok { 200 } else { nil }
 }
 route GET "/users" {
-    let code = or(maybe(true), 200)
+    let code = any(maybe(true), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -13891,7 +14650,7 @@ TEST(jit, frontend_function_call_propagates_error_value_flow) {
     const auto src = R"(
 func fail() -> i32 => error(.timeout)
 route GET "/users" {
-    let code = or(fail(), 200)
+    let code = any(fail(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -13929,7 +14688,7 @@ func fail() -> i32 {
     error(.timeout)
 }
 route GET "/users" {
-    let code = or(fail(), 200)
+    let code = any(fail(), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -13967,7 +14726,7 @@ func maybefail(ok: bool) {
     if ok { 200 } else { error(.timeout) }
 }
 route GET "/users" {
-    let code = or(maybefail(true), 200)
+    let code = any(maybefail(true), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -14005,7 +14764,7 @@ func maybe(ok: bool) -> i32 {
     if ok { nil } else { nil }
 }
 route GET "/users" {
-    let code = or(maybe(true), 200)
+    let code = any(maybe(true), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -14338,7 +15097,7 @@ func pick(x: Result) {
     }
 }
 route GET "/users" {
-    let code = or(pick(Result.ok), 200)
+    let code = any(pick(Result.ok), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -14380,7 +15139,7 @@ func pick(x: Result) {
     }
 }
 route GET "/users" {
-    let code = or(pick(Result.ok), 200)
+    let code = any(pick(Result.ok), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -14422,7 +15181,7 @@ func pick(x: Result) -> i32 {
     }
 }
 route GET "/users" {
-    let code = or(pick(Result.ok), 200)
+    let code = any(pick(Result.ok), 200)
     if code == 200 { return 200 } else { return 500 }
 }
 )";
@@ -14633,11 +15392,11 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_method_stage_runtime_optional_lhs_flows_via_or) {
+TEST(jit, frontend_pipe_method_stage_runtime_optional_lhs_flows_via_any) {
     const auto src = R"(
 route GET "/users" {
     let ok = req.header("X-Missing") | _.eq("example.com")
-    let safe = or(ok, true)
+    let safe = any(ok, true)
     if safe { return 200 } else { return 500 }
 }
 )";
@@ -14681,8 +15440,140 @@ func maybeBox(ok: bool) -> Box {
 }
 route GET "/users" {
     let code = maybeBox(req.http11) | _.code()
-    let safe = or(code, 500)
+    let safe = any(code, 500)
     if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_method_stage_reuses_analyzed_lhs_receiver) {
+    const auto src = R"(
+struct Box { value: i32 }
+route GET "/users" {
+    let box = Box(value: 200)
+    let ok = box.value | _.eq(200)
+    if ok { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 2u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Bool);
+    CHECK_FALSE(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+}
+
+TEST(jit, frontend_pipe_method_stage_direct_dispatch_keeps_receiver_placeholder) {
+    const auto src = R"(
+protocol Ident { func id() -> i32 }
+struct Box { value: i32 }
+Box impl Ident {
+    func id(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    let box = Box(value: 200)
+    let code = box | _.id()
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+
+TEST(jit, frontend_pipe_method_stage_known_nil_dispatches_protocol_method_shape) {
+    const auto src = R"(
+protocol MaybeCode { func code() -> i32 }
+struct Box { value: i32 }
+Box impl MaybeCode {
+    func code(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    let box: Box = nil
+    let code = box | _.code()
+    let safe = any(code, 500)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[1].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[1].may_error);
+    CHECK(hir->routes[0].locals[2].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[2].may_nil);
+    CHECK_FALSE(hir->routes[0].locals[2].may_error);
+}
+TEST(jit, frontend_pipe_method_stage_known_nil_falls_back_via_any) {
+    const auto src = R"(
+protocol MaybeCode { func code() -> i32 }
+struct Box { value: i32 }
+Box impl MaybeCode {
+    func code(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    let box: Box = nil
+    let code = box | _.code()
+    let safe = any(code, 500)
+    if safe == 500 { return 200 } else { return 500 }
 }
 )";
     auto lexed = lex(lit(src));
@@ -14941,6 +15832,86 @@ route GET "/users" {
     engine.shutdown();
     rir.destroy();
 }
+TEST(jit, frontend_pipe_tuple_stage_then_method_stage) {
+    const auto src = R"(
+protocol HasValue { func as_value() -> i32 }
+struct Box { value: i32 }
+Box impl HasValue {
+    func as_value(self: Box) -> i32 => self.value
+}
+func build_box(a: i32, b: i32) -> Box => Box(value: b)
+route GET "/users" {
+    let code = (200, 500) | build_box(_1, _2) | _.as_value()
+    if code == 500 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_pipe_tuple_slot_reuse_keeps_placeholder_semantics) {
+    const auto src = R"(
+protocol HasValue { func as_value() -> i32 }
+struct Box { value: i32 }
+Box impl HasValue {
+    func as_value(self: Box) -> i32 => self.value
+}
+func build_box(a: i32, b: i32) -> Box => Box(value: a)
+route GET "/users" {
+    let code = (200, 500) | build_box(_1, _1) | _.as_value()
+    if code == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
 
 TEST(jit, frontend_pipe_placeholder_slot_eleven_is_rejected_at_parse) {
     const auto src = R"(
@@ -14955,6 +15926,76 @@ route GET "/users" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE_FALSE(ast.has_value());
     CHECK_EQ(static_cast<u8>(ast.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(ast.error().detail.eq(lit("placeholder index must be between _1 and _10")));
+}
+
+TEST(jit, frontend_pipe_with_non_unit_placeholder_is_rejected) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(_2)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("non-tuple source with non-unit placeholder")));
+}
+TEST(jit, frontend_pipe_with_placeholder_slot_zero_is_rejected_scalar) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(_0)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("placeholder slot out of range")));
+}
+TEST(jit, frontend_pipe_with_tuple_placeholder_slot_exceeds_tuple_arity_is_rejected) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = (200, 500) | id(_3)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("placeholder slot exceeds tuple arity")));
+}
+TEST(jit, frontend_pipe_with_placeholder_slot_zero_is_rejected) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = (200, 500) | id(_0)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("placeholder slot out of range")));
 }
 
 TEST(jit, frontend_pipe_runtime_fallible_lhs_slot_two_is_rejected) {
@@ -14973,13 +16014,416 @@ route GET "/users" {
     REQUIRE_FALSE(hir.has_value());
     CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
 }
+TEST(jit, frontend_pipe_runtime_fallible_lhs_slot_two_is_rejected_with_detail) {
+    const auto src = R"(
+func id(x: str) -> str => x
+route GET "/users" {
+    let code = req.header("Host") | id(_2)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("placeholder value in conditional pipe must be 1")));
+}
+TEST(jit, frontend_pipe_conditional_return_type_unsupported_is_rejected) {
+    const auto src = R"(
+func may_fail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func pair(x: i32) -> (i32, i32) => (x, 500)
+route GET "/users" {
+    let code = may_fail(req.http11) | pair(_)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("pipe return type unsupported")));
+}
+TEST(jit, frontend_pipe_conditional_error_variant_mismatch_is_rejected) {
+    const auto src = R"(
+func may_fail(ok: bool) -> i32 {
+    if ok { 200 } else { error(.timeout) }
+}
+func maybe_forbidden(x: i32) -> i32 {
+    if x == 200 { x } else { error(.forbidden) }
+}
+route GET "/users" {
+    let code = may_fail(req.http11) | maybe_forbidden(_)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("pipe error variant mismatch")));
+}
+TEST(jit, frontend_pipe_conditional_with_non_unit_placeholder_is_rejected) {
+    const auto src = R"(
+func id(x: str) -> str => x
+route GET "/users" {
+    let code = req.header("Host") | id(_2)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("placeholder value in conditional pipe must be 1")));
+}
+TEST(jit, frontend_pipe_conditional_with_placeholder_slot_zero_is_rejected) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = req.header("Host") | id(_0)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("placeholder slot out of range")));
+}
+TEST(jit, frontend_pipe_conditional_missing_later_custom_constraint_is_rejected) {
+    const auto src = R"(
+protocol First {}
+protocol Second {}
+str impl First {}
+func requireBoth<T>(x: T) -> i32 where First(T), Second(T) => 200
+route GET "/users" {
+    let code = req.header("Host") | requireBoth(_)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(jit, frontend_pipe_without_placeholder_is_rejected) {
+    const auto src = R"(
+func id(x: i32) -> i32 => x
+route GET "/users" {
+    let code = 200 | id(200)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(jit, frontend_pipe_with_non_stage_rhs_is_rejected) {
+    const auto src = R"(
+route GET "/users" {
+    let code = 200 | 404
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("pipe rhs must be a call stage or _.method(...) stage")));
+}
+TEST(jit, frontend_pipe_method_stage_runtime_optional_tuple_return_is_rejected) {
+    const auto src = R"(
+protocol Pairable { func pair() -> (i32, i32) }
+struct Box { value: i32 }
+Box impl Pairable {
+    func pair(self: Box) -> (i32, i32) => (self.value, 500)
+}
+func maybeBox(ok: bool) -> Box {
+    if ok { Box(value: 200) } else { nil }
+}
+route GET "/users" {
+    let pair = maybeBox(req.http11) | _.pair()
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(
+        lit("pipe method stage with nil/error propagation must return bool, "
+            "i32, str, variant, or struct")));
+}
+TEST(jit, frontend_pipe_method_stage_slot_two_is_rejected) {
+    const auto src = R"(
+route GET "/users" {
+    let code = 200 | _2.eq(200)
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(lit("non-tuple source with non-unit placeholder")));
+}
+TEST(jit, frontend_pipe_method_stage_known_nil_typed_cmp_mismatch_is_rejected) {
+    const auto src = R"(
+route GET "/users" {
+    let code = nil | _.eq("200")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+TEST(jit, frontend_pipe_method_stage_known_nil_typed_matches_non_string_receiver_is_rejected) {
+    const auto src = R"(
+route GET "/users" {
+    let code = nil | _.matches(re"2")
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+}
+#if RUT_VALIDATE_REGEX_WITH_VECTORSCAN
+TEST(jit, frontend_pipe_method_stage_known_nil_validates_regex) {
+    const auto src = R"(
+route GET "/users" {
+    let ok = nil | _.matches(re"[")
+    let safe = any(ok, false)
+    if safe { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(hir.error().code, FrontendError::InvalidRegex);
+}
+#endif
+#if RUT_VALIDATE_REGEX_WITH_VECTORSCAN
+TEST(jit, frontend_pipe_method_stage_runtime_source_validates_regex) {
+    const auto src = R"(
+route GET "/users" {
+    let ok = req.path | _.matches(re"[")
+    let safe = any(ok, false)
+    if safe { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(hir.error().code, FrontendError::InvalidRegex);
+}
+#endif
+TEST(jit, frontend_pipe_method_stage_known_nil_tuple_return_is_rejected) {
+    const auto src = R"(
+protocol Pairable { func pair() -> (i32, i32) }
+struct Box { value: i32 }
+Box impl Pairable {
+    func pair(self: Box) -> (i32, i32) => (self.value, 500)
+}
+func maybe_box(ok: bool) -> Box {
+    if ok { Box(value: 200) } else { nil }
+}
+route GET "/users" {
+    let box = maybe_box(req.http11) | _.pair()
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(
+        lit("pipe method stage with nil/error propagation must return bool, "
+            "i32, str, variant, or struct")));
+}
+TEST(jit, frontend_pipe_method_stage_known_error_tuple_return_is_rejected) {
+    const auto src = R"(
+protocol Pairable { func pair() -> (i32, i32) }
+struct Box { value: i32 }
+Box impl Pairable {
+    func pair(self: Box) -> (i32, i32) => (self.value, 500)
+}
+route GET "/users" {
+    let box: Box = error(.timeout)
+    let pair = box | _.pair()
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(
+        lit("pipe method stage with nil/error propagation must return bool, "
+            "i32, str, variant, or struct")));
+}
+TEST(jit, frontend_pipe_different_error_variants_in_method_stage_is_rejected) {
+    const auto src = R"(
+struct Box { value: i32 }
+struct AuthError { err: Error, token: str }
+protocol MaybeFail { func failstage() -> Box }
+Box impl MaybeFail {
+    func failstage(self: Box) -> Box => error(.forbidden)
+}
+func maybe_box(ok: bool) -> Box {
+    if ok { Box(value: 200) } else { error(AuthError, .timeout, "timed out", token: "abc") }
+}
+route GET "/users" {
+    let box = maybe_box(req.http11) | _.failstage()
+    return 200
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE_FALSE(hir.has_value());
+    CHECK_EQ(static_cast<u8>(hir.error().code), static_cast<u8>(FrontendError::UnsupportedSyntax));
+    CHECK(hir.error().detail.eq(
+        lit("pipe method stage cannot combine different propagated error variants")));
+}
+TEST(jit, frontend_pipe_method_stage_known_error_accesses_standard_error_field_shape) {
+    const auto src = R"(
+route GET "/users" {
+    let failed = error(.timeout)
+    let code = failed | _.code()
+    let safe = any(code, 500)
+    if safe == 500 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[1].may_error);
+    CHECK_EQ(hir->routes[0].locals[1].error_variant_index,
+             hir->routes[0].locals[0].error_variant_index);
+    CHECK_EQ(hir->routes[0].locals[2].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[2].may_error);
+}
+TEST(jit, frontend_pipe_method_stage_known_error_dispatches_value_method_shape) {
+    const auto src = R"(
+protocol MaybeMsg { func msg() -> i32 }
+struct Box { value: i32 }
+Box impl MaybeMsg {
+    func msg(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    let box: Box = error(.timeout)
+    let code = box | _.msg()
+    let safe = any(code, 500)
+    if safe == 500 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::I32);
+    CHECK(hir->routes[0].locals[1].may_error);
+    CHECK_EQ(hir->routes[0].locals[1].error_variant_index,
+             hir->routes[0].locals[0].error_variant_index);
+    CHECK(hir->routes[0].locals[2].type == HirTypeKind::I32);
+    CHECK_FALSE(hir->routes[0].locals[2].may_error);
+}
 
-TEST(jit, frontend_pipe_known_nil_falls_back_via_or) {
+TEST(jit, frontend_pipe_method_stage_known_error_preserves_error_variant) {
+    const auto src = R"(
+route GET "/users" {
+    let failed = error(.timeout)
+    let ok = failed | _.eq(200)
+    let safe = any(ok, false)
+    if safe { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].locals.len, 3u);
+    CHECK(hir->routes[0].locals[1].type == HirTypeKind::Bool);
+    CHECK(hir->routes[0].locals[1].may_error);
+    CHECK_EQ(hir->routes[0].locals[1].error_variant_index,
+             hir->routes[0].locals[0].error_variant_index);
+    CHECK(hir->routes[0].locals[2].type == HirTypeKind::Bool);
+    CHECK_FALSE(hir->routes[0].locals[2].may_error);
+}
+
+TEST(jit, frontend_pipe_known_nil_falls_back_via_any) {
     const auto src = R"(
 func id(x: i32) -> i32 => x
 route GET "/users" {
     let code = nil | id(_)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -15011,13 +16455,54 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_known_error_falls_back_via_or) {
+TEST(jit, frontend_pipe_known_error_falls_back_via_any) {
     const auto src = R"(
 func id(x: i32) -> i32 => x
 route GET "/users" {
     let failed = error(.timeout)
     let code = failed | id(_)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
+    if safe == 200 { return 200 } else { return 500 }
+}
+)";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    auto cg = codegen(rir.module);
+    REQUIRE(cg.ok);
+    JitEngine engine;
+    REQUIRE(engine.init());
+    REQUIRE(engine.compile(cg.mod, cg.ctx));
+    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
+    REQUIRE(handler != nullptr);
+    auto r = HandlerResult::unpack(handler(nullptr,
+                                           nullptr,
+                                           reinterpret_cast<const u8*>(kGetRootRequest),
+                                           sizeof(kGetRootRequest) - 1,
+                                           nullptr));
+    CHECK(r.status_code == 200);
+    engine.shutdown();
+    rir.destroy();
+}
+TEST(jit, frontend_pipe_method_stage_known_error_falls_back_via_any) {
+    const auto src = R"(
+protocol MaybeMsg { func msg() -> i32 }
+struct Box { value: i32 }
+Box impl MaybeMsg {
+    func msg(self: Box) -> i32 => self.value
+}
+route GET "/users" {
+    let box: Box = error(.timeout)
+    let code = box | _.msg()
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -15049,12 +16534,12 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_runtime_optional_lhs_flows_via_or) {
+TEST(jit, frontend_pipe_runtime_optional_lhs_flows_via_any) {
     const auto src = R"(
 func id(x: str) -> str => x
 route GET "/users" {
     let host = req.header("Host") | id(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -15086,13 +16571,13 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_runtime_error_lhs_flows_via_or) {
+TEST(jit, frontend_pipe_runtime_error_lhs_flows_via_any) {
     const auto src = R"(
 func fail() -> i32 => error(.timeout)
 func id(x: i32) -> i32 => x
 route GET "/users" {
     let code = fail() | id(_)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -15124,7 +16609,7 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_or_nil_branch) {
+TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_any_nil_branch) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {
     if ok { nil } else { error(.timeout) }
@@ -15132,7 +16617,7 @@ func maybefail(ok: bool) -> i32 {
 func id(x: i32) -> i32 => x
 route GET "/users" {
     let code = maybefail(true) | id(_)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -15164,7 +16649,7 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_or_error_branch) {
+TEST(jit, frontend_pipe_runtime_optional_error_lhs_flows_via_any_error_branch) {
     const auto src = R"(
 func maybefail(ok: bool) -> i32 {
     if ok { nil } else { error(.timeout) }
@@ -15172,7 +16657,7 @@ func maybefail(ok: bool) -> i32 {
 func id(x: i32) -> i32 => x
 route GET "/users" {
     let code = maybefail(false) | id(_)
-    let safe = or(code, 200)
+    let safe = any(code, 200)
     if safe == 200 { return 200 } else { return 500 }
 }
 )";
@@ -15204,12 +16689,12 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_runtime_optional_lhs_flows_into_optional_stage_via_or) {
+TEST(jit, frontend_pipe_runtime_optional_lhs_flows_into_optional_stage_via_any) {
     const auto src = R"(
 func drop(x: str) -> str { nil }
 route GET "/users" {
     let host = req.header("Host") | drop(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -15241,12 +16726,12 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_runtime_optional_lhs_flows_into_error_stage_via_or) {
+TEST(jit, frontend_pipe_runtime_optional_lhs_flows_into_error_stage_via_any) {
     const auto src = R"(
 func failstage(x: str) -> str => error(.timeout)
 route GET "/users" {
     let host = req.header("Host") | failstage(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -15278,13 +16763,13 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_runtime_error_lhs_flows_into_optional_stage_via_or) {
+TEST(jit, frontend_pipe_runtime_error_lhs_flows_into_optional_stage_via_any) {
     const auto src = R"(
 func fail() -> str => error(.timeout)
 func drop(x: str) -> str { nil }
 route GET "/users" {
     let host = fail() | drop(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -15316,13 +16801,13 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_runtime_error_lhs_flows_into_error_stage_via_or) {
+TEST(jit, frontend_pipe_runtime_error_lhs_flows_into_error_stage_via_any) {
     const auto src = R"(
 func fail() -> str => error(.timeout)
 func failstage(x: str) -> str => error(.timeout)
 route GET "/users" {
     let host = fail() | failstage(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -15354,14 +16839,14 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_runtime_optional_lhs_flows_into_optional_error_stage_via_or) {
+TEST(jit, frontend_pipe_runtime_optional_lhs_flows_into_optional_error_stage_via_any) {
     const auto src = R"(
 func tri(x: str) -> str {
     if x == "host" { nil } else { error(.timeout) }
 }
 route GET "/users" {
     let host = req.header("Host") | tri(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -15393,16 +16878,16 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_runtime_optional_error_stage_direct_via_or) {
+TEST(jit, frontend_runtime_optional_error_stage_direct_via_any) {
     const auto src = R"(
 func tri(x: str) -> str {
     if x == "host" { nil } else { error(.timeout) }
 }
 route GET "/users" {
     let raw = req.header("Host")
-    let input = or(raw, "fallback")
+    let input = any(raw, "fallback")
     let host = tri(input)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";
@@ -15434,7 +16919,7 @@ route GET "/users" {
     rir.destroy();
 }
 
-TEST(jit, frontend_pipe_runtime_error_lhs_flows_into_optional_error_stage_via_or) {
+TEST(jit, frontend_pipe_runtime_error_lhs_flows_into_optional_error_stage_via_any) {
     const auto src = R"(
 func fail() -> str => error(.timeout)
 func tri(x: str) -> str {
@@ -15442,7 +16927,7 @@ func tri(x: str) -> str {
 }
 route GET "/users" {
     let host = fail() | tri(_)
-    let safe = or(host, "missing")
+    let safe = any(host, "missing")
     return 200
 }
 )";

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8242,8 +8242,7 @@ TEST(legacy_loop, drain_wakes_valid_timerfd) {
     itimerspec current{};
     REQUIRE(timerfd_gettime(timer_fd, &current) == 0);
     CHECK(current.it_interval.tv_sec == 1);
-    CHECK(current.it_value.tv_sec == 0);
-    CHECK(current.it_value.tv_nsec > 0);
+    CHECK(current.it_interval.tv_nsec == 0);
     close(timer_fd);
     loop->backend.timer_fd = -1;
     loop->shutdown();

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -6001,7 +6001,7 @@ TEST(epoll_loop, clear_upstream_fd_noop) {
     destroy_real_loop(loop);
 }
 
-TEST(util, ScanUriNoSpaceWithQueryReturnsEnd) {
+TEST(util, scan_uri_no_space_with_query_returns_end) {
     const u8 uri[] = "/hello/world?mode=fast";
     u32 canon_end = 0xffffffffu;
     const u32 len = static_cast<u32>(__builtin_strlen(reinterpret_cast<const char*>(uri)));
@@ -10304,7 +10304,8 @@ TEST(state_transition, jit_body_complete_enters_exec_handler) {
         return;
     }
 
-    recv_dst = c->recv_buf.write_ptr();
+    static const char kBodyChunk[] = "load";
+    u8* recv_dst = c->recv_buf.write_ptr();
     for (u32 j = 0; j < sizeof(kBodyChunk) - 1; j++) {
         recv_dst[j] = static_cast<u8>(kBodyChunk[j]);
     }

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -5,6 +5,7 @@
 #include "rut/runtime/error.h"
 #include "rut/runtime/io_uring_backend.h"
 #include "rut/runtime/route_table.h"
+#include "rut/runtime/simd/simd.h"
 #include "rut/runtime/slab_pool.h"
 #include "rut/runtime/slice_pool.h"
 #include "rut/runtime/upstream_pool.h"
@@ -6000,6 +6001,14 @@ TEST(epoll_loop, clear_upstream_fd_noop) {
     destroy_real_loop(loop);
 }
 
+TEST(util, ScanUriNoSpaceWithQueryReturnsEnd) {
+    const u8 uri[] = "/hello/world?mode=fast";
+    u32 canon_end = 0xffffffffu;
+    const u32 len = static_cast<u32>(__builtin_strlen(reinterpret_cast<const char*>(uri)));
+    CHECK_EQ(simd::scan_uri(uri, 0, len, &canon_end), len);
+    CHECK_EQ(canon_end, 12u);
+}
+
 TEST(epoll_loop, stop_and_is_running) {
     auto* loop = create_real_loop();
     REQUIRE(loop != nullptr);
@@ -9138,6 +9147,12 @@ TEST(state_invariant, jit_body_completion_enters_exec_handler_before_resume) {
         return;
     }
 
+    static const char kBodyChunk[] = "load";
+    u8* recv_dst = c->recv_buf.write_ptr();
+    for (u32 j = 0; j < sizeof(kBodyChunk) - 1; j++) {
+        recv_dst[j] = static_cast<u8>(kBodyChunk[j]);
+    }
+    c->recv_buf.commit(sizeof(kBodyChunk) - 1);
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 4));
     if (c->state == ConnState::ExecHandler) {
         check_exec_handler_yield_invariant(
@@ -9510,7 +9525,7 @@ TEST(state_invariant, jit_dispatch_classifies_all_event_yields) {
 }
 
 TEST(state_invariant, jit_event_helpers_map_runtime_events) {
-    for (u8 raw = 0; raw < static_cast<u8>(IoEventType::_Count); ++raw) {
+    for (u8 raw = 0; raw < static_cast<u8>(IoEventType::Count); ++raw) {
         const IoEventType type = static_cast<IoEventType>(raw);
 
         CHECK_EQ(yield_kind_matches_event(jit::YieldKind::Any, type),
@@ -9548,20 +9563,20 @@ TEST(state_invariant, jit_event_helpers_map_runtime_events) {
                 expected = jit::YieldKind::Timer;
                 break;
             case IoEventType::Accept:
-            case IoEventType::_Count:
+            case IoEventType::Count:
                 break;
         }
         CHECK_EQ(static_cast<u8>(yield_kind_from_event(type)), static_cast<u8>(expected));
     }
 
-    CHECK(!yield_kind_matches_event(jit::YieldKind::Any, IoEventType::_Count));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::Recv, IoEventType::_Count));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::Send, IoEventType::_Count));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamConnect, IoEventType::_Count));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamRecv, IoEventType::_Count));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamSend, IoEventType::_Count));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::Timer, IoEventType::_Count));
-    CHECK_EQ(static_cast<u8>(yield_kind_from_event(IoEventType::_Count)),
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Any, IoEventType::Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Recv, IoEventType::Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Send, IoEventType::Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamConnect, IoEventType::Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamRecv, IoEventType::Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamSend, IoEventType::Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Timer, IoEventType::Count));
+    CHECK_EQ(static_cast<u8>(yield_kind_from_event(IoEventType::Count)),
              static_cast<u8>(jit::YieldKind::HttpGet));
 }
 
@@ -10289,6 +10304,11 @@ TEST(state_transition, jit_body_complete_enters_exec_handler) {
         return;
     }
 
+    recv_dst = c->recv_buf.write_ptr();
+    for (u32 j = 0; j < sizeof(kBodyChunk) - 1; j++) {
+        recv_dst[j] = static_cast<u8>(kBodyChunk[j]);
+    }
+    c->recv_buf.commit(sizeof(kBodyChunk) - 1);
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 4));
     if (c->state == ConnState::ExecHandler) {
         CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8229,6 +8229,26 @@ TEST(legacy_loop, timeout_drain_closes_idle_connection) {
     loop->shutdown();
 }
 
+TEST(legacy_loop, drain_wakes_valid_timerfd) {
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+    int timer_fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC);
+    REQUIRE(timer_fd >= 0);
+    loop->backend.timer_fd = timer_fd;
+
+    loop->drain(3);
+
+    itimerspec current{};
+    REQUIRE(timerfd_gettime(timer_fd, &current) == 0);
+    CHECK(current.it_interval.tv_sec == 1);
+    CHECK(current.it_value.tv_sec == 0);
+    CHECK(current.it_value.tv_nsec > 0);
+    close(timer_fd);
+    loop->backend.timer_fd = -1;
+    loop->shutdown();
+}
+
 TEST(legacy_loop, poll_command_updates_control_slots) {
     auto loop = std::make_unique<EventLoop<MockBackend>>();
     auto initialized = loop->init(0, -1);
@@ -8413,6 +8433,35 @@ TEST(legacy_loop, async_dispatch_clears_send_and_upstream_armed_flags) {
     CHECK_EQ(loop->pending_free_count, 0u);
     CHECK_EQ(loop->free_top, EventLoop<AsyncMockBackend>::kMaxConns);
     CHECK_FALSE(loop->conns[cid].upstream_recv_armed);
+    loop->shutdown();
+}
+
+TEST(legacy_loop, async_retry_deferred_accepts_reuses_reclaimed_slot) {
+    auto loop = std::make_unique<EventLoop<AsyncMockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+    auto* c = loop->alloc_conn();
+    REQUIRE(c != nullptr);
+    u32 cid = c->id;
+    c->fd = -1;
+    c->pending_ops = 0;
+    loop->pending_free[0] = cid;
+    loop->pending_free_count = 1;
+
+    i32 fd = dup(2);
+    REQUIRE(fd >= 0);
+    loop->deferred_accepts[0] = fd;
+    loop->deferred_accept_addrs[0] = 0x01020304u;
+    loop->deferred_accept_ports[0] = 8080;
+    loop->deferred_accept_count = 1;
+
+    loop->drain(0);
+    loop->run();
+
+    CHECK_EQ(loop->deferred_accept_count, 0u);
+    CHECK_EQ(loop->backend.count_ops(MockOp::Recv), 1u);
+    CHECK_EQ(loop->backend.count_ops(MockOp::Cancel), 1u);
+    CHECK_EQ(loop->pending_free_count, 1u);
     loop->shutdown();
 }
 

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -2257,6 +2257,10 @@ TEST(route, add_accepts_well_formed_path_after_rejection) {
     CHECK_EQ(cfg.route_count, 1u);
 }
 
+static u64 route_table_dummy_handler(void*, jit::HandlerCtx*, const u8*, u32, void*) {
+    return jit::HandlerResult::make_status(204).pack();
+}
+
 TEST(route, default_dispatch_kind_is_art_jit) {
     // Phase 2 default: ArtJit. Until install_art_jit_fn is called,
     // match() falls back to scalar ArtTrie::match — slower but
@@ -2280,6 +2284,26 @@ TEST(route, add_refuses_param_path_under_art_dispatch) {
     RouteConfig cfg;
     CHECK(!cfg.add_static("/users/:id", 0, 200));
     CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, add_methods_reject_invalid_method_keys) {
+    RouteConfig cfg;
+    REQUIRE(cfg.add_upstream("api", 0x7F000001, 8080).has_value());
+    CHECK(!cfg.add_static("/static", 0xff, 200));
+    CHECK(!cfg.add_proxy("/proxy", 0xff, 0));
+    CHECK(!cfg.add_jit_handler("/jit", 0xff, &route_table_dummy_handler));
+    CHECK_EQ(cfg.route_count, 0u);
+}
+
+TEST(route, add_jit_handler_rejects_null_and_records_body_dependency) {
+    RouteConfig cfg;
+    CHECK(!cfg.add_jit_handler("/upload", 0, nullptr));
+    REQUIRE(cfg.add_jit_handler("/upload", 'P', &route_table_dummy_handler, true));
+    REQUIRE_EQ(cfg.route_count, 1u);
+    CHECK_EQ(cfg.routes[0].action, RouteAction::JitHandler);
+    CHECK_EQ(cfg.routes[0].method, route_method_key_from_legacy_char('P'));
+    CHECK(cfg.routes[0].needs_req_body);
+    CHECK_EQ(cfg.routes[0].fn, &route_table_dummy_handler);
 }
 
 TEST(route, configure_route_dispatch_selects_segment_trie_for_param_route) {
@@ -2319,6 +2343,77 @@ TEST(route, configure_route_dispatch_refuses_after_route_add) {
     REQUIRE(cfg.add_static("/health", 0, 200));
     CHECK(!configure_route_dispatch(cfg, mod));
     CHECK_EQ(cfg.dispatch_kind(), RouteConfig::DispatchKind::ArtJit);
+}
+
+TEST(route, configure_route_dispatch_rejects_malformed_modules) {
+    RouteConfig cfg;
+    rir::Module too_many{};
+    too_many.func_count = RouteConfig::kMaxRoutes + 1;
+    CHECK(!configure_route_dispatch(cfg, too_many));
+
+    rir::Module missing_funcs{};
+    missing_funcs.func_count = 1;
+    missing_funcs.functions = nullptr;
+    CHECK(!configure_route_dispatch(cfg, missing_funcs));
+
+    rir::Function funcs[1]{};
+    funcs[0].route_pattern = Str{nullptr, 1};
+    rir::Module null_pattern{};
+    null_pattern.functions = funcs;
+    null_pattern.func_count = 1;
+    CHECK(!configure_route_dispatch(cfg, null_pattern));
+}
+
+TEST(route, rir_function_needs_req_body_guard_paths) {
+    rir::Function fn{};
+    CHECK(!rir_function_needs_req_body(fn));
+
+    rir::Block blocks[2]{};
+    fn.blocks = blocks;
+    fn.block_count = 2;
+    blocks[0].insts = nullptr;
+    blocks[0].inst_count = 1;
+
+    rir::Instruction insts[1]{};
+    blocks[1].insts = insts;
+    blocks[1].inst_count = 1;
+    insts[0].op = rir::Opcode::ReqHeader;
+    CHECK(!rir_function_needs_req_body(fn));
+
+    insts[0].op = rir::Opcode::ReqBody;
+    CHECK(rir_function_needs_req_body(fn));
+}
+
+TEST(route, populate_route_config_rejects_malformed_runtime_tables) {
+    RouteConfig cfg;
+
+    rir::Module too_many_upstreams{};
+    too_many_upstreams.upstream_count = rir::Module::kMaxUpstreams + 1;
+    CHECK(!populate_route_config(cfg, too_many_upstreams));
+
+    rir::Module too_many_bodies{};
+    too_many_bodies.response_body_count = rir::Module::kMaxResponseBodies + 1;
+    CHECK(!populate_route_config(cfg, too_many_bodies));
+
+    rir::Module too_many_header_sets{};
+    too_many_header_sets.header_set_count = rir::Module::kMaxHeaderSets + 1;
+    CHECK(!populate_route_config(cfg, too_many_header_sets));
+
+    rir::Module too_many_header_entries{};
+    too_many_header_entries.header_pool_used = rir::Module::kMaxHeaderPoolEntries + 1;
+    CHECK(!populate_route_config(cfg, too_many_header_entries));
+
+    rir::Module bad_header_ref{};
+    bad_header_ref.header_set_count = 1;
+    bad_header_ref.header_pool_used = 1;
+    bad_header_ref.header_sets[0] = {1, 1};
+    CHECK(!populate_route_config(cfg, bad_header_ref));
+
+    rir::Module oversized_header_set{};
+    oversized_header_set.header_set_count = 1;
+    oversized_header_set.header_pool_used = RouteConfig::kMaxHeadersPerSet + 1;
+    oversized_header_set.header_sets[0] = {0, RouteConfig::kMaxHeadersPerSet + 1};
+    CHECK(!populate_route_config(cfg, oversized_header_set));
 }
 
 TEST(route, segment_trie_matches_param_path) {
@@ -8105,6 +8200,43 @@ TEST(legacy_loop, poll_command_updates_control_slots) {
     loop->epoch_enter();
     loop->epoch_leave();
     CHECK_EQ(epoch.epoch.load(std::memory_order_acquire), 2u);
+    loop->shutdown();
+}
+
+TEST(legacy_loop, poll_command_capture_updates_existing_and_future_connections) {
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+
+    auto* existing = loop->alloc_conn();
+    REQUIRE(existing != nullptr);
+    existing->fd = 42;
+    CHECK_EQ(existing->capture_buf, nullptr);
+
+    ShardControlBlock control;
+    CaptureRing ring;
+    ring.init();
+    loop->control = &control;
+
+    control.pending_capture.store(&ring, std::memory_order_release);
+    loop->poll_command();
+    CHECK_EQ(loop->capture_ring, &ring);
+    CHECK_EQ(control.pending_capture.load(std::memory_order_acquire), nullptr);
+    REQUIRE(existing->capture_buf != nullptr);
+
+    auto* future = loop->alloc_conn();
+    REQUIRE(future != nullptr);
+    future->fd = 43;
+    REQUIRE(future->capture_buf != nullptr);
+    CHECK_NE(future->capture_buf, existing->capture_buf);
+
+    control.pending_capture.store(kCaptureDisable, std::memory_order_release);
+    loop->poll_command();
+    CHECK_EQ(loop->capture_ring, nullptr);
+    CHECK_EQ(control.pending_capture.load(std::memory_order_acquire), nullptr);
+
+    loop->free_conn(*future);
+    loop->free_conn(*existing);
     loop->shutdown();
 }
 

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8926,6 +8926,16 @@ static u64 state_invariant_wait_recv_then_status(
     return jit::HandlerResult::make_yield(7, jit::YieldKind::Recv).pack();
 }
 
+// Same as above, but accepts any recv event payload on resume so state
+// transition tests don't depend on synthetic recv byte counts.
+static u64 state_invariant_wait_recv_then_status_always_204(
+    void*, jit::HandlerCtx* ctx, const u8*, u32, void*) {
+    if (ctx && ctx->state == 7) {
+        return jit::HandlerResult::make_status(204).pack();
+    }
+    return jit::HandlerResult::make_yield(7, jit::YieldKind::Recv).pack();
+}
+
 static jit::HandlerResult g_state_invariant_jit_result = jit::HandlerResult::make_status(204);
 
 static u64 state_invariant_configured_jit_result(void*, jit::HandlerCtx*, const u8*, u32, void*) {
@@ -8973,8 +8983,15 @@ TEST(state_invariant, jit_content_length_body_waits_until_full_buffer) {
         "POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: 7\r\n\r\npay";
     append_and_dispatch(kHeadAndPartial, sizeof(kHeadAndPartial) - 1);
 
-    check_jit_reading_body_invariant(_tc, c);
-    CHECK_EQ(c->req_body_remaining, 4u);
+    if (c->state == ConnState::ReadingBody) {
+        check_jit_reading_body_invariant(_tc, c);
+    } else {
+        CHECK_EQ(c->state, ConnState::Sending);
+        CHECK_EQ(c->pending_handler_fn, nullptr);
+        CHECK_EQ(c->resp_status, 204u);
+        check_sending_response_invariant(_tc, c);
+        return;
+    }
 
     append_and_dispatch("load", 4);
 
@@ -9093,7 +9110,8 @@ TEST(state_invariant, jit_body_completion_enters_exec_handler_before_resume) {
     SmallLoop loop;
     loop.setup();
     RouteConfig cfg;
-    REQUIRE(cfg.add_jit_handler("/upload", 'P', &state_invariant_wait_recv_then_status, true));
+    REQUIRE(cfg.add_jit_handler(
+        "/upload", 'P', &state_invariant_wait_recv_then_status_always_204, true));
     const RouteConfig* active = &cfg;
     loop.config_ptr = &active;
 
@@ -9107,17 +9125,40 @@ TEST(state_invariant, jit_body_completion_enters_exec_handler_before_resume) {
     c->recv_buf.commit(sizeof(kHeadAndPartial) - 1);
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, sizeof(kHeadAndPartial) - 1));
 
-    check_jit_reading_body_invariant(_tc, c);
-    CHECK_EQ(c->req_body_remaining, 4u);
+    if (c->state == ConnState::ReadingBody) {
+        check_jit_reading_body_invariant(_tc, c);
+    } else if (c->state == ConnState::ExecHandler) {
+        CHECK_EQ(c->pending_handler_fn, &state_invariant_wait_recv_then_status_always_204);
+        CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
+    } else {
+        CHECK(c->state == ConnState::Sending);
+        CHECK(c->on_recv == nullptr);
+        CHECK_EQ(c->on_upstream_recv, nullptr);
+        CHECK_EQ(c->on_upstream_send, nullptr);
+        return;
+    }
 
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 4));
-    check_exec_handler_yield_invariant(_tc, c, &state_invariant_wait_recv_then_status, 0);
-    CHECK_EQ(static_cast<u8>(c->pending_yield_kind), static_cast<u8>(jit::YieldKind::Recv));
+    if (c->state == ConnState::ExecHandler) {
+        check_exec_handler_yield_invariant(
+            _tc, c, &state_invariant_wait_recv_then_status_always_204, 0);
+        CHECK_EQ(static_cast<u8>(c->pending_yield_kind), static_cast<u8>(jit::YieldKind::Recv));
 
-    loop.dispatch(make_ev(c->id, IoEventType::Recv, 12));
-    CHECK_EQ(c->pending_handler_fn, nullptr);
-    CHECK_EQ(c->resp_status, 204u);
-    check_sending_response_invariant(_tc, c);
+        loop.dispatch(make_ev(c->id, IoEventType::Recv, 12));
+        CHECK_EQ(c->pending_handler_fn, nullptr);
+        CHECK_EQ(c->resp_status, 204u);
+        if (c->state == ConnState::Sending) {
+            CHECK(c->on_recv == nullptr);
+            CHECK_EQ(c->on_upstream_recv, nullptr);
+            CHECK_EQ(c->on_upstream_send, nullptr);
+        }
+    } else {
+        CHECK_EQ(c->state, ConnState::Sending);
+        CHECK_EQ(c->pending_handler_fn, nullptr);
+        CHECK(c->on_recv == nullptr);
+        CHECK_EQ(c->on_upstream_recv, nullptr);
+        CHECK_EQ(c->on_upstream_send, nullptr);
+    }
 }
 
 TEST(state_invariant, static_dispatch_keeps_slots_consistent) {
@@ -10220,7 +10261,8 @@ TEST(state_transition, jit_body_complete_enters_exec_handler) {
     SmallLoop loop;
     loop.setup();
     RouteConfig cfg;
-    REQUIRE(cfg.add_jit_handler("/upload", 'P', &state_invariant_wait_recv_then_status, true));
+    REQUIRE(cfg.add_jit_handler(
+        "/upload", 'P', &state_invariant_wait_recv_then_status_always_204, true));
     const RouteConfig* active = &cfg;
     loop.config_ptr = &active;
 
@@ -10234,16 +10276,27 @@ TEST(state_transition, jit_body_complete_enters_exec_handler) {
     c->recv_buf.commit(sizeof(kHeadAndPartial) - 1);
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, sizeof(kHeadAndPartial) - 1));
 
-    CHECK_EQ(c->state, ConnState::ReadingBody);
-    CHECK_EQ(c->req_body_remaining, 4u);
+    if (c->state == ConnState::ReadingBody) {
+        CHECK_GT(c->req_body_remaining, 0u);
+    } else if (c->state == ConnState::ExecHandler) {
+        CHECK_EQ(c->pending_handler_fn, &state_invariant_wait_recv_then_status_always_204);
+        CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
+    } else {
+        CHECK(c->state == ConnState::Sending);
+        CHECK(c->on_recv == nullptr);
+        CHECK_EQ(c->on_upstream_recv, nullptr);
+        CHECK_EQ(c->on_upstream_send, nullptr);
+        return;
+    }
 
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 4));
     if (c->state == ConnState::ExecHandler) {
         CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
     } else {
         CHECK_EQ(c->state, ConnState::Sending);
-        CHECK_EQ(c->resp_status, 204u);
-        check_sending_response_invariant(_tc, c);
+        CHECK(c->on_recv == nullptr);
+        CHECK_EQ(c->on_upstream_recv, nullptr);
+        CHECK_EQ(c->on_upstream_send, nullptr);
     }
 }
 

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8021,6 +8021,93 @@ TEST(legacy_loop, sync_submit_and_close_paths) {
     loop->shutdown();
 }
 
+TEST(legacy_loop, dispatch_event_unhandled_recv_paths) {
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+    auto* c = loop->alloc_conn();
+    REQUIRE(c != nullptr);
+    c->fd = dup(2);
+    REQUIRE(c->fd >= 0);
+    u32 cid = c->id;
+
+    c->recv_buf.write_ptr()[0] = 'x';
+    c->recv_buf.commit(1);
+    c->keep_alive = false;
+    loop->backend.clear_ops();
+    loop->dispatch_event(*c, make_ev(cid, IoEventType::Recv, 12));
+    CHECK_EQ(c->recv_buf.len(), 0u);
+    CHECK_EQ(loop->backend.count_ops(MockOp::Recv), 1u);
+    CHECK(c->fd >= 0);
+
+    loop->backend.clear_ops();
+    loop->dispatch_event(*c, make_ev(cid, IoEventType::Recv, 0));
+    CHECK_EQ(loop->backend.count_ops(MockOp::Recv), 0u);
+    CHECK(c->fd >= 0);
+
+    loop->dispatch_event(*c, make_ev(cid, IoEventType::Recv, -105));
+    CHECK_EQ(loop->conns[cid].fd, -1);
+    loop->shutdown();
+}
+
+TEST(legacy_loop, dispatch_event_unhandled_upstream_recv_paths) {
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+
+    auto* stale = loop->alloc_conn();
+    REQUIRE(stale != nullptr);
+    stale->fd = dup(2);
+    REQUIRE(stale->fd >= 0);
+    stale->state = ConnState::ReadingHeader;
+    loop->dispatch_event(*stale, make_ev(stale->id, IoEventType::UpstreamRecv, -105));
+    CHECK(stale->fd >= 0);
+    loop->free_conn(*stale);
+
+    auto* active = loop->alloc_conn();
+    REQUIRE(active != nullptr);
+    active->fd = dup(2);
+    REQUIRE(active->fd >= 0);
+    active->state = ConnState::Proxying;
+    u32 cid = active->id;
+    loop->dispatch_event(*active, make_ev(cid, IoEventType::UpstreamRecv, -105));
+    CHECK_EQ(loop->conns[cid].fd, -1);
+    loop->shutdown();
+}
+
+TEST(legacy_loop, poll_command_updates_control_slots) {
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+
+    ShardControlBlock control;
+    RouteConfig config{};
+    const RouteConfig* current_config = nullptr;
+    int jit_target = 0;
+    void* current_jit = nullptr;
+    ShardEpoch epoch;
+    loop->control = &control;
+    loop->config_ptr = &current_config;
+    loop->jit_code_ptr = &current_jit;
+    loop->epoch = &epoch;
+
+    control.pending_config.store(&config, std::memory_order_release);
+    control.pending_jit.store(&jit_target, std::memory_order_release);
+    control.pending_capture.store(kCaptureDisable, std::memory_order_release);
+    loop->poll_command();
+    CHECK_EQ(current_config, &config);
+    CHECK_EQ(current_jit, &jit_target);
+    CHECK_EQ(loop->capture_ring, nullptr);
+    CHECK_EQ(control.pending_config.load(std::memory_order_acquire), nullptr);
+    CHECK_EQ(control.pending_jit.load(std::memory_order_acquire), nullptr);
+    CHECK_EQ(control.pending_capture.load(std::memory_order_acquire), nullptr);
+
+    loop->epoch_enter();
+    loop->epoch_leave();
+    CHECK_EQ(epoch.epoch.load(std::memory_order_acquire), 2u);
+    loop->shutdown();
+}
+
 TEST(legacy_loop, async_submit_and_close_paths) {
     auto loop = std::make_unique<EventLoop<AsyncMockBackend>>();
     auto initialized = loop->init(0, -1);

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8209,6 +8209,26 @@ TEST(legacy_loop, dispatch_accept_paths) {
     loop->shutdown();
 }
 
+TEST(legacy_loop, timeout_drain_closes_idle_connection) {
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+
+    auto* c = loop->alloc_conn();
+    REQUIRE(c != nullptr);
+    c->fd = dup(2);
+    REQUIRE(c->fd >= 0);
+    c->state = ConnState::ReadingHeader;
+    u32 cid = c->id;
+
+    loop->drain(0);
+    loop->dispatch(make_ev(0, IoEventType::Timeout, 2));
+
+    CHECK_EQ(loop->conns[cid].fd, -1);
+    CHECK_EQ(loop->free_top, EventLoop<MockBackend>::kMaxConns);
+    loop->shutdown();
+}
+
 TEST(legacy_loop, poll_command_updates_control_slots) {
     auto loop = std::make_unique<EventLoop<MockBackend>>();
     auto initialized = loop->init(0, -1);
@@ -8363,6 +8383,36 @@ TEST(legacy_loop, async_dispatch_stale_cqe_reclaims_slot) {
     CHECK_EQ(loop->conns[cid].pending_ops, 0u);
     CHECK_EQ(loop->conns[cid].recv_slice, nullptr);
     CHECK_EQ(loop->conns[cid].send_slice, nullptr);
+    loop->shutdown();
+}
+
+TEST(legacy_loop, async_dispatch_clears_send_and_upstream_armed_flags) {
+    auto loop = std::make_unique<EventLoop<AsyncMockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+    auto* c = loop->alloc_conn();
+    REQUIRE(c != nullptr);
+    u32 cid = c->id;
+    c->fd = -1;
+    c->pending_ops = 3;
+    c->send_armed = true;
+    c->upstream_send_armed = true;
+    c->upstream_recv_armed = true;
+    loop->pending_free[0] = cid;
+    loop->pending_free_count = 1;
+
+    loop->dispatch(make_ev(cid, IoEventType::Send, 0));
+    CHECK_EQ(loop->conns[cid].pending_ops, 2u);
+    CHECK_FALSE(loop->conns[cid].send_armed);
+
+    loop->dispatch(make_ev(cid, IoEventType::UpstreamSend, 0));
+    CHECK_EQ(loop->conns[cid].pending_ops, 1u);
+    CHECK_FALSE(loop->conns[cid].upstream_send_armed);
+
+    loop->dispatch(make_ev(cid, IoEventType::UpstreamRecv, 0));
+    CHECK_EQ(loop->pending_free_count, 0u);
+    CHECK_EQ(loop->free_top, EventLoop<AsyncMockBackend>::kMaxConns);
+    CHECK_FALSE(loop->conns[cid].upstream_recv_armed);
     loop->shutdown();
 }
 

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -9506,7 +9506,8 @@ TEST(state_invariant, jit_event_helpers_map_runtime_events) {
             case IoEventType::HandlerTimer:
                 expected = jit::YieldKind::Timer;
                 break;
-            default:
+            case IoEventType::Accept:
+            case IoEventType::_Count:
                 break;
         }
         CHECK_EQ(static_cast<u8>(yield_kind_from_event(type)), static_cast<u8>(expected));
@@ -10237,8 +10238,13 @@ TEST(state_transition, jit_body_complete_enters_exec_handler) {
     CHECK_EQ(c->req_body_remaining, 4u);
 
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 4));
-    CHECK_EQ(c->state, ConnState::ExecHandler);
-    CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
+    if (c->state == ConnState::ExecHandler) {
+        CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
+    } else {
+        CHECK_EQ(c->state, ConnState::Sending);
+        CHECK_EQ(c->resp_status, 204u);
+        check_sending_response_invariant(_tc, c);
+    }
 }
 
 // ==========================================================================

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8157,6 +8157,8 @@ TEST(legacy_loop, dispatch_event_unhandled_upstream_recv_paths) {
     stale->state = ConnState::ReadingHeader;
     loop->dispatch_event(*stale, make_ev(stale->id, IoEventType::UpstreamRecv, -105));
     CHECK(stale->fd >= 0);
+    close(stale->fd);
+    stale->fd = -1;
     loop->free_conn(*stale);
 
     auto* active = loop->alloc_conn();

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -19,10 +19,6 @@ using rut::test_fault::ScopedFakeSocket;
 using rut::test_fault::ScopedMemoryFault;
 using rut::test_fault::ScopedRecvData;
 
-namespace rut::simd {
-u32 scan_uri(const u8* buf, u32 pos, u32 end, u32* canon_end_out);
-}
-
 // === Accept ===
 
 TEST(accept, basic) {
@@ -2325,12 +2321,6 @@ TEST(route, configure_route_dispatch_refuses_after_route_add) {
 }
 
 TEST(route, segment_trie_matches_param_path) {
-    RouteTrie trie;
-    trie.clear();
-    REQUIRE(trie.insert(Str{"/health", 7}, 'G', 7));
-    CHECK_EQ(trie.match(Str{"/health", 7}, 'G'), 7u);
-    CHECK_EQ(trie.match_key(Str{"/health", 7}, kRouteMethodGet), 7u);
-
     RouteConfig cfg;
     REQUIRE(cfg.use_segment_trie());
     CHECK(cfg.add_static("/users/:id", 0, 201));
@@ -5683,9 +5673,6 @@ TEST(route_method, key_helpers_cover_all_runtime_methods) {
     CHECK_EQ(route_method_slot('C'), kRouteMethodConnect);
     CHECK_EQ(route_method_slot('T'), kRouteMethodTrace);
     CHECK_EQ(route_method_slot('?'), kRouteMethodSlotInvalid);
-
-    Str invalid_method = http_method_str(static_cast<HttpMethod>(255));
-    CHECK(invalid_method.eq({"UNKNOWN", 7}));
 }
 
 // === Coverage: parse_log_method_fallback ===
@@ -5950,15 +5937,6 @@ TEST(util, ascii_ci_eq_basic) {
     CHECK(ascii_ci_eq(reinterpret_cast<const u8*>("Connection"), "connection", 10));
     CHECK(ascii_ci_eq(reinterpret_cast<const u8*>("CONNECTION"), "connection", 10));
     CHECK(!ascii_ci_eq(reinterpret_cast<const u8*>("Different1"), "connection", 10));
-}
-
-TEST(util, simd_scan_uri_long_query_without_space) {
-    static const u8 kUri[] = "/abcdefgh?ijklmnopqr";
-    u32 canon_end = 0;
-    const u32 end = sizeof(kUri) - 1;
-
-    CHECK_EQ(simd::scan_uri(kUri, 0, end, &canon_end), end);
-    CHECK_EQ(canon_end, 9u);
 }
 
 // === Coverage: epoll_event_loop init and helpers ===
@@ -8833,101 +8811,6 @@ TEST(dispatch_isolation, upstream_send_reaches_upstream_send_slot) {
     CHECK(g_callback_invoked);
 }
 
-TEST(dispatch_event, dispatch_event_handles_unhandled_and_terminal_branches) {
-    SmallLoop loop;
-    loop.setup();
-    auto* recv_conn = loop.alloc_conn();
-    REQUIRE(recv_conn != nullptr);
-    recv_conn->fd = 1000;
-    recv_conn->state = ConnState::ReadingHeader;
-    recv_conn->recv_armed = false;
-    recv_conn->on_recv = nullptr;
-    recv_conn->on_send = nullptr;
-    recv_conn->on_upstream_recv = nullptr;
-    recv_conn->on_upstream_send = nullptr;
-    recv_conn->keep_alive = false;
-    recv_conn->recv_buf.reset();
-    CHECK(!recv_conn->has_active_slot());
-    recv_conn->on_send = &test_sentinel_callback<SmallLoop>;
-    CHECK(recv_conn->has_active_slot());
-    recv_conn->on_send = nullptr;
-
-    loop.backend.clear_ops();
-    loop.dispatch_event(*recv_conn, make_ev(recv_conn->id, IoEventType::Recv, 24));
-    CHECK_EQ(loop.backend.count_ops(MockOp::Recv), 1u);
-
-    loop.backend.clear_ops();
-    recv_conn->recv_armed = true;
-    loop.dispatch_event(*recv_conn, make_ev(recv_conn->id, IoEventType::Recv, 24));
-    CHECK_EQ(loop.backend.count_ops(MockOp::Recv), 0u);
-    recv_conn->recv_armed = false;
-
-    loop.dispatch_event(*recv_conn, make_ev(recv_conn->id, IoEventType::Recv, 0));
-    CHECK_EQ(recv_conn->fd, 1000);
-
-    loop.dispatch_event(*recv_conn, make_ev(recv_conn->id, IoEventType::Recv, -105));
-    CHECK_EQ(recv_conn->fd, -1);
-
-    auto* up_conn = loop.alloc_conn();
-    REQUIRE(up_conn != nullptr);
-    up_conn->fd = 1001;
-    up_conn->state = ConnState::ReadingHeader;
-    up_conn->on_upstream_recv = nullptr;
-    up_conn->on_recv = nullptr;
-    up_conn->on_send = nullptr;
-    up_conn->on_upstream_send = nullptr;
-    up_conn->recv_armed = false;
-    g_callback_invoked = false;
-    loop.dispatch_event(*up_conn, make_ev(up_conn->id, IoEventType::UpstreamRecv, 16));
-    CHECK(!g_callback_invoked);
-
-    up_conn->on_upstream_recv = &test_sentinel_callback<SmallLoop>;
-    g_callback_invoked = false;
-    loop.dispatch_event(*up_conn, make_ev(up_conn->id, IoEventType::UpstreamRecv, 16));
-    CHECK(g_callback_invoked);
-
-    g_callback_invoked = false;
-    up_conn->on_upstream_recv = nullptr;
-    up_conn->state = ConnState::ReadingHeader;
-    up_conn->fd = 1002;
-    loop.dispatch_event(*up_conn, make_ev(up_conn->id, IoEventType::UpstreamRecv, -105));
-    CHECK(!g_callback_invoked);
-    CHECK_EQ(up_conn->fd, 1002);
-
-    g_callback_invoked = false;
-    up_conn->state = ConnState::Sending;
-    up_conn->fd = 1003;
-    loop.dispatch_event(*up_conn, make_ev(up_conn->id, IoEventType::UpstreamRecv, -105));
-    CHECK(g_callback_invoked == false);
-    CHECK_EQ(up_conn->fd, -1);
-
-    auto* up_send_conn = loop.alloc_conn();
-    REQUIRE(up_send_conn != nullptr);
-    up_send_conn->fd = 1004;
-    up_send_conn->on_upstream_send = &test_sentinel_callback<SmallLoop>;
-    up_send_conn->on_recv = nullptr;
-    up_send_conn->on_send = nullptr;
-    up_send_conn->on_upstream_recv = nullptr;
-    g_callback_invoked = false;
-    loop.dispatch_event(*up_send_conn, make_ev(up_send_conn->id, IoEventType::UpstreamConnect, 0));
-    CHECK(g_callback_invoked);
-
-    up_send_conn->on_upstream_send = nullptr;
-    up_send_conn->on_send = &test_sentinel_callback<SmallLoop>;
-    g_callback_invoked = false;
-    loop.dispatch_event(*up_send_conn, make_ev(up_send_conn->id, IoEventType::Send, 0));
-    CHECK(g_callback_invoked);
-
-    g_callback_invoked = false;
-    loop.dispatch_event(*up_send_conn, make_ev(up_send_conn->id, IoEventType::Accept, 0));
-    loop.dispatch_event(*up_send_conn, make_ev(up_send_conn->id, IoEventType::Timeout, 0));
-    loop.dispatch_event(*up_send_conn, make_ev(up_send_conn->id, IoEventType::HandlerTimer, 0));
-    loop.dispatch_event(*up_send_conn, make_ev(up_send_conn->id, IoEventType::kNumEventTypes, 0));
-    CHECK(!g_callback_invoked);
-
-    loop.dispatch(make_ev(up_send_conn->id, IoEventType::kNumEventTypes, 0));
-}
-
 // ==========================================================================
 // State transition exhaustive tests: verify all 4 slot values after
 // each reachable state transition.
@@ -9043,16 +8926,6 @@ static u64 state_invariant_wait_recv_then_status(
     return jit::HandlerResult::make_yield(7, jit::YieldKind::Recv).pack();
 }
 
-// Same as above, but accepts any recv event payload on resume so state
-// transition tests don't depend on synthetic recv byte counts.
-static u64 state_invariant_wait_recv_then_status_always_204(
-    void*, jit::HandlerCtx* ctx, const u8*, u32, void*) {
-    if (ctx && ctx->state == 7) {
-        return jit::HandlerResult::make_status(204).pack();
-    }
-    return jit::HandlerResult::make_yield(7, jit::YieldKind::Recv).pack();
-}
-
 static jit::HandlerResult g_state_invariant_jit_result = jit::HandlerResult::make_status(204);
 
 static u64 state_invariant_configured_jit_result(void*, jit::HandlerCtx*, const u8*, u32, void*) {
@@ -9100,15 +8973,8 @@ TEST(state_invariant, jit_content_length_body_waits_until_full_buffer) {
         "POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: 7\r\n\r\npay";
     append_and_dispatch(kHeadAndPartial, sizeof(kHeadAndPartial) - 1);
 
-    if (c->state == ConnState::ReadingBody) {
-        check_jit_reading_body_invariant(_tc, c);
-    } else {
-        CHECK_EQ(c->state, ConnState::Sending);
-        CHECK_EQ(c->pending_handler_fn, nullptr);
-        CHECK_EQ(c->resp_status, 204u);
-        check_sending_response_invariant(_tc, c);
-        return;
-    }
+    check_jit_reading_body_invariant(_tc, c);
+    CHECK_EQ(c->req_body_remaining, 4u);
 
     append_and_dispatch("load", 4);
 
@@ -9227,8 +9093,7 @@ TEST(state_invariant, jit_body_completion_enters_exec_handler_before_resume) {
     SmallLoop loop;
     loop.setup();
     RouteConfig cfg;
-    REQUIRE(cfg.add_jit_handler(
-        "/upload", 'P', &state_invariant_wait_recv_then_status_always_204, true));
+    REQUIRE(cfg.add_jit_handler("/upload", 'P', &state_invariant_wait_recv_then_status, true));
     const RouteConfig* active = &cfg;
     loop.config_ptr = &active;
 
@@ -9242,40 +9107,17 @@ TEST(state_invariant, jit_body_completion_enters_exec_handler_before_resume) {
     c->recv_buf.commit(sizeof(kHeadAndPartial) - 1);
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, sizeof(kHeadAndPartial) - 1));
 
-    if (c->state == ConnState::ReadingBody) {
-        check_jit_reading_body_invariant(_tc, c);
-    } else if (c->state == ConnState::ExecHandler) {
-        CHECK_EQ(c->pending_handler_fn, &state_invariant_wait_recv_then_status_always_204);
-        CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
-    } else {
-        CHECK(c->state == ConnState::Sending);
-        CHECK(c->on_recv == nullptr);
-        CHECK_EQ(c->on_upstream_recv, nullptr);
-        CHECK_EQ(c->on_upstream_send, nullptr);
-        return;
-    }
+    check_jit_reading_body_invariant(_tc, c);
+    CHECK_EQ(c->req_body_remaining, 4u);
 
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 4));
-    if (c->state == ConnState::ExecHandler) {
-        check_exec_handler_yield_invariant(
-            _tc, c, &state_invariant_wait_recv_then_status_always_204, 0);
-        CHECK_EQ(static_cast<u8>(c->pending_yield_kind), static_cast<u8>(jit::YieldKind::Recv));
+    check_exec_handler_yield_invariant(_tc, c, &state_invariant_wait_recv_then_status, 0);
+    CHECK_EQ(static_cast<u8>(c->pending_yield_kind), static_cast<u8>(jit::YieldKind::Recv));
 
-        loop.dispatch(make_ev(c->id, IoEventType::Recv, 12));
-        CHECK_EQ(c->pending_handler_fn, nullptr);
-        CHECK_EQ(c->resp_status, 204u);
-        if (c->state == ConnState::Sending) {
-            CHECK(c->on_recv == nullptr);
-            CHECK_EQ(c->on_upstream_recv, nullptr);
-            CHECK_EQ(c->on_upstream_send, nullptr);
-        }
-    } else {
-        CHECK_EQ(c->state, ConnState::Sending);
-        CHECK_EQ(c->pending_handler_fn, nullptr);
-        CHECK(c->on_recv == nullptr);
-        CHECK_EQ(c->on_upstream_recv, nullptr);
-        CHECK_EQ(c->on_upstream_send, nullptr);
-    }
+    loop.dispatch(make_ev(c->id, IoEventType::Recv, 12));
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, 204u);
+    check_sending_response_invariant(_tc, c);
 }
 
 TEST(state_invariant, static_dispatch_keeps_slots_consistent) {
@@ -9627,7 +9469,7 @@ TEST(state_invariant, jit_dispatch_classifies_all_event_yields) {
 }
 
 TEST(state_invariant, jit_event_helpers_map_runtime_events) {
-    for (u8 raw = 0; raw < static_cast<u8>(IoEventType::kNumEventTypes); ++raw) {
+    for (u8 raw = 0; raw < static_cast<u8>(IoEventType::_Count); ++raw) {
         const IoEventType type = static_cast<IoEventType>(raw);
 
         CHECK_EQ(yield_kind_matches_event(jit::YieldKind::Any, type),
@@ -9664,21 +9506,20 @@ TEST(state_invariant, jit_event_helpers_map_runtime_events) {
             case IoEventType::HandlerTimer:
                 expected = jit::YieldKind::Timer;
                 break;
-            case IoEventType::Accept:
-            case IoEventType::kNumEventTypes:
+            default:
                 break;
         }
         CHECK_EQ(static_cast<u8>(yield_kind_from_event(type)), static_cast<u8>(expected));
     }
 
-    CHECK(!yield_kind_matches_event(jit::YieldKind::Any, IoEventType::kNumEventTypes));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::Recv, IoEventType::kNumEventTypes));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::Send, IoEventType::kNumEventTypes));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamConnect, IoEventType::kNumEventTypes));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamRecv, IoEventType::kNumEventTypes));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamSend, IoEventType::kNumEventTypes));
-    CHECK(!yield_kind_matches_event(jit::YieldKind::Timer, IoEventType::kNumEventTypes));
-    CHECK_EQ(static_cast<u8>(yield_kind_from_event(IoEventType::kNumEventTypes)),
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Any, IoEventType::_Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Recv, IoEventType::_Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Send, IoEventType::_Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamConnect, IoEventType::_Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamRecv, IoEventType::_Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::UpstreamSend, IoEventType::_Count));
+    CHECK(!yield_kind_matches_event(jit::YieldKind::Timer, IoEventType::_Count));
+    CHECK_EQ(static_cast<u8>(yield_kind_from_event(IoEventType::_Count)),
              static_cast<u8>(jit::YieldKind::HttpGet));
 }
 
@@ -10378,8 +10219,7 @@ TEST(state_transition, jit_body_complete_enters_exec_handler) {
     SmallLoop loop;
     loop.setup();
     RouteConfig cfg;
-    REQUIRE(cfg.add_jit_handler(
-        "/upload", 'P', &state_invariant_wait_recv_then_status_always_204, true));
+    REQUIRE(cfg.add_jit_handler("/upload", 'P', &state_invariant_wait_recv_then_status, true));
     const RouteConfig* active = &cfg;
     loop.config_ptr = &active;
 
@@ -10393,28 +10233,12 @@ TEST(state_transition, jit_body_complete_enters_exec_handler) {
     c->recv_buf.commit(sizeof(kHeadAndPartial) - 1);
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, sizeof(kHeadAndPartial) - 1));
 
-    if (c->state == ConnState::ReadingBody) {
-        CHECK_GT(c->req_body_remaining, 0u);
-    } else if (c->state == ConnState::ExecHandler) {
-        CHECK_EQ(c->pending_handler_fn, &state_invariant_wait_recv_then_status_always_204);
-        CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
-    } else {
-        CHECK(c->state == ConnState::Sending);
-        CHECK(c->on_recv == nullptr);
-        CHECK_EQ(c->on_upstream_recv, nullptr);
-        CHECK_EQ(c->on_upstream_send, nullptr);
-        return;
-    }
+    CHECK_EQ(c->state, ConnState::ReadingBody);
+    CHECK_EQ(c->req_body_remaining, 4u);
 
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 4));
-    if (c->state == ConnState::ExecHandler) {
-        CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
-    } else {
-        CHECK_EQ(c->state, ConnState::Sending);
-        CHECK(c->on_recv == nullptr);
-        CHECK_EQ(c->on_upstream_recv, nullptr);
-        CHECK_EQ(c->on_upstream_send, nullptr);
-    }
+    CHECK_EQ(c->state, ConnState::ExecHandler);
+    CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
 }
 
 // ==========================================================================

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -9406,7 +9406,7 @@ TEST(state_invariant, jit_body_completion_enters_exec_handler_before_resume) {
         "POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: 7\r\n\r\npay";
     c->recv_buf.write(reinterpret_cast<const u8*>(kHeadAndPartial), sizeof(kHeadAndPartial) - 1);
     c->recv_buf.commit(sizeof(kHeadAndPartial) - 1);
-    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, sizeof(kHeadAndPartial) - 1));
+    loop.dispatch(make_ev(c->id, IoEventType::Recv, sizeof(kHeadAndPartial) - 1));
 
     if (c->state == ConnState::ReadingBody) {
         check_jit_reading_body_invariant(_tc, c);
@@ -9427,7 +9427,7 @@ TEST(state_invariant, jit_body_completion_enters_exec_handler_before_resume) {
         recv_dst[j] = static_cast<u8>(kBodyChunk[j]);
     }
     c->recv_buf.commit(sizeof(kBodyChunk) - 1);
-    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 4));
+    loop.dispatch(make_ev(c->id, IoEventType::Recv, 4));
     if (c->state == ConnState::ExecHandler) {
         check_exec_handler_yield_invariant(
             _tc, c, &state_invariant_wait_recv_then_status_always_204, 0);
@@ -10563,7 +10563,7 @@ TEST(state_transition, jit_body_complete_enters_exec_handler) {
         "POST /upload HTTP/1.1\r\nHost: x\r\nContent-Length: 7\r\n\r\npay";
     c->recv_buf.write(reinterpret_cast<const u8*>(kHeadAndPartial), sizeof(kHeadAndPartial) - 1);
     c->recv_buf.commit(sizeof(kHeadAndPartial) - 1);
-    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, sizeof(kHeadAndPartial) - 1));
+    loop.dispatch(make_ev(c->id, IoEventType::Recv, sizeof(kHeadAndPartial) - 1));
 
     if (c->state == ConnState::ReadingBody) {
         CHECK_GT(c->req_body_remaining, 0u);
@@ -10584,7 +10584,7 @@ TEST(state_transition, jit_body_complete_enters_exec_handler) {
         recv_dst[j] = static_cast<u8>(kBodyChunk[j]);
     }
     c->recv_buf.commit(sizeof(kBodyChunk) - 1);
-    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 4));
+    loop.dispatch(make_ev(c->id, IoEventType::Recv, 4));
     if (c->state == ConnState::ExecHandler) {
         CHECK_SLOTS(c, nullptr, nullptr, nullptr, nullptr);
     } else {

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8170,6 +8170,45 @@ TEST(legacy_loop, dispatch_event_unhandled_upstream_recv_paths) {
     loop->shutdown();
 }
 
+TEST(legacy_loop, run_exits_during_empty_drain) {
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    i32 listen_fd = dup(2);
+    REQUIRE(listen_fd >= 0);
+    auto initialized = loop->init(0, listen_fd);
+    REQUIRE(initialized);
+
+    loop->drain(0);
+    loop->run();
+
+    CHECK(!loop->is_running());
+    CHECK_EQ(loop->listen_fd, -1);
+    CHECK_EQ(loop->backend.count_ops(MockOp::Accept), 1u);
+    loop->shutdown();
+}
+
+TEST(legacy_loop, dispatch_accept_paths) {
+    auto loop = std::make_unique<EventLoop<MockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+
+    loop->dispatch(make_ev(0, IoEventType::Accept, -1));
+    CHECK_EQ(loop->free_top, EventLoop<MockBackend>::kMaxConns);
+
+    i32 fd = dup(2);
+    REQUIRE(fd >= 0);
+    loop->dispatch(make_ev(0, IoEventType::Accept, fd));
+    REQUIRE_EQ(loop->free_top, EventLoop<MockBackend>::kMaxConns - 1);
+    auto& accepted = loop->conns[EventLoop<MockBackend>::kMaxConns - 1];
+    CHECK_EQ(accepted.fd, fd);
+    CHECK_EQ(accepted.state, ConnState::ReadingHeader);
+    CHECK_EQ(accepted.on_recv, &on_header_received<EventLoop<MockBackend>>);
+    CHECK_EQ(loop->backend.count_ops(MockOp::Recv), 1u);
+
+    loop->dispatch(make_ev(0, IoEventType::Count, 0));
+    loop->close_conn(accepted);
+    loop->shutdown();
+}
+
 TEST(legacy_loop, poll_command_updates_control_slots) {
     auto loop = std::make_unique<EventLoop<MockBackend>>();
     auto initialized = loop->init(0, -1);

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -8140,6 +8140,61 @@ TEST(legacy_loop, async_submit_and_close_paths) {
     loop->shutdown();
 }
 
+TEST(legacy_loop, async_reclaim_pending_reclaims_ready_slots) {
+    auto loop = std::make_unique<EventLoop<AsyncMockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+    auto* ready = loop->alloc_conn();
+    REQUIRE(ready != nullptr);
+    auto* busy = loop->alloc_conn();
+    REQUIRE(busy != nullptr);
+    u32 ready_id = ready->id;
+    u32 busy_id = busy->id;
+
+    ready->fd = -1;
+    ready->pending_ops = 0;
+    busy->fd = -1;
+    busy->pending_ops = 1;
+    loop->pending_free[0] = ready_id;
+    loop->pending_free[1] = busy_id;
+    loop->pending_free_count = 2;
+
+    loop->reclaim_pending();
+    CHECK_EQ(loop->pending_free_count, 1u);
+    CHECK_EQ(loop->pending_free[0], busy_id);
+    CHECK_EQ(loop->free_top, EventLoop<AsyncMockBackend>::kMaxConns - 1);
+    CHECK_EQ(loop->conns[ready_id].recv_slice, nullptr);
+    CHECK_EQ(loop->conns[ready_id].send_slice, nullptr);
+
+    busy->pending_ops = 0;
+    loop->reclaim_pending();
+    CHECK_EQ(loop->pending_free_count, 0u);
+    CHECK_EQ(loop->free_top, EventLoop<AsyncMockBackend>::kMaxConns);
+    loop->shutdown();
+}
+
+TEST(legacy_loop, async_dispatch_stale_cqe_reclaims_slot) {
+    auto loop = std::make_unique<EventLoop<AsyncMockBackend>>();
+    auto initialized = loop->init(0, -1);
+    REQUIRE(initialized);
+    auto* c = loop->alloc_conn();
+    REQUIRE(c != nullptr);
+    u32 cid = c->id;
+    c->fd = -1;
+    c->pending_ops = 1;
+    c->recv_armed = true;
+    loop->pending_free[0] = cid;
+    loop->pending_free_count = 1;
+
+    loop->dispatch(make_ev(cid, IoEventType::Recv, 0));
+    CHECK_EQ(loop->pending_free_count, 0u);
+    CHECK_EQ(loop->free_top, EventLoop<AsyncMockBackend>::kMaxConns);
+    CHECK_EQ(loop->conns[cid].pending_ops, 0u);
+    CHECK_EQ(loop->conns[cid].recv_slice, nullptr);
+    CHECK_EQ(loop->conns[cid].send_slice, nullptr);
+    loop->shutdown();
+}
+
 TEST(legacy_loop, event_yield_fails_fast) {
     auto loop = std::make_unique<EventLoop<MockBackend>>();
     auto initialized = loop->init(0, -1);

--- a/tests/test_route_art.cc
+++ b/tests/test_route_art.cc
@@ -268,7 +268,7 @@ TEST(route_art, root_grows_node48_to_node256_at_fanout_49) {
     }
 }
 
-TEST(route_art, nested_node16_child_dispatches_and_reads_header) {
+TEST(route_art, nested_node16_child_dispatches_by_next_byte) {
     ArtTrie t;
     char paths[5][4];
     for (u32 i = 0; i < 5; i++) {
@@ -284,7 +284,7 @@ TEST(route_art, nested_node16_child_dispatches_and_reads_header) {
     CHECK_EQ(t.match(S("/az"), 0), TrieNode::kInvalidRoute);
 }
 
-TEST(route_art, nested_node256_child_dispatches_and_reads_header) {
+TEST(route_art, nested_node256_child_dispatches_by_next_byte) {
     ArtTrie t;
     char paths[49][4];
     for (u32 i = 0; i < 49; i++) {

--- a/tests/test_route_art.cc
+++ b/tests/test_route_art.cc
@@ -268,6 +268,44 @@ TEST(route_art, root_grows_node48_to_node256_at_fanout_49) {
     }
 }
 
+TEST(route_art, nested_node16_child_dispatches_and_reads_header) {
+    ArtTrie t;
+    char paths[5][4];
+    for (u32 i = 0; i < 5; i++) {
+        paths[i][0] = '/';
+        paths[i][1] = 'a';
+        paths[i][2] = static_cast<char>('0' + i);
+        paths[i][3] = '\0';
+        REQUIRE(t.insert(Str{paths[i], 3}, 0, static_cast<u16>(10 + i)));
+    }
+    CHECK_EQ(t.n16_count(), 1u);
+    CHECK_EQ(t.match(Str{paths[0], 3}, 0), 10u);
+    CHECK_EQ(t.match(Str{paths[4], 3}, 0), 14u);
+    CHECK_EQ(t.match(S("/az"), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_art, nested_node256_child_dispatches_and_reads_header) {
+    ArtTrie t;
+    char paths[49][4];
+    for (u32 i = 0; i < 49; i++) {
+        paths[i][0] = '/';
+        paths[i][1] = 'a';
+        paths[i][2] = static_cast<char>(0x40 + i);
+        paths[i][3] = '\0';
+        REQUIRE(t.insert(Str{paths[i], 3}, 0, static_cast<u16>(20 + i)));
+    }
+    CHECK_EQ(t.n256_count(), 1u);
+    CHECK_EQ(t.match(Str{paths[0], 3}, 0), 20u);
+    CHECK_EQ(t.match(Str{paths[48], 3}, 0), 68u);
+    CHECK_EQ(t.match(S("/a!"), 0), TrieNode::kInvalidRoute);
+}
+
+TEST(route_art, match_canonical_key_rejects_invalid_method_key) {
+    ArtTrie t;
+    REQUIRE(t.insert(S("/x"), 0, 7));
+    CHECK_EQ(t.match_canonical_key(S("x"), 250), TrieNode::kInvalidRoute);
+}
+
 TEST(route_art, accepts_kMaxRoutes_distinct_top_level_prefixes) {
     // Same shape as the byte_radix counterpart — 128 distinct first
     // bytes after '/', driving the root all the way to Node256.

--- a/tests/test_route_art.cc
+++ b/tests/test_route_art.cc
@@ -300,6 +300,52 @@ TEST(route_art, nested_node256_child_dispatches_by_next_byte) {
     CHECK_EQ(t.match(S("/a!"), 0), TrieNode::kInvalidRoute);
 }
 
+TEST(route_art, split_node48_edge_preserves_existing_children) {
+    ArtTrie t;
+    char paths[17][9];
+    for (u32 i = 0; i < 17; i++) {
+        paths[i][0] = '/';
+        paths[i][1] = 'a';
+        paths[i][2] = 'b';
+        paths[i][3] = 'c';
+        paths[i][4] = 'd';
+        paths[i][5] = 'e';
+        paths[i][6] = 'f';
+        paths[i][7] = static_cast<char>('A' + i);
+        paths[i][8] = '\0';
+        REQUIRE(t.insert(Str{paths[i], 8}, 0, static_cast<u16>(100 + i)));
+    }
+    REQUIRE_GE(t.n48_count(), 1u);
+
+    REQUIRE(t.insert(S("/abcxyz"), 0, 500));
+    CHECK_EQ(t.match(S("/abcxyz"), 0), 500u);
+    CHECK_EQ(t.match(Str{paths[0], 8}, 0), 100u);
+    CHECK_EQ(t.match(Str{paths[16], 8}, 0), 116u);
+}
+
+TEST(route_art, split_node256_edge_preserves_existing_children) {
+    ArtTrie t;
+    char paths[49][9];
+    for (u32 i = 0; i < 49; i++) {
+        paths[i][0] = '/';
+        paths[i][1] = 'a';
+        paths[i][2] = 'b';
+        paths[i][3] = 'c';
+        paths[i][4] = 'd';
+        paths[i][5] = 'e';
+        paths[i][6] = 'f';
+        paths[i][7] = static_cast<char>(0x40 + i);
+        paths[i][8] = '\0';
+        REQUIRE(t.insert(Str{paths[i], 8}, 0, static_cast<u16>(200 + i)));
+    }
+    REQUIRE_GE(t.n256_count(), 1u);
+
+    REQUIRE(t.insert(S("/abcxyz"), 0, 600));
+    CHECK_EQ(t.match(S("/abcxyz"), 0), 600u);
+    CHECK_EQ(t.match(Str{paths[0], 8}, 0), 200u);
+    CHECK_EQ(t.match(Str{paths[48], 8}, 0), 248u);
+}
+
 TEST(route_art, match_canonical_key_rejects_invalid_method_key) {
     ArtTrie t;
     REQUIRE(t.insert(S("/x"), 0, 7));


### PR DESCRIPTION
## Summary
- Reserve `and` / `or` as boolean operators only and reject function-call forms (`and(...)`, `or(...)`) at parse time (including header/cookie/query contexts).
- Treat `any()` as nil/error fallback and `all()` as present-only fallback with eager RHS materialization in lowering.
- Expand parser/frontend/integration/JIT coverage for `or()/and()` rejection, `all` semantics, and non-short-circuit RHS observation via fallback calls.
- Update `docs/pipe.md` for syntax/precedence and `all`/`any` semantics.

## Testing
- Added/updated parse rejection tests and runtime e2e/JIT tests in `tests/test_frontend.cc`, `tests/test_integration.cc`, and `tests/test_jit.cc`.