### PR TITLE
Add state invariant coverage and capture ring begin/commit API tests

### DIFF
--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -134,31 +134,33 @@ void on_request_complete(Loop* loop, Connection& conn, u16 status, u32 resp_size
         loop->access_log->push(entry);
     }
 
-    // TODO: avoid 8KB stack alloc + double copy by adding a reserve/commit
-    // API to CaptureRing (write directly into ring slot). Acceptable for now
-    // since capture is a debug feature, not always-on production path.
     if (loop->capture_ring && conn.capture_buf && conn.capture_header_len > 0) {
-        CaptureEntry cap;
-        __builtin_memset(&cap, 0, sizeof(cap));
-        cap.timestamp_us = realtime_us();
-        cap.req_content_length = conn.req_content_length;
-        cap.resp_content_length = resp_size;
-        cap.resp_status = status;
-        cap.raw_header_len = conn.capture_header_len;
-        cap.peer_port = conn.peer_port;
-        cap.method = conn.req_method;
-        cap.shard_id = conn.shard_id;
-        cap.flags =
+        CaptureEntry* cap_entry = nullptr;
+        u32 expected_wp = 0;
+        if (!loop->capture_ring->begin_push(&cap_entry, &expected_wp)) {
+            return;
+        }
+        auto* cap = cap_entry;
+        __builtin_memset(cap, 0, sizeof(*cap));
+        cap->timestamp_us = realtime_us();
+        cap->req_content_length = conn.req_content_length;
+        cap->resp_content_length = resp_size;
+        cap->resp_status = status;
+        cap->raw_header_len = conn.capture_header_len;
+        cap->peer_port = conn.peer_port;
+        cap->method = conn.req_method;
+        cap->shard_id = conn.shard_id;
+        cap->flags =
             (conn.capture_header_len == CaptureEntry::kMaxHeaderLen) ? kCaptureFlagTruncated : 0;
-        constexpr u32 kCopyLen = sizeof(conn.upstream_name) < sizeof(cap.upstream_name)
+        constexpr u32 kCopyLen = sizeof(conn.upstream_name) < sizeof(cap->upstream_name)
                                      ? sizeof(conn.upstream_name)
-                                     : sizeof(cap.upstream_name);
+                                     : sizeof(cap->upstream_name);
         for (u32 i = 0; i < kCopyLen; i++) {
-            cap.upstream_name[i] = conn.upstream_name[i];
+            cap->upstream_name[i] = conn.upstream_name[i];
             if (conn.upstream_name[i] == '\0') break;
         }
-        __builtin_memcpy(cap.raw_headers, conn.capture_buf, conn.capture_header_len);
-        loop->capture_ring->push(cap);
+        __builtin_memcpy(cap->raw_headers, conn.capture_buf, conn.capture_header_len);
+        loop->capture_ring->commit_push(expected_wp);
     }
 }
 

--- a/include/rut/runtime/traffic_capture.h
+++ b/include/rut/runtime/traffic_capture.h
@@ -88,17 +88,37 @@ struct CaptureRing {
         read_pos = 0;
     }
 
