### PR TITLE
[codex] Add handler verifier automaton MVP

### DIFF
--- a/docs/user-code-formal-verification.md
+++ b/docs/user-code-formal-verification.md
@@ -199,19 +199,22 @@ Covered today:
   starts from the same state-zero dispatch root used by codegen,
 - lowered yield kinds are restricted to runtime-schedulable wait/event kinds,
 - a small runtime-protocol model classifies each lowered yield by pending
-  operation and callback slot, and rejects yield shapes that the event loop
-  cannot safely schedule, such as downstream-send event yields and upstream
-  connect/recv/send yields without a target payload,
+  operation, callback slot, and submit/completion/fail-closed transition shape,
+  and rejects yield shapes that the event loop cannot safely schedule, such as
+  downstream-send event yields and upstream connect/recv/send yields without a
+  target payload,
 - runtime-protocol verifier failures include a compact Rut-facing trace with
   the yield kind, payload, modeled pending operation, callback slot, and failure
-  reason.
+  reason,
+- a handler-verification automaton MVP summarizes route terminators, yields,
+  resume edges, and runtime transition counts for the next explicit-state
+  checker.
 
 This is not yet the full safety/deadlock checker described above. It is the
 foundation for that checker: a route automaton must be structurally valid before
 Rut can prove callback hygiene, declared resume targets, or progress properties.
-The next verifier layer should use the runtime-protocol model as the seed for a
-larger handler automaton with explicit completion/failure transitions and
-callback-slot hygiene checks.
+The next verifier layer should turn this automaton summary into an explicit-state
+safety/deadlock checker with callback-slot hygiene checks.
 
 ## TLA+ Role
 

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -131,11 +131,25 @@ enum class VerifyRuntimeProtocolReason : u8 {
     MissingUpstreamTarget,
 };
 
