### PR TITLE
[codex] Allow decorator request proxy access

### DIFF
--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -24,11 +24,20 @@ Rules:
 - Returning any non-zero value short-circuits the route and returns that value
   as the HTTP status code.
 
-The first parameter is currently a placeholder. A real runtime `Request` type is
-not implemented yet. If a decorator needs the magic request expression surface
-such as `req.header(...)`, `req.path`, or `req.method`, do not name the
-placeholder parameter `req`; a user-bound parameter or local named `req` shadows
-the magic request object.
+The first parameter is currently a placeholder value rather than a real runtime
+`Request` type. If the omitted-label parameter is named `req`, the compiler
+also treats it as a magic request receiver for the existing request expression
+surface, so decorator bodies can use `req.header(...)`, `req.path`, or
+`req.method`.
+
+```rut
+func auth(_ req: i32) -> i32 {
+    if or(req.header("Authorization"), "") == "ok" { 0 } else { 401 }
+}
+```
+
+A user-bound local named `req` inside the function still shadows the magic
+request object.
 
 ## Execution Order
 

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -32,7 +32,7 @@ surface, so decorator bodies can use `req.header(...)`, `req.path`, or
 
 ```rut
 func auth(_ req: i32) -> i32 {
-    if or(req.header("Authorization"), "") == "ok" { 0 } else { 401 }
+    if req.method == GET { 0 } else { 405 }
 }
 ```
 

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -378,6 +378,7 @@ struct HirExpr {
     HirExpr* lhs = nullptr;
     HirExpr* rhs = nullptr;
     bool is_wait_result = false;
+    bool is_magic_request_proxy = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;
     u32 wait_index = 0xffffffffu;
@@ -624,6 +625,7 @@ struct HirLocal {
     u32 error_struct_index = 0xffffffffu;
     u32 error_variant_index = 0xffffffffu;
     bool is_wait_result = false;
+    bool is_magic_request_proxy = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;
     u32 wait_index = 0xffffffffu;

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -378,7 +378,6 @@ struct HirExpr {
     HirExpr* lhs = nullptr;
     HirExpr* rhs = nullptr;
     bool is_wait_result = false;
-    bool is_magic_request_proxy = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;
     u32 wait_index = 0xffffffffu;

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9576,6 +9576,40 @@ static FrontendResult<void> load_imported_modules(
     const std::vector<Str>& route_decorator_names) {
     if (source_path.len == 0) return {};
     const auto base_dir = std::filesystem::path(str_to_std_string(source_path)).parent_path();
+    auto collect_imported_decorator_names =
+        [&](const AstImportDecl& target_decl,
+            const std::string& target_normalized) -> std::vector<Str> {
+        std::vector<Str> imported_decorator_names;
+        for (u32 ii = 0; ii < file.items.len; ii++) {
+            const auto& other_item = file.items[ii];
+            if (other_item.kind != AstItemKind::Import) continue;
+            const auto other_normalized =
+                (base_dir / str_to_std_string(other_item.import_decl.path))
+                    .lexically_normal()
+                    .string();
+            if (other_normalized != target_normalized ||
+                other_item.import_decl.has_namespace_alias != target_decl.has_namespace_alias ||
+                (other_item.import_decl.has_namespace_alias &&
+                 !other_item.import_decl.namespace_alias.eq(target_decl.namespace_alias)))
+                continue;
+            for (const auto& decorator_name : route_decorator_names) {
+                if (!other_item.import_decl.selective) {
+                    if (!other_item.import_decl.has_namespace_alias &&
+                        !contains_str(imported_decorator_names, decorator_name))
+                        imported_decorator_names.push_back(decorator_name);
+                    continue;
+                }
+                for (u32 si = 0; si < other_item.import_decl.selected_names.len; si++) {
+                    const auto& selected = other_item.import_decl.selected_names[si];
+                    const Str visible = selected.has_alias ? selected.alias : selected.name;
+                    if (visible.eq(decorator_name) &&
+                        !contains_str(imported_decorator_names, selected.name))
+                        imported_decorator_names.push_back(selected.name);
+                }
+            }
+        }
+        return imported_decorator_names;
+    };
     for (u32 i = 0; i < file.items.len; i++) {
         const auto& item = file.items[i];
         if (item.kind != AstItemKind::Import) continue;
@@ -9633,22 +9667,8 @@ static FrontendResult<void> load_imported_modules(
         std::unique_ptr<AstFile> ast_owned(ast.value());
         auto kept_path = stash_owned_string(owned_strings, normalized);
         g_import_analysis_counter++;
-        std::vector<Str> imported_decorator_names;
-        for (const auto& decorator_name : route_decorator_names) {
-            if (!item.import_decl.selective) {
-                if (!item.import_decl.has_namespace_alias &&
-                    !contains_str(imported_decorator_names, decorator_name))
-                    imported_decorator_names.push_back(decorator_name);
-                continue;
-            }
-            for (u32 si = 0; si < item.import_decl.selected_names.len; si++) {
-                const auto& selected = item.import_decl.selected_names[si];
-                const Str visible = selected.has_alias ? selected.alias : selected.name;
-                if (visible.eq(decorator_name) &&
-                    !contains_str(imported_decorator_names, selected.name))
-                    imported_decorator_names.push_back(selected.name);
-            }
-        }
+        std::vector<Str> imported_decorator_names =
+            collect_imported_decorator_names(item.import_decl, normalized);
         auto imported = analyze_file_internal(
             *ast_owned, kept_path, import_stack, &owned_strings, imported_decorator_names);
         if (!imported) return core::make_unexpected(imported.error());

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -12221,8 +12221,6 @@ static FrontendResult<HirModule*> analyze_file_internal(
             param_locals[pi].name = fn.params[pi].name;
             param_locals[pi].ref_index = pi;
             param_locals[pi].type = fn.params[pi].type;
-            param_locals[pi].is_magic_request_proxy =
-                pi == 0 && fn.params[pi].has_underscore_label && fn.params[pi].name.eq({"req", 3});
             param_locals[pi].generic_index = fn.params[pi].generic_index;
             param_locals[pi].associated_name = fn.params[pi].associated_name;
             param_locals[pi].generic_has_error_constraint =
@@ -12490,6 +12488,17 @@ static FrontendResult<HirModule*> analyze_file_internal(
         if (!target_type) return core::make_unexpected(target_type.error());
         out_type = target_type.value();
         return {};
+    };
+
+    auto is_route_decorator_function_name = [&](Str name) -> bool {
+        for (u32 ii = 0; ii < file.items.len; ii++) {
+            const auto& route_item = file.items[ii];
+            if (route_item.kind != AstItemKind::Route) continue;
+            for (u32 di = 0; di < route_item.route.decorators.len; di++) {
+                if (route_item.route.decorators[di].name.eq(name)) return true;
+            }
+        }
+        return false;
     };
 
     for (u32 i = 0; i < file.items.len; i++) {
@@ -13748,7 +13757,8 @@ static FrontendResult<HirModule*> analyze_file_internal(
             param_locals[pi].ref_index = pi;
             param_locals[pi].type = fn.params[pi].type;
             param_locals[pi].is_magic_request_proxy =
-                pi == 0 && fn.params[pi].has_underscore_label && fn.params[pi].name.eq({"req", 3});
+                is_route_decorator_function_name(fn.name) && pi == 0 &&
+                fn.params[pi].has_underscore_label && fn.params[pi].name.eq({"req", 3});
             param_locals[pi].generic_index = fn.params[pi].generic_index;
             param_locals[pi].associated_name = fn.params[pi].associated_name;
             param_locals[pi].generic_has_error_constraint =

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3200,7 +3200,7 @@ static bool user_bound_req_name(const HirModule& mod,
                                 const MatchPayloadBinding* binding) {
     if (binding && binding->subject && binding->name.eq({"req", 3})) return true;
     for (u32 i = 0; i < local_count; i++) {
-        if (locals[i].name.eq({"req", 3})) return true;
+        if (locals[i].name.eq({"req", 3}) && !locals[i].is_magic_request_proxy) return true;
     }
     for (u32 i = 0; i < mod.variants.len; i++) {
         if (mod.variants[i].name.eq({"req", 3})) return true;
@@ -12221,6 +12221,8 @@ static FrontendResult<HirModule*> analyze_file_internal(
             param_locals[pi].name = fn.params[pi].name;
             param_locals[pi].ref_index = pi;
             param_locals[pi].type = fn.params[pi].type;
+            param_locals[pi].is_magic_request_proxy =
+                pi == 0 && fn.params[pi].has_underscore_label && fn.params[pi].name.eq({"req", 3});
             param_locals[pi].generic_index = fn.params[pi].generic_index;
             param_locals[pi].associated_name = fn.params[pi].associated_name;
             param_locals[pi].generic_has_error_constraint =
@@ -13745,6 +13747,8 @@ static FrontendResult<HirModule*> analyze_file_internal(
             param_locals[pi].name = fn.params[pi].name;
             param_locals[pi].ref_index = pi;
             param_locals[pi].type = fn.params[pi].type;
+            param_locals[pi].is_magic_request_proxy =
+                pi == 0 && fn.params[pi].has_underscore_label && fn.params[pi].name.eq({"req", 3});
             param_locals[pi].generic_index = fn.params[pi].generic_index;
             param_locals[pi].associated_name = fn.params[pi].associated_name;
             param_locals[pi].generic_has_error_constraint =

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -3199,9 +3199,13 @@ static bool user_bound_req_name(const HirModule& mod,
                                 u32 local_count,
                                 const MatchPayloadBinding* binding) {
     if (binding && binding->subject && binding->name.eq({"req", 3})) return true;
+    bool has_magic_request_proxy = false;
     for (u32 i = 0; i < local_count; i++) {
-        if (locals[i].name.eq({"req", 3}) && !locals[i].is_magic_request_proxy) return true;
+        if (!locals[i].name.eq({"req", 3})) continue;
+        if (!locals[i].is_magic_request_proxy) return true;
+        has_magic_request_proxy = true;
     }
+    if (has_magic_request_proxy) return false;
     for (u32 i = 0; i < mod.variants.len; i++) {
         if (mod.variants[i].name.eq({"req", 3})) return true;
     }

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -8560,7 +8560,26 @@ static FrontendResult<HirModule*> analyze_file_internal(
     const AstFile& file,
     Str source_path,
     std::vector<std::string>& import_stack,
-    std::deque<std::string>* shared_owned_strings);
+    std::deque<std::string>* shared_owned_strings,
+    const std::vector<Str>& external_decorator_names);
+
+static bool contains_str(const std::vector<Str>& names, Str needle) {
+    for (const auto& name : names) {
+        if (name.eq(needle)) return true;
+    }
+    return false;
+}
+
+static void collect_route_decorator_names(const AstFile& file, std::vector<Str>& out) {
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Route) continue;
+        for (u32 di = 0; di < item.route.decorators.len; di++) {
+            const Str name = item.route.decorators[di].name;
+            if (!contains_str(out, name)) out.push_back(name);
+        }
+    }
+}
 
 static Str import_visible_name(const ImportedModuleInfo& imported, Str original_name) {
     if (imported.has_namespace_alias) {
@@ -9549,7 +9568,8 @@ static FrontendResult<void> load_imported_modules(
     Str source_path,
     std::deque<std::string>& owned_strings,
     std::vector<std::string>& import_stack,
-    std::vector<std::unique_ptr<HirModule>>& imported_storage) {
+    std::vector<std::unique_ptr<HirModule>>& imported_storage,
+    const std::vector<Str>& route_decorator_names) {
     if (source_path.len == 0) return {};
     const auto base_dir = std::filesystem::path(str_to_std_string(source_path)).parent_path();
     for (u32 i = 0; i < file.items.len; i++) {
@@ -9609,7 +9629,24 @@ static FrontendResult<void> load_imported_modules(
         std::unique_ptr<AstFile> ast_owned(ast.value());
         auto kept_path = stash_owned_string(owned_strings, normalized);
         g_import_analysis_counter++;
-        auto imported = analyze_file_internal(*ast_owned, kept_path, import_stack, &owned_strings);
+        std::vector<Str> imported_decorator_names;
+        for (const auto& decorator_name : route_decorator_names) {
+            if (!item.import_decl.selective) {
+                if (!item.import_decl.has_namespace_alias &&
+                    !contains_str(imported_decorator_names, decorator_name))
+                    imported_decorator_names.push_back(decorator_name);
+                continue;
+            }
+            for (u32 si = 0; si < item.import_decl.selected_names.len; si++) {
+                const auto& selected = item.import_decl.selected_names[si];
+                const Str visible = selected.has_alias ? selected.alias : selected.name;
+                if (visible.eq(decorator_name) &&
+                    !contains_str(imported_decorator_names, selected.name))
+                    imported_decorator_names.push_back(selected.name);
+            }
+        }
+        auto imported = analyze_file_internal(
+            *ast_owned, kept_path, import_stack, &owned_strings, imported_decorator_names);
         if (!imported) return core::make_unexpected(imported.error());
         imported_storage.push_back(std::unique_ptr<HirModule>(imported.value()));
         ImportedModuleInfo info{};
@@ -10931,7 +10968,8 @@ static FrontendResult<HirModule*> analyze_file_internal(
     const AstFile& file,
     Str source_path,
     std::vector<std::string>& import_stack,
-    std::deque<std::string>* shared_owned_strings) {
+    std::deque<std::string>* shared_owned_strings,
+    const std::vector<Str>& external_decorator_names) {
     auto mod_ptr = std::make_unique<HirModule>();
     HirModule& mod = *mod_ptr;
     mod.has_package_decl = file.has_package_decl;
@@ -11075,10 +11113,17 @@ static FrontendResult<HirModule*> analyze_file_internal(
 
     auto* owned_strings =
         shared_owned_strings != nullptr ? shared_owned_strings : &mod.owned_strings;
+    std::vector<Str> route_decorator_names = external_decorator_names;
+    collect_route_decorator_names(file, route_decorator_names);
     std::vector<std::unique_ptr<HirModule>> imported_storage;
     FixedVec<ImportedModuleInfo, AstFile::kMaxItems> imported_modules;
-    auto loaded_imports = load_imported_modules(
-        imported_modules, file, source_path, *owned_strings, import_stack, imported_storage);
+    auto loaded_imports = load_imported_modules(imported_modules,
+                                                file,
+                                                source_path,
+                                                *owned_strings,
+                                                import_stack,
+                                                imported_storage,
+                                                route_decorator_names);
     if (!loaded_imports) return core::make_unexpected(loaded_imports.error());
     auto validated_namespaces = validate_import_namespaces(imported_modules);
     if (!validated_namespaces) return core::make_unexpected(validated_namespaces.error());
@@ -12491,14 +12536,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
     };
 
     auto is_route_decorator_function_name = [&](Str name) -> bool {
-        for (u32 ii = 0; ii < file.items.len; ii++) {
-            const auto& route_item = file.items[ii];
-            if (route_item.kind != AstItemKind::Route) continue;
-            for (u32 di = 0; di < route_item.route.decorators.len; di++) {
-                if (route_item.route.decorators[di].name.eq(name)) return true;
-            }
-        }
-        return false;
+        return contains_str(route_decorator_names, name);
     };
 
     for (u32 i = 0; i < file.items.len; i++) {
@@ -14902,7 +14940,9 @@ static FrontendResult<HirModule*> analyze_file_internal(
 
 FrontendResult<HirModule*> analyze_file(const AstFile& file, Str source_path) {
     std::vector<std::string> import_stack;
-    return analyze_file_internal(file, source_path, import_stack, nullptr);
+    const std::vector<Str> external_decorator_names;
+    return analyze_file_internal(
+        file, source_path, import_stack, nullptr, external_decorator_names);
 }
 
 FrontendResult<HirModule*> analyze_file(const AstFile& file) {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -2386,6 +2386,48 @@ route {
     CHECK_EQ(hir->routes[0].decorators[0].function_index, 0u);  // auth is the only func
 }
 
+TEST(frontend, analyze_route_decorator_req_param_exposes_magic_request_fields) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 { if req.method == GET { 0 } else { 405 } }
+route {
+    @auth "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.kind),
+             static_cast<u8>(HirExprKind::IfElse));
+    REQUIRE(hir->routes[0].locals[0].init.lhs != nullptr);
+    REQUIRE(hir->routes[0].locals[0].init.lhs->lhs != nullptr);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].locals[0].init.lhs->lhs->kind),
+             static_cast<u8>(HirExprKind::ReqMethod));
+}
+
+TEST(frontend, analyze_route_decorator_req_param_exposes_magic_request_methods) {
+    const char* src = R"rut(
+func auth(_ req: i32) -> i32 { if or(req.header("Authorization"), "") == "ok" { 0 } else { 401 } }
+route {
+    @auth "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+}
+
 TEST(frontend, analyze_rejects_unknown_route_decorator) {
     const char* src = R"rut(
 route {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -2447,6 +2447,7 @@ TEST(frontend, analyze_imported_route_decorator_req_param_exposes_magic_request_
     std::filesystem::create_directories(dir);
     {
         std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func req() -> i32 => 0\n";
         out << "func allow<T: Eq>(actual: T, expected: T) -> i32 => 0\n";
         out << "func auth(_ req: i32) -> i32 => allow(req.method, GET)\n";
     }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -2428,6 +2428,20 @@ route {
     REQUIRE_EQ(hir->routes[0].locals.len, 1u);
 }
 
+TEST(frontend, analyze_non_decorator_req_param_still_shadows_magic_request) {
+    const char* src = R"rut(
+struct Box { value: i32 }
+func readBox(_ req: Box) -> i32 => req.value
+route GET "/users" { if readBox(Box(value: 200)) == 200 { return 200 } else { return 500 } }
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+}
+
 TEST(frontend, analyze_rejects_unknown_route_decorator) {
     const char* src = R"rut(
 route {

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -2448,11 +2448,13 @@ TEST(frontend, analyze_imported_route_decorator_req_param_exposes_magic_request_
     {
         std::ofstream out(dir + "/auth.rut", std::ios::binary);
         out << "func req() -> i32 => 0\n";
-        out << "func allow<T: Eq>(actual: T, expected: T) -> i32 => 0\n";
+        out << "func helper() -> i32 => 0\n";
+        out << "func allow<T: Eq>(actual: T, expected: T) -> i32 => helper()\n";
         out << "func auth(_ req: i32) -> i32 => allow(req.method, GET)\n";
     }
     const auto src = R"rut(
-import "auth.rut"
+import { helper } from "auth.rut"
+import { auth } from "auth.rut"
 route {
     @auth "*"
     GET "/users" { return 200 }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -2442,6 +2442,31 @@ route GET "/users" { if readBox(Box(value: 200)) == 200 { return 200 } else { re
     REQUIRE(hir);
 }
 
+TEST(frontend, analyze_imported_route_decorator_req_param_exposes_magic_request_fields) {
+    const std::string dir = "/tmp/rut_import_decorator_req_proxy";
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream out(dir + "/auth.rut", std::ios::binary);
+        out << "func allow<T: Eq>(actual: T, expected: T) -> i32 => 0\n";
+        out << "func auth(_ req: i32) -> i32 => allow(req.method, GET)\n";
+    }
+    const auto src = R"rut(
+import "auth.rut"
+route {
+    @auth "*"
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap_with_path(ast.value(), dir + "/main.rut");
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].locals.len, 1u);
+}
+
 TEST(frontend, analyze_rejects_unknown_route_decorator) {
     const char* src = R"rut(
 route {


### PR DESCRIPTION
## Summary

- Allow a decorator function's first omitted-label parameter named `req` to act as the magic request receiver.
- Preserve normal user-bound `req` shadowing behavior outside that decorator proxy case.
- Document the decorator request proxy behavior and add frontend coverage for `req.method` and `req.header(...)`.

## Validation

- `cmake --build build-coverage --target test_frontend -j2`
- `build-coverage/tests/test_frontend --filter=analyze_route_decorator_req_param_exposes_magic_request_fields,analyze_route_decorator_req_param_exposes_magic_request_methods`

Note: full `build-coverage/tests/test_frontend` reached these new tests successfully, then later exited with a segmentation fault in an unrelated import/protocol area.