### PR TITLE
[codex] Add route-local verifier cycle check

### DIFF
--- a/docs/user-code-formal-verification.md
+++ b/docs/user-code-formal-verification.md
@@ -208,13 +208,15 @@ Covered today:
   reason,
 - a handler-verification automaton MVP summarizes route terminators, yields,
   resume edges, and runtime transition counts for the next explicit-state
-  checker.
+  checker,
+- a first route-local automaton check rejects synchronous CFG cycles made only
+  of branch/jump nodes, before Rut attempts larger runtime composition.
 
 This is not yet the full safety/deadlock checker described above. It is the
 foundation for that checker: a route automaton must be structurally valid before
 Rut can prove callback hygiene, declared resume targets, or progress properties.
-The next verifier layer should turn this automaton summary into an explicit-state
-safety/deadlock checker with callback-slot hygiene checks.
+The next verifier layer should compose yielded states with callback-slot hygiene
+and runtime completion/failure transitions.
 
 ## TLA+ Role
 

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -29,6 +29,8 @@ enum class VerifyIssueCode : u8 {
     MissingYieldNextState,
     YieldMetadataMismatch,
     InvalidYieldRuntimeProtocol,
+    InvalidHandlerAutomaton,
+    NonYieldingControlCycle,
     YieldCountMismatch,
     TooManyYieldStates,
     TooManyBlocks,
@@ -254,6 +256,8 @@ struct VerifyHandlerAutomatonNode {
     VerifyHandlerNodeKind kind = VerifyHandlerNodeKind::Terminal;
     u32 block_index = 0;
     u32 inst_index = 0;
+    u32 target_count = 0;
+    u32 targets[2]{};
     u8 yield_kind = 0;
     u32 yield_payload = 0;
     u16 next_state = 0;
@@ -270,6 +274,25 @@ struct VerifyHandlerAutomaton {
     u32 runtime_submit_count = 0;
     u32 runtime_completion_count = 0;
     u32 runtime_fail_closed_count = 0;
+};
+
+enum class VerifyHandlerCheckIssueCode : u8 {
+    None,
+    MissingAutomaton,
+    InvalidTarget,
+    DeadEnd,
+    NonYieldingCycle,
+};
+
+struct VerifyHandlerCheckIssue {
+    VerifyHandlerCheckIssueCode code = VerifyHandlerCheckIssueCode::None;
+    u32 node_index = 0;
+    u32 target_index = 0;
+};
+
+struct VerifyHandlerCheckResult {
+    bool ok = true;
+    VerifyHandlerCheckIssue issue{};
 };
 
 inline VerifyYieldRuntimeClass verify_yield_runtime_class(u8 kind) {
@@ -405,9 +428,14 @@ inline bool build_verify_handler_automaton(const Function* fn, VerifyHandlerAuto
 
         if (term.op == Opcode::Br) {
             node.kind = VerifyHandlerNodeKind::Branch;
+            node.target_count = 2;
+            node.targets[0] = term.imm.block_targets[0].id;
+            node.targets[1] = term.imm.block_targets[1].id;
             out.edge_count += 2;
         } else if (term.op == Opcode::Jmp) {
             node.kind = VerifyHandlerNodeKind::Jump;
+            node.target_count = 1;
+            node.targets[0] = term.imm.block_targets[0].id;
             out.edge_count += 1;
         } else if (term.is_yield()) {
             if (term.op != Opcode::YieldTimer) {
@@ -419,6 +447,13 @@ inline bool build_verify_handler_automaton(const Function* fn, VerifyHandlerAuto
             node.next_state = verify_yield_timer_next_state(term);
             node.runtime =
                 VerifyRuntimeProtocolModel::check_yield(node.yield_kind, node.yield_payload);
+            if (fn->has_explicit_resume_blocks && node.next_state <= fn->yield_count) {
+                node.target_count = 1;
+                node.targets[0] = fn->resume_blocks[node.next_state];
+            } else if (fn->state_zero_enters_entry && fn->resume_terminal_block < fn->block_count) {
+                node.target_count = 1;
+                node.targets[0] = fn->resume_terminal_block;
+            }
             out.yield_count++;
             out.edge_count += 1;
             out.runtime_submit_count += node.runtime.submit_transition_count;
@@ -431,6 +466,83 @@ inline bool build_verify_handler_automaton(const Function* fn, VerifyHandlerAuto
     }
 
     return true;
+}
+
+inline VerifyHandlerCheckResult verify_handler_automaton(const VerifyHandlerAutomaton& automaton) {
+    VerifyHandlerCheckResult result{};
+
+    if (automaton.node_count == 0) {
+        result.ok = false;
+        result.issue.code = VerifyHandlerCheckIssueCode::MissingAutomaton;
+        return result;
+    }
+
+    for (u32 ni = 0; ni < automaton.node_count; ni++) {
+        const VerifyHandlerAutomatonNode& node = automaton.nodes[ni];
+        if ((node.kind == VerifyHandlerNodeKind::Branch ||
+             node.kind == VerifyHandlerNodeKind::Jump ||
+             node.kind == VerifyHandlerNodeKind::Yield) &&
+            node.target_count == 0) {
+            result.ok = false;
+            result.issue.code = VerifyHandlerCheckIssueCode::DeadEnd;
+            result.issue.node_index = ni;
+            return result;
+        }
+        for (u32 ti = 0; ti < node.target_count; ti++) {
+            if (node.targets[ti] >= automaton.node_count) {
+                result.ok = false;
+                result.issue.code = VerifyHandlerCheckIssueCode::InvalidTarget;
+                result.issue.node_index = ni;
+                result.issue.target_index = node.targets[ti];
+                return result;
+            }
+        }
+    }
+
+    u8 color[VerifyHandlerAutomaton::kMaxNodes]{};
+    u32 stack[VerifyHandlerAutomaton::kMaxNodes]{};
+    u32 next_target[VerifyHandlerAutomaton::kMaxNodes]{};
+    for (u32 start = 0; start < automaton.node_count; start++) {
+        if (color[start] != 0) continue;
+        if (automaton.nodes[start].kind != VerifyHandlerNodeKind::Branch &&
+            automaton.nodes[start].kind != VerifyHandlerNodeKind::Jump) {
+            color[start] = 2;
+            continue;
+        }
+
+        u32 depth = 0;
+        stack[depth++] = start;
+        color[start] = 1;
+        while (depth > 0) {
+            const u32 ni = stack[depth - 1];
+            const VerifyHandlerAutomatonNode& node = automaton.nodes[ni];
+            if (next_target[ni] >= node.target_count) {
+                color[ni] = 2;
+                depth--;
+                continue;
+            }
+
+            const u32 target = node.targets[next_target[ni]++];
+            const VerifyHandlerAutomatonNode& target_node = automaton.nodes[target];
+            if (target_node.kind != VerifyHandlerNodeKind::Branch &&
+                target_node.kind != VerifyHandlerNodeKind::Jump) {
+                continue;
+            }
+            if (color[target] == 1) {
+                result.ok = false;
+                result.issue.code = VerifyHandlerCheckIssueCode::NonYieldingCycle;
+                result.issue.node_index = ni;
+                result.issue.target_index = target;
+                return result;
+            }
+            if (color[target] == 0) {
+                color[target] = 1;
+                stack[depth++] = target;
+            }
+        }
+    }
+
+    return result;
 }
 
 inline VerifyResult verify_function(const Function* fn,
@@ -702,6 +814,24 @@ inline VerifyResult verify_function(const Function* fn,
         }
     }
 
+    VerifyHandlerAutomaton automaton{};
+    if (!build_verify_handler_automaton(fn, automaton)) {
+        return verify_fail(summary, VerifyIssueCode::InvalidHandlerAutomaton, function_index);
+    }
+    const VerifyHandlerCheckResult automaton_check = verify_handler_automaton(automaton);
+    if (!automaton_check.ok) {
+        const VerifyIssueCode code =
+            automaton_check.issue.code == VerifyHandlerCheckIssueCode::NonYieldingCycle
+                ? VerifyIssueCode::NonYieldingControlCycle
+                : VerifyIssueCode::InvalidHandlerAutomaton;
+        return verify_fail(summary,
+                           code,
+                           function_index,
+                           automaton_check.issue.node_index,
+                           0,
+                           automaton_check.issue.target_index);
+    }
+
     VerifyResult result{};
     result.ok = true;
     result.summary = summary;
@@ -776,6 +906,10 @@ inline const char* verify_issue_code_name(VerifyIssueCode code) {
             return "YieldMetadataMismatch";
         case VerifyIssueCode::InvalidYieldRuntimeProtocol:
             return "InvalidYieldRuntimeProtocol";
+        case VerifyIssueCode::InvalidHandlerAutomaton:
+            return "InvalidHandlerAutomaton";
+        case VerifyIssueCode::NonYieldingControlCycle:
+            return "NonYieldingControlCycle";
         case VerifyIssueCode::YieldCountMismatch:
             return "YieldCountMismatch";
         case VerifyIssueCode::TooManyYieldStates:

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -1090,9 +1090,13 @@ TEST(RirVerifier, HandlerAutomatonSummarizesTimerYieldAndTerminal) {
     CHECK_EQ(automaton.runtime_fail_closed_count, 1u);
     CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].kind),
              static_cast<u8>(VerifyHandlerNodeKind::Yield));
+    CHECK_EQ(automaton.nodes[entry.id].target_count, 1u);
+    CHECK_EQ(automaton.nodes[entry.id].targets[0], resume.id);
     CHECK_EQ(automaton.nodes[entry.id].yield_kind, static_cast<u8>(jit::YieldKind::Timer));
     CHECK_EQ(automaton.nodes[entry.id].yield_payload, 50u);
     CHECK_EQ(automaton.nodes[entry.id].next_state, 1u);
+    auto check = verify_handler_automaton(automaton);
+    REQUIRE(check.ok);
 
     ctx.destroy();
 }
@@ -1140,6 +1144,44 @@ TEST(RirVerifier, HandlerAutomatonSummarizesTimedAnyAsTimerAndRecv) {
              static_cast<u8>(VerifyRuntimePendingOp::Timer));
     CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].runtime.secondary_callback_slot),
              static_cast<u8>(VerifyRuntimeCallbackSlot::HandlerTimer));
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, HandlerAutomatonRejectsNonYieldingControlCycle) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 0));
+    auto entry = V(b.create_block(fn, lit("entry")));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_jmp(entry));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::NonYieldingControlCycle));
+    CHECK_EQ(result.issue.block_index, entry.id);
+    CHECK_EQ(result.issue.target_index, entry.id);
+
+    VerifyHandlerAutomaton automaton{};
+    REQUIRE(build_verify_handler_automaton(fn, automaton));
+    CHECK_EQ(automaton.node_count, 1u);
+    CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].kind),
+             static_cast<u8>(VerifyHandlerNodeKind::Jump));
+    CHECK_EQ(automaton.nodes[entry.id].target_count, 1u);
+    CHECK_EQ(automaton.nodes[entry.id].targets[0], entry.id);
+
+    auto check = verify_handler_automaton(automaton);
+    REQUIRE(!check.ok);
+    CHECK_EQ(static_cast<u8>(check.issue.code),
+             static_cast<u8>(VerifyHandlerCheckIssueCode::NonYieldingCycle));
+    CHECK_EQ(check.issue.node_index, entry.id);
+    CHECK_EQ(check.issue.target_index, entry.id);
 
     ctx.destroy();
 }


### PR DESCRIPTION
## Summary
- record explicit automaton targets for branch, jump, and yield resume edges
- add a route-local automaton checker that rejects synchronous branch/jump cycles with no yield or terminal boundary
- document the new MVP verifier layer and cover the accepted timer path plus a rejected self-jump cycle

## Tests
- `cmake --build build --target test_rir`
- `./build/tests/test_rir`
- `git diff --check`