+enum class VerifyRuntimeTransitionKind : u8 {
+    Submit,
+    Complete,
+    FailClosed,
+};
+
 struct VerifyRuntimeProtocolCheck {
     bool ok = false;
     VerifyRuntimeProtocolReason reason = VerifyRuntimeProtocolReason::Ok;
     VerifyRuntimePendingOp pending_op = VerifyRuntimePendingOp::None;
     VerifyRuntimeCallbackSlot callback_slot = VerifyRuntimeCallbackSlot::None;
+    VerifyRuntimePendingOp secondary_pending_op = VerifyRuntimePendingOp::None;
+    VerifyRuntimeCallbackSlot secondary_callback_slot = VerifyRuntimeCallbackSlot::None;
+    bool submit_transition = false;
+    bool completion_transition = false;
+    bool fail_closed_transition = false;
+    u8 submit_transition_count = 0;
+    u8 completion_transition_count = 0;
+    u8 fail_closed_transition_count = 0;
 };
 
 struct VerifyRuntimeProtocolModel {
@@ -146,12 +160,31 @@ struct VerifyRuntimeProtocolModel {
                 check.ok = true;
                 check.pending_op = VerifyRuntimePendingOp::Timer;
                 check.callback_slot = VerifyRuntimeCallbackSlot::HandlerTimer;
+                check.submit_transition = true;
+                check.completion_transition = true;
+                check.fail_closed_transition = true;
+                check.submit_transition_count = 1;
+                check.completion_transition_count = 1;
+                check.fail_closed_transition_count = 1;
                 return check;
             case jit::YieldKind::Any:
             case jit::YieldKind::Recv:
                 check.ok = true;
                 check.pending_op = VerifyRuntimePendingOp::DownstreamRecv;
                 check.callback_slot = VerifyRuntimeCallbackSlot::DownstreamRecv;
+                check.submit_transition = true;
+                check.completion_transition = true;
+                check.fail_closed_transition = true;
+                check.submit_transition_count = 1;
+                check.completion_transition_count = 1;
+                check.fail_closed_transition_count = 1;
+                if (static_cast<jit::YieldKind>(kind) == jit::YieldKind::Any && payload != 0) {
+                    check.secondary_pending_op = VerifyRuntimePendingOp::Timer;
+                    check.secondary_callback_slot = VerifyRuntimeCallbackSlot::HandlerTimer;
+                    check.submit_transition_count = 2;
+                    check.completion_transition_count = 2;
+                    check.fail_closed_transition_count = 2;
+                }
                 return check;
             case jit::YieldKind::UpstreamConnect:
                 check.pending_op = VerifyRuntimePendingOp::UpstreamConnect;
@@ -161,6 +194,12 @@ struct VerifyRuntimeProtocolModel {
                     return check;
                 }
                 check.ok = true;
+                check.submit_transition = true;
+                check.completion_transition = true;
+                check.fail_closed_transition = true;
+                check.submit_transition_count = 1;
+                check.completion_transition_count = 1;
+                check.fail_closed_transition_count = 1;
                 return check;
             case jit::YieldKind::UpstreamRecv:
                 check.pending_op = VerifyRuntimePendingOp::UpstreamRecv;
@@ -170,6 +209,12 @@ struct VerifyRuntimeProtocolModel {
                     return check;
                 }
                 check.ok = true;
+                check.submit_transition = true;
+                check.completion_transition = true;
+                check.fail_closed_transition = true;
+                check.submit_transition_count = 1;
+                check.completion_transition_count = 1;
+                check.fail_closed_transition_count = 1;
                 return check;
             case jit::YieldKind::UpstreamSend:
                 check.pending_op = VerifyRuntimePendingOp::UpstreamSend;
@@ -179,6 +224,12 @@ struct VerifyRuntimeProtocolModel {
                     return check;
                 }
                 check.ok = true;
+                check.submit_transition = true;
+                check.completion_transition = true;
+                check.fail_closed_transition = true;
+                check.submit_transition_count = 1;
+                check.completion_transition_count = 1;
+                check.fail_closed_transition_count = 1;
                 return check;
             case jit::YieldKind::Send:
             case jit::YieldKind::HttpGet:
@@ -190,6 +241,35 @@ struct VerifyRuntimeProtocolModel {
         check.reason = VerifyRuntimeProtocolReason::UnsupportedEventYield;
         return check;
     }
+};
+
+enum class VerifyHandlerNodeKind : u8 {
+    Terminal,
+    Branch,
+    Jump,
+    Yield,
+};
+
+struct VerifyHandlerAutomatonNode {
+    VerifyHandlerNodeKind kind = VerifyHandlerNodeKind::Terminal;
+    u32 block_index = 0;
+    u32 inst_index = 0;
+    u8 yield_kind = 0;
+    u32 yield_payload = 0;
+    u16 next_state = 0;
+    VerifyRuntimeProtocolCheck runtime{};
+};
+
+struct VerifyHandlerAutomaton {
+    static constexpr u32 kMaxNodes = 4096;
+    VerifyHandlerAutomatonNode nodes[kMaxNodes]{};
+    u32 node_count = 0;
+    u32 edge_count = 0;
+    u32 terminal_count = 0;
+    u32 yield_count = 0;
+    u32 runtime_submit_count = 0;
+    u32 runtime_completion_count = 0;
+    u32 runtime_fail_closed_count = 0;
 };
 
 inline VerifyYieldRuntimeClass verify_yield_runtime_class(u8 kind) {
@@ -301,6 +381,56 @@ inline u8 verify_yield_timer_kind(const Instruction& inst) {
 inline u16 verify_yield_timer_next_state(const Instruction& inst) {
     const u64 packed = static_cast<u64>(inst.imm.i64_val);
     return static_cast<u16>((packed >> 32) & 0xffffu);
+}
+
+inline bool build_verify_handler_automaton(const Function* fn, VerifyHandlerAutomaton& out) {
+    out = VerifyHandlerAutomaton{};
+
+    if (fn == nullptr || fn->block_count == 0 || fn->blocks == nullptr ||
+        fn->block_count > VerifyHandlerAutomaton::kMaxNodes) {
+        return false;
+    }
+
+    for (u32 bi = 0; bi < fn->block_count; bi++) {
+        const Block& block = fn->blocks[bi];
+        if (block.inst_count == 0 || block.insts == nullptr) {
+            return false;
+        }
+
+        const u32 inst_index = block.inst_count - 1;
+        const Instruction& term = block.insts[inst_index];
+        VerifyHandlerAutomatonNode& node = out.nodes[out.node_count++];
+        node.block_index = bi;
+        node.inst_index = inst_index;
+
+        if (term.op == Opcode::Br) {
+            node.kind = VerifyHandlerNodeKind::Branch;
+            out.edge_count += 2;
+        } else if (term.op == Opcode::Jmp) {
+            node.kind = VerifyHandlerNodeKind::Jump;
+            out.edge_count += 1;
+        } else if (term.is_yield()) {
+            if (term.op != Opcode::YieldTimer) {
+                return false;
+            }
+            node.kind = VerifyHandlerNodeKind::Yield;
+            node.yield_kind = verify_yield_timer_kind(term);
+            node.yield_payload = static_cast<u32>(static_cast<u64>(term.imm.i64_val));
+            node.next_state = verify_yield_timer_next_state(term);
+            node.runtime =
+                VerifyRuntimeProtocolModel::check_yield(node.yield_kind, node.yield_payload);
+            out.yield_count++;
+            out.edge_count += 1;
+            out.runtime_submit_count += node.runtime.submit_transition_count;
+            out.runtime_completion_count += node.runtime.completion_transition_count;
+            out.runtime_fail_closed_count += node.runtime.fail_closed_transition_count;
+        } else {
+            node.kind = VerifyHandlerNodeKind::Terminal;
+            out.terminal_count++;
+        }
+    }
+
+    return true;
 }
 
 inline VerifyResult verify_function(const Function* fn,

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -996,6 +996,53 @@ TEST(RirVerifier, RuntimeProtocolModelMapsConnectToUpstreamSendSlot) {
              static_cast<u8>(VerifyRuntimeCallbackSlot::UpstreamSend));
 }
 
+TEST(RirVerifier, RuntimeProtocolModelAddsFailureTransitionForUpstreamYield) {
+    auto check = VerifyRuntimeProtocolModel::check_yield(
+        static_cast<u8>(jit::YieldKind::UpstreamConnect), 1);
+    REQUIRE(check.ok);
+    CHECK(check.submit_transition);
+    CHECK(check.completion_transition);
+    CHECK(check.fail_closed_transition);
+    CHECK_EQ(static_cast<u8>(check.pending_op),
+             static_cast<u8>(VerifyRuntimePendingOp::UpstreamConnect));
+    CHECK_EQ(static_cast<u8>(check.callback_slot),
+             static_cast<u8>(VerifyRuntimeCallbackSlot::UpstreamSend));
+}
+
+TEST(RirVerifier, RuntimeProtocolModelMarksTimerSchedulingFailureClosed) {
+    auto check =
+        VerifyRuntimeProtocolModel::check_yield(static_cast<u8>(jit::YieldKind::Timer), 50);
+    REQUIRE(check.ok);
+    CHECK(check.submit_transition);
+    CHECK(check.completion_transition);
+    CHECK(check.fail_closed_transition);
+    CHECK_EQ(check.submit_transition_count, 1u);
+    CHECK_EQ(check.completion_transition_count, 1u);
+    CHECK_EQ(check.fail_closed_transition_count, 1u);
+    CHECK_EQ(static_cast<u8>(check.pending_op), static_cast<u8>(VerifyRuntimePendingOp::Timer));
+    CHECK_EQ(static_cast<u8>(check.callback_slot),
+             static_cast<u8>(VerifyRuntimeCallbackSlot::HandlerTimer));
+}
+
+TEST(RirVerifier, RuntimeProtocolModelCountsTimedAnyTimerAndRecvTransitions) {
+    auto check = VerifyRuntimeProtocolModel::check_yield(static_cast<u8>(jit::YieldKind::Any), 25);
+    REQUIRE(check.ok);
+    CHECK(check.submit_transition);
+    CHECK(check.completion_transition);
+    CHECK(check.fail_closed_transition);
+    CHECK_EQ(check.submit_transition_count, 2u);
+    CHECK_EQ(check.completion_transition_count, 2u);
+    CHECK_EQ(check.fail_closed_transition_count, 2u);
+    CHECK_EQ(static_cast<u8>(check.pending_op),
+             static_cast<u8>(VerifyRuntimePendingOp::DownstreamRecv));
+    CHECK_EQ(static_cast<u8>(check.callback_slot),
+             static_cast<u8>(VerifyRuntimeCallbackSlot::DownstreamRecv));
+    CHECK_EQ(static_cast<u8>(check.secondary_pending_op),
+             static_cast<u8>(VerifyRuntimePendingOp::Timer));
+    CHECK_EQ(static_cast<u8>(check.secondary_callback_slot),
+             static_cast<u8>(VerifyRuntimeCallbackSlot::HandlerTimer));
+}
+
 TEST(RirVerifier, RuntimeProtocolModelReportsUnsupportedEventYield) {
     auto check = VerifyRuntimeProtocolModel::check_yield(static_cast<u8>(jit::YieldKind::Send), 0);
     REQUIRE(!check.ok);
@@ -1004,6 +1051,140 @@ TEST(RirVerifier, RuntimeProtocolModelReportsUnsupportedEventYield) {
     CHECK_EQ(static_cast<u8>(check.pending_op), static_cast<u8>(VerifyRuntimePendingOp::None));
     CHECK_EQ(static_cast<u8>(check.callback_slot),
              static_cast<u8>(VerifyRuntimeCallbackSlot::None));
+}
+
+TEST(RirVerifier, HandlerAutomatonSummarizesTimerYieldAndTerminal) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(result.ok);
+
+    VerifyHandlerAutomaton automaton{};
+    REQUIRE(build_verify_handler_automaton(fn, automaton));
+    CHECK_EQ(automaton.node_count, 2u);
+    CHECK_EQ(automaton.yield_count, 1u);
+    CHECK_EQ(automaton.terminal_count, 1u);
+    CHECK_EQ(automaton.edge_count, 1u);
+    CHECK_EQ(automaton.runtime_submit_count, 1u);
+    CHECK_EQ(automaton.runtime_completion_count, 1u);
+    CHECK_EQ(automaton.runtime_fail_closed_count, 1u);
+    CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].kind),
+             static_cast<u8>(VerifyHandlerNodeKind::Yield));
+    CHECK_EQ(automaton.nodes[entry.id].yield_kind, static_cast<u8>(jit::YieldKind::Timer));
+    CHECK_EQ(automaton.nodes[entry.id].yield_payload, 50u);
+    CHECK_EQ(automaton.nodes[entry.id].next_state, 1u);
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, HandlerAutomatonSummarizesTimedAnyAsTimerAndRecv) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {25};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Any)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Any), 25, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(result.ok);
+
+    VerifyHandlerAutomaton automaton{};
+    REQUIRE(build_verify_handler_automaton(fn, automaton));
+    CHECK_EQ(automaton.node_count, 2u);
+    CHECK_EQ(automaton.yield_count, 1u);
+    CHECK_EQ(automaton.terminal_count, 1u);
+    CHECK_EQ(automaton.edge_count, 1u);
+    CHECK_EQ(automaton.runtime_submit_count, 2u);
+    CHECK_EQ(automaton.runtime_completion_count, 2u);
+    CHECK_EQ(automaton.runtime_fail_closed_count, 2u);
+    CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].runtime.pending_op),
+             static_cast<u8>(VerifyRuntimePendingOp::DownstreamRecv));
+    CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].runtime.callback_slot),
+             static_cast<u8>(VerifyRuntimeCallbackSlot::DownstreamRecv));
+    CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].runtime.secondary_pending_op),
+             static_cast<u8>(VerifyRuntimePendingOp::Timer));
+    CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].runtime.secondary_callback_slot),
+             static_cast<u8>(VerifyRuntimeCallbackSlot::HandlerTimer));
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, HandlerAutomatonSummarizesUpstreamFailurePath) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {1};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::UpstreamConnect)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::UpstreamConnect), 1, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(result.ok);
+
+    VerifyHandlerAutomaton automaton{};
+    REQUIRE(build_verify_handler_automaton(fn, automaton));
+    CHECK_EQ(automaton.node_count, 2u);
+    CHECK_EQ(automaton.yield_count, 1u);
+    CHECK_EQ(automaton.terminal_count, 1u);
+    CHECK_EQ(automaton.edge_count, 1u);
+    CHECK_EQ(automaton.runtime_submit_count, 1u);
+    CHECK_EQ(automaton.runtime_completion_count, 1u);
+    CHECK_EQ(automaton.runtime_fail_closed_count, 1u);
+    CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].runtime.pending_op),
+             static_cast<u8>(VerifyRuntimePendingOp::UpstreamConnect));
+    CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].runtime.callback_slot),
+             static_cast<u8>(VerifyRuntimeCallbackSlot::UpstreamSend));
+
+    ctx.destroy();
 }
 
 TEST(RirVerifier, RejectsYieldTerminatorMetadataMismatch) {


### PR DESCRIPTION
## Summary
- add runtime protocol submit/completion/fail-closed transition flags for lowered yields
- add a handler-verification automaton MVP that summarizes route terminators, yield nodes, resume edges, and runtime transition counts
- document the updated verifier direction and cover timer/upstream automaton summaries in RIR tests

## Tests
- `cmake --build build --target test_rir`
- `./build/tests/test_rir`
- `git diff --check`