### PR TITLE
[codex] Add runtime protocol yield checks

### DIFF
--- a/docs/user-code-formal-verification.md
+++ b/docs/user-code-formal-verification.md
@@ -189,12 +189,25 @@ Covered today:
 - every block has exactly one final terminator,
 - branch and jump targets point at existing blocks,
 - all blocks are reachable by default,
-- RIR yield terminators match function yield metadata,
-- yield kinds are inside the runtime ABI range.
+- RIR yield terminators are lowered to the executable `YieldTimer` state-machine
+  boundary; non-lowered yield opcodes are rejected,
+- encoded yield kind, next-state, and payload fields match function yield
+  metadata for every block, including dead blocks when reachability is relaxed,
+- each yield state has exactly one producer: duplicate and missing encoded
+  `next_state` values are rejected,
+- yield functions declare a supported resume mapping, and verifier reachability
+  starts from the same state-zero dispatch root used by codegen,
+- lowered yield kinds are restricted to runtime-schedulable wait/event kinds,
+- the first runtime-protocol checks reject yield shapes that the event loop
+  cannot safely schedule, such as downstream-send event yields and upstream
+  connect/recv/send yields without a target payload.
 
 This is not yet the full safety/deadlock checker described above. It is the
 foundation for that checker: a route automaton must be structurally valid before
 Rut can prove callback hygiene, declared resume targets, or progress properties.
