### PR TITLE
Refine Rut verifier direction

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -63,7 +63,15 @@ This file currently remains the umbrella design doc until that split happens.
 
 - Replace nginx configuration files and OpenResty Lua with a single strongly-typed language
 - Catch most errors at compile time (type errors, route conflicts, invalid values)
-- Easy for LLMs to generate and understand
+- Keep the language low-ambiguity: the same gateway problem should usually have
+  one obvious solution, and at most one or two accepted idioms
+- Make programs mechanically inspectable: control flow, IO waits, routing, and
+  failure behavior should be reducible to a small state machine
+- Make correctness testable by replay and simulation: captured traffic should
+  exercise the same route semantics as production execution
+- Be safe for LLM-assisted generation: prefer constrained constructs,
+  deterministic diagnostics, and verifier-friendly semantics over expressive
+  freedom that creates plausible but wrong code
 - High performance: C100K+ capable, minimal latency overhead
 - Hot reload without downtime
 - Minimal dependencies, maximal control
@@ -74,6 +82,10 @@ This file currently remains the umbrella design doc until that split happens.
 - L4 load balancer (this is L7 HTTP only)
 - DPDK / kernel bypass networking (not worth the trade-off in cloud environments)
 - Compatibility with nginx configuration format
+- Multiple equivalent language surfaces for the same operation
+- Accepting ambiguous code and relying on style guides, runtime behavior, or LLM
+  prompts to resolve intent
+- Requiring external general-purpose formal tools to validate normal user code
 
 ---
 
@@ -132,13 +144,30 @@ status matrix above.
 
 ### 3.1 Design Principles
 
-- **Swift-inspired syntax**: guard statements, named parameters, optional chaining, string interpolation — clean and readable, high LLM generation accuracy
+- **Low ambiguity first**: every feature should have a narrow role, predictable
+  grammar, and a small number of accepted idioms. If two constructs solve the
+  same common problem equally well, one should usually be removed or made
+  clearly secondary.
+- **LLM-safe by construction**: Rut should reduce the blast radius of generated
+  code by constraining the language, making invalid intent easy to diagnose, and
+  avoiding clever surface forms that look plausible but mean different things.
+- **Swift-inspired syntax where it reduces ambiguity**: guard statements, named
+  parameters, optional chaining, string interpolation — clean and readable, but
+  only when the semantics remain mechanically simple.
 - **HTTP concepts are native objects**: methods, status codes, headers, URLs, CIDR, media types are first-class language constructs, not strings
 - **All functions inline at compile time**: no runtime function calls, each route compiles to a single flat state machine
 - **Async is invisible**: no async/await/future/promise — user writes sequential code, compiler finds I/O points and generates state machines automatically
 - **Strong typing with domain types**: Duration, ByteSize, StatusCode, IP, CIDR, MediaType with compile-time validation
 - **Middleware = ordinary functions**: return a status code to reject, return nothing to pass through
 - **Bounded execution**: no `while`, no recursion, `for` only iterates finite collections — every handler has a compile-time execution bound, cannot stall a shard
+- **Replay and simulation are first-class**: route semantics should be
+  deterministic enough that captured traffic can be replayed through the same
+  decision logic used in production, with differences treated as bugs or
+  explicitly modeled environment effects.
+- **Verifier-friendly semantics**: user code should lower to a compact control
+  graph with explicit terminal responses, waits, forwards, and failure paths.
+  Features that cannot be represented in that graph should be rejected, bounded,
+  or isolated behind explicit escape hatches.
 - **Three-layer model**: `listen` (downstream/client) → .rut file (gateway logic) → `upstream` (backend). No `gateway` or `downstream` keyword — the .rut file IS the gateway, `listen` IS the downstream config
 - **Minimal keyword set**: `func`, `let`, `var`, `const`, `guard`, `struct`, `route`, `match`, `if`, `else`, `for`, `in`, `return`, `defer`, `upstream`, `listen`, `tls`, `defaults`, `forward`, `websocket`, `fire`, `submit`, `wait`, `timer`, `init`, `shutdown`, `firewall`, `throttle`, `per`, `notify`, `import`, `using`, `as`, `and`, `or`, `not`, `nil`, `true`, `false`
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -156,7 +156,10 @@ status matrix above.
   only when the semantics remain mechanically simple.
 - **HTTP concepts are native objects**: methods, status codes, headers, URLs, CIDR, media types are first-class language constructs, not strings
 - **All functions inline at compile time**: no runtime function calls, each route compiles to a single flat state machine
