### PR TITLE
Add verifier runtime state wait arm checks

### DIFF
--- a/docs/user-code-formal-verification.md
+++ b/docs/user-code-formal-verification.md
@@ -211,12 +211,18 @@ Covered today:
   checker,
 - a first route-local automaton check rejects synchronous CFG cycles made only
   of branch/jump nodes, before Rut attempts larger runtime composition.
+- a minimal explicit-state runtime checker composes yield nodes with declared
+  wait-arm masks, callback slots, pending operations, completion transitions,
+  and fail-closed transitions,
+- the current `wait any { downstream.recv(), timer(ms) }` subset carries an
+  exact verifier-visible arm mask even though the runtime ABI still uses
+  `YieldKind::Any`.
 
 This is not yet the full safety/deadlock checker described above. It is the
 foundation for that checker: a route automaton must be structurally valid before
 Rut can prove callback hygiene, declared resume targets, or progress properties.
-The next verifier layer should compose yielded states with callback-slot hygiene
-and runtime completion/failure transitions.
+The next verifier layer should add richer counterexample traces and grow the
+same explicit-state model as Rut admits more wait arms and async capabilities.
 
 ## TLA+ Role
 

--- a/docs/wait.md
+++ b/docs/wait.md
@@ -333,8 +333,9 @@ The following are future work rather than current behavior:
 - Response starts inside `wait(downstream.send(response(...)))`; use terminal
   `return response(...)` for downstream responses until route completion can
   model "send and finish" without a second terminal response.
-- Exact event subsets inside `wait any`; today it uses current-connection `Any`
-  once the listed forms validate.
+- Exact event subsets beyond the current `downstream.recv()` plus `timer(ms)`
+  `wait any` subset. The current subset carries a verifier-visible exact arm
+  mask while the runtime ABI still uses current-connection `Any`.
 - Parameterized IO starts inside `wait any`; start the operation before a later
   race wait until that payload has a richer representation.
 - `wait any` arm result binding such as `r = downstream.recv() => { ... }`.

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -55,6 +55,37 @@ enum class WaitEventKind : u8 {
     UpstreamSend,
 };
 
