### PR TITLE
[codex] Add RIR verifier MVP

### DIFF
--- a/docs/user-code-formal-verification.md
+++ b/docs/user-code-formal-verification.md
@@ -178,6 +178,24 @@ The first prototype should model one or two representative handlers, not the
 whole language. A good initial target is a handler with `wait any { ... }`, a
 timer timeout branch, and an upstream connect/send/recv path.
 
+## Current MVP
+
+The first native verifier entry point is RIR graph validation. It is intentionally
+small: it checks route-local block structure before any larger runtime model is
+introduced.
+
+Covered today:
+
+- every block has exactly one final terminator,
+- branch and jump targets point at existing blocks,
+- all blocks are reachable by default,
+- RIR yield terminators match function yield metadata,
+- yield kinds are inside the runtime ABI range.
+
+This is not yet the full safety/deadlock checker described above. It is the
+foundation for that checker: a route automaton must be structurally valid before
+Rut can prove callback hygiene, declared resume targets, or progress properties.
+
 ## TLA+ Role
 
 TLA+ should stay in the project for design-level runtime invariants and for

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -265,6 +265,14 @@ inline VerifyResult verify_function(const Function* fn,
             fn->resume_terminal_block >= fn->block_count) {
             return verify_fail(summary, VerifyIssueCode::InvalidStateZeroEntry, function_index);
         }