-- **Async is invisible**: no async/await/future/promise — user writes sequential code, compiler finds I/O points and generates state machines automatically
+- **Async suspension is explicit**: no async/await/future/promise, but every
+  operation that can suspend a handler must be visible as `wait`, `forward`, or
+  another explicit async boundary. The compiler lowers these points into state
+  machines; ordinary helper functions should not hide new yield points.
 - **Strong typing with domain types**: Duration, ByteSize, StatusCode, IP, CIDR, MediaType with compile-time validation
 - **Middleware = ordinary functions**: return a status code to reject, return nothing to pass through
 - **Bounded execution**: no `while`, no recursion, `for` only iterates finite collections — every handler has a compile-time execution bound, cannot stall a shard

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -152,8 +152,9 @@ status matrix above.
   code by constraining the language, making invalid intent easy to diagnose, and
   avoiding clever surface forms that look plausible but mean different things.
 - **Swift-inspired syntax where it reduces ambiguity**: guard statements, named
-  parameters, optional chaining, string interpolation — clean and readable, but
-  only when the semantics remain mechanically simple.
+  parameters, and string interpolation are useful when their semantics remain
+  mechanically simple. Symbol-heavy convenience forms stay non-core until they
+  prove clearer than named forms.
 - **HTTP concepts are native objects**: methods, status codes, headers, URLs, CIDR, media types are first-class language constructs, not strings
 - **All functions inline at compile time**: no runtime function calls, each route compiles to a single flat state machine
 - **Async suspension is explicit**: no async/await/future/promise, but every
@@ -221,13 +222,21 @@ and   or   not                  // boolean (keywords)
 ==  !=  <  >  <=  >=           // comparison
 =                               // assignment
 ?                               // nil check postfix (x?)
-?.                              // optional chaining (x?.method)
-??                              // null coalescing (x ?? default)
-!                               // logical not (alias for not)
 @                               // decorator prefix
 =>                              // single-expression body / branch result
 ->                              // function return type
 ```
+
+Rut Core intentionally avoids symbolic optional chaining and null-coalescing as
+the primary surface. Use named fallback and explicit binding instead:
+
+- `value.or(default)` for "usable value or fallback"
+- `guard let x = expr else { ... }` when absence/failure must stop the route
+- `match` when the reason for absence/failure matters
+
+The symbolic forms `?.`, `??`, and `!` remain non-core/reserved until there is
+evidence that they reduce ambiguity for humans, diagnostics, and LLM-generated
+code.
 
 ### 3.2.2 Core Control-Flow Surface
 
@@ -782,13 +791,13 @@ short forms therefore work on the value channel and naturally see failure as `ni
 Users who care about the precise error reason enter an explicit error-handling path
 with `guard` (and later possibly `match`).
 
-**Value-flow operators**
+**Value-flow surface**
 
 | Syntax | Meaning |
 |--------|---------|
 | `x?` | nil check on the usable value channel |
-| `x?.field` / `x?.method()` | continue only if a usable value exists |
-| `x ?? default` | provide a default when no usable value exists |
+| `x.or(default)` | provide a fallback when no usable value exists |
+| `guard let x = expr else { ... }` | bind usable value or terminate |
 | `a | f(_, ...)` | pipeline over the usable value channel |
 
 These operators intentionally optimize for the common case: keep the normal logic
@@ -798,9 +807,10 @@ That means a pipeline or optional-style expression may ignore detailed error cau
 and simply continue in terms of "value present" vs "value absent":
 
 ```swift
-let name = req.query("name") ?? "anonymous"
+let name = req.query("name").or("anonymous")
 let parts = req.path | trimPrefix("/api", _) | split(_, "/")
-let userName = findUser(id)?.profile?.name ?? "guest"
+let user = findUser(id).or(GuestUser)
+let userName = user.profileName.or("guest")
 ```
 
 When a caller needs to care about the failure reason rather than just the absence
@@ -824,7 +834,8 @@ only project tuple slots; they do not introduce a separate error model.
 Rut `guard` is intentionally narrower than Swift-style optional unwrapping:
 
 - `guard` handles **error**, not `nil`
-- `nil` remains part of the normal value channel and is handled by `?`, `?.`, `??`, and `or(...)`
+- `nil` remains part of the normal value channel and is handled by `?`,
+  `.or(...)`, `guard let`, or `match`
 - `guard ... else { ... }` must terminate control flow in the `else` block
 - `guard let x = expr else { ... }` binds the success value of `expr`, but does not implicitly unwrap optional payloads inside that success value
 
@@ -849,7 +860,8 @@ Examples:
 ```swift
 let page = req.query("page").or("1")
 let n = parseInt(raw).or(0)
-let name = findUser(id)?.profile?.name.or("guest")
+let user = findUser(id).or(GuestUser)
+let name = user.profileName.or("guest")
 ```
 
 `or(...)` is deliberately value-oriented. It does not expose or classify the error.
