### PR TITLE
Extend state invariant coverage for buffered proxy send failure

### DIFF
--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -179,6 +179,7 @@ template <typename Loop>
 void on_header_received(void* lp, Connection& conn, IoEvent ev) {
     auto* loop = static_cast<Loop*>(lp);
     // Slot: on_recv. dispatch_event guarantees ev.type == Recv.
+    conn.send_progress = 0;
 
     if (ev.result <= 0) {
         loop->close_conn(conn);
@@ -398,32 +399,38 @@ template <typename Loop>
 void on_response_sent(void* lp, Connection& conn, IoEvent ev) {
     auto* loop = static_cast<Loop*>(lp);
     const u32 kSendLen = conn.send_buf.len();
+    const u32 kResult = static_cast<u32>(ev.result);
 
     if (ev.result < 0) {
         loop->close_conn(conn);
         return;
     }
 
-    const u32 kResult = static_cast<u32>(ev.result);
-    if (kResult > kSendLen) {
+    if (conn.send_progress > kSendLen) {
         loop->close_conn(conn);
         return;
     }
+    if (kResult > (kSendLen - conn.send_progress)) {
+        loop->close_conn(conn);
+        return;
+    }
+    conn.send_progress += kResult;
 
-    if (kResult < kSendLen) {
+    if (conn.send_progress < kSendLen) {
         if (kResult == 0u) {
             // No progress cannot guarantee eventual completion.
             loop->close_conn(conn);
             return;
         }
 
-        const u32 kRemaining = kSendLen - kResult;
+        const u32 kRemaining = kSendLen - conn.send_progress;
         conn.transition_to_sending(&on_response_sent<Loop>);
-        loop->submit_send(conn, conn.send_buf.data() + kResult, kRemaining);
+        loop->submit_send(conn, conn.send_buf.data() + conn.send_progress, kRemaining);
         return;
     }
 
     // Send complete — clear all slots (will set on_recv for keep-alive below).
+    conn.send_progress = 0;
     conn.clear_slots();
 
     on_request_complete(loop, conn, conn.resp_status, conn.send_buf.len());

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -134,31 +134,33 @@ void on_request_complete(Loop* loop, Connection& conn, u16 status, u32 resp_size
         loop->access_log->push(entry);
     }
 
-    // TODO: avoid 8KB stack alloc + double copy by adding a reserve/commit
-    // API to CaptureRing (write directly into ring slot). Acceptable for now
-    // since capture is a debug feature, not always-on production path.
     if (loop->capture_ring && conn.capture_buf && conn.capture_header_len > 0) {
-        CaptureEntry cap;
-        __builtin_memset(&cap, 0, sizeof(cap));
-        cap.timestamp_us = realtime_us();
-        cap.req_content_length = conn.req_content_length;
-        cap.resp_content_length = resp_size;
-        cap.resp_status = status;
-        cap.raw_header_len = conn.capture_header_len;
-        cap.peer_port = conn.peer_port;
-        cap.method = conn.req_method;
-        cap.shard_id = conn.shard_id;
-        cap.flags =
+        CaptureEntry* cap_entry = nullptr;
+        u32 expected_wp = 0;
+        if (!loop->capture_ring->begin_push(&cap_entry, &expected_wp)) {
+            return;
+        }
+        auto* cap = cap_entry;
+        __builtin_memset(cap, 0, sizeof(*cap));
+        cap->timestamp_us = realtime_us();
+        cap->req_content_length = conn.req_content_length;
+        cap->resp_content_length = resp_size;
+        cap->resp_status = status;
+        cap->raw_header_len = conn.capture_header_len;
+        cap->peer_port = conn.peer_port;
+        cap->method = conn.req_method;
+        cap->shard_id = conn.shard_id;
+        cap->flags =
             (conn.capture_header_len == CaptureEntry::kMaxHeaderLen) ? kCaptureFlagTruncated : 0;
-        constexpr u32 kCopyLen = sizeof(conn.upstream_name) < sizeof(cap.upstream_name)
+        constexpr u32 kCopyLen = sizeof(conn.upstream_name) < sizeof(cap->upstream_name)
                                      ? sizeof(conn.upstream_name)
-                                     : sizeof(cap.upstream_name);
+                                     : sizeof(cap->upstream_name);
         for (u32 i = 0; i < kCopyLen; i++) {
-            cap.upstream_name[i] = conn.upstream_name[i];
+            cap->upstream_name[i] = conn.upstream_name[i];
             if (conn.upstream_name[i] == '\0') break;
         }
-        __builtin_memcpy(cap.raw_headers, conn.capture_buf, conn.capture_header_len);
-        loop->capture_ring->push(cap);
+        __builtin_memcpy(cap->raw_headers, conn.capture_buf, conn.capture_header_len);
+        loop->capture_ring->commit_push(expected_wp);
     }
 }
 

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -397,20 +397,34 @@ void on_jit_request_body_recvd(void* lp, Connection& conn, IoEvent ev) {
 template <typename Loop>
 void on_response_sent(void* lp, Connection& conn, IoEvent ev) {
     auto* loop = static_cast<Loop*>(lp);
-    // Send complete — clear all slots (will set on_recv for keep-alive below).
-    conn.clear_slots();
+    const u32 kSendLen = conn.send_buf.len();
 
     if (ev.result < 0) {
         loop->close_conn(conn);
         return;
     }
 
-    // Validate full send — partial sends (possible with io_uring) would serve
-    // truncated responses. Close rather than risk corruption on keep-alive.
-    if (static_cast<u32>(ev.result) != conn.send_buf.len()) {
+    const u32 kResult = static_cast<u32>(ev.result);
+    if (kResult > kSendLen) {
         loop->close_conn(conn);
         return;
     }
+
+    if (kResult < kSendLen) {
+        if (kResult == 0u) {
+            // No progress cannot guarantee eventual completion.
+            loop->close_conn(conn);
+            return;
+        }
+
+        const u32 kRemaining = kSendLen - kResult;
+        conn.transition_to_sending(&on_response_sent<Loop>);
+        loop->submit_send(conn, conn.send_buf.data() + kResult, kRemaining);
+        return;
+    }
+
+    // Send complete — clear all slots (will set on_recv for keep-alive below).
+    conn.clear_slots();
 
     on_request_complete(loop, conn, conn.resp_status, conn.send_buf.len());
     loop->epoch_leave();

--- a/include/rut/runtime/connection_base.h
+++ b/include/rut/runtime/connection_base.h
@@ -251,6 +251,7 @@ struct ConnectionBase {
     u8* send_slice;
     Buffer recv_buf;
     Buffer send_buf;
+    u32 send_progress;
 
     // Upstream recv buffer — separate from client recv_buf to prevent:
     // 1. Client pipelined data being parsed as upstream response
@@ -331,6 +332,7 @@ struct ConnectionBase {
         send_slice = nullptr;
         recv_buf.bind(nullptr, 0);
         send_buf.bind(nullptr, 0);
+        send_progress = 0;
         upstream_recv_slice = nullptr;
         upstream_recv_buf.bind(nullptr, 0);
     }

--- a/include/rut/runtime/traffic_capture.h
+++ b/include/rut/runtime/traffic_capture.h
@@ -88,17 +88,37 @@ struct CaptureRing {
         read_pos = 0;
     }
 
+    // Producer: reserve one slot for writing a capture entry. Returns false when full.
+    // The caller should fill `*out` then call `commit_push(expected_wp)`.
+    bool begin_push(CaptureEntry** out, u32* expected_wp) {
+        const u32 wp = write_pos.load(std::memory_order_relaxed);
+        const u32 rp = read_pos.load(std::memory_order_acquire);
+        if (wp - rp >= kCapacity) {
+            return false;  // full
+        }
+        if (out) {
+            *out = &entries[wp & kMask];
+        }
+        if (expected_wp) {
+            *expected_wp = wp;
+        }
+        return true;
+    }
+
+    // Producer: complete a reservation started by begin_push().
+    void commit_push(u32 expected_wp) {
+        write_pos.store(expected_wp + 1, std::memory_order_release);
+    }
+
     // Producer: write an entry. Returns false if full (entry dropped).
     bool push(const CaptureEntry& entry) {
-        u32 wp = write_pos.load(std::memory_order_relaxed);
-        u32 rp = read_pos.load(std::memory_order_acquire);
-
-        if (wp - rp >= kCapacity) {
-            return false;  // full — drop
+        CaptureEntry* slot = nullptr;
+        u32 expected_wp = 0;
+        if (!begin_push(&slot, &expected_wp)) {
+            return false;
         }
-
-        entries[wp & kMask] = entry;
-        write_pos.store(wp + 1, std::memory_order_release);
+        entries[expected_wp & kMask] = entry;
+        commit_push(expected_wp);
         return true;
     }
 

--- a/tests/test_metrics.cc
+++ b/tests/test_metrics.cc
@@ -252,10 +252,16 @@ TEST_F(MetricsLoopF, requests_active_decremented_on_send_error) {
     CHECK_EQ(self.m.requests_active, 0u);
 }
 
-TEST_F(MetricsLoopF, requests_active_decremented_on_partial_send) {
+TEST_F(MetricsLoopF, requests_active_decremented_after_partial_send_completes) {
     REQUIRE(self.accept_and_recv());
     CHECK_EQ(self.m.requests_active, 1u);
-    self.loop.inject_and_dispatch(make_ev(self.cid, IoEventType::Send, 1));
+    const u32 send_len = self.c->send_buf.len();
+    REQUIRE(send_len > 1u);
+    const u32 partial_len = 1u;
+    self.loop.inject_and_dispatch(make_ev(self.cid, IoEventType::Send, static_cast<i32>(partial_len)));
+    CHECK_EQ(self.m.requests_active, 1u);
+    self.loop.inject_and_dispatch(
+        make_ev(self.cid, IoEventType::Send, static_cast<i32>(send_len - partial_len)));
     CHECK_EQ(self.m.requests_active, 0u);
 }
 

--- a/tests/test_metrics.cc
+++ b/tests/test_metrics.cc
@@ -258,7 +258,8 @@ TEST_F(MetricsLoopF, requests_active_decremented_after_partial_send_completes) {
     const u32 send_len = self.c->send_buf.len();
     REQUIRE(send_len > 1u);
     const u32 partial_len = 1u;
-    self.loop.inject_and_dispatch(make_ev(self.cid, IoEventType::Send, static_cast<i32>(partial_len)));
+    self.loop.inject_and_dispatch(
+        make_ev(self.cid, IoEventType::Send, static_cast<i32>(partial_len)));
     CHECK_EQ(self.m.requests_active, 1u);
     self.loop.inject_and_dispatch(
         make_ev(self.cid, IoEventType::Send, static_cast<i32>(send_len - partial_len)));

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -9771,6 +9771,33 @@ TEST(state_invariant, early_response_during_body_send_has_one_upstream_slot) {
         _tc, c, &on_body_send_with_early_response<SmallLoop>);
 }
 
+TEST(state_invariant, request_body_send_error_with_buffered_response_keeps_proxy_slots) {
+    SmallLoop loop;
+    loop.setup();
+    auto* c = setup_body_streaming_proxy(loop, 200, 10);
+    REQUIRE(c != nullptr);
+
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 50));
+    check_proxying_body_stream_invariant(_tc,
+                                         c,
+                                         nullptr,
+                                         &on_early_upstream_recvd_send_inflight<SmallLoop>,
+                                         &on_request_body_sent<SmallLoop>);
+
+    c->upstream_recv_buf.reset();
+    u8* dst = c->upstream_recv_buf.write_ptr();
+    for (u32 j = 0; j < kMockHttpResponseLen; j++) dst[j] = static_cast<u8>(kMockHttpResponse[j]);
+    c->upstream_recv_buf.commit(kMockHttpResponseLen);
+
+    loop.inject_and_dispatch(make_ev(c->id, IoEventType::UpstreamSend, -32));
+
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->on_recv, nullptr);
+    CHECK_EQ(c->on_send, &on_proxy_response_sent<SmallLoop>);
+    CHECK_EQ(c->on_upstream_recv, nullptr);
+    CHECK_EQ(c->on_upstream_send, nullptr);
+}
+
 TEST(state_invariant, jit_timer_yield_keeps_exec_handler_slots_clear) {
     SmallLoop loop;
     loop.setup();

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -1186,7 +1186,7 @@ TEST(copilot4, arena_alloc_overflow_returns_null) {
     a.destroy();
 }
 
-// === Partial send (TODO #1) ===
+// === Partial send behavior ===
 
 // Verify send_buf uses Buffer API correctly
 TEST(send_buf, write_and_data) {
@@ -1404,8 +1404,8 @@ TEST(copilot5, mock_10_keepalive_cycles) {
     CHECK_EQ(conn->fd, 42);  // still alive
 }
 
-// Regression: partial send TODO exists (code documents the limitation).
-// Verify that add_send with immediate success queues a synthetic completion.
+// Regression: partial sends are now handled by on_response_sent continuation logic.
+// Verify that add_send with immediate success still queues a synthetic completion.
 TEST(copilot5, add_send_immediate_success) {
     SmallLoop loop;
     loop.setup();
@@ -5809,17 +5809,31 @@ TEST(log_method, fallback_all) {
 
 // === Coverage: on_response_sent edge cases ===
 
-TEST(send, partial_send_closes) {
+TEST(send, partial_send_continues) {
     SmallLoop loop;
     loop.setup();
     loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
     auto* c = loop.find_fd(42);
     REQUIRE(c != nullptr);
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 100));
-    // on_response_sent expects send_buf.len() == ev.result
+    const u32 full_send_len = c->send_buf.len();
+    REQUIRE(full_send_len > 1u);
+
     u32 cid = c->id;
-    loop.inject_and_dispatch(make_ev(cid, IoEventType::Send, 1));  // partial
-    CHECK_EQ(loop.conns[cid].fd, -1);                              // closed
+    // First completion is partial: callback should continue sending remainder.
+    const u32 partial_len = 1u;
+    loop.inject_and_dispatch(make_ev(cid, IoEventType::Send, static_cast<i32>(partial_len)));
+    CHECK_NE(loop.conns[cid].fd, -1);        // still open
+    CHECK_EQ(loop.conns[cid].on_send, &on_response_sent<SmallLoop>);
+    auto* send_op = loop.backend.last_op(MockOp::Send);
+    REQUIRE(send_op != nullptr);
+    CHECK_EQ(send_op->send_len, full_send_len - partial_len);
+
+    // Remaining completion closes the response and returns to request parsing.
+    loop.inject_and_dispatch(
+        make_ev(cid, IoEventType::Send, static_cast<i32>(full_send_len - partial_len)));
+    CHECK_GE(loop.conns[cid].fd, 0);            // kept alive (default is keep-alive)
+    CHECK_EQ(c->state, ConnState::ReadingHeader);
 }
 
 // === Coverage: on_header_received stale events ===

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -5823,7 +5823,7 @@ TEST(send, partial_send_continues) {
 
     u32 cid = c->id;
     loop.inject_and_dispatch(make_ev(cid, IoEventType::Send, static_cast<i32>(first_partial)));
-    CHECK_NE(loop.conns[cid].fd, -1);        // still open
+    CHECK_NE(loop.conns[cid].fd, -1);  // still open
     CHECK_EQ(loop.conns[cid].on_send, &on_response_sent<SmallLoop>);
     auto* send_op = loop.backend.last_op(MockOp::Send);
     REQUIRE(send_op != nullptr);
@@ -5832,8 +5832,7 @@ TEST(send, partial_send_continues) {
 
     // Second completion is also partial for the remaining chunk.
     REQUIRE(send_op->send_len > second_partial);
-    loop.inject_and_dispatch(
-        make_ev(cid, IoEventType::Send, static_cast<i32>(second_partial)));
+    loop.inject_and_dispatch(make_ev(cid, IoEventType::Send, static_cast<i32>(second_partial)));
     CHECK_NE(loop.conns[cid].fd, -1);  // still open
     send_op = loop.backend.last_op(MockOp::Send);
     REQUIRE(send_op != nullptr);
@@ -5841,9 +5840,9 @@ TEST(send, partial_send_continues) {
     CHECK_EQ(send_op->send_buf, c->send_buf.data() + first_partial + second_partial);
 
     // Final completion closes the response and returns to request parsing.
-    loop.inject_and_dispatch(
-        make_ev(cid, IoEventType::Send, static_cast<i32>(full_send_len - first_partial - second_partial)));
-    CHECK_GE(loop.conns[cid].fd, 0);            // kept alive (default is keep-alive)
+    loop.inject_and_dispatch(make_ev(
+        cid, IoEventType::Send, static_cast<i32>(full_send_len - first_partial - second_partial)));
+    CHECK_GE(loop.conns[cid].fd, 0);  // kept alive (default is keep-alive)
     CHECK_EQ(c->state, ConnState::ReadingHeader);
 }
 

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -5817,21 +5817,32 @@ TEST(send, partial_send_continues) {
     REQUIRE(c != nullptr);
     loop.inject_and_dispatch(make_ev(c->id, IoEventType::Recv, 100));
     const u32 full_send_len = c->send_buf.len();
-    REQUIRE(full_send_len > 1u);
+    const u32 first_partial = 2u;
+    const u32 second_partial = 2u;
+    REQUIRE(full_send_len > first_partial + second_partial);
 
     u32 cid = c->id;
-    // First completion is partial: callback should continue sending remainder.
-    const u32 partial_len = 1u;
-    loop.inject_and_dispatch(make_ev(cid, IoEventType::Send, static_cast<i32>(partial_len)));
+    loop.inject_and_dispatch(make_ev(cid, IoEventType::Send, static_cast<i32>(first_partial)));
     CHECK_NE(loop.conns[cid].fd, -1);        // still open
     CHECK_EQ(loop.conns[cid].on_send, &on_response_sent<SmallLoop>);
     auto* send_op = loop.backend.last_op(MockOp::Send);
     REQUIRE(send_op != nullptr);
-    CHECK_EQ(send_op->send_len, full_send_len - partial_len);
+    CHECK_EQ(send_op->send_len, full_send_len - first_partial);
+    CHECK_EQ(send_op->send_buf, c->send_buf.data() + first_partial);
 
-    // Remaining completion closes the response and returns to request parsing.
+    // Second completion is also partial for the remaining chunk.
+    REQUIRE(send_op->send_len > second_partial);
     loop.inject_and_dispatch(
-        make_ev(cid, IoEventType::Send, static_cast<i32>(full_send_len - partial_len)));
+        make_ev(cid, IoEventType::Send, static_cast<i32>(second_partial)));
+    CHECK_NE(loop.conns[cid].fd, -1);  // still open
+    send_op = loop.backend.last_op(MockOp::Send);
+    REQUIRE(send_op != nullptr);
+    CHECK_EQ(send_op->send_len, full_send_len - first_partial - second_partial);
+    CHECK_EQ(send_op->send_buf, c->send_buf.data() + first_partial + second_partial);
+
+    // Final completion closes the response and returns to request parsing.
+    loop.inject_and_dispatch(
+        make_ev(cid, IoEventType::Send, static_cast<i32>(full_send_len - first_partial - second_partial)));
     CHECK_GE(loop.conns[cid].fd, 0);            // kept alive (default is keep-alive)
     CHECK_EQ(c->state, ConnState::ReadingHeader);
 }

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -10208,6 +10208,58 @@ TEST(state_invariant, jit_event_yield_starts_runtime_operations) {
     CHECK_EQ(loop.backend.count_ops(MockOp::PauseRecv), 1u);
 }
 
+TEST(state_invariant, jit_upstream_send_mismatch_fail_closes_slots) {
+    SmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    c->upstream_fd = 100;
+    c->upstream_idx = 0;
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 13;
+    outcome.yield_kind = jit::YieldKind::UpstreamSend;
+    outcome.timer_ms = 3;  // target index=2, mismatched with upstream_idx=0
+    loop.backend.clear_ops();
+
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, kStatusBadGateway);
+    check_sending_response_invariant(_tc, c);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+    CHECK_EQ(c->upstream_fd, 100);
+}
+
+TEST(state_invariant, jit_upstream_recv_mismatch_fail_closes_slots) {
+    SmallLoop loop;
+    loop.setup();
+
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+    c->upstream_fd = 100;
+    c->upstream_idx = 0;
+
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 14;
+    outcome.yield_kind = jit::YieldKind::UpstreamRecv;
+    outcome.timer_ms = 3;  // target index=2, mismatched with upstream_idx=0
+    loop.backend.clear_ops();
+
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
+
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, kStatusBadGateway);
+    check_sending_response_invariant(_tc, c);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+    CHECK_EQ(c->upstream_fd, 100);
+}
+
 TEST(state_invariant, jit_upstream_wait_target_mismatch_fails_closed) {
     SmallLoop loop;
     loop.setup();

--- a/tests/test_traffic_capture.cc
+++ b/tests/test_traffic_capture.cc
@@ -182,6 +182,47 @@ TEST(capture_ring, full_drops) {
     CHECK(ring.push(entry));
 }
 
+TEST(capture_ring, begin_push_and_commit) {
+    CaptureRing ring;
+    ring.init();
+
+    CaptureEntry* slot = nullptr;
+    u32 wp = 0;
+    CHECK(ring.begin_push(&slot, &wp));
+    REQUIRE(slot != nullptr);
+
+    __builtin_memset(slot, 0, sizeof(*slot));
+    slot->resp_status = 201;
+    slot->method = static_cast<u8>(LogHttpMethod::Post);
+    slot->raw_header_len = 4;
+    const u8 prefix[] = {'P', 'O', 'S', 'T'};
+    for (u32 i = 0; i < 4; i++) slot->raw_headers[i] = prefix[i];
+    ring.commit_push(wp);
+
+    CHECK_EQ(ring.available(), 1u);
+
+    CaptureEntry out{};
+    CHECK(ring.pop(out));
+    CHECK_EQ(out.resp_status, 201);
+    CHECK_EQ(out.method, static_cast<u8>(LogHttpMethod::Post));
+    CHECK_EQ(out.raw_header_len, 4);
+    CHECK_EQ(out.raw_headers[0], 'P');
+    CHECK_EQ(out.raw_headers[3], 'T');
+
+    ring.pop(out);
+    CHECK_EQ(ring.available(), 0u);
+
+    CaptureEntry* full_slots[CaptureRing::kCapacity];
+    for (u32 i = 0; i < CaptureRing::kCapacity; i++) {
+        u32 full_wp = 0;
+        CHECK(ring.begin_push(&full_slots[i], &full_wp));
+        CHECK_NE(full_slots[i], nullptr);
+        ring.commit_push(full_wp);
+    }
+    CHECK_EQ(ring.available(), CaptureRing::kCapacity);
+    CHECK(!ring.begin_push(nullptr, nullptr));
+}
+
 TEST(capture_ring, fifo_order) {
     CaptureRing ring;
     ring.init();


### PR DESCRIPTION
Adds a missing state-invariant test for the proxy body-streaming path when upstream send fails after a buffered upstream response is already available.

Also includes the earlier formatting-only cleanup on the same branch.

Validation:
- clang-format --dry-run --Werror tests/test_network.cc
- cmake --build build-coverage --target test_network -j2
- ctest --output-on-failure --test-dir build-coverage -R test_network -j2