+        if (!fn->has_explicit_resume_blocks && fn->state_zero_entry_block != fn->blocks[0].id.id) {
+            return verify_fail(summary,
+                               VerifyIssueCode::InvalidStateZeroEntry,
+                               function_index,
+                               0,
+                               0,
+                               fn->state_zero_entry_block);
+        }
     }
     if (fn->has_explicit_resume_blocks) {
         if (fn->yield_count >= Function::kMaxResumeBlocks) {

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -20,6 +20,7 @@ enum class VerifyIssueCode : u8 {
     InvalidJumpTarget,
     InvalidStateZeroEntry,
     InvalidResumeBlock,
+    MissingYieldResumeMapping,
     MissingYieldMetadata,
     UnsupportedYieldTerminator,
     InvalidYieldKind,
@@ -256,6 +257,9 @@ inline VerifyResult verify_function(const Function* fn,
     }
     summary.yield_count = fn->yield_count;
 
+    if (fn->yield_count > 0 && !fn->has_explicit_resume_blocks && !fn->state_zero_enters_entry) {
+        return verify_fail(summary, VerifyIssueCode::MissingYieldResumeMapping, function_index);
+    }
     if (fn->state_zero_enters_entry) {
         if (fn->state_zero_entry_block >= fn->block_count ||
             fn->resume_terminal_block >= fn->block_count) {
@@ -404,6 +408,8 @@ inline const char* verify_issue_code_name(VerifyIssueCode code) {
             return "InvalidStateZeroEntry";
         case VerifyIssueCode::InvalidResumeBlock:
             return "InvalidResumeBlock";
+        case VerifyIssueCode::MissingYieldResumeMapping:
+            return "MissingYieldResumeMapping";
         case VerifyIssueCode::MissingYieldMetadata:
             return "MissingYieldMetadata";
         case VerifyIssueCode::UnsupportedYieldTerminator:

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rut/compiler/rir.h"
+#include "rut/compiler/rir_printer.h"
 #include "rut/jit/handler_abi.h"
 
 namespace rut {
@@ -352,6 +353,76 @@ inline VerifyResult verify_module(const Module& mod, VerifyOptions options = {})
     result.ok = true;
     result.summary = summary;
     return result;
+}
+
+inline const char* verify_issue_code_name(VerifyIssueCode code) {
+    switch (code) {
+        case VerifyIssueCode::None:
+            return "None";
+        case VerifyIssueCode::MissingFunction:
+            return "MissingFunction";
+        case VerifyIssueCode::MissingBlocks:
+            return "MissingBlocks";
+        case VerifyIssueCode::MissingEntry:
+            return "MissingEntry";
+        case VerifyIssueCode::BlockIdMismatch:
+            return "BlockIdMismatch";
+        case VerifyIssueCode::MissingInstructions:
+            return "MissingInstructions";
+        case VerifyIssueCode::MissingTerminator:
+            return "MissingTerminator";
+        case VerifyIssueCode::TerminatorBeforeEnd:
+            return "TerminatorBeforeEnd";
+        case VerifyIssueCode::InvalidBranchTarget:
+            return "InvalidBranchTarget";
+        case VerifyIssueCode::InvalidJumpTarget:
+            return "InvalidJumpTarget";
+        case VerifyIssueCode::InvalidStateZeroEntry:
+            return "InvalidStateZeroEntry";
+        case VerifyIssueCode::InvalidResumeBlock:
+            return "InvalidResumeBlock";
+        case VerifyIssueCode::MissingYieldMetadata:
+            return "MissingYieldMetadata";
+        case VerifyIssueCode::UnsupportedYieldTerminator:
+            return "UnsupportedYieldTerminator";
+        case VerifyIssueCode::InvalidYieldKind:
+            return "InvalidYieldKind";
+        case VerifyIssueCode::InvalidYieldNextState:
+            return "InvalidYieldNextState";
+        case VerifyIssueCode::YieldMetadataMismatch:
+            return "YieldMetadataMismatch";
+        case VerifyIssueCode::YieldCountMismatch:
+            return "YieldCountMismatch";
+        case VerifyIssueCode::TooManyBlocks:
+            return "TooManyBlocks";
+        case VerifyIssueCode::UnreachableBlock:
+            return "UnreachableBlock";
+    }
+    return "Unknown";
+}
+
+inline void format_verify_result(PrintBuf& buf, const VerifyResult& result) {
+    buf.put_cstr("rir verifier: ");
+    if (result.ok) {
+        buf.put_cstr("ok");
+        return;
+    }
+
+    buf.put_cstr(verify_issue_code_name(result.issue.code));
+    buf.put_cstr(" function=");
+    buf.put_u32(result.issue.function_index);
+    buf.put_cstr(" block=");
+    buf.put_u32(result.issue.block_index);
+    buf.put_cstr(" inst=");
+    buf.put_u32(result.issue.inst_index);
+
+    if (result.issue.code == VerifyIssueCode::UnsupportedYieldTerminator) {
+        buf.put_cstr(" opcode=");
+        print_opcode(buf, static_cast<Opcode>(result.issue.target_index));
+    } else {
+        buf.put_cstr(" target=");
+        buf.put_u32(result.issue.target_index);
+    }
 }
 
 }  // namespace rir

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -24,8 +24,11 @@ enum class VerifyIssueCode : u8 {
     UnsupportedYieldTerminator,
     InvalidYieldKind,
     InvalidYieldNextState,
+    DuplicateYieldNextState,
+    MissingYieldNextState,
     YieldMetadataMismatch,
     YieldCountMismatch,
+    TooManyYieldStates,
     TooManyBlocks,
     UnreachableBlock,
 };
@@ -116,6 +119,10 @@ inline VerifyResult verify_function(const Function* fn,
     if (fn->block_count > kMaxVerifierBlocks) {
         return verify_fail(summary, VerifyIssueCode::TooManyBlocks, function_index);
     }
+    if (fn->yield_count >= Function::kMaxResumeBlocks) {
+        return verify_fail(
+            summary, VerifyIssueCode::TooManyYieldStates, function_index, 0, 0, fn->yield_count);
+    }
 
     summary.block_count = fn->block_count;
 
@@ -128,6 +135,7 @@ inline VerifyResult verify_function(const Function* fn,
     worklist[work_end++] = 0;
 
     u32 seen_yield_terminators = 0;
+    bool seen_yield_next_state[Function::kMaxResumeBlocks]{};
 
     for (u32 bi = 0; bi < fn->block_count; bi++) {
         const Block& block = fn->blocks[bi];
@@ -203,6 +211,15 @@ inline VerifyResult verify_function(const Function* fn,
                                        block.inst_count - 1,
                                        next_state);
                 }
+                if (seen_yield_next_state[next_state]) {
+                    return verify_fail(summary,
+                                       VerifyIssueCode::DuplicateYieldNextState,
+                                       function_index,
+                                       bi,
+                                       block.inst_count - 1,
+                                       next_state);
+                }
+                seen_yield_next_state[next_state] = true;
             }
             seen_yield_terminators++;
         } else {
@@ -217,6 +234,12 @@ inline VerifyResult verify_function(const Function* fn,
                            0,
                            seen_yield_terminators,
                            fn->yield_count);
+    }
+    for (u32 yi = 1; yi <= fn->yield_count; yi++) {
+        if (!seen_yield_next_state[yi]) {
+            return verify_fail(
+                summary, VerifyIssueCode::MissingYieldNextState, function_index, 0, yi, yi);
+        }
     }
     if (fn->yield_count > 0 && (fn->yield_payload == nullptr || fn->yield_kinds == nullptr)) {
         return verify_fail(summary, VerifyIssueCode::MissingYieldMetadata, function_index);
@@ -389,10 +412,16 @@ inline const char* verify_issue_code_name(VerifyIssueCode code) {
             return "InvalidYieldKind";
         case VerifyIssueCode::InvalidYieldNextState:
             return "InvalidYieldNextState";
+        case VerifyIssueCode::DuplicateYieldNextState:
+            return "DuplicateYieldNextState";
+        case VerifyIssueCode::MissingYieldNextState:
+            return "MissingYieldNextState";
         case VerifyIssueCode::YieldMetadataMismatch:
             return "YieldMetadataMismatch";
         case VerifyIssueCode::YieldCountMismatch:
             return "YieldCountMismatch";
+        case VerifyIssueCode::TooManyYieldStates:
+            return "TooManyYieldStates";
         case VerifyIssueCode::TooManyBlocks:
             return "TooManyBlocks";
         case VerifyIssueCode::UnreachableBlock:

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -81,7 +81,21 @@ inline VerifyResult verify_fail(VerifySummary summary,
 }
 
 inline bool verify_valid_yield_kind(u8 kind) {
-    return kind <= static_cast<u8>(jit::YieldKind::UpstreamSend);
+    switch (static_cast<jit::YieldKind>(kind)) {
+        case jit::YieldKind::Timer:
+        case jit::YieldKind::Any:
+        case jit::YieldKind::Recv:
+        case jit::YieldKind::Send:
+        case jit::YieldKind::UpstreamConnect:
+        case jit::YieldKind::UpstreamRecv:
+        case jit::YieldKind::UpstreamSend:
+            return true;
+        case jit::YieldKind::HttpGet:
+        case jit::YieldKind::HttpPost:
+        case jit::YieldKind::Forward:
+            return false;
+    }
+    return false;
 }
 
 inline bool verify_valid_block_target(const Function& fn, BlockId target) {

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -280,6 +280,14 @@ inline VerifyResult verify_function(const Function* fn,
                                    fn->resume_blocks[i]);
             }
         }
+        if (fn->resume_blocks[0] != fn->blocks[0].id.id) {
+            return verify_fail(summary,
+                               VerifyIssueCode::InvalidStateZeroEntry,
+                               function_index,
+                               0,
+                               0,
+                               fn->resume_blocks[0]);
+        }
     }
 
     while (work_start < work_end) {

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -1,0 +1,273 @@
+#pragma once
+
+#include "rut/compiler/rir.h"
+#include "rut/jit/handler_abi.h"
+
+namespace rut {
+namespace rir {
+
+enum class VerifyIssueCode : u8 {
+    None,
+    MissingFunction,
+    MissingBlocks,
+    MissingEntry,
+    BlockIdMismatch,
+    MissingInstructions,
+    MissingTerminator,
+    TerminatorBeforeEnd,
+    InvalidBranchTarget,
+    InvalidJumpTarget,
+    InvalidStateZeroEntry,
+    InvalidResumeBlock,
+    MissingYieldMetadata,
+    InvalidYieldKind,
+    YieldCountMismatch,
+    TooManyBlocks,
+    UnreachableBlock,
+};
+
+struct VerifyIssue {
+    VerifyIssueCode code = VerifyIssueCode::None;
+    u32 function_index = 0;
+    u32 block_index = 0;
+    u32 inst_index = 0;
+    u32 target_index = 0;
+};
+
+struct VerifySummary {
+    u32 function_count = 0;
+    u32 block_count = 0;
+    u32 reachable_block_count = 0;
+    u32 terminal_block_count = 0;
+    u32 yield_count = 0;
+    u32 branch_edge_count = 0;
+};
+
+struct VerifyOptions {
+    // Rut route automata should not carry dead blocks: dead IR makes later
+    // verifier traces ambiguous and can hide stale lowering paths.
+    bool require_all_blocks_reachable = true;
+};
+
+struct VerifyResult {
+    bool ok = true;
+    VerifyIssue issue{};
+    VerifySummary summary{};
+};
+
+inline VerifyResult verify_fail(VerifySummary summary,
+                                VerifyIssueCode code,
+                                u32 function_index,
+                                u32 block_index = 0,
+                                u32 inst_index = 0,
+                                u32 target_index = 0) {
+    VerifyResult result{};
+    result.ok = false;
+    result.summary = summary;
+    result.issue.code = code;
+    result.issue.function_index = function_index;
+    result.issue.block_index = block_index;
+    result.issue.inst_index = inst_index;
+    result.issue.target_index = target_index;
+    return result;
+}
+
+inline bool verify_valid_yield_kind(u8 kind) {
+    return kind <= static_cast<u8>(jit::YieldKind::UpstreamSend);
+}
+
+inline bool verify_valid_block_target(const Function& fn, BlockId target) {
+    return target != kNoBlock && target.id < fn.block_count;
+}
+
+inline VerifyResult verify_function(const Function* fn,
+                                    u32 function_index = 0,
+                                    VerifyOptions options = {}) {
+    VerifySummary summary{};
+    summary.function_count = 1;
+
+    if (fn == nullptr) {
+        return verify_fail(summary, VerifyIssueCode::MissingFunction, function_index);
+    }
+    if (fn->block_count == 0) {
+        return verify_fail(summary, VerifyIssueCode::MissingEntry, function_index);
+    }
+    if (fn->blocks == nullptr) {
+        return verify_fail(summary, VerifyIssueCode::MissingBlocks, function_index);
+    }
+
+    static constexpr u32 kMaxVerifierBlocks = 4096;
+    if (fn->block_count > kMaxVerifierBlocks) {
+        return verify_fail(summary, VerifyIssueCode::TooManyBlocks, function_index);
+    }
+
+    summary.block_count = fn->block_count;
+
+    bool reachable[kMaxVerifierBlocks]{};
+    u32 worklist[kMaxVerifierBlocks]{};
+    u32 work_start = 0;
+    u32 work_end = 0;
+
+    reachable[0] = true;
+    worklist[work_end++] = 0;
+
+    u32 seen_yield_terminators = 0;
+
+    for (u32 bi = 0; bi < fn->block_count; bi++) {
+        const Block& block = fn->blocks[bi];
+        if (block.id.id != bi) {
+            return verify_fail(summary, VerifyIssueCode::BlockIdMismatch, function_index, bi);
+        }
+        if (block.inst_count > 0 && block.insts == nullptr) {
+            return verify_fail(summary, VerifyIssueCode::MissingInstructions, function_index, bi);
+        }
+        if (block.inst_count == 0 || block.terminator() == nullptr) {
+            return verify_fail(summary, VerifyIssueCode::MissingTerminator, function_index, bi);
+        }
+        for (u32 ii = 0; ii + 1 < block.inst_count; ii++) {
+            if (block.insts[ii].is_terminator()) {
+                return verify_fail(
+                    summary, VerifyIssueCode::TerminatorBeforeEnd, function_index, bi, ii);
+            }
+        }
+
+        const Instruction& term = block.insts[block.inst_count - 1];
+        if (term.op == Opcode::Br) {
+            if (!verify_valid_block_target(*fn, term.imm.block_targets[0])) {
+                return verify_fail(summary,
+                                   VerifyIssueCode::InvalidBranchTarget,
+                                   function_index,
+                                   bi,
+                                   block.inst_count - 1,
+                                   term.imm.block_targets[0].id);
+            }
+            if (!verify_valid_block_target(*fn, term.imm.block_targets[1])) {
+                return verify_fail(summary,
+                                   VerifyIssueCode::InvalidBranchTarget,
+                                   function_index,
+                                   bi,
+                                   block.inst_count - 1,
+                                   term.imm.block_targets[1].id);
+            }
+        } else if (term.op == Opcode::Jmp) {
+            if (!verify_valid_block_target(*fn, term.imm.block_targets[0])) {
+                return verify_fail(summary,
+                                   VerifyIssueCode::InvalidJumpTarget,
+                                   function_index,
+                                   bi,
+                                   block.inst_count - 1,
+                                   term.imm.block_targets[0].id);
+            }
+        } else if (term.is_yield()) {
+            seen_yield_terminators++;
+        } else {
+            summary.terminal_block_count++;
+        }
+    }
+
+    if (fn->yield_count != seen_yield_terminators) {
+        return verify_fail(summary,
+                           VerifyIssueCode::YieldCountMismatch,
+                           function_index,
+                           0,
+                           seen_yield_terminators,
+                           fn->yield_count);
+    }
+    if (fn->yield_count > 0 && (fn->yield_payload == nullptr || fn->yield_kinds == nullptr)) {
+        return verify_fail(summary, VerifyIssueCode::MissingYieldMetadata, function_index);
+    }
+    for (u32 yi = 0; yi < fn->yield_count; yi++) {
+        if (!verify_valid_yield_kind(fn->yield_kinds[yi])) {
+            return verify_fail(summary,
+                               VerifyIssueCode::InvalidYieldKind,
+                               function_index,
+                               0,
+                               yi,
+                               fn->yield_kinds[yi]);
+        }
+    }
+    summary.yield_count = fn->yield_count;
+
+    if (fn->state_zero_enters_entry) {
+        if (fn->state_zero_entry_block >= fn->block_count ||
+            fn->resume_terminal_block >= fn->block_count) {
+            return verify_fail(summary, VerifyIssueCode::InvalidStateZeroEntry, function_index);
+        }
+    }
+    if (fn->has_explicit_resume_blocks) {
+        for (u32 i = 0; i < fn->yield_count && i < Function::kMaxResumeBlocks; i++) {
+            if (fn->resume_blocks[i] >= fn->block_count) {
+                return verify_fail(summary,
+                                   VerifyIssueCode::InvalidResumeBlock,
+                                   function_index,
+                                   0,
+                                   i,
+                                   fn->resume_blocks[i]);
+            }
+        }
+    }
+
+    while (work_start < work_end) {
+        const u32 bi = worklist[work_start++];
+        summary.reachable_block_count++;
+        const Block& block = fn->blocks[bi];
+        const Instruction& term = block.insts[block.inst_count - 1];
+        if (term.op == Opcode::Br) {
+            const u32 targets[2] = {term.imm.block_targets[0].id, term.imm.block_targets[1].id};
+            for (u32 i = 0; i < 2; i++) {
+                summary.branch_edge_count++;
+                if (!reachable[targets[i]]) {
+                    reachable[targets[i]] = true;
+                    worklist[work_end++] = targets[i];
+                }
+            }
+        } else if (term.op == Opcode::Jmp) {
+            const u32 target = term.imm.block_targets[0].id;
+            summary.branch_edge_count++;
+            if (!reachable[target]) {
+                reachable[target] = true;
+                worklist[work_end++] = target;
+            }
+        }
+    }
+
+    if (options.require_all_blocks_reachable) {
+        for (u32 bi = 0; bi < fn->block_count; bi++) {
+            if (!reachable[bi]) {
+                return verify_fail(summary, VerifyIssueCode::UnreachableBlock, function_index, bi);
+            }
+        }
+    }
+
+    VerifyResult result{};
+    result.ok = true;
+    result.summary = summary;
+    return result;
+}
+
+inline VerifyResult verify_module(const Module& mod, VerifyOptions options = {}) {
+    VerifySummary summary{};
+    summary.function_count = mod.func_count;
+
+    if (mod.func_count > 0 && mod.functions == nullptr) {
+        return verify_fail(summary, VerifyIssueCode::MissingFunction, 0);
+    }
+
+    for (u32 fi = 0; fi < mod.func_count; fi++) {
+        VerifyResult result = verify_function(&mod.functions[fi], fi, options);
+        if (!result.ok) return result;
+        summary.block_count += result.summary.block_count;
+        summary.reachable_block_count += result.summary.reachable_block_count;
+        summary.terminal_block_count += result.summary.terminal_block_count;
+        summary.yield_count += result.summary.yield_count;
+        summary.branch_edge_count += result.summary.branch_edge_count;
+    }
+
+    VerifyResult result{};
+    result.ok = true;
+    result.summary = summary;
+    return result;
+}
+
+}  // namespace rir
+}  // namespace rut

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -21,6 +21,8 @@ enum class VerifyIssueCode : u8 {
     InvalidResumeBlock,
     MissingYieldMetadata,
     InvalidYieldKind,
+    InvalidYieldNextState,
+    YieldMetadataMismatch,
     YieldCountMismatch,
     TooManyBlocks,
     UnreachableBlock,
@@ -78,6 +80,18 @@ inline bool verify_valid_yield_kind(u8 kind) {
 
 inline bool verify_valid_block_target(const Function& fn, BlockId target) {
     return target != kNoBlock && target.id < fn.block_count;
+}
+
+inline u8 verify_yield_timer_kind(const Instruction& inst) {
+    const u64 packed = static_cast<u64>(inst.imm.i64_val);
+    u8 kind = static_cast<u8>((packed >> 48) & 0xffu);
+    if (kind == 0) kind = static_cast<u8>(jit::YieldKind::Timer);
+    return kind;
+}
+
+inline u16 verify_yield_timer_next_state(const Instruction& inst) {
+    const u64 packed = static_cast<u64>(inst.imm.i64_val);
+    return static_cast<u16>((packed >> 32) & 0xffffu);
 }
 
 inline VerifyResult verify_function(const Function* fn,
@@ -159,6 +173,27 @@ inline VerifyResult verify_function(const Function* fn,
                                    term.imm.block_targets[0].id);
             }
         } else if (term.is_yield()) {
+            if (term.op == Opcode::YieldTimer) {
+                const u8 kind = verify_yield_timer_kind(term);
+                if (!verify_valid_yield_kind(kind)) {
+                    return verify_fail(summary,
+                                       VerifyIssueCode::InvalidYieldKind,
+                                       function_index,
+                                       bi,
+                                       block.inst_count - 1,
+                                       kind);
+                }
+
+                const u16 next_state = verify_yield_timer_next_state(term);
+                if (next_state == 0 || next_state > fn->yield_count) {
+                    return verify_fail(summary,
+                                       VerifyIssueCode::InvalidYieldNextState,
+                                       function_index,
+                                       bi,
+                                       block.inst_count - 1,
+                                       next_state);
+                }
+            }
             seen_yield_terminators++;
         } else {
             summary.terminal_block_count++;
@@ -195,7 +230,10 @@ inline VerifyResult verify_function(const Function* fn,
         }
     }
     if (fn->has_explicit_resume_blocks) {
-        for (u32 i = 0; i < fn->yield_count && i < Function::kMaxResumeBlocks; i++) {
+        if (fn->yield_count >= Function::kMaxResumeBlocks) {
+            return verify_fail(summary, VerifyIssueCode::InvalidResumeBlock, function_index);
+        }
+        for (u32 i = 0; i <= fn->yield_count; i++) {
             if (fn->resume_blocks[i] >= fn->block_count) {
                 return verify_fail(summary,
                                    VerifyIssueCode::InvalidResumeBlock,
@@ -227,6 +265,44 @@ inline VerifyResult verify_function(const Function* fn,
             if (!reachable[target]) {
                 reachable[target] = true;
                 worklist[work_end++] = target;
+            }
+        } else if (term.op == Opcode::YieldTimer) {
+            const u16 next_state = verify_yield_timer_next_state(term);
+            const u8 kind = verify_yield_timer_kind(term);
+            const u32 payload = static_cast<u32>(static_cast<u64>(term.imm.i64_val));
+
+            if (next_state == 0 || next_state > fn->yield_count) {
+                return verify_fail(summary,
+                                   VerifyIssueCode::InvalidYieldNextState,
+                                   function_index,
+                                   bi,
+                                   block.inst_count - 1,
+                                   next_state);
+            }
+            const u32 yi = static_cast<u32>(next_state - 1);
+            if (fn->yield_kinds[yi] != kind || fn->yield_payload[yi] != payload) {
+                return verify_fail(summary,
+                                   VerifyIssueCode::YieldMetadataMismatch,
+                                   function_index,
+                                   bi,
+                                   block.inst_count - 1,
+                                   next_state);
+            }
+
+            if (fn->has_explicit_resume_blocks) {
+                const u32 target = fn->resume_blocks[next_state];
+                summary.branch_edge_count++;
+                if (!reachable[target]) {
+                    reachable[target] = true;
+                    worklist[work_end++] = target;
+                }
+            } else if (fn->state_zero_enters_entry) {
+                const u32 target = fn->resume_terminal_block;
+                summary.branch_edge_count++;
+                if (!reachable[target]) {
+                    reachable[target] = true;
+                    worklist[work_end++] = target;
+                }
             }
         }
     }

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -146,9 +146,6 @@ inline VerifyResult verify_function(const Function* fn,
     u32 work_start = 0;
     u32 work_end = 0;
 
-    reachable[0] = true;
-    worklist[work_end++] = 0;
-
     u32 seen_yield_terminators = 0;
     bool seen_yield_next_state[Function::kMaxResumeBlocks]{};
 
@@ -279,14 +276,6 @@ inline VerifyResult verify_function(const Function* fn,
             fn->resume_terminal_block >= fn->block_count) {
             return verify_fail(summary, VerifyIssueCode::InvalidStateZeroEntry, function_index);
         }
-        if (!fn->has_explicit_resume_blocks && fn->state_zero_entry_block != fn->blocks[0].id.id) {
-            return verify_fail(summary,
-                               VerifyIssueCode::InvalidStateZeroEntry,
-                               function_index,
-                               0,
-                               0,
-                               fn->state_zero_entry_block);
-        }
     }
     if (fn->has_explicit_resume_blocks) {
         if (fn->yield_count >= Function::kMaxResumeBlocks) {
@@ -302,15 +291,16 @@ inline VerifyResult verify_function(const Function* fn,
                                    fn->resume_blocks[i]);
             }
         }
-        if (fn->resume_blocks[0] != fn->blocks[0].id.id) {
-            return verify_fail(summary,
-                               VerifyIssueCode::InvalidStateZeroEntry,
-                               function_index,
-                               0,
-                               0,
-                               fn->resume_blocks[0]);
-        }
     }
+
+    u32 reachable_root = fn->blocks[0].id.id;
+    if (fn->has_explicit_resume_blocks) {
+        reachable_root = fn->resume_blocks[0];
+    } else if (fn->state_zero_enters_entry) {
+        reachable_root = fn->state_zero_entry_block;
+    }
+    reachable[reachable_root] = true;
+    worklist[work_end++] = reachable_root;
 
     while (work_start < work_end) {
         const u32 bi = worklist[work_start++];

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -20,6 +20,7 @@ enum class VerifyIssueCode : u8 {
     InvalidStateZeroEntry,
     InvalidResumeBlock,
     MissingYieldMetadata,
+    UnsupportedYieldTerminator,
     InvalidYieldKind,
     InvalidYieldNextState,
     YieldMetadataMismatch,
@@ -173,6 +174,14 @@ inline VerifyResult verify_function(const Function* fn,
                                    term.imm.block_targets[0].id);
             }
         } else if (term.is_yield()) {
+            if (term.op != Opcode::YieldTimer) {
+                return verify_fail(summary,
+                                   VerifyIssueCode::UnsupportedYieldTerminator,
+                                   function_index,
+                                   bi,
+                                   block.inst_count - 1,
+                                   static_cast<u32>(term.op));
+            }
             if (term.op == Opcode::YieldTimer) {
                 const u8 kind = verify_yield_timer_kind(term);
                 if (!verify_valid_yield_kind(kind)) {

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -149,6 +149,10 @@ inline VerifyResult verify_function(const Function* fn,
     u32 seen_yield_terminators = 0;
     bool seen_yield_next_state[Function::kMaxResumeBlocks]{};
 
+    if (fn->yield_count > 0 && (fn->yield_payload == nullptr || fn->yield_kinds == nullptr)) {
+        return verify_fail(summary, VerifyIssueCode::MissingYieldMetadata, function_index);
+    }
+
     for (u32 bi = 0; bi < fn->block_count; bi++) {
         const Block& block = fn->blocks[bi];
         if (block.id.id != bi) {
@@ -231,6 +235,16 @@ inline VerifyResult verify_function(const Function* fn,
                                        block.inst_count - 1,
                                        next_state);
                 }
+                const u32 yi = static_cast<u32>(next_state - 1);
+                const u32 payload = static_cast<u32>(static_cast<u64>(term.imm.i64_val));
+                if (fn->yield_kinds[yi] != kind || fn->yield_payload[yi] != payload) {
+                    return verify_fail(summary,
+                                       VerifyIssueCode::YieldMetadataMismatch,
+                                       function_index,
+                                       bi,
+                                       block.inst_count - 1,
+                                       next_state);
+                }
                 seen_yield_next_state[next_state] = true;
             }
             seen_yield_terminators++;
@@ -252,9 +266,6 @@ inline VerifyResult verify_function(const Function* fn,
             return verify_fail(
                 summary, VerifyIssueCode::MissingYieldNextState, function_index, 0, yi, yi);
         }
-    }
-    if (fn->yield_count > 0 && (fn->yield_payload == nullptr || fn->yield_kinds == nullptr)) {
-        return verify_fail(summary, VerifyIssueCode::MissingYieldMetadata, function_index);
     }
     for (u32 yi = 0; yi < fn->yield_count; yi++) {
         if (!verify_valid_yield_kind(fn->yield_kinds[yi])) {
@@ -325,21 +336,10 @@ inline VerifyResult verify_function(const Function* fn,
             }
         } else if (term.op == Opcode::YieldTimer) {
             const u16 next_state = verify_yield_timer_next_state(term);
-            const u8 kind = verify_yield_timer_kind(term);
-            const u32 payload = static_cast<u32>(static_cast<u64>(term.imm.i64_val));
 
             if (next_state == 0 || next_state > fn->yield_count) {
                 return verify_fail(summary,
                                    VerifyIssueCode::InvalidYieldNextState,
-                                   function_index,
-                                   bi,
-                                   block.inst_count - 1,
-                                   next_state);
-            }
-            const u32 yi = static_cast<u32>(next_state - 1);
-            if (fn->yield_kinds[yi] != kind || fn->yield_payload[yi] != payload) {
-                return verify_fail(summary,
-                                   VerifyIssueCode::YieldMetadataMismatch,
                                    function_index,
                                    bi,
                                    block.inst_count - 1,

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -328,7 +328,7 @@ TEST(frontend, rir_verifier_e2e_reports_invalid_resume_block) {
     rir.destroy();
 }
 
-TEST(frontend, rir_verifier_e2e_reports_invalid_state_zero_resume_target) {
+TEST(frontend, rir_verifier_e2e_reports_state_zero_resume_target_that_skips_entry) {
     FrontendRirModule rir{};
     REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
     auto& fn = rir.module.functions[0];
@@ -341,15 +341,15 @@ TEST(frontend, rir_verifier_e2e_reports_invalid_state_zero_resume_target) {
     auto verified = rir::verify_module(rir.module);
     REQUIRE(!verified.ok);
     CHECK_EQ(static_cast<u8>(verified.issue.code),
-             static_cast<u8>(rir::VerifyIssueCode::InvalidStateZeroEntry));
+             static_cast<u8>(rir::VerifyIssueCode::UnreachableBlock));
     const std::string text = format_verify_text(verified);
-    CHECK(text.find("rir verifier: InvalidStateZeroEntry") != std::string::npos);
-    CHECK(text.find("target=") != std::string::npos);
+    CHECK(text.find("rir verifier: UnreachableBlock") != std::string::npos);
+    CHECK(text.find("block=0") != std::string::npos);
 
     rir.destroy();
 }
 
-TEST(frontend, rir_verifier_e2e_reports_invalid_non_explicit_state_zero_entry) {
+TEST(frontend, rir_verifier_e2e_reports_non_explicit_state_zero_that_skips_entry) {
     FrontendRirModule rir{};
     REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
     auto& fn = rir.module.functions[0];
@@ -365,10 +365,10 @@ TEST(frontend, rir_verifier_e2e_reports_invalid_non_explicit_state_zero_entry) {
     auto verified = rir::verify_module(rir.module);
     REQUIRE(!verified.ok);
     CHECK_EQ(static_cast<u8>(verified.issue.code),
-             static_cast<u8>(rir::VerifyIssueCode::InvalidStateZeroEntry));
+             static_cast<u8>(rir::VerifyIssueCode::UnreachableBlock));
     const std::string text = format_verify_text(verified);
-    CHECK(text.find("rir verifier: InvalidStateZeroEntry") != std::string::npos);
-    CHECK(text.find("target=") != std::string::npos);
+    CHECK(text.find("rir verifier: UnreachableBlock") != std::string::npos);
+    CHECK(text.find("block=0") != std::string::npos);
 
     rir.destroy();
 }

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -3,10 +3,12 @@
 #include "rut/compiler/lower_rir.h"
 #include "rut/compiler/mir_build.h"
 #include "rut/compiler/parser.h"
+#include "rut/compiler/verifier.h"
 #include "test.h"
 #include <cstdio>
 #include <filesystem>
 #include <fstream>
+#include <string>
 using namespace rut;
 static Str lit(const char* s) {
     u32 n = 0;
@@ -32,6 +34,19 @@ static bool function_has_op(const rir::Function& fn, rir::Opcode op) {
     }
     return false;
 }
+
+static bool replace_first_op(rir::Function& fn, rir::Opcode from, rir::Opcode to) {
+    for (u32 bi = 0; bi < fn.block_count; bi++) {
+        for (u32 ii = 0; ii < fn.blocks[bi].inst_count; ii++) {
+            if (fn.blocks[bi].insts[ii].op == from) {
+                fn.blocks[bi].insts[ii].op = to;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 // RAII wrapper for FrontendResult<T*>. The frontend APIs (parse_file,
 // analyze_file, build_mir) all .release() a unique_ptr and hand back a raw
 // pointer. Tests allocated hundreds of these without ever deleting; before
@@ -96,6 +111,48 @@ static HeapFrontendResult<MirModule> build_mir_heap(const HirModule& module) {
     if (!mir) return {core::make_unexpected(mir.error())};
     return {mir.value()};
 }
+
+TEST(frontend, rir_verifier_e2e_reports_non_lowered_yield_terminator) {
+    const char* src = "route GET \"/sleep\" { wait(1) return 204 }\n";
+
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+
+    FrontendRirModule rir{};
+    auto lowered = lower_to_rir(mir.value(), rir);
+    REQUIRE(lowered);
+    REQUIRE_EQ(rir.module.func_count, 1u);
+    REQUIRE(function_has_op(rir.module.functions[0], rir::Opcode::YieldTimer));
+
+    // Simulate a stale lowering/codegen boundary bug: the source went through
+    // the full frontend pipeline, but the RIR handed to verifier still contains
+    // a non-lowered yield opcode that current JIT codegen cannot execute.
+    REQUIRE(replace_first_op(
+        rir.module.functions[0], rir::Opcode::YieldTimer, rir::Opcode::YieldHttpGet));
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::UnsupportedYieldTerminator));
+
+    char msg_data[256];
+    rir::PrintBuf msg;
+    msg.init(msg_data, sizeof(msg_data), -1);
+    rir::format_verify_result(msg, verified);
+    const std::string text(msg.data, msg.len);
+    CHECK(text.find("rir verifier: UnsupportedYieldTerminator") != std::string::npos);
+    CHECK(text.find("function=0") != std::string::npos);
+    CHECK(text.find("opcode=yield.http_get") != std::string::npos);
+
+    rir.destroy();
+}
+
 TEST(frontend, lex_parse_return_route) {
     const char* src = "upstream api\nroute GET \"/users\" { return 200 }\n";
     auto lexed = lex(lit(src));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -302,6 +302,26 @@ TEST(frontend, rir_verifier_e2e_reports_invalid_resume_block) {
     rir.destroy();
 }
 
+TEST(frontend, rir_verifier_e2e_reports_missing_yield_resume_mapping) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
+    auto& fn = rir.module.functions[0];
+    REQUIRE_GT(fn.yield_count, 0u);
+    REQUIRE(fn.has_explicit_resume_blocks || fn.state_zero_enters_entry);
+
+    fn.has_explicit_resume_blocks = false;
+    fn.state_zero_enters_entry = false;
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::MissingYieldResumeMapping));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: MissingYieldResumeMapping") != std::string::npos);
+
+    rir.destroy();
+}
+
 TEST(frontend, lex_parse_return_route) {
     const char* src = "upstream api\nroute GET \"/users\" { return 200 }\n";
     auto lexed = lex(lit(src));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -237,6 +237,32 @@ TEST(frontend, rir_verifier_e2e_reports_invalid_encoded_yield_kind) {
     rir.destroy();
 }
 
+TEST(frontend, rir_verifier_e2e_reports_unsupported_lowered_yield_kind) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
+    auto& fn = rir.module.functions[0];
+    auto* yield = find_first_op(fn, rir::Opcode::YieldTimer);
+    REQUIRE(yield != nullptr);
+    REQUIRE(fn.yield_kinds != nullptr);
+
+    const u64 packed = static_cast<u64>(yield->imm.i64_val);
+    const u64 payload = packed & 0xffffffffu;
+    const u64 next_state = (packed >> 32) & 0xffffu;
+    yield->imm.i64_val = static_cast<i64>((static_cast<u64>(jit::YieldKind::HttpPost) << 48) |
+                                          (next_state << 32) | payload);
+    fn.yield_kinds[0] = static_cast<u8>(jit::YieldKind::HttpPost);
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::InvalidYieldKind));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: InvalidYieldKind") != std::string::npos);
+    CHECK(text.find("target=1") != std::string::npos);
+
+    rir.destroy();
+}
+
 TEST(frontend, rir_verifier_e2e_reports_yield_metadata_mismatch) {
     FrontendRirModule rir{};
     REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -302,6 +302,27 @@ TEST(frontend, rir_verifier_e2e_reports_invalid_resume_block) {
     rir.destroy();
 }
 
+TEST(frontend, rir_verifier_e2e_reports_invalid_state_zero_resume_target) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
+    auto& fn = rir.module.functions[0];
+    REQUIRE(fn.has_explicit_resume_blocks);
+    REQUIRE_GT(fn.yield_count, 0u);
+    REQUIRE_NE(fn.resume_blocks[fn.yield_count], fn.blocks[0].id.id);
+
+    fn.resume_blocks[0] = fn.resume_blocks[fn.yield_count];
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::InvalidStateZeroEntry));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: InvalidStateZeroEntry") != std::string::npos);
+    CHECK(text.find("target=") != std::string::npos);
+
+    rir.destroy();
+}
+
 TEST(frontend, rir_verifier_e2e_reports_missing_yield_resume_mapping) {
     FrontendRirModule rir{};
     REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -323,6 +323,30 @@ TEST(frontend, rir_verifier_e2e_reports_invalid_state_zero_resume_target) {
     rir.destroy();
 }
 
+TEST(frontend, rir_verifier_e2e_reports_invalid_non_explicit_state_zero_entry) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
+    auto& fn = rir.module.functions[0];
+    REQUIRE(fn.has_explicit_resume_blocks);
+    REQUIRE_GT(fn.yield_count, 0u);
+    REQUIRE_NE(fn.resume_blocks[fn.yield_count], fn.blocks[0].id.id);
+
+    fn.has_explicit_resume_blocks = false;
+    fn.state_zero_enters_entry = true;
+    fn.state_zero_entry_block = fn.resume_blocks[fn.yield_count];
+    fn.resume_terminal_block = fn.resume_blocks[fn.yield_count];
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::InvalidStateZeroEntry));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: InvalidStateZeroEntry") != std::string::npos);
+    CHECK(text.find("target=") != std::string::npos);
+
+    rir.destroy();
+}
+
 TEST(frontend, rir_verifier_e2e_reports_missing_yield_resume_mapping) {
     FrontendRirModule rir{};
     REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -47,6 +47,23 @@ static bool replace_first_op(rir::Function& fn, rir::Opcode from, rir::Opcode to
     return false;
 }
 
+static rir::Instruction* find_nth_op(rir::Function& fn, rir::Opcode op, u32 ordinal) {
+    u32 seen = 0;
+    for (u32 bi = 0; bi < fn.block_count; bi++) {
+        for (u32 ii = 0; ii < fn.blocks[bi].inst_count; ii++) {
+            if (fn.blocks[bi].insts[ii].op == op) {
+                if (seen == ordinal) return &fn.blocks[bi].insts[ii];
+                seen++;
+            }
+        }
+    }
+    return nullptr;
+}
+
+static rir::Instruction* find_first_op(rir::Function& fn, rir::Opcode op) {
+    return find_nth_op(fn, op, 0);
+}
+
 // RAII wrapper for FrontendResult<T*>. The frontend APIs (parse_file,
 // analyze_file, build_mir) all .release() a unique_ptr and hand back a raw
 // pointer. Tests allocated hundreds of these without ever deleting; before
@@ -112,21 +129,44 @@ static HeapFrontendResult<MirModule> build_mir_heap(const HirModule& module) {
     return {mir.value()};
 }
 
-TEST(frontend, rir_verifier_e2e_reports_non_lowered_yield_terminator) {
-    const char* src = "route GET \"/sleep\" { wait(1) return 204 }\n";
-
+static bool lower_src_to_rir(const char* src, FrontendRirModule& rir) {
     auto lexed = lex(lit(src));
-    REQUIRE(lexed);
+    if (!lexed) return false;
     auto ast = parse_file_heap(lexed.value());
-    REQUIRE(ast);
+    if (!ast) return false;
     auto hir = analyze_file_heap(ast.value());
-    REQUIRE(hir);
+    if (!hir) return false;
     auto mir = build_mir_heap(hir.value());
-    REQUIRE(mir);
-
-    FrontendRirModule rir{};
+    if (!mir) return false;
     auto lowered = lower_to_rir(mir.value(), rir);
-    REQUIRE(lowered);
+    return static_cast<bool>(lowered);
+}
+
+static std::string format_verify_text(const rir::VerifyResult& result) {
+    char msg_data[256];
+    rir::PrintBuf msg;
+    msg.init(msg_data, sizeof(msg_data), -1);
+    rir::format_verify_result(msg, result);
+    return std::string(msg.data, msg.len);
+}
+
+TEST(frontend, rir_verifier_e2e_accepts_lowered_wait_route) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
+    REQUIRE_EQ(rir.module.func_count, 1u);
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(verified.ok);
+    CHECK_EQ(verified.summary.function_count, 1u);
+    CHECK_EQ(verified.summary.yield_count, 1u);
+    CHECK(format_verify_text(verified).find("rir verifier: ok") != std::string::npos);
+
+    rir.destroy();
+}
+
+TEST(frontend, rir_verifier_e2e_reports_non_lowered_yield_terminator) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
     REQUIRE_EQ(rir.module.func_count, 1u);
     REQUIRE(function_has_op(rir.module.functions[0], rir::Opcode::YieldTimer));
 
@@ -141,14 +181,123 @@ TEST(frontend, rir_verifier_e2e_reports_non_lowered_yield_terminator) {
     CHECK_EQ(static_cast<u8>(verified.issue.code),
              static_cast<u8>(rir::VerifyIssueCode::UnsupportedYieldTerminator));
 
-    char msg_data[256];
-    rir::PrintBuf msg;
-    msg.init(msg_data, sizeof(msg_data), -1);
-    rir::format_verify_result(msg, verified);
-    const std::string text(msg.data, msg.len);
+    const std::string text = format_verify_text(verified);
     CHECK(text.find("rir verifier: UnsupportedYieldTerminator") != std::string::npos);
     CHECK(text.find("function=0") != std::string::npos);
     CHECK(text.find("opcode=yield.http_get") != std::string::npos);
+
+    rir.destroy();
+}
+
+TEST(frontend, rir_verifier_e2e_reports_invalid_yield_next_state) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
+    auto& fn = rir.module.functions[0];
+    auto* yield = find_first_op(fn, rir::Opcode::YieldTimer);
+    REQUIRE(yield != nullptr);
+
+    const u64 packed = static_cast<u64>(yield->imm.i64_val);
+    const u64 payload = packed & 0xffffffffu;
+    const u64 kind = (packed >> 48) & 0xffu;
+    yield->imm.i64_val =
+        static_cast<i64>((kind << 48) | (static_cast<u64>(fn.yield_count + 1) << 32) | payload);
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::InvalidYieldNextState));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: InvalidYieldNextState") != std::string::npos);
+    CHECK(text.find("target=2") != std::string::npos);
+
+    rir.destroy();
+}
+
+TEST(frontend, rir_verifier_e2e_reports_invalid_encoded_yield_kind) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
+    auto& fn = rir.module.functions[0];
+    auto* yield = find_first_op(fn, rir::Opcode::YieldTimer);
+    REQUIRE(yield != nullptr);
+
+    const u64 packed = static_cast<u64>(yield->imm.i64_val);
+    const u64 payload = packed & 0xffffffffu;
+    const u64 next_state = (packed >> 32) & 0xffffu;
+    yield->imm.i64_val =
+        static_cast<i64>((static_cast<u64>(99) << 48) | (next_state << 32) | payload);
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::InvalidYieldKind));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: InvalidYieldKind") != std::string::npos);
+    CHECK(text.find("target=99") != std::string::npos);
+
+    rir.destroy();
+}
+
+TEST(frontend, rir_verifier_e2e_reports_yield_metadata_mismatch) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
+    auto& fn = rir.module.functions[0];
+    auto* yield = find_first_op(fn, rir::Opcode::YieldTimer);
+    REQUIRE(yield != nullptr);
+
+    yield->imm.i64_val = static_cast<i64>(static_cast<u64>(yield->imm.i64_val) + 1u);
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::YieldMetadataMismatch));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: YieldMetadataMismatch") != std::string::npos);
+    CHECK(text.find("target=1") != std::string::npos);
+
+    rir.destroy();
+}
+
+TEST(frontend, rir_verifier_e2e_reports_duplicate_yield_next_state) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(500) wait(1000) return 204 }\n", rir));
+    auto& fn = rir.module.functions[0];
+    REQUIRE_EQ(fn.yield_count, 2u);
+    auto* second_yield = find_nth_op(fn, rir::Opcode::YieldTimer, 1);
+    REQUIRE(second_yield != nullptr);
+
+    const u64 packed = static_cast<u64>(second_yield->imm.i64_val);
+    const u64 payload = packed & 0xffffffffu;
+    const u64 kind = (packed >> 48) & 0xffu;
+    second_yield->imm.i64_val =
+        static_cast<i64>((kind << 48) | (static_cast<u64>(1) << 32) | payload);
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::DuplicateYieldNextState));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: DuplicateYieldNextState") != std::string::npos);
+    CHECK(text.find("target=1") != std::string::npos);
+
+    rir.destroy();
+}
+
+TEST(frontend, rir_verifier_e2e_reports_invalid_resume_block) {
+    FrontendRirModule rir{};
+    REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(1) return 204 }\n", rir));
+    auto& fn = rir.module.functions[0];
+    REQUIRE(fn.has_explicit_resume_blocks);
+    REQUIRE_GT(fn.yield_count, 0u);
+
+    fn.resume_blocks[fn.yield_count] = fn.block_count;
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::InvalidResumeBlock));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: InvalidResumeBlock") != std::string::npos);
+    CHECK(text.find("target=") != std::string::npos);
 
     rir.destroy();
 }

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -943,6 +943,45 @@ TEST(RirVerifier, RejectsDuplicateYieldNextState) {
     ctx.destroy();
 }
 