+enum WaitEventArmMask : u8 {
+    kWaitEventArmNone = 0,
+    kWaitEventArmTimer = 1u << 0,
+    kWaitEventArmRecv = 1u << 1,
+    kWaitEventArmSend = 1u << 2,
+    kWaitEventArmUpstreamConnect = 1u << 3,
+    kWaitEventArmUpstreamRecv = 1u << 4,
+    kWaitEventArmUpstreamSend = 1u << 5,
+};
+
+inline u8 wait_event_kind_default_arm_mask(WaitEventKind kind, u32 payload = 0) {
+    switch (kind) {
+        case WaitEventKind::Timer:
+            return kWaitEventArmTimer;
+        case WaitEventKind::Any:
+            return static_cast<u8>(kWaitEventArmRecv |
+                                   (payload != 0 ? kWaitEventArmTimer : kWaitEventArmNone));
+        case WaitEventKind::Recv:
+            return kWaitEventArmRecv;
+        case WaitEventKind::Send:
+            return kWaitEventArmSend;
+        case WaitEventKind::UpstreamConnect:
+            return kWaitEventArmUpstreamConnect;
+        case WaitEventKind::UpstreamRecv:
+            return kWaitEventArmUpstreamRecv;
+        case WaitEventKind::UpstreamSend:
+            return kWaitEventArmUpstreamSend;
+    }
+    return kWaitEventArmNone;
+}
+
 // Single response header key/value pair, used by `response(N, headers: {...})`.
 // Both fields are non-owning views into the lexer's source buffer.
 struct AstHeaderKV {

--- a/include/rut/compiler/hir.h
+++ b/include/rut/compiler/hir.h
@@ -382,6 +382,7 @@ struct HirExpr {
     bool is_wait_result = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;
+    u8 wait_arm_mask = kWaitEventArmTimer;
     u32 wait_index = 0xffffffffu;
     static constexpr u32 kMaxFieldInits = 8;
     // HIR-level cap stays at 8 even though AstExpr::kMaxArgs = 32: HirRoute
@@ -629,6 +630,7 @@ struct HirLocal {
     bool is_magic_request_proxy = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;
+    u8 wait_arm_mask = kWaitEventArmTimer;
     u32 wait_index = 0xffffffffu;
     HirExpr init{};
 };
@@ -885,6 +887,7 @@ struct HirRoute {
         u32 ms = 0;  // duration in milliseconds; packed into the u32 yield
                      // payload (status_code + upstream_id) at codegen time.
                      // Parser caps at UINT32_MAX (~49 days).
+        u8 arm_mask = kWaitEventArmTimer;
     };
 
     Span span{};

--- a/include/rut/compiler/mir.h
+++ b/include/rut/compiler/mir.h
@@ -177,6 +177,7 @@ struct MirValue {
     bool is_wait_result = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;
+    u8 wait_arm_mask = kWaitEventArmTimer;
     u32 wait_index = 0xffffffffu;
     static constexpr u32 kMaxFieldInits = 8;
     static constexpr u32 kMaxArgs = 8;
@@ -203,6 +204,7 @@ struct MirLocal {
     bool is_wait_result = false;
     WaitEventKind wait_event_kind = WaitEventKind::Timer;
     u32 wait_payload = 0;
+    u8 wait_arm_mask = kWaitEventArmTimer;
     u32 wait_index = 0xffffffffu;
     MirValue init{};
 };
@@ -232,6 +234,7 @@ struct MirTerminator {
     u32 else_block = 0;
     WaitEventKind yield_event_kind = WaitEventKind::Timer;
     u32 yield_ms = 0;
+    u8 yield_arm_mask = kWaitEventArmTimer;
     u16 yield_next_state = 0;
     // Optional response body literal — carried verbatim from HIR for
     // ReturnStatus terminators. lower_rir maps identical literals to a
@@ -254,6 +257,7 @@ struct MirFunction {
         Span span{};
         WaitEventKind event_kind = WaitEventKind::Timer;
         u32 ms = 0;
+        u8 arm_mask = kWaitEventArmTimer;
     };
 
     Span span{};

--- a/include/rut/compiler/rir.h
+++ b/include/rut/compiler/rir.h
@@ -369,9 +369,11 @@ struct Function {
 
     // Per-yield ABI metadata. yield_payload[i] is the u32 payload carried
     // by state i+1, and yield_kinds[i] is the jit::YieldKind ABI byte.
-    // Both arrays are arena-allocated with length = yield_count.
+    // yield_arm_masks[i] is verifier metadata for the declared wait arms.
+    // All arrays are arena-allocated with length = yield_count.
     u32* yield_payload;
     u8* yield_kinds;
+    u8* yield_arm_masks;
 
     Block* entry() { return block_count > 0 ? &blocks[0] : nullptr; }
     const Block* entry() const { return block_count > 0 ? &blocks[0] : nullptr; }

--- a/include/rut/compiler/rir_builder.h
+++ b/include/rut/compiler/rir_builder.h
@@ -6,6 +6,30 @@
 namespace rut {
 namespace rir {
 
+inline u8 default_yield_arm_mask(u8 kind, u32 payload) {
+    switch (static_cast<jit::YieldKind>(kind)) {
+        case jit::YieldKind::Timer:
+            return 1u << 0;
+        case jit::YieldKind::Any:
+            return static_cast<u8>((1u << 1) | (payload != 0 ? (1u << 0) : 0));
+        case jit::YieldKind::Recv:
+            return 1u << 1;
+        case jit::YieldKind::Send:
+            return 1u << 2;
+        case jit::YieldKind::UpstreamConnect:
+            return 1u << 3;
+        case jit::YieldKind::UpstreamRecv:
+            return 1u << 4;
+        case jit::YieldKind::UpstreamSend:
+            return 1u << 5;
+        case jit::YieldKind::HttpGet:
+        case jit::YieldKind::HttpPost:
+        case jit::YieldKind::Forward:
+            return 0;
+    }
+    return 0;
+}
+
 // ── RIR Builder ─────────────────────────────────────────────────────
 // Stateful builder for constructing RIR functions. All memory is
 // allocated from the module's arena — no malloc, no stdlib.
@@ -119,6 +143,7 @@ struct Builder {
         for (u32 i = 0; i < Function::kMaxResumeBlocks; i++) fn->resume_blocks[i] = 0;
         fn->yield_payload = nullptr;
         fn->yield_kinds = nullptr;
+        fn->yield_arm_masks = nullptr;
         fn->blocks = blocks;
         fn->block_count = 0;
         fn->block_cap = kInitBlocks;
@@ -137,22 +162,28 @@ struct Builder {
     VoidResult set_yield_payload(Function* fn,
                                  const u32* ms_list,
                                  u32 count,
-                                 const u8* kind_list = nullptr) {
+                                 const u8* kind_list = nullptr,
+                                 const u8* arm_mask_list = nullptr) {
         if (count == 0) {
             fn->yield_count = 0;
             fn->yield_payload = nullptr;
             fn->yield_kinds = nullptr;
+            fn->yield_arm_masks = nullptr;
             return {};
         }
         auto* buf = mod->arena->alloc_array<u32>(count);
         auto* kinds = mod->arena->alloc_array<u8>(count);
-        if (!buf || !kinds) return err(RirError::OutOfMemory);
+        auto* arm_masks = mod->arena->alloc_array<u8>(count);
+        if (!buf || !kinds || !arm_masks) return err(RirError::OutOfMemory);
         for (u32 i = 0; i < count; i++) {
             buf[i] = ms_list[i];
             kinds[i] = kind_list ? kind_list[i] : kDefaultYieldKind;
+            arm_masks[i] =
+                arm_mask_list ? arm_mask_list[i] : default_yield_arm_mask(kinds[i], buf[i]);
         }
         fn->yield_payload = buf;
         fn->yield_kinds = kinds;
+        fn->yield_arm_masks = arm_masks;
         fn->yield_count = count;
         return {};
     }

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -30,6 +30,7 @@ enum class VerifyIssueCode : u8 {
     YieldMetadataMismatch,
     InvalidYieldRuntimeProtocol,
     InvalidHandlerAutomaton,
+    InvalidRuntimeStateModel,
     NonYieldingControlCycle,
     YieldCountMismatch,
     TooManyYieldStates,
@@ -245,6 +246,64 @@ struct VerifyRuntimeProtocolModel {
     }
 };
 
+inline u8 verify_yield_default_arm_mask(u8 kind, u32 payload) {
+    switch (static_cast<jit::YieldKind>(kind)) {
+        case jit::YieldKind::Timer:
+            return 1u << 0;
+        case jit::YieldKind::Any:
+            return static_cast<u8>((1u << 1) | (payload != 0 ? (1u << 0) : 0));
+        case jit::YieldKind::Recv:
+            return 1u << 1;
+        case jit::YieldKind::Send:
+            return 1u << 2;
+        case jit::YieldKind::UpstreamConnect:
+            return 1u << 3;
+        case jit::YieldKind::UpstreamRecv:
+            return 1u << 4;
+        case jit::YieldKind::UpstreamSend:
+            return 1u << 5;
+        case jit::YieldKind::HttpGet:
+        case jit::YieldKind::HttpPost:
+        case jit::YieldKind::Forward:
+            return 0;
+    }
+    return 0;
+}
+
+inline u8 verify_runtime_pending_op_arm_mask(VerifyRuntimePendingOp op) {
+    switch (op) {
+        case VerifyRuntimePendingOp::None:
+            return 0;
+        case VerifyRuntimePendingOp::Timer:
+            return 1u << 0;
+        case VerifyRuntimePendingOp::DownstreamRecv:
+            return 1u << 1;
+        case VerifyRuntimePendingOp::UpstreamConnect:
+            return 1u << 3;
+        case VerifyRuntimePendingOp::UpstreamRecv:
+            return 1u << 4;
+        case VerifyRuntimePendingOp::UpstreamSend:
+            return 1u << 5;
+    }
+    return 0;
+}
+
+inline u8 verify_runtime_callback_slot_mask(VerifyRuntimeCallbackSlot slot) {
+    switch (slot) {
+        case VerifyRuntimeCallbackSlot::None:
+            return 0;
+        case VerifyRuntimeCallbackSlot::HandlerTimer:
+            return 1u << 0;
+        case VerifyRuntimeCallbackSlot::DownstreamRecv:
+            return 1u << 1;
+        case VerifyRuntimeCallbackSlot::UpstreamRecv:
+            return 1u << 2;
+        case VerifyRuntimeCallbackSlot::UpstreamSend:
+            return 1u << 3;
+    }
+    return 0;
+}
+
 enum class VerifyHandlerNodeKind : u8 {
     Terminal,
     Branch,
@@ -260,6 +319,7 @@ struct VerifyHandlerAutomatonNode {
     u32 targets[2]{};
     u8 yield_kind = 0;
     u32 yield_payload = 0;
+    u8 wait_arm_mask = 0;
     u16 next_state = 0;
     VerifyRuntimeProtocolCheck runtime{};
 };
@@ -282,6 +342,9 @@ enum class VerifyHandlerCheckIssueCode : u8 {
     InvalidTarget,
     DeadEnd,
     NonYieldingCycle,
+    MissingRuntimeTransition,
+    CallbackSlotMismatch,
+    WaitArmMaskMismatch,
 };
 
 struct VerifyHandlerCheckIssue {
@@ -293,6 +356,8 @@ struct VerifyHandlerCheckIssue {
 struct VerifyHandlerCheckResult {
     bool ok = true;
     VerifyHandlerCheckIssue issue{};
+    u32 runtime_state_count = 0;
+    u32 runtime_transition_count = 0;
 };
 
 inline VerifyYieldRuntimeClass verify_yield_runtime_class(u8 kind) {
@@ -445,6 +510,13 @@ inline bool build_verify_handler_automaton(const Function* fn, VerifyHandlerAuto
             node.yield_kind = verify_yield_timer_kind(term);
             node.yield_payload = static_cast<u32>(static_cast<u64>(term.imm.i64_val));
             node.next_state = verify_yield_timer_next_state(term);
+            if (node.next_state != 0 && node.next_state <= fn->yield_count &&
+                fn->yield_arm_masks != nullptr) {
+                node.wait_arm_mask = fn->yield_arm_masks[node.next_state - 1];
+            } else {
+                node.wait_arm_mask =
+                    verify_yield_default_arm_mask(node.yield_kind, node.yield_payload);
+            }
             node.runtime =
                 VerifyRuntimeProtocolModel::check_yield(node.yield_kind, node.yield_payload);
             if (fn->has_explicit_resume_blocks && node.next_state <= fn->yield_count) {
@@ -545,6 +617,62 @@ inline VerifyHandlerCheckResult verify_handler_automaton(const VerifyHandlerAuto
     return result;
 }
 
+inline VerifyHandlerCheckResult verify_handler_runtime_states(
+    const VerifyHandlerAutomaton& automaton) {
+    VerifyHandlerCheckResult result{};
+
+    if (automaton.node_count == 0) {
+        result.ok = false;
+        result.issue.code = VerifyHandlerCheckIssueCode::MissingAutomaton;
+        return result;
+    }
+
+    for (u32 ni = 0; ni < automaton.node_count; ni++) {
+        const VerifyHandlerAutomatonNode& node = automaton.nodes[ni];
+        if (node.kind != VerifyHandlerNodeKind::Yield) continue;
+
+        result.runtime_state_count += 2;       // handler-running + runtime-waiting
+        result.runtime_transition_count += 1;  // submit into runtime-waiting
+
+        if (!node.runtime.ok || !node.runtime.submit_transition ||
+            !node.runtime.completion_transition || !node.runtime.fail_closed_transition ||
+            node.runtime.submit_transition_count == 0 ||
+            node.runtime.completion_transition_count != node.runtime.submit_transition_count ||
+            node.runtime.fail_closed_transition_count != node.runtime.submit_transition_count) {
+            result.ok = false;
+            result.issue.code = VerifyHandlerCheckIssueCode::MissingRuntimeTransition;
+            result.issue.node_index = ni;
+            return result;
+        }
+
+        const u8 callback_mask = static_cast<u8>(
+            verify_runtime_callback_slot_mask(node.runtime.callback_slot) |
+            verify_runtime_callback_slot_mask(node.runtime.secondary_callback_slot));
+        const u8 pending_arm_mask =
+            static_cast<u8>(verify_runtime_pending_op_arm_mask(node.runtime.pending_op) |
+                            verify_runtime_pending_op_arm_mask(node.runtime.secondary_pending_op));
+        if (callback_mask == 0 || pending_arm_mask == 0) {
+            result.ok = false;
+            result.issue.code = VerifyHandlerCheckIssueCode::CallbackSlotMismatch;
+            result.issue.node_index = ni;
+            return result;
+        }
+
+        if (node.wait_arm_mask != pending_arm_mask) {
+            result.ok = false;
+            result.issue.code = VerifyHandlerCheckIssueCode::WaitArmMaskMismatch;
+            result.issue.node_index = ni;
+            result.issue.target_index = node.wait_arm_mask;
+            return result;
+        }
+
+        result.runtime_transition_count += node.runtime.completion_transition_count;
+        result.runtime_transition_count += node.runtime.fail_closed_transition_count;
+    }
+
+    return result;
+}
+
 inline VerifyResult verify_function(const Function* fn,
                                     u32 function_index = 0,
                                     VerifyOptions options = {}) {
@@ -580,7 +708,8 @@ inline VerifyResult verify_function(const Function* fn,
     u32 seen_yield_terminators = 0;
     bool seen_yield_next_state[Function::kMaxResumeBlocks]{};
 
-    if (fn->yield_count > 0 && (fn->yield_payload == nullptr || fn->yield_kinds == nullptr)) {
+    if (fn->yield_count > 0 && (fn->yield_payload == nullptr || fn->yield_kinds == nullptr ||
+                                fn->yield_arm_masks == nullptr)) {
         return verify_fail(summary, VerifyIssueCode::MissingYieldMetadata, function_index);
     }
 
@@ -831,6 +960,15 @@ inline VerifyResult verify_function(const Function* fn,
                            0,
                            automaton_check.issue.target_index);
     }
+    const VerifyHandlerCheckResult runtime_state_check = verify_handler_runtime_states(automaton);
+    if (!runtime_state_check.ok) {
+        return verify_fail(summary,
+                           VerifyIssueCode::InvalidRuntimeStateModel,
+                           function_index,
+                           runtime_state_check.issue.node_index,
+                           0,
+                           runtime_state_check.issue.target_index);
+    }
 
     VerifyResult result{};
     result.ok = true;
@@ -908,6 +1046,8 @@ inline const char* verify_issue_code_name(VerifyIssueCode code) {
             return "InvalidYieldRuntimeProtocol";
         case VerifyIssueCode::InvalidHandlerAutomaton:
             return "InvalidHandlerAutomaton";
+        case VerifyIssueCode::InvalidRuntimeStateModel:
+            return "InvalidRuntimeStateModel";
         case VerifyIssueCode::NonYieldingControlCycle:
             return "NonYieldingControlCycle";
         case VerifyIssueCode::YieldCountMismatch:

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -4985,6 +4985,7 @@ static FrontendResult<HirExpr> analyze_function_body_stmt(const AstStatement& st
 struct WaitSpec {
     WaitEventKind kind = WaitEventKind::Timer;
     u32 payload = 0;
+    u8 arm_mask = kWaitEventArmTimer;
 };
 
 static FrontendResult<u32> find_wait_upstream_index(const HirModule& mod, const AstExpr& arg) {
@@ -5018,6 +5019,7 @@ static FrontendResult<WaitSpec> analyze_wait_io_op_spec(const AstExpr& op, const
     if (is_downstream && op.name.eq({"recv", 4})) {
         if (op.args.len != 0) return frontend_error(FrontendError::UnsupportedSyntax, op.span);
         spec.kind = WaitEventKind::Recv;
+        spec.arm_mask = wait_event_kind_default_arm_mask(spec.kind, spec.payload);
         return spec;
     }
     if (is_downstream && op.name.eq({"send", 4})) {
@@ -5029,6 +5031,7 @@ static FrontendResult<WaitSpec> analyze_wait_io_op_spec(const AstExpr& op, const
         auto upstream = find_wait_upstream_index(mod, *op.lhs->args[0]);
         if (!upstream) return core::make_unexpected(upstream.error());
         spec.payload = upstream.value() + 1;
+        spec.arm_mask = wait_event_kind_default_arm_mask(spec.kind, spec.payload);
         return spec;
     }
     if (is_upstream && op.name.eq({"recv", 4})) {
@@ -5037,6 +5040,7 @@ static FrontendResult<WaitSpec> analyze_wait_io_op_spec(const AstExpr& op, const
         if (!upstream) return core::make_unexpected(upstream.error());
         spec.kind = WaitEventKind::UpstreamRecv;
         spec.payload = upstream.value() + 1;
+        spec.arm_mask = wait_event_kind_default_arm_mask(spec.kind, spec.payload);
         return spec;
     }
     if (is_upstream && op.name.eq({"send", 4})) {
@@ -5047,6 +5051,7 @@ static FrontendResult<WaitSpec> analyze_wait_io_op_spec(const AstExpr& op, const
         if (!upstream) return core::make_unexpected(upstream.error());
         spec.kind = WaitEventKind::UpstreamSend;
         spec.payload = upstream.value() + 1;
+        spec.arm_mask = wait_event_kind_default_arm_mask(spec.kind, spec.payload);
         return spec;
     }
     return frontend_error(FrontendError::UnsupportedSyntax, op.span, op.name);
@@ -5077,6 +5082,7 @@ static FrontendResult<WaitSpec> analyze_wait_value_spec(const AstExpr& expr,
         WaitSpec spec{};
         spec.kind = expr.wait_event_kind;
         spec.payload = ms;
+        spec.arm_mask = wait_event_kind_default_arm_mask(spec.kind, spec.payload);
         return spec;
     }
 
@@ -5099,6 +5105,7 @@ static FrontendResult<HirExpr> analyze_wait_result_expr(const AstExpr& expr, con
     out.is_wait_result = true;
     out.wait_event_kind = wait_spec->kind;
     out.wait_payload = wait_spec->payload;
+    out.wait_arm_mask = wait_spec->arm_mask;
     return out;
 }
 
@@ -6665,6 +6672,7 @@ static FrontendResult<HirExpr> analyze_expr_impl(const AstExpr& expr,
             out.is_wait_result = locals[i].is_wait_result;
             out.wait_event_kind = locals[i].wait_event_kind;
             out.wait_payload = locals[i].wait_payload;
+            out.wait_arm_mask = locals[i].wait_arm_mask;
             out.wait_index = locals[i].wait_index;
             out.generic_index = locals[i].generic_index;
             out.associated_name = locals[i].associated_name;
@@ -10342,6 +10350,7 @@ static FrontendResult<WaitSpec> analyze_wait_stmt_spec(const AstStatement& stmt,
         WaitSpec spec{};
         spec.kind = stmt.wait_event_kind;
         spec.payload = stmt.status_code;
+        spec.arm_mask = wait_event_kind_default_arm_mask(spec.kind, spec.payload);
         return spec;
     }
 
@@ -10392,6 +10401,7 @@ static FrontendResult<void> analyze_wait_any_stmt_control(const AstStatement& st
     wait.span = stmt.span;
     wait.event_kind = WaitEventKind::Any;
     wait.ms = timer_ms;
+    wait.arm_mask = static_cast<u8>(kWaitEventArmRecv | kWaitEventArmTimer);
     const u32 wait_index = route.waits.len;
     if (!route.waits.push(wait)) return frontend_error(FrontendError::TooManyItems, stmt.span);
 
@@ -10402,6 +10412,7 @@ static FrontendResult<void> analyze_wait_any_stmt_control(const AstStatement& st
     base.is_wait_result = true;
     base.wait_event_kind = WaitEventKind::Any;
     base.wait_payload = timer_ms;
+    base.wait_arm_mask = wait.arm_mask;
     base.wait_index = wait_index;
     if (!route.exprs.push(base)) return frontend_error(FrontendError::TooManyItems, stmt.span);
 
@@ -10548,6 +10559,7 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
             local.is_wait_result = init->is_wait_result;
             local.wait_event_kind = init->wait_event_kind;
             local.wait_payload = init->wait_payload;
+            local.wait_arm_mask = init->wait_arm_mask;
             local.wait_index = init->wait_index;
             local.generic_index = init->generic_index;
             local.generic_has_error_constraint = init->generic_has_error_constraint;
@@ -11176,6 +11188,7 @@ static FrontendResult<u32> analyze_for_stmt(const AstStatement& stmt,
                             local.is_wait_result = init->is_wait_result;
                             local.wait_event_kind = init->wait_event_kind;
                             local.wait_payload = init->wait_payload;
+                            local.wait_arm_mask = init->wait_arm_mask;
                             local.wait_index = init->wait_index;
                             local.generic_index = init->generic_index;
                             local.generic_has_error_constraint = init->generic_has_error_constraint;
@@ -14819,6 +14832,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 w.span = stmt.span;
                 w.event_kind = wait_spec->kind;
                 w.ms = wait_spec->payload;
+                w.arm_mask = wait_spec->arm_mask;
                 if (!route.waits.push(w))
                     return frontend_error(FrontendError::TooManyItems, stmt.span);
                 continue;
@@ -14917,6 +14931,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
                     w.span = stmt.expr.span;
                     w.event_kind = init->wait_event_kind;
                     w.ms = init->wait_payload;
+                    w.arm_mask = init->wait_arm_mask;
                     init->wait_index = route.waits.len;
                     if (!route.waits.push(w))
                         return frontend_error(FrontendError::TooManyItems, stmt.span);
@@ -14928,6 +14943,7 @@ static FrontendResult<HirModule*> analyze_file_internal(
                 local.is_wait_result = init->is_wait_result;
                 local.wait_event_kind = init->wait_event_kind;
                 local.wait_payload = init->wait_payload;
+                local.wait_arm_mask = init->wait_arm_mask;
                 local.wait_index = init->wait_index;
                 local.generic_index = init->generic_index;
                 local.generic_has_error_constraint = init->generic_has_error_constraint;

--- a/src/compiler/lower_rir.cc
+++ b/src/compiler/lower_rir.cc
@@ -3336,11 +3336,14 @@ FrontendResult<void> lower_to_rir(const MirModule& mir, FrontendRirModule& out) 
         if (mir.functions[i].waits.len > 0) {
             u32 ms_list[MirFunction::kMaxWaits]{};
             u8 kind_list[MirFunction::kMaxWaits]{};
+            u8 arm_mask_list[MirFunction::kMaxWaits]{};
             for (u32 wi = 0; wi < mir.functions[i].waits.len; wi++) {
                 ms_list[wi] = mir.functions[i].waits[wi].ms;
                 kind_list[wi] = yield_kind_abi(mir.functions[i].waits[wi].event_kind);
+                arm_mask_list[wi] = mir.functions[i].waits[wi].arm_mask;
             }
-            if (!b.set_yield_payload(fn.value(), ms_list, mir.functions[i].waits.len, kind_list)) {
+            if (!b.set_yield_payload(
+                    fn.value(), ms_list, mir.functions[i].waits.len, kind_list, arm_mask_list)) {
                 out.destroy();
                 return frontend_error(FrontendError::OutOfMemory, mir.functions[i].span);
             }

--- a/src/compiler/mir_build.cc
+++ b/src/compiler/mir_build.cc
@@ -658,6 +658,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.is_wait_result = expr.is_wait_result;
         v.wait_event_kind = expr.wait_event_kind;
         v.wait_payload = expr.wait_payload;
+        v.wait_arm_mask = expr.wait_arm_mask;
         v.wait_index = expr.wait_index;
         v.variant_index = expr.variant_index;
         v.struct_index = expr.struct_index;
@@ -673,6 +674,7 @@ static FrontendResult<MirValue> mir_value(const HirExpr& expr,
         v.is_wait_result = true;
         v.wait_event_kind = expr.wait_event_kind;
         v.wait_payload = expr.wait_payload;
+        v.wait_arm_mask = expr.wait_arm_mask;
         v.wait_index = expr.wait_index;
         return v;
     }
@@ -857,6 +859,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             w.span = module.routes[i].waits[wi].span;
             w.event_kind = module.routes[i].waits[wi].event_kind;
             w.ms = module.routes[i].waits[wi].ms;
+            w.arm_mask = module.routes[i].waits[wi].arm_mask;
             if (!fn.waits.push(w)) return frontend_error(FrontendError::TooManyItems, w.span);
         }
 
@@ -902,6 +905,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             local.is_wait_result = module.routes[i].locals[li].is_wait_result;
             local.wait_event_kind = module.routes[i].locals[li].wait_event_kind;
             local.wait_payload = module.routes[i].locals[li].wait_payload;
+            local.wait_arm_mask = module.routes[i].locals[li].wait_arm_mask;
             local.wait_index = module.routes[i].locals[li].wait_index;
             auto init = mir_value(module.routes[i].locals[li].init, module, &fn);
             if (!init) return core::make_unexpected(init.error());
@@ -1221,6 +1225,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
                     step_block.term.span = wait.span;
                     step_block.term.yield_event_kind = wait.event_kind;
                     step_block.term.yield_ms = wait.ms;
+                    step_block.term.yield_arm_mask = wait.arm_mask;
                     step_block.term.yield_next_state = static_cast<u16>(wait_ordinal);
                     fn.resume_blocks[wait_ordinal] = next_index;
                 }
@@ -2374,6 +2379,7 @@ FrontendResult<MirModule*> build_mir(const HirModule& module) {
             yield_block.term.span = fn.waits[0].span;
             yield_block.term.yield_event_kind = fn.waits[0].event_kind;
             yield_block.term.yield_ms = fn.waits[0].ms;
+            yield_block.term.yield_arm_mask = fn.waits[0].arm_mask;
             yield_block.term.yield_next_state = 1;
             if (!fn.blocks.push(yield_block))
                 return frontend_error(FrontendError::TooManyItems, fn.span);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -2263,6 +2263,8 @@ TEST(frontend, analyze_wait_any_statement_lowers_to_any_wait_and_if_control) {
     REQUIRE_EQ(hir->routes[0].waits.len, 1u);
     CHECK_EQ(hir->routes[0].waits[0].event_kind, WaitEventKind::Any);
     CHECK_EQ(hir->routes[0].waits[0].ms, 250u);
+    CHECK_EQ(hir->routes[0].waits[0].arm_mask,
+             static_cast<u8>(kWaitEventArmRecv | kWaitEventArmTimer));
     CHECK_EQ(static_cast<u8>(hir->routes[0].control.kind), static_cast<u8>(HirControlKind::If));
     CHECK_EQ(static_cast<u8>(hir->routes[0].control.cond.kind),
              static_cast<u8>(HirExprKind::WaitField));

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -1,3 +1,4 @@
+#include "rut/compiler/ast.h"
 #include "rut/compiler/rir.h"
 #include "rut/compiler/rir_builder.h"
 #include "rut/compiler/rir_printer.h"
@@ -586,6 +587,38 @@ TEST(RirVerifier, RejectsYieldCountMismatch) {
     ctx.destroy();
 }
 
+TEST(RirVerifier, RejectsMissingYieldArmMaskMetadata) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {50};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Timer)};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds));
+    fn->yield_arm_masks = nullptr;
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Timer), 50, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::MissingYieldMetadata));
+
+    ctx.destroy();
+}
+
 TEST(RirVerifier, RejectsNonLoweredYieldTerminator) {
     TestContext ctx;
     REQUIRE(ctx.init());
@@ -1144,6 +1177,53 @@ TEST(RirVerifier, HandlerAutomatonSummarizesTimedAnyAsTimerAndRecv) {
              static_cast<u8>(VerifyRuntimePendingOp::Timer));
     CHECK_EQ(static_cast<u8>(automaton.nodes[entry.id].runtime.secondary_callback_slot),
              static_cast<u8>(VerifyRuntimeCallbackSlot::HandlerTimer));
+    CHECK_EQ(automaton.nodes[entry.id].wait_arm_mask,
+             static_cast<u8>(kWaitEventArmRecv | kWaitEventArmTimer));
+    auto runtime_check = verify_handler_runtime_states(automaton);
+    REQUIRE(runtime_check.ok);
+    CHECK_EQ(runtime_check.runtime_state_count, 2u);
+    CHECK_EQ(runtime_check.runtime_transition_count, 5u);
+
+    ctx.destroy();
+}
+
+TEST(RirVerifier, RuntimeStateCheckerRejectsAnyWithMissingDeclaredArm) {
+    TestContext ctx;
+    REQUIRE(ctx.init());
+
+    Builder b;
+    b.init(&ctx.mod);
+
+    auto* fn = V(b.create_function(lit("test_fn"), lit("/test"), 1));
+    auto entry = V(b.create_block(fn, lit("entry")));
+    auto resume = V(b.create_block(fn, lit("resume")));
+
+    u32 payloads[1] = {25};
+    u8 kinds[1] = {static_cast<u8>(jit::YieldKind::Any)};
+    u8 arm_masks[1] = {kWaitEventArmTimer};
+    VOK(b.set_yield_payload(fn, payloads, 1, kinds, arm_masks));
+    BlockId resume_blocks[2] = {entry, resume};
+    VOK(b.set_explicit_resume_blocks(fn, resume_blocks, 2));
+
+    b.set_insert_point(fn, entry);
+    VOK(b.emit_yield_event(static_cast<u8>(jit::YieldKind::Any), 25, 1));
+
+    b.set_insert_point(fn, resume);
+    VOK(b.emit_ret_status(204));
+
+    auto result = verify_function(fn);
+    REQUIRE(!result.ok);
+    CHECK_EQ(static_cast<u8>(result.issue.code),
+             static_cast<u8>(VerifyIssueCode::InvalidRuntimeStateModel));
+    CHECK_EQ(result.issue.block_index, entry.id);
+    CHECK_EQ(result.issue.target_index, static_cast<u32>(kWaitEventArmTimer));
+
+    VerifyHandlerAutomaton automaton{};
+    REQUIRE(build_verify_handler_automaton(fn, automaton));
+    auto runtime_check = verify_handler_runtime_states(automaton);
+    REQUIRE(!runtime_check.ok);
+    CHECK_EQ(static_cast<u8>(runtime_check.issue.code),
+             static_cast<u8>(VerifyHandlerCheckIssueCode::WaitArmMaskMismatch));
 
     ctx.destroy();
 }

--- a/tests/test_simulate_engine.cc
+++ b/tests/test_simulate_engine.cc
@@ -561,6 +561,9 @@ TEST(simulate_engine, wait_any_statement_uses_concrete_wait_kind) {
     REQUIRE_GE(rir.module.functions[0].yield_count, 1u);
     CHECK_EQ(rir.module.functions[0].yield_kinds[0], static_cast<u8>(jit::YieldKind::Any));
     CHECK_EQ(rir.module.functions[0].yield_payload[0], 50u);
+    REQUIRE(rir.module.functions[0].yield_arm_masks != nullptr);
+    CHECK_EQ(rir.module.functions[0].yield_arm_masks[0],
+             static_cast<u8>(kWaitEventArmRecv | kWaitEventArmTimer));
 
     Engine engine;
     REQUIRE(engine.init(rir.module, nullptr, 0));


### PR DESCRIPTION
## Summary
- carry verifier-visible wait arm masks from HIR through MIR into RIR yield metadata
- add an explicit-state runtime checker that validates yield pending ops, callback slots, completion/failure transitions, and declared wait arm masks
- document the current `wait any { downstream.recv(), timer(ms) }` coverage and add focused frontend/RIR/simulate tests

## Tests
- `./build/tests/test_rir`
- `./build/tests/test_frontend`
- `./build/tests/test_simulate_engine`
- `git diff --check`