### PR TITLE
Tighten Rut core wait syntax

### DIFF
--- a/docs/wait.md
+++ b/docs/wait.md
@@ -154,17 +154,14 @@ route POST "/upload" {
 }
 ```
 
-The older `wait(any(...))` expression form remains available as legacy syntax
-while existing examples and tests migrate, but it is not the Rut Core race form:
+The older `wait(any(...))` expression form is no longer Rut Core syntax. Use
+`wait any { ... }` when a route needs to branch on the winning race event:
 
 ```rut
 route POST "/upload" {
-    let ev = wait(any(downstream.recv(), timer(2000)))
-    if ev.timer {
-        return 408
-    } else {
-        guard ev.ok else { return 400 }
-        return 200
+    wait any {
+        downstream.recv() => { return 200 }
+        timer(2000) => { return 408 }
     }
 }
 ```
@@ -229,9 +226,9 @@ For this slice, "completion wait" is the important boundary:
   upstream and waits for its completion.
 - Upstream recv/send waits preserve the named upstream target and fail closed
   if the current upstream socket was opened for a different target.
-- `wait(any(downstream.recv(), timer(250)))` waits for downstream recv and also
-  resumes with `kind = 3` when the timeout fires. Upstream arms inside
-  `any(...)` are rejected until the arm list is carried through lowering.
+- `wait any { downstream.recv() => { ... } timer(250) => { ... } }` waits for
+  downstream recv or the timer, then runs the winning arm. The legacy
+  expression form `wait(any(...))` is rejected.
 
 ## Supported Route Shape
 
@@ -336,10 +333,10 @@ The following are future work rather than current behavior:
 - Response starts inside `wait(downstream.send(response(...)))`; use terminal
   `return response(...)` for downstream responses until route completion can
   model "send and finish" without a second terminal response.
-- Exact event subsets inside `wait(any(...))`; today it uses current-connection `Any`
+- Exact event subsets inside `wait any`; today it uses current-connection `Any`
   once the listed forms validate.
-- Parameterized IO starts inside `wait(any(...))`; start the operation before a
-  later race wait until that payload has a richer representation.
+- Parameterized IO starts inside `wait any`; start the operation before a later
+  race wait until that payload has a richer representation.
 - `wait any` arm result binding such as `r = downstream.recv() => { ... }`.
 - Non-wait `let` bindings after a `wait(...)`.
 - Waits inside nested blocks, loops, branches, or decorator bodies.

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5062,38 +5062,8 @@ static bool wait_timer_call_ms(const AstExpr& op, u32& ms) {
     return true;
 }
 
-static FrontendResult<WaitSpec> analyze_wait_any_call(const AstExpr& call,
-                                                      const HirModule& mod,
-                                                      u32& ms) {
-    if (call.kind != AstExprKind::Call || !call.name.eq({"any", 3}) || call.args.len == 0)
-        return frontend_error(FrontendError::UnsupportedSyntax, call.span);
-    bool saw_event = false;
-    bool saw_timer = false;
-    for (u32 ai = 0; ai < call.args.len; ai++) {
-        const AstExpr* arg = call.args[ai];
-        if (arg == nullptr) return frontend_error(FrontendError::UnsupportedSyntax, call.span);
-        u32 timer_ms = 0;
-        if (wait_timer_call_ms(*arg, timer_ms)) {
-            if (saw_timer) return frontend_error(FrontendError::UnsupportedSyntax, arg->span);
-            saw_timer = true;
-            ms = timer_ms;
-            continue;
-        }
-        if (arg->kind == AstExprKind::MethodCall && arg->args.len != 0)
-            return frontend_error(FrontendError::UnsupportedSyntax, arg->span);
-        auto event_spec = analyze_wait_io_op_spec(*arg, mod);
-        if (!event_spec) return core::make_unexpected(event_spec.error());
-        if (event_spec->payload != 0)
-            return frontend_error(FrontendError::UnsupportedSyntax, arg->span);
-        if (event_spec->kind != WaitEventKind::Recv)
-            return frontend_error(FrontendError::UnsupportedSyntax, arg->span);
-        saw_event = true;
-    }
-    if (!saw_event) return frontend_error(FrontendError::UnsupportedSyntax, call.span);
-    WaitSpec spec{};
-    spec.kind = WaitEventKind::Any;
-    spec.payload = ms;
-    return spec;
+static FrontendResult<WaitSpec> analyze_wait_any_call(const AstExpr& call, const HirModule&, u32&) {
+    return frontend_error(FrontendError::UnsupportedSyntax, call.span);
 }
 
 static FrontendResult<WaitSpec> analyze_wait_value_spec(const AstExpr& expr,

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -206,6 +206,20 @@ TEST(frontend, lex_recognizes_and_or_keywords) {
     CHECK_EQ(static_cast<u8>(lexed->tokens[3].type), static_cast<u8>(TokenType::KwOr));
 }
 
+TEST(frontend, lex_rejects_non_core_optional_symbols) {
+    const char* sources[] = {
+        "route GET \"/x\" { let name = req.query(\"name\") ?? \"anonymous\" return 200 }\n",
+        "route GET \"/x\" { let ok = req.authorization?.hasPrefix(\"Bearer\") return 200 }\n",
+        "route GET \"/x\" { guard !req.path.contains(\"/../\") else { return 403 } return 200 "
+        "}\n",
+    };
+    for (const char* src : sources) {
+        auto lexed = lex(lit(src));
+        REQUIRE(!lexed);
+        CHECK_EQ(lexed.error().code, FrontendError::UnexpectedChar);
+    }
+}
+
 TEST(frontend, parse_supports_infix_or_expression) {
     const char* src = "route GET \"/x\" { let x = true or false return 200 }\n";
     auto lexed = lex(lit(src));
@@ -2472,7 +2486,7 @@ TEST(frontend, analyze_wait_result_fields) {
              static_cast<u8>(HirExprKind::WaitField));
 }
 
-TEST(frontend, analyze_wait_result_event_predicate_fields) {
+TEST(frontend, analyze_rejects_wait_any_expression_event_predicates) {
     const char* src =
         "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(250))) "
         "guard ev.timer else { return 500 } guard ev.recv else { return 501 } "
@@ -2484,14 +2498,8 @@ TEST(frontend, analyze_wait_result_event_predicate_fields) {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE(hir);
-    REQUIRE_EQ(hir->routes[0].guards.len, 6u);
-    for (u32 i = 0; i < hir->routes[0].guards.len; i++) {
-        CHECK_EQ(static_cast<u8>(hir->routes[0].guards[i].cond.kind),
-                 static_cast<u8>(HirExprKind::WaitField));
-        CHECK_EQ(static_cast<u8>(hir->routes[0].guards[i].cond.type),
-                 static_cast<u8>(HirTypeKind::Bool));
-    }
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
 TEST(frontend, analyze_rejects_unbound_wait_result_field) {
@@ -2652,7 +2660,7 @@ TEST(frontend, analyze_wait_connect_argument_records_upstream_payload) {
     CHECK_EQ(hir->routes[0].waits[0].ms, 1u);
 }
 
-TEST(frontend, analyze_wait_any_records_event_payload) {
+TEST(frontend, analyze_rejects_wait_any_expression) {
     const char* src =
         "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(250))) return 204 }\n";
     auto lexed = lex(lit(src));
@@ -2660,10 +2668,8 @@ TEST(frontend, analyze_wait_any_records_event_payload) {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE(hir);
-    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
-    CHECK_EQ(hir->routes[0].waits[0].event_kind, WaitEventKind::Any);
-    CHECK_EQ(hir->routes[0].waits[0].ms, 250u);
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
 TEST(frontend, analyze_rejects_timer_only_wait_any) {

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -18462,6 +18462,7 @@ TEST(jit, frontend_route_wait_event_predicate_fields_drive_control_flow) {
         YieldKind resume_kind;
     };
     const Case cases[] = {
+        {"wait(250)", "timer", YieldKind::Timer},
         {"wait(downstream.recv())", "recv", YieldKind::Recv},
         {"wait(downstream.recv())", "send", YieldKind::Send},
         {"wait(upstream(api).connect())", "upstream_connect", YieldKind::UpstreamConnect},

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -18070,7 +18070,6 @@ TEST(jit, frontend_route_event_waits_emit_event_yield_kinds) {
     };
     const Case cases[] = {
         {"wait()", YieldKind::Any, 0},
-        {"wait(any(downstream.recv(), timer(250)))", YieldKind::Any, 250},
         {"wait(downstream.recv())", YieldKind::Recv, 0},
         {"wait(upstream(api).connect())", YieldKind::UpstreamConnect, 1},
         {"wait(upstream(api).recv())", YieldKind::UpstreamRecv, 1},
@@ -18463,7 +18462,6 @@ TEST(jit, frontend_route_wait_event_predicate_fields_drive_control_flow) {
         YieldKind resume_kind;
     };
     const Case cases[] = {
-        {"wait(any(downstream.recv(), timer(250)))", "timer", YieldKind::Timer},
         {"wait(downstream.recv())", "recv", YieldKind::Recv},
         {"wait(downstream.recv())", "send", YieldKind::Send},
         {"wait(upstream(api).connect())", "upstream_connect", YieldKind::UpstreamConnect},
@@ -18536,7 +18534,7 @@ TEST(jit, frontend_route_wait_event_predicate_fields_drive_control_flow) {
     }
 }
 
-TEST(jit, frontend_route_wait_result_fields_survive_later_waits) {
+TEST(jit, frontend_route_wait_any_expression_result_fields_are_rejected) {
     const auto src = R"rut(
 route GET "/x" {
     let first = wait(any(downstream.recv(), timer(250)))
@@ -18553,55 +18551,8 @@ route GET "/x" {
     auto ast = parse_file_heap(lexed.value());
     REQUIRE(ast);
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE(hir);
-    auto mir = build_mir_heap(hir.value());
-    REQUIRE(mir);
-    FrontendRirModule rir{};
-    auto lowered = lower_to_rir(mir.value(), rir);
-    REQUIRE(lowered);
-    auto cg = codegen(rir.module);
-    REQUIRE(cg.ok);
-    JitEngine engine;
-    REQUIRE(engine.init());
-    REQUIRE(engine.compile(cg.mod, cg.ctx));
-    auto handler = reinterpret_cast<HandlerFn>(engine.lookup("handler_route_0"));
-    REQUIRE(handler != nullptr);
-
-    TestHandlerCtxFrame frame{};
-    HandlerCtx& ctx = frame.ctx;
-    ctx.state = 0;
-    auto first_yield = HandlerResult::unpack(handler(nullptr,
-                                                     &ctx,
-                                                     reinterpret_cast<const u8*>(kGetRootRequest),
-                                                     sizeof(kGetRootRequest) - 1,
-                                                     nullptr));
-    REQUIRE_EQ(static_cast<u8>(first_yield.action), static_cast<u8>(HandlerAction::Yield));
-    CHECK_EQ(static_cast<u8>(first_yield.yield_kind), static_cast<u8>(YieldKind::Any));
-
-    ctx.state = first_yield.next_state;
-    ctx.resume_event_kind = static_cast<u32>(YieldKind::Timer);
-    ctx.resume_event_result = 0;
-    auto second_yield = HandlerResult::unpack(handler(nullptr,
-                                                      &ctx,
-                                                      reinterpret_cast<const u8*>(kGetRootRequest),
-                                                      sizeof(kGetRootRequest) - 1,
-                                                      nullptr));
-    REQUIRE_EQ(static_cast<u8>(second_yield.action), static_cast<u8>(HandlerAction::Yield));
-    CHECK_EQ(static_cast<u8>(second_yield.yield_kind), static_cast<u8>(YieldKind::Recv));
-
-    ctx.state = second_yield.next_state;
-    ctx.resume_event_kind = static_cast<u32>(YieldKind::Recv);
-    ctx.resume_event_result = 8;
-    auto done = HandlerResult::unpack(handler(nullptr,
-                                              &ctx,
-                                              reinterpret_cast<const u8*>(kGetRootRequest),
-                                              sizeof(kGetRootRequest) - 1,
-                                              nullptr));
-    CHECK_EQ(static_cast<u8>(done.action), static_cast<u8>(HandlerAction::ReturnStatus));
-    CHECK_EQ(done.status_code, 204);
-
-    engine.shutdown();
-    rir.destroy();
+    REQUIRE_FALSE(hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
 }
 
 TEST(jit, frontend_route_multiple_waits_chain_through_states) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -585,7 +585,7 @@ TEST(simulate_engine, wait_any_expression_is_rejected) {
         "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(50))) if ev.timer { "
         "return 408 } else { return 204 } }\n";
     FrontendRirModule rir{};
-    CHECK(!compile_to_rir(src, rir));
+    REQUIRE_FALSE(compile_to_rir(src, rir));
 }
 
 TEST(simulate_engine, wait_any_expression_recv_predicate_is_rejected) {
@@ -593,7 +593,7 @@ TEST(simulate_engine, wait_any_expression_recv_predicate_is_rejected) {
         "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(50))) if ev.recv { "
         "return 204 } else { return 408 } }\n";
     FrontendRirModule rir{};
-    CHECK(!compile_to_rir(src, rir));
+    REQUIRE_FALSE(compile_to_rir(src, rir));
 }
 
 TEST(simulate_engine, nested_wait_any_expression_is_rejected) {
@@ -605,7 +605,7 @@ TEST(simulate_engine, nested_wait_any_expression_is_rejected) {
         "if second.recv { return 204 } else { return 409 } "
         "}\n";
     FrontendRirModule rir{};
-    CHECK(!compile_to_rir(src, rir));
+    REQUIRE_FALSE(compile_to_rir(src, rir));
 }
 
 TEST(simulate_engine, wait_any_prefers_terminal_mismatch_over_failed_candidate) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -580,45 +580,23 @@ TEST(simulate_engine, wait_any_statement_can_match_recv_winner) {
     rir.destroy();
 }
 
-TEST(simulate_engine, wait_any_expression_can_resume_with_timer_predicate) {
+TEST(simulate_engine, wait_any_expression_is_rejected) {
     const char* src =
         "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(50))) if ev.timer { "
         "return 408 } else { return 204 } }\n";
     FrontendRirModule rir{};
-    REQUIRE(compile_to_rir(src, rir));
-
-    Engine engine;
-    REQUIRE(engine.init(rir.module, nullptr, 0));
-
-    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 408));
-    CHECK_EQ(result.verdict, Verdict::Match);
-    CHECK_EQ(result.actual_status, 408u);
-    CHECK_EQ(result.yield_count, 1u);
-
-    engine.shutdown();
-    rir.destroy();
+    CHECK(!compile_to_rir(src, rir));
 }
 
-TEST(simulate_engine, wait_any_expression_can_match_recv_predicate) {
+TEST(simulate_engine, wait_any_expression_recv_predicate_is_rejected) {
     const char* src =
-        "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(50))) if ev.timer { "
-        "return 408 } else { return 204 } }\n";
+        "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(50))) if ev.recv { "
+        "return 204 } else { return 408 } }\n";
     FrontendRirModule rir{};
-    REQUIRE(compile_to_rir(src, rir));
-
-    Engine engine;
-    REQUIRE(engine.init(rir.module, nullptr, 0));
-
-    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
-    CHECK_EQ(result.verdict, Verdict::Match);
-    CHECK_EQ(result.actual_status, 204u);
-    CHECK_EQ(result.yield_count, 1u);
-
-    engine.shutdown();
-    rir.destroy();
+    CHECK(!compile_to_rir(src, rir));
 }
 
-TEST(simulate_engine, nested_wait_any_can_match_later_recv_winner) {
+TEST(simulate_engine, nested_wait_any_expression_is_rejected) {
     const char* src =
         "route GET \"/x\" { "
         "let first = wait(any(downstream.recv(), timer(50))) "
@@ -627,18 +605,7 @@ TEST(simulate_engine, nested_wait_any_can_match_later_recv_winner) {
         "if second.recv { return 204 } else { return 409 } "
         "}\n";
     FrontendRirModule rir{};
-    REQUIRE(compile_to_rir(src, rir));
-
-    Engine engine;
-    REQUIRE(engine.init(rir.module, nullptr, 0));
-
-    const auto result = simulate_one(engine, make_entry("GET /x HTTP/1.1\r\nHost: x\r\n\r\n", 204));
-    CHECK_EQ(result.verdict, Verdict::Match);
-    CHECK_EQ(result.actual_status, 204u);
-    CHECK_EQ(result.yield_count, 2u);
-
-    engine.shutdown();
-    rir.destroy();
+    CHECK(!compile_to_rir(src, rir));
 }
 
 TEST(simulate_engine, wait_any_prefers_terminal_mismatch_over_failed_candidate) {

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -383,6 +383,19 @@ static bool compile_to_rir(const char* src, FrontendRirModule& rir) {
     return true;
 }
 
+#define REQUIRE_WAIT_ANY_EXPRESSION_UNSUPPORTED(src)                 \
+    do {                                                             \
+        auto lexed = lex(Str{src, static_cast<u32>(strlen(src))});   \
+        REQUIRE(lexed);                                              \
+        auto ast = parse_file(lexed.value());                        \
+        REQUIRE(ast);                                                \
+        std::unique_ptr<AstFile> ast_owned(ast.value());             \
+        auto hir = analyze_file(*ast_owned);                         \
+        REQUIRE_FALSE(hir);                                          \
+        CHECK_EQ(static_cast<u8>(hir.error().code),                  \
+                 static_cast<u8>(FrontendError::UnsupportedSyntax)); \
+    } while (0)
+
 TEST(simulate_engine, wait_handler_drives_state_machine_to_terminal_status) {
     // Source handler: one wait(500) then return 204. The simulate engine
     // must drive the yield chain to completion offline (skipping the
@@ -584,16 +597,14 @@ TEST(simulate_engine, wait_any_expression_is_rejected) {
     const char* src =
         "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(50))) if ev.timer { "
         "return 408 } else { return 204 } }\n";
-    FrontendRirModule rir{};
-    REQUIRE_FALSE(compile_to_rir(src, rir));
+    REQUIRE_WAIT_ANY_EXPRESSION_UNSUPPORTED(src);
 }
 
 TEST(simulate_engine, wait_any_expression_recv_predicate_is_rejected) {
     const char* src =
         "route GET \"/x\" { let ev = wait(any(downstream.recv(), timer(50))) if ev.recv { "
         "return 204 } else { return 408 } }\n";
-    FrontendRirModule rir{};
-    REQUIRE_FALSE(compile_to_rir(src, rir));
+    REQUIRE_WAIT_ANY_EXPRESSION_UNSUPPORTED(src);
 }
 
 TEST(simulate_engine, nested_wait_any_expression_is_rejected) {
@@ -604,8 +615,7 @@ TEST(simulate_engine, nested_wait_any_expression_is_rejected) {
         "let second = wait(any(downstream.recv(), timer(50))) "
         "if second.recv { return 204 } else { return 409 } "
         "}\n";
-    FrontendRirModule rir{};
-    REQUIRE_FALSE(compile_to_rir(src, rir));
+    REQUIRE_WAIT_ANY_EXPRESSION_UNSUPPORTED(src);
 }
 
 TEST(simulate_engine, wait_any_prefers_terminal_mismatch_over_failed_candidate) {


### PR DESCRIPTION
## Summary
- reject legacy expression-form `wait(any(...))` so async races use the canonical `wait any { ... }` syntax
- keep the existing `wait any` statement coverage as the supported race form, including JIT coverage
- add frontend coverage that `?.`, `??`, and `!` remain outside Rut Core syntax

## Verification
- `cmake --build build --target test_jit test_frontend test_simulate_engine`
- `./build/tests/test_jit`
- `./build/tests/test_frontend`
- `./build/tests/test_simulate_engine`
- `git diff --check`