+TEST(RirVerifier, RejectsDeadYieldMetadataMismatchWhenReachabilityRelaxed) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto dead_yield = V(b.create_block(fn, lit("dead_yield")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_ret_status(204));
+
+    b.set_insert_point(fn, dead_yield);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 99, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    VerifyOptions relaxed{};
+    relaxed.require_all_blocks_reachable = false;
+    auto result = verify_function(fn, 0, relaxed);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::YieldMetadataMismatch));
+    CHECK_EQ(result.issue.block_index, dead_yield.id);
+    CHECK_EQ(result.issue.target_index, 1u);
+
+    ctx.destroy();
+}
+
 TEST(RirVerifier, RejectsUnreachableBlockByDefault) {
     TestContext ctx;
     REQUIRE(ctx.init());

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -586,6 +586,33 @@ TEST(RirVerifier, RejectsYieldCountMismatch) {
     ctx.destroy();
 }
 
+TEST(RirVerifier, RejectsNonLoweredYieldTerminator) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+
+    b.set_insert_point(fn, entry);
+    V(b.emit_yield_http_get(lit("http://auth/verify"), kNoValue));
+
+    u32 payloads[1] = {0};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::HttpGet)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::UnsupportedYieldTerminator));
+    CHECK_EQ(result.issue.block_index, entry.id);
+    CHECK_EQ(result.issue.target_index, static_cast<u32>(Opcode::YieldHttpGet));
+
+    ctx.destroy();
+}
+
 TEST(RirVerifier, TreatsExplicitYieldResumeBlockAsReachable) {
     TestContext ctx;
     REQUIRE(ctx.init());

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -1,6 +1,7 @@
 #include "rut/compiler/rir.h"
 #include "rut/compiler/rir_builder.h"
 #include "rut/compiler/rir_printer.h"
+#include "rut/compiler/verifier.h"
 #include "test.h"
 
 using namespace rut;
@@ -470,6 +471,150 @@ TEST(RirBuilder, InstructionIsTerminator) {
     inst.op = Opcode::YieldHttpGet;
     CHECK(inst.is_terminator());
     CHECK(inst.is_yield());
+}
+
+TEST(RirVerifier, AcceptsReturnAndBranchRouteGraph) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto reject = V(b.create_block(fn, lit("reject")));
+
+    b.set_insert_point(fn, entry);
+    auto cond = V(b.emit_const_bool(true));
+    VOK(b.emit_br(cond, ok, reject));
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(204));
+
+    b.set_insert_point(fn, reject);
+    VOK(b.emit_ret_status(403));
+
+    auto result = verify_function(fn);
+    REQUIRE(result.ok);
+    CHECK_EQ(result.summary.block_count, 3u);
+    CHECK_EQ(result.summary.reachable_block_count, 3u);
+    CHECK_EQ(result.summary.terminal_block_count, 2u);
+    CHECK_EQ(result.summary.branch_edge_count, 2u);
+    CHECK_EQ(result.summary.yield_count, 0u);
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RejectsMissingTerminator) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    b.set_insert_point(fn, entry);
+    V(b.emit_const_i32(1));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::MissingTerminator));
+    CHECK_EQ(result.issue.block_index, entry.id);
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RejectsInvalidBranchTarget) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto ok = V(b.create_block(fn, lit("ok")));
+    auto reject = V(b.create_block(fn, lit("reject")));
+
+    b.set_insert_point(fn, entry);
+    auto cond = V(b.emit_const_bool(true));
+    VOK(b.emit_br(cond, ok, reject));
+    fn->blocks[entry.id].insts[1].imm.block_targets[1] = BlockId{99};
+
+    b.set_insert_point(fn, ok);
+    VOK(b.emit_ret_status(204));
+
+    b.set_insert_point(fn, reject);
+    VOK(b.emit_ret_status(403));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::InvalidBranchTarget));
+    CHECK_EQ(result.issue.block_index, entry.id);
+    CHECK_EQ(result.issue.target_index, 99u);
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RejectsYieldCountMismatch) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    u32 payloads[2] = {50, 100};
+    u8 kinds[2] = {static_cast<u8>(jit::YieldKind::Timer), static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 2, kinds));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::YieldCountMismatch));
+    CHECK_EQ(result.issue.inst_index, 1u);
+    CHECK_EQ(result.issue.target_index, 2u);
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RejectsUnreachableBlockByDefault) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto dead = V(b.create_block(fn, lit("dead")));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_ret_status(204));
+    b.set_insert_point(fn, dead);
+    VOK(b.emit_ret_status(500));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::UnreachableBlock));
+    CHECK_EQ(result.issue.block_index, dead.id);
+
+    VerifyOptions relaxed{};
+    relaxed.require_all_blocks_reachable = false;
+    auto relaxed_result = verify_function(fn, 0, relaxed);
+    REQUIRE(relaxed_result.ok);
+    CHECK_EQ(relaxed_result.summary.reachable_block_count, 1u);
+
+    ctx.destroy();
 }
 
 TEST(RirBuilder, ValueIdSentinel) {

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -644,6 +644,39 @@ TEST(RirVerifier, TreatsExplicitYieldResumeBlockAsReachable) {
     ctx.destroy();
 }
 
+TEST(RirVerifier, RejectsExplicitResumeStateZeroDifferentFromEntry) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+    fn->resume_blocks[0] = resume.id;
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::InvalidStateZeroEntry));
+    CHECK_EQ(result.issue.target_index, resume.id);
+
+    ctx.destroy();
+}
+
 TEST(RirVerifier, RejectsYieldWithoutResumeMapping) {
     TestContext ctx;
     REQUIRE(ctx.init());

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -677,6 +677,41 @@ TEST(RirVerifier, RejectsExplicitResumeStateZeroDifferentFromEntry) {
     ctx.destroy();
 }
 
+TEST(RirVerifier, RejectsNonExplicitStateZeroDifferentFromEntry) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto stale_entry = V(b.create_block(fn, lit("stale_entry")));
+    auto terminal = V(b.create_block(fn, lit("terminal")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    VOK(b.set_state_zero_entry_resume(fn, terminal, stale_entry));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+
+    b.set_insert_point(fn, stale_entry);
+    VOK(b.emit_ret_status(202));
+
+    b.set_insert_point(fn, terminal);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::InvalidStateZeroEntry));
+    CHECK_EQ(result.issue.target_index, stale_entry.id);
+
+    ctx.destroy();
+}
+
 TEST(RirVerifier, RejectsYieldWithoutResumeMapping) {
     TestContext ctx;
     REQUIRE(ctx.init());

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -586,6 +586,137 @@ TEST(RirVerifier, RejectsYieldCountMismatch) {
     ctx.destroy();
 }
 
+TEST(RirVerifier, TreatsExplicitYieldResumeBlockAsReachable) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(result.ok);
+    CHECK_EQ(result.summary.reachable_block_count, 2u);
+    CHECK_EQ(result.summary.branch_edge_count, 1u);
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RejectsInvalidYieldNextState) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+    fn->blocks[entry.id].insts[0].imm.i64_val =
+        (static_cast<i64>(jit::YieldKind::Timer) << 48) | (static_cast<i64>(2) << 32) | 50;
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::InvalidYieldNextState));
+    CHECK_EQ(result.issue.target_index, 2u);
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RejectsInvalidEncodedYieldKind) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+    fn->blocks[entry.id].insts[0].imm.i64_val =
+        (static_cast<i64>(99) << 48) | (static_cast<i64>(1) << 32) | 50;
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::InvalidYieldKind));
+    CHECK_EQ(result.issue.target_index, 99u);
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RejectsYieldTerminatorMetadataMismatch) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 75, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::YieldMetadataMismatch));
+    CHECK_EQ(result.issue.target_index, 1u);
+
+    ctx.destroy();
+}
+
 TEST(RirVerifier, RejectsUnreachableBlockByDefault) {
     TestContext ctx;
     REQUIRE(ctx.init());

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -805,6 +805,38 @@ TEST(RirVerifier, RejectsInvalidEncodedYieldKind) {
     ctx.destroy();
 }
 
+TEST(RirVerifier, RejectsUnsupportedLoweredYieldKind) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::HttpPost)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::HttpPost), 50, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::InvalidYieldKind));
+    CHECK_EQ(result.issue.target_index, static_cast<u32>(jit::YieldKind::HttpPost));
+
+    ctx.destroy();
+}
+
 TEST(RirVerifier, RejectsYieldTerminatorMetadataMismatch) {
     TestContext ctx;
     REQUIRE(ctx.init());

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -644,6 +644,31 @@ TEST(RirVerifier, TreatsExplicitYieldResumeBlockAsReachable) {
     ctx.destroy();
 }
 
+TEST(RirVerifier, RejectsYieldWithoutResumeMapping) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::MissingYieldResumeMapping));
+
+    ctx.destroy();
+}
+
 TEST(RirVerifier, RejectsInvalidYieldNextState) {
     TestContext ctx;
     REQUIRE(ctx.init());

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -644,7 +644,42 @@ TEST(RirVerifier, TreatsExplicitYieldResumeBlockAsReachable) {
     ctx.destroy();
 }
 
-TEST(RirVerifier, RejectsExplicitResumeStateZeroDifferentFromEntry) {
+TEST(RirVerifier, AcceptsExplicitStateZeroPreludeThatReachesEntry) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto prelude = V(b.create_block(fn, lit("prelude")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {prelude, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, prelude);
+    VOK(b.emit_jmp(entry));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(result.ok);
+    CHECK_EQ(result.summary.reachable_block_count, 3u);
+    CHECK_EQ(result.summary.branch_edge_count, 2u);
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RejectsExplicitResumeStateZeroThatSkipsEntry) {
     TestContext ctx;
     REQUIRE(ctx.init());
 
@@ -671,13 +706,13 @@ TEST(RirVerifier, RejectsExplicitResumeStateZeroDifferentFromEntry) {
     auto result = verify_function(fn);
     REQUIRE(!result.ok);
     CHECK_EQ(static_cast<u8>(result.issue.code),
-             static_cast<u8>(VerifyIssueCode::InvalidStateZeroEntry));
-    CHECK_EQ(result.issue.target_index, resume.id);
+             static_cast<u8>(VerifyIssueCode::UnreachableBlock));
+    CHECK_EQ(result.issue.block_index, entry.id);
 
     ctx.destroy();
 }
 
-TEST(RirVerifier, RejectsNonExplicitStateZeroDifferentFromEntry) {
+TEST(RirVerifier, RejectsNonExplicitStateZeroThatSkipsEntry) {
     TestContext ctx;
     REQUIRE(ctx.init());
 
@@ -706,8 +741,8 @@ TEST(RirVerifier, RejectsNonExplicitStateZeroDifferentFromEntry) {
     auto result = verify_function(fn);
     REQUIRE(!result.ok);
     CHECK_EQ(static_cast<u8>(result.issue.code),
-             static_cast<u8>(VerifyIssueCode::InvalidStateZeroEntry));
-    CHECK_EQ(result.issue.target_index, stale_entry.id);
+             static_cast<u8>(VerifyIssueCode::UnreachableBlock));
+    CHECK_EQ(result.issue.block_index, entry.id);
 
     ctx.destroy();
 }

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -744,6 +744,45 @@ TEST(RirVerifier, RejectsYieldTerminatorMetadataMismatch) {
     ctx.destroy();
 }
 
+TEST(RirVerifier, RejectsDuplicateYieldNextState) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume1 = V(b.create_block(fn, lit("resume1")));
+    auto resume2 = V(b.create_block(fn, lit("resume2")));
+
+    u32 payloads[2] = {50, 100};
+    u8 kinds[2] = {static_cast<u8>(jit::YieldKind::Timer), static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 2, kinds));
+    BlockId resume_blocks[3] = {entry, resume1, resume2};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 3));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+
+    b.set_insert_point(fn, resume1);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 100, 2));
+    fn->blocks[resume1.id].insts[0].imm.i64_val =
+        (static_cast<i64>(jit::YieldKind::Timer) << 48) | (static_cast<i64>(1) << 32) | 100;
+
+    b.set_insert_point(fn, resume2);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::DuplicateYieldNextState));
+    CHECK_EQ(result.issue.block_index, resume1.id);
+    CHECK_EQ(result.issue.target_index, 1u);
+
+    ctx.destroy();
+}
+
 TEST(RirVerifier, RejectsUnreachableBlockByDefault) {
     TestContext ctx;
     REQUIRE(ctx.init());


### PR DESCRIPTION
## Summary

Adds a small native verifier entry point for RIR route graphs. The verifier checks structural invariants that must hold before Rut can reason about stronger runtime properties.

Covered in this MVP:

- final terminator shape for every block
- branch and jump target validity
- default reachability from entry
- yield terminator count matching function metadata
- yield kind range validation against the runtime ABI
- basic state-zero and explicit resume block bounds

The formal verification notes now describe this as the current native verifier foundation, separate from broader TLA+/deadlock/progress modeling.

## Validation

- `cmake --build build --target test_rir`
- `./build/tests/test_rir`
- `git diff --check`
- `git diff --cached --check`