+The next verifier layer should lift the currently hard-coded runtime-protocol
+checks into a compact handler automaton with explicit pending operation and
+callback-slot state.
 
 ## TLA+ Role
 

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -28,6 +28,7 @@ enum class VerifyIssueCode : u8 {
     DuplicateYieldNextState,
     MissingYieldNextState,
     YieldMetadataMismatch,
+    InvalidYieldRuntimeProtocol,
     YieldCountMismatch,
     TooManyYieldStates,
     TooManyBlocks,
@@ -90,6 +91,52 @@ inline bool verify_valid_yield_kind(u8 kind) {
         case jit::YieldKind::UpstreamRecv:
         case jit::YieldKind::UpstreamSend:
             return true;
+        case jit::YieldKind::HttpGet:
+        case jit::YieldKind::HttpPost:
+        case jit::YieldKind::Forward:
+            return false;
+    }
+    return false;
+}
+
+enum class VerifyYieldRuntimeClass : u8 {
+    Timer,
+    Event,
+    Unsupported,
+};
+
+inline VerifyYieldRuntimeClass verify_yield_runtime_class(u8 kind) {
+    switch (static_cast<jit::YieldKind>(kind)) {
+        case jit::YieldKind::Timer:
+            return VerifyYieldRuntimeClass::Timer;
+        case jit::YieldKind::Any:
+        case jit::YieldKind::Recv:
+        case jit::YieldKind::UpstreamConnect:
+        case jit::YieldKind::UpstreamRecv:
+        case jit::YieldKind::UpstreamSend:
+            return VerifyYieldRuntimeClass::Event;
+        case jit::YieldKind::Send:
+        case jit::YieldKind::HttpGet:
+        case jit::YieldKind::HttpPost:
+        case jit::YieldKind::Forward:
+            return VerifyYieldRuntimeClass::Unsupported;
+    }
+    return VerifyYieldRuntimeClass::Unsupported;
+}
+
+inline bool verify_valid_yield_runtime_protocol(u8 kind, u32 payload) {
+    if (verify_yield_runtime_class(kind) == VerifyYieldRuntimeClass::Unsupported) return false;
+
+    switch (static_cast<jit::YieldKind>(kind)) {
+        case jit::YieldKind::Timer:
+        case jit::YieldKind::Any:
+        case jit::YieldKind::Recv:
+            return true;
+        case jit::YieldKind::UpstreamConnect:
+        case jit::YieldKind::UpstreamRecv:
+        case jit::YieldKind::UpstreamSend:
+            return payload != 0;
+        case jit::YieldKind::Send:
         case jit::YieldKind::HttpGet:
         case jit::YieldKind::HttpPost:
         case jit::YieldKind::Forward:
@@ -237,6 +284,14 @@ inline VerifyResult verify_function(const Function* fn,
                 }
                 const u32 yi = static_cast<u32>(next_state - 1);
                 const u32 payload = static_cast<u32>(static_cast<u64>(term.imm.i64_val));
+                if (!verify_valid_yield_runtime_protocol(kind, payload)) {
+                    return verify_fail(summary,
+                                       VerifyIssueCode::InvalidYieldRuntimeProtocol,
+                                       function_index,
+                                       bi,
+                                       block.inst_count - 1,
+                                       kind);
+                }
                 if (fn->yield_kinds[yi] != kind || fn->yield_payload[yi] != payload) {
                     return verify_fail(summary,
                                        VerifyIssueCode::YieldMetadataMismatch,
@@ -444,6 +499,8 @@ inline const char* verify_issue_code_name(VerifyIssueCode code) {
             return "MissingYieldNextState";
         case VerifyIssueCode::YieldMetadataMismatch:
             return "YieldMetadataMismatch";
+        case VerifyIssueCode::InvalidYieldRuntimeProtocol:
+            return "InvalidYieldRuntimeProtocol";
         case VerifyIssueCode::YieldCountMismatch:
             return "YieldCountMismatch";
         case VerifyIssueCode::TooManyYieldStates:

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -283,6 +283,64 @@ TEST(frontend, rir_verifier_e2e_reports_yield_metadata_mismatch) {
     rir.destroy();
 }
 
+TEST(frontend, rir_verifier_e2e_reports_invalid_yield_runtime_protocol) {
+    FrontendRirModule rir{};
+    REQUIRE(
+        lower_src_to_rir("upstream api at \"127.0.0.1:9000\"\n"
+                         "route GET \"/connect\" { wait(upstream(api).connect()) return 204 }\n",
+                         rir));
+    auto& fn = rir.module.functions[0];
+    auto* yield = find_first_op(fn, rir::Opcode::YieldTimer);
+    REQUIRE(yield != nullptr);
+    REQUIRE(fn.yield_payload != nullptr);
+
+    const u64 packed = static_cast<u64>(yield->imm.i64_val);
+    const u64 next_state = (packed >> 32) & 0xffffu;
+    const u64 kind = (packed >> 48) & 0xffu;
+    REQUIRE_EQ(kind, static_cast<u64>(jit::YieldKind::UpstreamConnect));
+    yield->imm.i64_val = static_cast<i64>((kind << 48) | (next_state << 32));
+    fn.yield_payload[0] = 0;
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::InvalidYieldRuntimeProtocol));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: InvalidYieldRuntimeProtocol") != std::string::npos);
+    CHECK(text.find("target=7") != std::string::npos);
+
+    rir.destroy();
+}
+
+TEST(frontend, rir_verifier_e2e_reports_targetless_upstream_io_yield) {
+    FrontendRirModule rir{};
+    REQUIRE(
+        lower_src_to_rir("upstream api at \"127.0.0.1:9000\"\n"
+                         "route GET \"/recv\" { wait(upstream(api).recv()) return 204 }\n",
+                         rir));
+    auto& fn = rir.module.functions[0];
+    auto* yield = find_first_op(fn, rir::Opcode::YieldTimer);
+    REQUIRE(yield != nullptr);
+    REQUIRE(fn.yield_payload != nullptr);
+
+    const u64 packed = static_cast<u64>(yield->imm.i64_val);
+    const u64 next_state = (packed >> 32) & 0xffffu;
+    const u64 kind = (packed >> 48) & 0xffu;
+    REQUIRE_EQ(kind, static_cast<u64>(jit::YieldKind::UpstreamRecv));
+    yield->imm.i64_val = static_cast<i64>((kind << 48) | (next_state << 32));
+    fn.yield_payload[0] = 0;
+
+    auto verified = rir::verify_module(rir.module);
+    REQUIRE(!verified.ok);
+    CHECK_EQ(static_cast<u8>(verified.issue.code),
+             static_cast<u8>(rir::VerifyIssueCode::InvalidYieldRuntimeProtocol));
+    const std::string text = format_verify_text(verified);
+    CHECK(text.find("rir verifier: InvalidYieldRuntimeProtocol") != std::string::npos);
+    CHECK(text.find("target=8") != std::string::npos);
+
+    rir.destroy();
+}
+
 TEST(frontend, rir_verifier_e2e_reports_duplicate_yield_next_state) {
     FrontendRirModule rir{};
     REQUIRE(lower_src_to_rir("route GET \"/sleep\" { wait(500) wait(1000) return 204 }\n", rir));

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -872,6 +872,106 @@ TEST(RirVerifier, RejectsUnsupportedLoweredYieldKind) {
     ctx.destroy();
 }
 
+TEST(RirVerifier, RejectsRuntimeUnsupportedDownstreamSendYield) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {0};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Send)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Send), 0, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::InvalidYieldRuntimeProtocol));
+    CHECK_EQ(result.issue.target_index, static_cast<u32>(jit::YieldKind::Send));
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RejectsUpstreamConnectYieldWithoutTargetPayload) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {0};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::UpstreamConnect)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::UpstreamConnect), 0, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::InvalidYieldRuntimeProtocol));
+    CHECK_EQ(result.issue.target_index, static_cast<u32>(jit::YieldKind::UpstreamConnect));
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RejectsUpstreamIoYieldWithoutTargetPayload) {
+    const jit::YieldKind kinds[] = {jit::YieldKind::UpstreamRecv, jit::YieldKind::UpstreamSend};
+
+    for (jit::YieldKind yield_kind : kinds) {
+        TestContext ctx;
+        REQUIRE(ctx.init());
+
+        Builder b;
+        b.init(&ctx.mod);
+
+        auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+        auto entry = V(b.create_block(fn, lit("entry")));
+        auto resume = V(b.create_block(fn, lit("resume")));
+
+        u32 payloads[1] = {0};
+        u8 encoded_kinds[1] = {static_cast<u8>(yield_kind)};
+        VOK(b.set_yield_payload(fn, payloads, 1, encoded_kinds));
+        BlockId resume_blocks[2] = {entry, resume};
+        VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+        b.set_insert_point(fn, entry);
+        VOK(b.emit_yield_event(static_cast<u8>(yield_kind), 0, 1));
+
+        b.set_insert_point(fn, resume);
+        VOK(b.emit_ret_status(204));
+
+        auto result = verify_function(fn);
+        REQUIRE(!result.ok);
+        CHECK_EQ(static_cast<u8>(result.issue.code),
+                 static_cast<u8>(VerifyIssueCode::InvalidYieldRuntimeProtocol));
+        CHECK_EQ(result.issue.target_index, static_cast<u32>(yield_kind));
+
+        ctx.destroy();
+    }
+}
+
 TEST(RirVerifier, RejectsYieldTerminatorMetadataMismatch) {
     TestContext ctx;
     REQUIRE(ctx.init());


### PR DESCRIPTION
## Summary

- Update the formal-verification notes to describe the current RIR verifier MVP coverage.
- Add runtime protocol validation for lowered yield shapes that the event loop cannot safely schedule.
- Reject downstream-send event yields and targetless upstream event yields (`UpstreamConnect`, `UpstreamRecv`, `UpstreamSend`).
- Cover the new verifier behavior with focused RIR tests and frontend e2e mutation tests.

## Validation

- `cmake --build build --target test_frontend test_rir`
- `./build/tests/test_rir`
- `./build/tests/test_frontend --filter=frontend.rir_verifier_e2e`
- `git diff --check`