+    // Producer: reserve one slot for writing a capture entry. Returns false when full.
+    // The caller should fill `*out` then call `commit_push(expected_wp)`.
+    bool begin_push(CaptureEntry** out, u32* expected_wp) {
+        const u32 wp = write_pos.load(std::memory_order_relaxed);
+        const u32 rp = read_pos.load(std::memory_order_acquire);
+        if (wp - rp >= kCapacity) {
+            return false;  // full
+        }
+        if (out) {
+            *out = &entries[wp & kMask];
+        }
+        if (expected_wp) {
+            *expected_wp = wp;
+        }
+        return true;
+    }
+
+    // Producer: complete a reservation started by begin_push().
+    void commit_push(u32 expected_wp) {
+        write_pos.store(expected_wp + 1, std::memory_order_release);
+    }
+
     // Producer: write an entry. Returns false if full (entry dropped).
     bool push(const CaptureEntry& entry) {
-        u32 wp = write_pos.load(std::memory_order_relaxed);
-        u32 rp = read_pos.load(std::memory_order_acquire);
-
-        if (wp - rp >= kCapacity) {
-            return false;  // full — drop
+        CaptureEntry* slot = nullptr;
+        u32 expected_wp = 0;
+        if (!begin_push(&slot, &expected_wp)) {
+            return false;
         }
-
-        entries[wp & kMask] = entry;
-        write_pos.store(wp + 1, std::memory_order_release);
+        entries[expected_wp & kMask] = entry;
+        commit_push(expected_wp);
         return true;
     }
 

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -10208,6 +10208,58 @@ TEST(state_invariant, jit_event_yield_starts_runtime_operations) {
     CHECK_EQ(loop.backend.count_ops(MockOp::PauseRecv), 1u);
 }
 
+TEST(state_invariant, jit_upstream_send_mismatch_fail_closes_slots) {
+    SmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    c->upstream_fd = 100;
+    c->upstream_idx = 0;
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 13;
+    outcome.yield_kind = jit::YieldKind::UpstreamSend;
+    outcome.timer_ms = 3;  // target index=2, mismatched with upstream_idx=0
+    loop.backend.clear_ops();
+
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, kStatusBadGateway);
+    check_sending_response_invariant(_tc, c);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+    CHECK_EQ(c->upstream_fd, 100);
+}
+
+TEST(state_invariant, jit_upstream_recv_mismatch_fail_closes_slots) {
+    SmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    c->upstream_fd = 100;
+    c->upstream_idx = 0;
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 14;
+    outcome.yield_kind = jit::YieldKind::UpstreamRecv;
+    outcome.timer_ms = 3;  // target index=2, mismatched with upstream_idx=0
+    loop.backend.clear_ops();
+
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, kStatusBadGateway);
+    check_sending_response_invariant(_tc, c);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+    CHECK_EQ(c->upstream_fd, 100);
+}
+
 TEST(state_invariant, jit_upstream_wait_target_mismatch_fails_closed) {
     SmallLoop loop;
     loop.setup();

--- a/tests/test_traffic_capture.cc
+++ b/tests/test_traffic_capture.cc
@@ -182,6 +182,47 @@ TEST(capture_ring, full_drops) {
     CHECK(ring.push(entry));
 }
 
+TEST(capture_ring, begin_push_and_commit) {
+    CaptureRing ring;
+    ring.init();
+
+    CaptureEntry* slot = nullptr;
+    u32 wp = 0;
+    CHECK(ring.begin_push(&slot, &wp));
+    REQUIRE(slot != nullptr);
+
+    __builtin_memset(slot, 0, sizeof(*slot));
+    slot->resp_status = 201;
+    slot->method = static_cast<u8>(LogHttpMethod::Post);
+    slot->raw_header_len = 4;
+    const u8 prefix[] = {'P', 'O', 'S', 'T'};
+    for (u32 i = 0; i < 4; i++) slot->raw_headers[i] = prefix[i];
+    ring.commit_push(wp);
+
+    CHECK_EQ(ring.available(), 1u);
+
+    CaptureEntry out{};
+    CHECK(ring.pop(out));
+    CHECK_EQ(out.resp_status, 201);
+    CHECK_EQ(out.method, static_cast<u8>(LogHttpMethod::Post));
+    CHECK_EQ(out.raw_header_len, 4);
+    CHECK_EQ(out.raw_headers[0], 'P');
+    CHECK_EQ(out.raw_headers[3], 'T');
+
+    ring.pop(out);
+    CHECK_EQ(ring.available(), 0u);
+
+    CaptureEntry* full_slots[CaptureRing::kCapacity];
+    for (u32 i = 0; i < CaptureRing::kCapacity; i++) {
+        u32 full_wp = 0;
+        CHECK(ring.begin_push(&full_slots[i], &full_wp));
+        CHECK_NE(full_slots[i], nullptr);
+        ring.commit_push(full_wp);
+    }
+    CHECK_EQ(ring.available(), CaptureRing::kCapacity);
+    CHECK(!ring.begin_push(nullptr, nullptr));
+}
+
 TEST(capture_ring, fifo_order) {
     CaptureRing ring;
     ring.init();


### PR DESCRIPTION
This PR adds missing coverage for JIT upstream mismatch event-yield error paths and introduces CaptureRing begin/commit API with test coverage.