@@ -1340,7 +1352,7 @@ func waf(_ req: Request) {
     guard !path.contains("/../") else { return 403, "path traversal" }
     guard !urlDecode(path).contains("/../") else { return 403, "encoded traversal" }
 
-    let input = "\(path) \(req.queryString ?? "")"
+    let input = "\(path) \(req.queryString.or(""))"
     guard !input.matches(re"(?i)UNION\s+SELECT|DROP\s+TABLE|<script|javascript:") else {
         log.warn("waf blocked", { addr: req.remoteAddr })
         return 403
@@ -2224,7 +2236,7 @@ matches all patterns simultaneously.
 ```swift
 // User writes N separate checks:
 func waf(_ req: Request) {
-    let input = "\(req.path) \(req.queryString ?? "")"
+    let input = "\(req.path) \(req.queryString.or(""))"
     guard !input.matches(re"(?i)UNION\s+SELECT") else { return 403 }
     guard !input.matches(re"(?i)DROP\s+TABLE") else { return 403 }
     guard !input.matches(re"<script") else { return 403 }
@@ -2848,13 +2860,13 @@ Bit operations: & | ^ << >> ~
 | Header spell | `req.athorization` | "warning: did you mean authorization?" |
 | Indirect call | `let f = auth; f(req)` | "functions cannot be assigned to variables" |
 | guard exhaustive | `guard expr else { ... }` with non-terminating or missing `else` | "guard must have else clause" |
-| Optional access | `req.authorization.hasPrefix("B")` | "value may be nil, use ?, ?., ??, or or(...)" |
+| Optional access | `req.authorization.hasPrefix("B")` | "value may be nil, use guard let, match, or .or(default)" |
 | Response middleware | `func f(_ resp: Response)` applied where only pre-middleware expected | "signature contains Response — this is a post-middleware, will run after handler" (info) |
 | TLS without host | `tls "x.com"` but no `x.com { }` in route | warning: "TLS cert declared but no routes for x.com" |
 | Host without TLS | `x.com { }` in route but no `tls "x.com"` and listen uses TLS | "no TLS certificate for host x.com" |
 | Duplicate TLS | two `tls "x.com"` declarations | "duplicate TLS declaration for x.com" |
 | Host pattern | `x.y.z { }` in route with invalid domain chars | "invalid host pattern" |
-| Error-capable value ignored | `let x = req.body(User)` and later code assumes a usable value without fallback/guard | "expression may fail; use guard, match, or a value fallback such as or(...)" |
+| Error-capable value ignored | `let x = req.body(User)` and later code assumes a usable value without fallback/guard | "expression may fail; use guard, match, or a value fallback such as .or(default)" |
 | Error/nil confusion | treating an error-capable value as plain Optional without an explicit value-flow operation | "failure and nil are distinct; use guard/match for error handling or value-flow operators to treat failure as no value" |
 | Regex syntax | `re"[unclosed"` | "invalid regex: unclosed bracket" |
 | Regex capture | `m[3]` but pattern has 2 groups | "regex has 2 capture groups, index 3 out of range" |
@@ -2914,7 +2926,7 @@ func auth(_ req: Request, role: string) -> User {
 | `guard ... else` | `guard jwtDecode(token, secret: key) else { return 401 }` | Perfect for middleware "reject or continue" pattern |
 | Named parameters | `auth(req, role: "user")` | Self-documenting calls, LLMs generate correct argument order |
 | `_` unlabeled param | `func auth(_ req: Request, role: string)` | First param (always req) doesn't need label |
-| Optional chaining | `req.authorization?.hasPrefix("Bearer ")` | Safe navigation on nullable headers |
+| Named fallback | `req.authorization.or("")` | Core optional fallback surface; symbolic chaining remains non-core/reserved |
 | `let` / `var` | `let x = ...` (immutable), `var x = ...` (mutable) | `var` only inside func/handler, not at top level |
 | String interpolation | `"\(req.method)\n\(req.path)"` | Cleaner than concatenation |
 | `.enumCase` | `balance: .leastConn` | Concise enum values |
@@ -3248,7 +3260,7 @@ null dereference) **must never take down the shard**.
 The compiler eliminates most crash sources:
 - Division by zero → compiler inserts check before every `/`, returns 500 if divisor is 0
 - Array out of bounds → compiler inserts bounds check on every `[]` access
-- Null/nil access → use `?`, `?.`, `??`, or `or(...)`; use `guard` only for explicit error handling
+- Null/nil access → use `?`, `.or(default)`, `guard let`, or `match`
 - Infinite loops → no `while`, no recursion, `for` only on finite collections
 - Stack overflow → all functions inline, no call stack depth
 
@@ -5521,12 +5533,12 @@ The semantic distinction still matters:
 - `error(...)` is structured failure information
 - HIR is allowed to preserve and analyze that failure information explicitly
 
-But the ergonomic operators of the language intentionally work in terms of the
-value channel:
+But the ergonomic value-flow surface intentionally works in terms of the value
+channel:
 
-- `|`, `?`, `?.`, and `??` are value-oriented syntax
+- `|`, `?`, and `.or(default)` are value-oriented syntax
 - they optimize for "keep going if a usable value exists"
-- in those forms, failure behaves like "no usable value", so the expression flows as `nil`
+- in these forms, failure behaves like "no usable value", so the expression flows as `nil`
 
 This is a deliberate usability tradeoff for gateway-style code, where many failures
 are tolerated locally and only need logging, counting, or fallback behavior.

--- a/docs/core-capabilities.md
+++ b/docs/core-capabilities.md
@@ -1,0 +1,84 @@
+# Core Capabilities
+
+Rut should keep the gateway capabilities needed for production, but each
+capability needs one canonical syntax and one verifier-visible meaning.
+
+## Core Surface
+
+The stable core surface should prioritize features that lower directly to a
+route automaton:
+
+- route matching,
+- domain-typed request inspection,
+- `let` and handler-local `var`,
+- `guard`, `if`, and `match`,
+- bounded `for` over finite inputs,
+- terminal `return`,
+- terminal `return forward(upstream)`,
+- explicit `wait(...)` and `wait any { ... }`,
+- bounded per-shard state.
+
+## Async Boundaries
+
+Rut code may look sequential, but every operation that can suspend must be
+visible at the source boundary.
+
+Canonical core forms:
+
+```rut
+return forward(api)
+
+let ev = wait(downstream.recv())
+
+wait any {
+    downstream.recv() => { return 204 }
+    timer(2000) => { return 408 }
+}
+```
+
+Non-terminal concurrent work such as `submit`, detached work such as `fire`, and
+one-off outbound HTTP calls are required capabilities, but they should share the
+same explicit async discipline before they are treated as stable core syntax.
+They must produce verifier-visible operations, replay events, and fail-closed
+paths.
+
+## Optional And Fallback
+
+Rut Core should prefer named fallback over symbolic optional chaining:
+
+```rut
+let page = req.query("page").or("1")
+
+guard let user = req.body(User) else {
+    return 400
+}
+```
+
+The symbolic forms `?.` and `??` are concise, but they are easy to overuse and
+harder to diagnose precisely. They should stay non-core/reserved until examples,
+diagnostics, and LLM-generated code show that they reduce rather than increase
+ambiguity.
+
+`any` and `all` should be reserved for race/concurrency meanings, not ordinary
+optional fallback.
+
+## State Consistency
+
+The first stable state model should be the smallest useful production set:
+
+- per-shard bounded state for fast local decisions,
+- one exact mode for request-visible consistency when needed.
+
+Additional modes such as broadcast notification, targeted notification, or
+external backing stores should be added only when their ordering, failure,
+replay, and verifier semantics are explicit.
+
+## Deferred Risks
+
+The current decorator design has two known risks:
+
+- execution order is not yet a strict first-instruction guard chain,
+- magic request binding through a parameter named `req` can be shadowed.
+
+These are not blockers for the current design pass, but they should be resolved
+before decorators become stable core syntax.

--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -136,7 +136,7 @@ The current design review keeps the following direction:
 - State consistency should be simplified to the production modes Rut actually
   needs first. Additional consistency/backing-store modes should wait until
   their replay and verifier contracts are precise.
-- Optional/fallback syntax remains open. Symbolic forms such as `?.` and `??`
-  are concise but may be less clear to new users and LLMs than named forms. The
-  core language should prefer whichever form yields the most deterministic
-  diagnostics and least ambiguity in generated code.
+- Optional/fallback syntax should prefer named forms in Rut Core. Use
+  `.or(default)`, `guard let`, or `match`; keep symbolic forms such as `?.` and
+  `??` non-core/reserved until they prove clearer for users, diagnostics, and
+  LLM-generated code.

--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -1,0 +1,107 @@
+# Design Goals
+
+Rut's language and runtime should be optimized for production gateway behavior
+that is easy to reason about, easy to test, and hard to misgenerate.
+
+## Low Ambiguity
+
+Rut should avoid multiple equivalent ways to express the same common operation.
+When a feature is added, it should have a narrow role and a clear interaction
+with existing constructs.
+
+Guidelines:
+
+- Prefer one canonical construct for each common gateway task.
+- Allow at most one secondary idiom when it materially improves readability.
+- Reject code whose intent depends on subtle precedence, overload resolution, or
+  implicit runtime behavior.
+- Prefer explicit domain constructs over strings or user-defined conventions.
+- Make diagnostics deterministic and prescriptive.
+
+This is a language-design constraint, not only a style preference. A smaller
+surface makes Rut easier for humans, compilers, verifiers, and LLMs to use
+correctly.
+
+## Mechanically Reducible Programs
+
+Every route should lower to a compact state machine. The compiler and verifier
+should be able to identify:
+
+- terminal responses,
+- upstream forwards,
+- timer and IO waits,
+- wait resume targets,
+- fail-closed branches,
+- bounded loops over finite inputs.
+
+Features that cannot be represented in this model should be rejected, bounded,
+or isolated behind an explicit escape hatch with weaker guarantees.
+
+## Verifier-Oriented Semantics
+
+Rut should not depend on general-purpose formal tools for normal user-code
+checks. The target is a native Rut verifier that checks the small automata
+generated from Rut IR.
+
+The verifier should focus on Rut-specific properties:
+
+- route state machines cannot deadlock in modeled runtime states,
+- event waits can only resume from declared event arms,
+- fail-closed branches exist for runtime operation failures,
+- callback slots and pending operations stay consistent with runtime state,
+- event-driven cycles make progress under explicit fairness assumptions.
+
+TLA+ can remain as a design-level reference for runtime invariants and checker
+validation, but Java/TLC should not be required to verify ordinary user code.
+
+## Replay and Simulation
+
+Captured traffic and synthetic events should be able to exercise the same route
+semantics as production execution. This keeps correctness grounded in concrete
+observations and lets CI compare expected behavior with replayed behavior.
+
+Replay and simulation should be used to test:
+
+- routing decisions,
+- response status and headers,
+- upstream selection and failover branches,
+- malformed input handling,
+- timeout and wait behavior,
+- hot-reload compatibility.
+
+When production behavior cannot be replayed exactly, the difference should be an
+explicitly modeled environment effect rather than an accidental gap.
+
+## LLM Risk Reduction
+
+Rut is expected to be used with LLM-assisted generation, so the language should
+be designed to reduce plausible wrong code.
+
+Useful constraints:
+
+- narrow grammar,
+- small keyword set,
+- domain-specific types,
+- no unbounded loops or recursion,
+- explicit `guard`, `match`, `wait`, and `forward` semantics,
+- deterministic formatting and diagnostics,
+- route-local verification feedback.
+
+The goal is not merely to make Rut easy for LLMs to write. The goal is to make
+incorrect generated code easy to reject, replay, simulate, or prove impossible
+within Rut's restricted semantics.
+
+## Feature Acceptance Rule
+
+A new language/runtime feature should answer these questions before it becomes
+part of the core surface:
+
+1. Does it introduce another way to solve a problem that already has a canonical
+   Rut form?
+2. Can it lower to the route state-machine model?
+3. Can replay or simulation exercise it deterministically?
+4. Can the native verifier check its safety and progress obligations?
+5. Does it reduce or increase the chance of LLM-generated plausible wrong code?
+
+If the answer is unclear, the feature should stay experimental or be expressed
+as a lower-level escape hatch rather than added to the main language.

--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -9,6 +9,10 @@ Rut should avoid multiple equivalent ways to express the same common operation.
 When a feature is added, it should have a narrow role and a clear interaction
 with existing constructs.
 
+Necessary gateway capabilities should not be removed merely because they add
+language surface. Instead, Rut should refine them into one canonical form with a
+small, explicit state-machine meaning.
+
 Guidelines:
 
 - Prefer one canonical construct for each common gateway task.
@@ -37,6 +41,11 @@ should be able to identify:
 Features that cannot be represented in this model should be rejected, bounded,
 or isolated behind an explicit escape hatch with weaker guarantees.
 
+Suspension points should be explicit in the source. Rut can still let users
+write sequential code, but IO that can yield must be declared through constructs
+such as `wait`, `forward`, or an explicitly asynchronous operation. Ordinary
+helper functions should not hide new runtime yield points.
+
 ## Verifier-Oriented Semantics
 
 Rut should not depend on general-purpose formal tools for normal user-code
@@ -53,6 +62,11 @@ The verifier should focus on Rut-specific properties:
 
 TLA+ can remain as a design-level reference for runtime invariants and checker
 validation, but Java/TLC should not be required to verify ordinary user code.
+
+The verifier should prefer a small set of capability-specific models over one
+large universal model. For example, cross-shard state can start with the modes
+Rut needs for production and grow only when replay, simulation, and verifier
+semantics are clear.
 
 ## Replay and Simulation
 
@@ -84,6 +98,7 @@ Useful constraints:
 - domain-specific types,
 - no unbounded loops or recursion,
 - explicit `guard`, `match`, `wait`, and `forward` semantics,
+- explicit async declarations for operations that can suspend,
 - deterministic formatting and diagnostics,
 - route-local verification feedback.
 
@@ -105,3 +120,23 @@ part of the core surface:
 
 If the answer is unclear, the feature should stay experimental or be expressed
 as a lower-level escape hatch rather than added to the main language.
+
+## Current Review Decisions
+
+The current design review keeps the following direction:
+
+- Required gateway capabilities should stay in the roadmap, but each one needs a
+  canonical, verifier-friendly form.
+- Async behavior should be explicit at the source boundary. The compiler may
+  lower sequential syntax into states, but it should not discover hidden yield
+  points inside ordinary helper code.
+- Decorator execution ordering and magic request binding are known risks, but
+  are deferred. They should be revisited before decorators become part of the
+  stable core surface.
+- State consistency should be simplified to the production modes Rut actually
+  needs first. Additional consistency/backing-store modes should wait until
+  their replay and verifier contracts are precise.
+- Optional/fallback syntax remains open. Symbolic forms such as `?.` and `??`
+  are concise but may be less clear to new users and LLMs than named forms. The
+  core language should prefer whichever form yields the most deterministic
+  diagnostics and least ambiguity in generated code.

--- a/docs/pipe.md
+++ b/docs/pipe.md
@@ -10,8 +10,9 @@ MIR/RIR opcode.
 
 Use `or` and `and` as boolean operators only. Function-call forms `or(...)` and
 `and(...)` are not supported, and `&&` / `||` are rejected at parse time. For
-optional/error fallback in expressions, use `any(...)` for nil/error fallback
-and `all(...)` for present-only fallback.
+optional/error fallback in expressions, Rut Core uses the named value method
+`.or(default)`. The names `any` and `all` are reserved for concurrent/race
+semantics rather than ordinary value fallback.
 
 ## Operator Precedence Notes
 
@@ -137,7 +138,7 @@ func allow_if_token(token: str, expected: str, ok_status: i32) -> i32 {
 
 route GET "/admin" {
     let code = req.header("Authorization") | allow_if_token(_, "Bearer root", 200)
-    let safe = any(code, 401)
+    let safe = code.or(401)
     if safe == 200 { return 200 } else { return 401 }
 }
 ```
@@ -161,7 +162,7 @@ arguments when a pipeline needs to project tuple slots.
 
 `req.header(...)` returns an optional string. A pipe stage only runs when the
 header is present; missing values flow through as `nil` and can be handled with
-`any(...)`.
+`.or(default)`.
 
 ```rut
 func tenant_from_host(host: str) -> str {
@@ -174,7 +175,7 @@ func status_for_tenant(tenant: str) -> i32 {
 
 route GET "/tenant" {
     let code = req.header("Host") | tenant_from_host(_) | status_for_tenant(_)
-    let safe = any(code, 404)
+    let safe = code.or(404)
     if safe == 200 { return 200 } else { return 404 }
 }
 ```
@@ -182,7 +183,7 @@ route GET "/tenant" {
 ## Error Flow
 
 Error values also flow through a pipe without calling later stages. Downstream
-`any(...)` can turn the error into a concrete fallback:
+`.or(default)` can turn the error into a concrete fallback:
 
 ```rut
 func parse_mode(raw: str) -> i32 {
@@ -195,7 +196,7 @@ func status_for_mode(mode: i32) -> i32 {
 
 route GET "/mode" {
     let code = req.header("X-Mode") | parse_mode(_) | status_for_mode(_)
-    let safe = any(code, 400)
+    let safe = code.or(400)
     if safe == 200 { return 200 } else { return 400 }
 }
 ```
@@ -203,22 +204,21 @@ route GET "/mode" {
 Known `nil` and known `error(...)` left-hand values are folded at analysis time
 and do not call the stage.
 
-`any(...)` and `all(...)` use conditional selection at runtime, so both operands
-are materialized before selection. If you need strict short-circuiting for
-side-effectful expressions, write it as an explicit `if` branch.
+Legacy fallback helpers such as `any(...)` and `all(...)` should not be used for
+ordinary value-flow code in Rut Core. If a fallback must be computed lazily or a
+side effect must short-circuit, write an explicit `if` branch.
 
-`all(...)` is the present-only fallback form:
+The present-only fallback shape should be spelled explicitly:
 
 ```rut
 route GET "/all" {
     let token = req.query("x-token")
-    let safe = all(token, any(token, ""))
+    let safe = if token? { token.or("") } else { "" }
     if safe == "" { return 401 } else { return 200 }
 }
 ```
 
-Use `all(...)` when you want the right-hand value to apply only when the
-left-hand value is present.
+Use explicit branching when the fallback rule is not simple "value or default".
 
 ## Tuple Slots
 

--- a/docs/user-code-formal-verification.md
+++ b/docs/user-code-formal-verification.md
@@ -49,7 +49,7 @@ The first useful handler model can be a finite automaton:
 - handler state/basic-block id,
 - terminal responses,
 - `wait(ms)` and event waits,
-- `wait(any(...))` arms,
+- `wait any { ... }` race arms,
 - upstream connect/send/recv waits,
 - `forward` actions,
 - fail-closed error responses.
@@ -175,7 +175,7 @@ to invoking TLC for every route.
    clear.
 
 The first prototype should model one or two representative handlers, not the
-whole language. A good initial target is a handler with `wait(any(...))`, a
+whole language. A good initial target is a handler with `wait any { ... }`, a
 timer timeout branch, and an upstream connect/send/recv path.
 
 ## TLA+ Role

--- a/docs/user-code-formal-verification.md
+++ b/docs/user-code-formal-verification.md
@@ -1,27 +1,48 @@
-# User Code Formal Verification
+# User Code Verification
 
-Rut can use the runtime TLA+ model as the start of a broader verification
-pipeline, but the useful target is narrower than "prove arbitrary user code is
-correct." The tractable target is:
+Rut can use the runtime TLA+ model as a reference point, but TLA+/TLC should not
+be the primary verification engine for user code. It is too general for Rut's
+hot path: it brings a Java dependency, explores more machinery than Rut needs,
+and is not shaped around fast per-route feedback.
 
-> Generate an abstract model from Rut's user-code IR and check that it preserves
-> the runtime protocol: legal state transitions, callback-slot hygiene, yielded
-> handler wakeups, fail-closed behavior, and progress under explicit fairness
-> assumptions.
+The tractable product direction is a Rut-specific verifier:
+
+> Compile Rut user-code IR into a small verification automaton and run a
+> purpose-built checker that proves Rut protocol properties: legal state
+> transitions, callback-slot hygiene, yielded handler wakeups, fail-closed
+> behavior, deadlock freedom, and progress under explicit fairness assumptions.
 
 ## Source of Truth
 
-The model should be generated from Rut's DSL/RIR, not from generated C++ or JIT
-machine code. The IR should be the single semantic source for:
+The verifier should consume Rut's DSL/RIR, not generated C++ or JIT machine
+code. The IR should be the single semantic source for:
 
 - generated runtime/JIT code,
-- generated TLA+ handler actions,
+- generated verification automata,
 - a manifest that maps IR operations to runtime transitions.
 
 This avoids reverse-engineering implementation details and gives the checker a
 small, stable language to reason about.
 
-## What to Model
+## Why Not TLA+ as the Main Engine
+
+TLA+ remains useful for the runtime's abstract design, but it is not the right
+execution engine for checking every user route:
+
+- It depends on TLC and Java in developer/CI environments.
+- It is optimized for general state-space exploration, not Rut's restricted
+  event-machine shape.
+- The generated specs would still require a translator, so the trusted boundary
+  does not disappear.
+- Liveness and fairness configuration is easy to make too weak, too strong, or
+  too slow.
+- The feedback loop should be close to parser/type-checker speed for common
+  routes.
+
+Rut should instead keep the TLA+ model as an oracle for validating the checker
+design and a source of test vectors for the custom engine.
+
+## Verification Automaton
 
 The first useful handler model can be a finite automaton:
 
@@ -33,9 +54,18 @@ The first useful handler model can be a finite automaton:
 - `forward` actions,
 - fail-closed error responses.
 
-The generated TLA+ module can compose this handler automaton with
-`spec/runtime_state.tla`. TLC then checks the combined state space instead of
-only the generic runtime state machine.
+The verifier should compose this handler automaton with a built-in model of the
+Rut runtime protocol. This model should be small enough to live in native code
+and run deterministically without external solvers.
+
+Each automaton node should carry:
+
+- the handler program point,
+- the abstract runtime state,
+- active callback slots,
+- pending yield kind and target,
+- pending runtime operation class,
+- bounded symbolic facts needed by Rut's control-flow rules.
 
 ## Properties to Check
 
@@ -67,16 +97,31 @@ Fairness must be explicit. Without assumptions such as "an armed timer
 eventually fires" or "a submitted send eventually succeeds or fails," any
 network program can be modeled as not making progress.
 
+## Custom Checker Shape
+
+The checker can be much simpler than a general-purpose model checker:
+
+- Use an explicit-state graph over Rut's finite protocol state.
+- Represent callback slots and pending operations as compact bitsets/enums.
+- Use worklist reachability for safety and deadlock checks.
+- Use strongly connected components for livelock/progress checks.
+- Run route-local checks first, then optionally compose multiple routes only
+  where shared runtime resources matter.
+- Emit counterexample traces in Rut terms, not TLA+ terms.
+
+This should make checks fast enough for normal CI and eventually for local
+developer feedback during compilation.
+
 ## Infinite Loops
 
-TLA+ can find finite-state livelocks and cycles in the abstract handler
-automaton. It cannot prove termination for arbitrary native code.
+The custom checker can find finite-state livelocks and cycles in the abstract
+handler automaton. It cannot prove termination for arbitrary native code.
 
 Rut should therefore split the problem:
 
 - Static CFG checks reject handler cycles that contain no `yield`, `return`,
   `forward`, or provably bounded progress.
-- TLA+ liveness checks verify the remaining event-driven cycles under fairness.
+- The verifier checks the remaining event-driven cycles under fairness.
 - Runtime watchdogs or fuel limits remain necessary for any native or
   insufficiently restricted user-code escape hatch.
 
@@ -87,11 +132,12 @@ This is not a full C++ verifier. It does not prove:
 - arbitrary arithmetic or string manipulation correctness,
 - memory safety or absence of undefined behavior in generated native code,
 - every kernel/network behavior,
-- correctness of the IR-to-TLA+ translator by itself.
+- correctness of the IR-to-automaton translator by itself.
 
 The translator risk should be reduced by generation discipline: both runtime
-code and TLA+ should come from the same IR, and CI should compare the generated
-manifest against runtime transition APIs and modeled TLA+ actions.
+code and verification automata should come from the same IR, and CI should
+compare the generated manifest against runtime transition APIs and checked
+automaton actions.
 
 ## Prior Art
 
@@ -110,21 +156,30 @@ Useful reference points:
 
 The closest shape for Rut is a mix of P's event-machine discipline, PlusCal or
 Quint's generated model-checkable actions, and Dafny's single-source semantic
-discipline.
+discipline. The implementation should be closer to P's specialized checker than
+to invoking TLC for every route.
 
 ## Incremental Plan
 
 1. Define a small handler-verification IR covering terminal responses, timers,
    event waits, upstream waits, and forward.
-2. Generate a TLA+ handler module plus an action manifest from that IR.
-3. Compose the generated handler module with `spec/runtime_state.tla`.
-4. Add TLC checks for deadlock, slot invariants, wait/resume legality, and a
-   small liveness property under explicit fairness assumptions.
-5. Compare the manifest against runtime transition helper names and generated
+2. Generate a compact handler automaton plus an action manifest from that IR.
+3. Implement a native explicit-state checker for safety and deadlock checks.
+4. Add SCC-based progress checks for Rut-specific liveness properties under
+   explicit fairness assumptions.
+5. Cross-check the checker against small TLA+ reference cases while the engine
+   is young.
+6. Compare the manifest against runtime transition helper names and generated
    JIT metadata in CI.
-6. Extend the IR only when the corresponding abstract semantics and checks are
+7. Extend the IR only when the corresponding abstract semantics and checks are
    clear.
 
 The first prototype should model one or two representative handlers, not the
 whole language. A good initial target is a handler with `wait(any(...))`, a
 timer timeout branch, and an upstream connect/send/recv path.
+
+## TLA+ Role
+
+TLA+ should stay in the project for design-level runtime invariants and for
+validating the custom checker's semantics. It should not be required to verify
+normal Rut user code.

--- a/docs/wait.md
+++ b/docs/wait.md
@@ -3,11 +3,11 @@
 `wait(...)` pauses a JIT route handler and resumes the same handler state
 machine when the requested timer or IO completion event occurs.
 
-## Event Model
+## Core Event Model
 
 The handler can suspend for three classes of events:
 
-- Any currently supported `wait(any(...))` arm: downstream recv or a timer.
+- A race declared with statement-form `wait any { ... }`.
 - A specific IO completion such as downstream recv/send or upstream
   connect/send/recv.
 - A timer deadline.
@@ -23,7 +23,6 @@ wait(downstream.recv())
 wait(upstream(api).connect())
 wait(upstream(api).recv())
 wait(upstream(api).send(req.body))
-wait(any(downstream.recv(), timer(250)))
 wait any {
     downstream.recv() => { return 204 }
     timer(250) => { return 408 }
@@ -42,13 +41,10 @@ The forms are either operation-start waits or completion waits:
 - `wait(upstream(api).send(req.body))` sends the current request buffer
   upstream and waits for the send completion.
 
-`wait(any(...))` resumes on any declared supported arm. Today that means
-`downstream.recv()` plus an optional `timer(N)` timeout arm; `N` is
-milliseconds.
-
-When the route needs different control flow for each winning arm, prefer
-statement-form `wait any`. The first slice supports a downstream recv arm and a
-timer arm, with direct terminal branch bodies:
+`wait any` is the canonical race form. Each winning arm has explicit route
+logic, which makes the generated state machine and verifier trace easier to
+read. The first slice supports a downstream recv arm and a timer arm, with
+direct terminal branch bodies:
 
 ```rut
 route POST "/upload" {
@@ -130,13 +126,13 @@ available after later waits:
 
 ```rut
 route POST "/upload" {
-    let first = wait(any(downstream.recv(), timer(2000)))
-    let second = wait(downstream.recv())
-    if first.timer {
-        return 408
-    } else {
-        guard second.ok else { return 400 }
-        return 204
+    wait any {
+        timer(2000) => { return 408 }
+        downstream.recv() => {
+            let second = wait(downstream.recv())
+            guard second.ok else { return 400 }
+            return 204
+        }
     }
 }
 ```
@@ -146,7 +142,7 @@ the ordered wait/guard sequence.
 
 ## Race Waits
 
-`wait any` is the clearest form when each winning event should run different
+`wait any` is the canonical form when each winning event should run different
 route logic:
 
 ```rut
@@ -158,7 +154,8 @@ route POST "/upload" {
 }
 ```
 
-The older `wait(any(...))` expression form remains available and returns the same result surface as other event waits:
+The older `wait(any(...))` expression form remains available as legacy syntax
+while existing examples and tests migrate, but it is not the Rut Core race form:
 
 ```rut
 route POST "/upload" {


### PR DESCRIPTION
## Summary
- shift the user-code verification plan away from generating TLA+ as the main engine
- document a Rut-specific native verifier based on compact automata, explicit-state reachability, and SCC progress checks
- keep TLA+ as a reference/oracle for runtime invariants and checker validation, not a user-code CI dependency

## Verification
- git diff --check HEAD~1 HEAD