### PR TITLE
[codex] Add explicit route chain syntax

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,6 +39,34 @@ Outstanding work items, prioritized for the next implementation passes.
 **Acceptance**:
 - The backlog item is complete when remaining uncovered transitions have explicit invariant assertions or are documented as intentionally exempt.
 
+## P1: Rut Core Syntax Reduction
+
+**Goal**: Keep the stable language surface small enough for deterministic
+review, verification, replay, and LLM-assisted generation.
+
+**Why**: Rut has accumulated compatibility syntax for decorators, pipe method
+stages, tuple-slot pipe placeholders, protocol-style methods, static loops, and
+match expansions. Some of these are useful, but stable core syntax needs one
+canonical spelling for common gateway tasks.
+
+**Work**:
+- Treat decorator syntax as compatibility and design `chain` as the stable
+  before/after handler middleware model.
+- Keep pipe in core, but document generated code around direct function stages:
+  `value | fn(_, arg)`.
+- Keep method-stage pipe syntax, placeholder-free pipe stages, and tuple-slot
+  pipe placeholders out of core examples unless compatibility requires them.
+- Revisit protocol/impl exposure so protocol methods do not read like general
+  structure member functions in generated Rut code.
+- Audit `match`, static `for`, and generic examples for constructs that should
+  be core, compatibility, or experimental.
+
+**Acceptance**:
+- Core docs distinguish stable core, compatibility, and experimental syntax.
+- Generated examples use one canonical spelling for pipe, middleware, fallback,
+  and async boundaries.
+- Compatibility syntax has a clear lowering or migration path to core forms.
+
 ## P0: Fault Injection Harness
 
 **Goal**: Make OS-level edge cases cheap to add and hard to skip.

--- a/docs/chains.md
+++ b/docs/chains.md
@@ -1,0 +1,111 @@
+# Chains
+
+Rut chains are reusable handler-adjacent processing steps. They replace
+decorator-style middleware with a smaller model that is explicit, ordered, and
+mechanically expandable into route control flow.
+
+## Purpose
+
+A chain groups common work that should run immediately before a route handler:
+
+```rut
+chain secure_upload {
+    before decode_body(req) else 400
+    before require_auth(req) else 401
+}
+```
+
+`before` steps run before the handler. They may fail closed, so each step must
+declare the status returned on failure.
+
+`after` is reserved for the same chain model, but it is not implemented yet. The
+parser accepts it so the design can be discussed in one syntax, but analysis
+rejects chains containing `after` until response-side lowering exists.
+
+If a route needs more precise control than "before handler" or "after handler",
+write that logic directly inside the handler with ordinary `guard`, `wait`,
+`forward`, `if`, and `match` statements.
+
+## Use Sites
+
+Chains can be attached to a route group:
+
+```rut
+chain common {
+    before require_host(req) else 400
+}
+
+route {
+    use chain common
+
+    GET "/:id" {
+        return 200
+    }
+}
+```
+
+An entry can attach a different chain when methods need different behavior:
+
+```rut
+chain read_secure {
+    before require_auth(req) else 401
+}
+
+chain upload_secure {
+    before decode_body(req) else 400
+    before require_auth(req) else 401
+    before limit_body(req, 1mb) else 413
+}
+
+route {
+    GET "/:id" use chain read_secure {
+        return 200
+    }
+
+    POST "/upload" use chain upload_secure {
+        return 204
+    }
+}
+```
+
+Route-group chains and entry chains compose in source order:
+
+```rut
+route {
+    use chain common
+
+    POST "/upload" use chain upload_secure {
+        return 204
+    }
+}
+```
+
+The expanded order is:
+
+```text
+common.before
+upload_secure.before
+handler
+common.after
+upload_secure.after
+```
+
+When `after` lowering is added, it should use the same final chain order.
+`after` is not a reverse wrapper unwind; it follows the code's visible order so
+review, replay, and generated code do not need an extra execution model.
+
+## Core Restrictions
+
+Rut Core should keep chains intentionally narrow:
+
+- `before` is the only implemented route-level extension point.
+- A `before` step must be a direct call and must declare `else <status>`.
+- `after` is reserved; until lowering exists, chains containing it are rejected.
+- Chain order is source order only; there is no priority or phase dispatch.
+- A route entry should attach at most one entry chain.
+- Chains are statically expanded before route verification.
+- Chain functions must not hide new suspension points. Any operation that can
+  suspend must be written explicitly in the handler.
+
+This keeps shared gateway behavior reusable without reintroducing decorator,
+plugin, or filter-chain ambiguity.

--- a/docs/core-capabilities.md
+++ b/docs/core-capabilities.md
@@ -16,6 +16,7 @@ route automaton:
 - terminal `return`,
 - terminal `return forward(upstream)`,
 - explicit `wait(...)` and `wait any { ... }`,
+- route `chain` before handler steps,
 - bounded per-shard state.
 
 ## Async Boundaries
@@ -73,6 +74,35 @@ Additional modes such as broadcast notification, targeted notification, or
 external backing stores should be added only when their ordering, failure,
 replay, and verifier semantics are explicit.
 
+## Handler Chains
+
+Decorator-style middleware is too flexible for Rut Core because binding,
+ordering, return-value conventions, and execution timing are not obvious from a
+route entry. Core middleware should use explicit chains instead:
+
+```rut
+chain secure_upload {
+    before decode_body(req) else 400
+    before require_auth(req) else 401
+}
+
+route {
+    use chain secure_upload
+
+    POST "/data" {
+        return 204
+    }
+}
+```
+
+The implemented chain boundary is `before` handler. More precise sequencing
+belongs inside the handler body. `before` steps may fail closed with an explicit
+status. `after` is reserved for handler-adjacent observability or cleanup, but
+chains containing it are rejected until response-side lowering exists. Group
+chains and entry chains compose in source order.
+
+See [chains.md](chains.md) for the current design direction.
+
 ## Deferred Risks
 
 The current decorator design has two known risks:
@@ -80,5 +110,6 @@ The current decorator design has two known risks:
 - execution order is not yet a strict first-instruction guard chain,
 - magic request binding through a parameter named `req` can be shadowed.
 
-These are not blockers for the current design pass, but they should be resolved
-before decorators become stable core syntax.
+These are not blockers for compatibility, but decorators should not become
+stable core syntax unless they can mechanically lower to the same chain model
+without adding hidden ordering or binding rules.

--- a/docs/decorators.md
+++ b/docs/decorators.md
@@ -3,6 +3,10 @@
 This document describes the decorator behavior implemented today. It is a
 route middleware subset, not a general language-level decorator system.
 
+Decorators are compatibility syntax, not the preferred Rut Core middleware
+model. New design work should use explicit `chain` declarations for `before`
+handler checks. See [chains.md](chains.md).
+
 ## Purpose
 
 A route decorator can allow the request to continue or reject it with an HTTP

--- a/docs/design-goals.md
+++ b/docs/design-goals.md
@@ -131,8 +131,9 @@ The current design review keeps the following direction:
   lower sequential syntax into states, but it should not discover hidden yield
   points inside ordinary helper code.
 - Decorator execution ordering and magic request binding are known risks, but
-  are deferred. They should be revisited before decorators become part of the
-  stable core surface.
+  the stable core should prefer explicit `chain` declarations. The implemented
+  core is limited to the `before` handler boundary. More precise sequencing
+  belongs inside the route handler.
 - State consistency should be simplified to the production modes Rut actually
   needs first. Additional consistency/backing-store modes should wait until
   their replay and verifier contracts are precise.
@@ -140,3 +141,6 @@ The current design review keeps the following direction:
   `.or(default)`, `guard let`, or `match`; keep symbolic forms such as `?.` and
   `??` non-core/reserved until they prove clearer for users, diagnostics, and
   LLM-generated code.
+- Chain order should be visible source order. Group chains and entry chains
+  compose in that order. If `after` lowering is added later, it should follow
+  the same visible order rather than a reverse wrapper unwind.

--- a/docs/pipe.md
+++ b/docs/pipe.md
@@ -35,8 +35,8 @@ operators.
 
 ## Lowering And Inlining
 
-Pipe is a source-level convenience, not a runtime abstraction. A pipeline such
-as:
+Pipe is a source-level convenience, not a runtime abstraction. A pipe expression
+such as:
 
 ```rut
 let code = 204 | normalize_status(_) | mask_internal_error(_)
@@ -68,10 +68,17 @@ if has_value(req.header("Host")) {
 
 where `tenant_from_host(...)` is also expanded into ordinary expression IR.
 
-## Basic Use
+## Core Style
 
-The right-hand side must be a function call stage. `_` and `_1` both mean "the
-whole value from the left-hand side":
+Rut Core uses pipe only as a small expression-composition helper. Generated and
+reviewed code should prefer one canonical stage shape:
+
+```rut
+value | function_name(_, arg)
+```
+
+The right-hand side must be a function call stage with an explicit `_`
+placeholder for the whole left-hand value:
 
 ```rut
 func normalize_status(code: i32) -> i32 {
@@ -84,18 +91,26 @@ route GET "/health" {
 }
 ```
 
-The same call can use `_1`:
+Do not use method-stage pipe syntax in core examples:
 
 ```rut
-let code = 204 | normalize_status(_1)
+let ok = 200 | _.eq(200)
 ```
 
-If a function-call stage has no placeholder, the left-hand value is passed as
-the first argument:
+Prefer the function-stage spelling instead:
 
 ```rut
-let code = 204 | normalize_status()
+let ok = 200 | eq(_, 200)
 ```
+
+Method-stage syntax makes the generated code look like a member call even when
+the operation is really a protocol or builtin helper. The function-stage form
+keeps name lookup explicit and avoids requiring generated code to guess which
+type owns a method.
+
+The implementation currently accepts some broader forms for compatibility, but
+Rut Core documentation and generated examples should not introduce them unless
+there is no equivalent direct function stage.
 
 ## Chaining
 
@@ -128,7 +143,7 @@ route GET "/users" {
 
 ## Placeholder Position
 
-The placeholder can appear in any argument position. This is useful when a stage
+The `_` placeholder can appear in any argument position. This is useful when a stage
 needs constants or policy values alongside the piped value:
 
 ```rut
@@ -145,7 +160,8 @@ route GET "/admin" {
 
 ## Method Stages
 
-The placeholder can also be the receiver of a method-call stage:
+Method-call stages are implemented today, but they are not Rut Core style. This
+shape is accepted for compatibility:
 
 ```rut
 route GET "/method-stage" {
@@ -156,7 +172,16 @@ route GET "/method-stage" {
 
 `_` and `_1` are accepted as method receivers. Tuple-slot receivers such as
 `_2.method(...)` are still rejected; use a function stage with tuple-slot
-arguments when a pipeline needs to project tuple slots.
+arguments when a pipe expression needs to project tuple slots.
+
+Prefer:
+
+```rut
+route GET "/method-stage" {
+    let ok = 200 | eq(_, 200)
+    if ok { return 200 } else { return 500 }
+}
+```
 
 ## Optional Header Flow
 
@@ -222,7 +247,12 @@ Use explicit branching when the fallback rule is not simple "value or default".
 
 ## Tuple Slots
 
-When the left-hand side is a tuple, numbered placeholders select tuple slots.
+Tuple-slot placeholders are implemented today, but they should stay outside the
+core generated style. They make pipe serve as both composition and destructuring.
+When tuple values are involved, prefer a named helper that receives the whole
+tuple, or bind the tuple fields explicitly before piping.
+
+The compatibility form uses numbered placeholders to select tuple slots.
 Indexes are 1-based:
 
 ```rut
@@ -301,6 +331,22 @@ route GET "/generic" {
   variant payloads, and generic tuple/struct shapes.
 - Optional/error propagation through runtime values.
 - JIT execution after lowering through existing call-expression machinery.
+
+## Rut Core Recommendation
+
+Generated Rut Core should use the smallest pipe subset:
+
+- Function-call stages only: `value | fn(_, other_arg)`.
+- A single whole-value `_` placeholder per stage.
+- No method-call stages such as `value | _.method(arg)`.
+- No placeholder-free stages such as `value | fn(arg)`.
+- No tuple-slot placeholders such as `_1` or `_2`.
+- Prefer at most four stages in one pipe chain; longer flows should introduce
+  named locals.
+
+The broader implemented surface remains useful for compatibility and targeted
+human-written code, but the core subset gives LLM-generated code one clear way
+to express value flow.
 
 ## Current Gaps
 

--- a/include/rut/compiler/ast.h
+++ b/include/rut/compiler/ast.h
@@ -15,6 +15,7 @@ enum class AstItemKind : u8 {
     Using,
     TypeAlias,
     Impl,
+    Chain,
     Route,
 };
 
@@ -394,6 +395,30 @@ struct AstDecorator {
     Str name{};
 };
 
+enum class AstChainStepKind : u8 {
+    Before,
+    After,
+};
+
+struct AstChainDecl {
+    struct Step {
+        AstChainStepKind kind = AstChainStepKind::Before;
+        Span span{};
+        AstExpr call{};
+        u32 else_status = 0;
+    };
+
+    Span span{};
+    Str name{};
+    static constexpr u32 kMaxSteps = 8;
+    FixedVec<Step, kMaxSteps> steps;
+};
+
+struct AstChainUse {
+    Span span{};
+    Str name{};
+};
+
 struct AstRouteDecl {
     Span span{};
     Span body_span{};
@@ -403,6 +428,8 @@ struct AstRouteDecl {
     FixedVec<AstStatement, kMaxStatements> statements;
     static constexpr u32 kMaxDecorators = 8;
     FixedVec<AstDecorator, kMaxDecorators> decorators;
+    static constexpr u32 kMaxChains = 4;
+    FixedVec<AstChainUse, kMaxChains> chains;
 };
 
 struct AstItem {
@@ -417,6 +444,7 @@ struct AstItem {
     AstUsingDecl using_decl{};
     AstTypeAliasDecl type_alias{};
     AstImplDecl impl_decl{};
+    AstChainDecl chain{};
     AstRouteDecl route{};
 };
 
@@ -581,6 +609,12 @@ private:
         }
     }
 
+    void rebase_chain(const AstFile& other, AstChainDecl& decl) {
+        for (u32 i = 0; i < decl.steps.len; i++) {
+            rebase_expr(other, decl.steps[i].call);
+        }
+    }
+
     void rebase_from(const AstFile& other) {
         for (u32 i = 0; i < type_pool.len; i++) rebase_type_ref(other, type_pool[i]);
         for (u32 i = 0; i < expr_pool.len; i++) rebase_expr(other, expr_pool[i]);
@@ -604,6 +638,9 @@ private:
                     break;
                 case AstItemKind::Impl:
                     rebase_impl(other, items[i].impl_decl);
+                    break;
+                case AstItemKind::Chain:
+                    rebase_chain(other, items[i].chain);
                     break;
                 case AstItemKind::Route:
                     for (u32 j = 0; j < items[i].route.statements.len; j++) {

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -9280,15 +9280,59 @@ static bool contains_str(const std::vector<Str>& names, Str needle) {
     return false;
 }
 
-static void collect_route_decorator_names(const AstFile& file, std::vector<Str>& out) {
+static FrontendResult<void> validate_unique_chain_names(const AstFile& file) {
     for (u32 i = 0; i < file.items.len; i++) {
         const auto& item = file.items[i];
-        if (item.kind != AstItemKind::Route) continue;
-        for (u32 di = 0; di < item.route.decorators.len; di++) {
-            const Str name = item.route.decorators[di].name;
+        if (item.kind != AstItemKind::Chain) continue;
+        for (u32 j = i + 1; j < file.items.len; j++) {
+            const auto& other = file.items[j];
+            if (other.kind == AstItemKind::Chain && other.chain.name.eq(item.chain.name))
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, other.chain.span, other.chain.name);
+        }
+    }
+    return {};
+}
+
+static bool chain_step_call_uses_req_placeholder(const AstExpr& call) {
+    return call.kind == AstExprKind::Call && call.args.len != 0 && call.args[0] != nullptr &&
+           call.args[0]->kind == AstExprKind::Ident && call.args[0]->name.eq({"req", 3});
+}
+
+static void collect_route_decorator_names(const AstFile& file, std::vector<Str>& out) {
+    std::vector<Str> attached_chain_names;
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind == AstItemKind::Route) {
+            for (u32 di = 0; di < item.route.decorators.len; di++) {
+                const Str name = item.route.decorators[di].name;
+                if (!contains_str(out, name)) out.push_back(name);
+            }
+            for (u32 ci = 0; ci < item.route.chains.len; ci++) {
+                const Str name = item.route.chains[ci].name;
+                if (!contains_str(attached_chain_names, name)) attached_chain_names.push_back(name);
+            }
+        }
+    }
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind != AstItemKind::Chain) continue;
+        if (!contains_str(attached_chain_names, item.chain.name)) continue;
+        for (u32 si = 0; si < item.chain.steps.len; si++) {
+            const auto& step = item.chain.steps[si];
+            if (!chain_step_call_uses_req_placeholder(step.call)) continue;
+            const Str name = step.call.name;
             if (!contains_str(out, name)) out.push_back(name);
         }
     }
+}
+
+static const AstChainDecl* find_chain_decl(const AstFile& file, Str name) {
+    for (u32 i = 0; i < file.items.len; i++) {
+        const auto& item = file.items[i];
+        if (item.kind == AstItemKind::Chain && item.chain.name.eq(name)) return &item.chain;
+    }
+    return nullptr;
 }
 
 static Str import_visible_name(const ImportedModuleInfo& imported, Str original_name) {
@@ -11939,6 +11983,8 @@ static FrontendResult<HirModule*> analyze_file_internal(
 
     auto* owned_strings =
         shared_owned_strings != nullptr ? shared_owned_strings : &mod.owned_strings;
+    auto validated_chain_names = validate_unique_chain_names(file);
+    if (!validated_chain_names) return core::make_unexpected(validated_chain_names.error());
     std::vector<Str> route_decorator_names = external_decorator_names;
     collect_route_decorator_names(file, route_decorator_names);
     std::vector<std::unique_ptr<HirModule>> imported_storage;
@@ -14921,6 +14967,85 @@ static FrontendResult<HirModule*> analyze_file_internal(
         route.method = route_method_key_from_token(item.route.method);
         if (route.method == 0)
             return frontend_error(FrontendError::UnsupportedSyntax, item.route.span);
+
+        auto analyze_chain_step_arg = [&](const AstExpr& arg) -> FrontendResult<HirExpr> {
+            if (arg.kind == AstExprKind::Ident && arg.name.eq({"req", 3})) {
+                HirExpr placeholder_req{};
+                placeholder_req.kind = HirExprKind::IntLit;
+                placeholder_req.type = HirTypeKind::I32;
+                placeholder_req.int_value = 0;
+                placeholder_req.span = arg.span;
+                return placeholder_req;
+            }
+            return analyze_expr(arg, &route, mod, route.locals.data, route.locals.len, nullptr);
+        };
+
+        auto analyze_chain_before_step = [&](const AstChainDecl::Step& step,
+                                             Span use_span) -> FrontendResult<void> {
+            if (step.call.kind != AstExprKind::Call)
+                return frontend_error(FrontendError::UnsupportedSyntax, step.call.span);
+            const u32 fn_index = find_function_index(mod, step.call.name);
+            if (fn_index == mod.functions.len)
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, step.call.span, step.call.name);
+            const auto& fn = mod.functions[fn_index];
+            if (fn.return_type != HirTypeKind::Bool)
+                return frontend_error(FrontendError::UnsupportedSyntax, step.call.span, fn.name);
+            if (fn.type_params.len != 0)
+                return frontend_error(FrontendError::UnsupportedSyntax, step.call.span, fn.name);
+            if (step.call.args.len != fn.params.len)
+                return frontend_error(FrontendError::UnsupportedSyntax, step.call.span, fn.name);
+
+            HirExpr args[AstExpr::kMaxArgs]{};
+            for (u32 ai = 0; ai < step.call.args.len; ai++) {
+                auto arg = analyze_chain_step_arg(*step.call.args[ai]);
+                if (!arg) return core::make_unexpected(arg.error());
+                auto expected = make_expected_param_expr(fn.params[ai]);
+                if (!same_hir_type_shape(mod, arg.value(), expected))
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax, step.call.args[ai]->span, fn.name);
+                args[ai] = arg.value();
+            }
+
+            auto cond = instantiate_function_expr(
+                fn.body, &route, mod, args, step.call.args.len, nullptr, 0);
+            if (!cond) return core::make_unexpected(cond.error());
+            if (cond->type != HirTypeKind::Bool || cond->may_nil || cond->may_error)
+                return frontend_error(FrontendError::UnsupportedSyntax, step.call.span, fn.name);
+
+            HirGuard guard{};
+            guard.span = use_span;
+            guard.cond = cond.value();
+            guard.fail_kind = HirGuard::FailKind::Term;
+            guard.fail_term.kind = HirTerminatorKind::ReturnStatus;
+            guard.fail_term.source_kind = HirTerminatorSourceKind::Literal;
+            guard.fail_term.status_code = static_cast<i32>(step.else_status);
+            guard.fail_term.span = step.span;
+            if (step.else_status < 100 || step.else_status > 999)
+                return frontend_error(FrontendError::InvalidStatusCode, step.span);
+            if (!route.guards.push(guard))
+                return frontend_error(FrontendError::TooManyItems, step.span);
+            return {};
+        };
+
+        for (u32 ci = 0; ci < item.route.chains.len; ci++) {
+            const auto& chain_use = item.route.chains[ci];
+            const AstChainDecl* chain = find_chain_decl(file, chain_use.name);
+            if (chain == nullptr)
+                return frontend_error(
+                    FrontendError::UnsupportedSyntax, chain_use.span, chain_use.name);
+            for (u32 si = 0; si < chain->steps.len; si++) {
+                const auto& step = chain->steps[si];
+                if (step.kind == AstChainStepKind::After)
+                    return frontend_error(
+                        FrontendError::UnsupportedSyntax,
+                        step.span,
+                        lit_str(
+                            "chain after steps are reserved until response-side lowering exists"));
+                auto before = analyze_chain_before_step(step, chain_use.span);
+                if (!before) return core::make_unexpected(before.error());
+            }
+        }
 
         // Slice-1 constraint: a route body has the shape
         //   let* ; wait* ; guard* ; terminal_control

--- a/src/compiler/parser.cc
+++ b/src/compiler/parser.cc
@@ -2206,6 +2206,93 @@ struct Parser {
         return d;
     }
 
+    bool is_use_chain_start() const {
+        return cur().type == TokenType::Ident && cur().text.eq({"use", 3}) &&
+               peek().type == TokenType::Ident && peek().text.eq({"chain", 5}) &&
+               peek(2).type == TokenType::Ident;
+    }
+
+    bool is_chain_decl_start() const {
+        return cur().type == TokenType::Ident && cur().text.eq({"chain", 5}) &&
+               peek().type == TokenType::Ident && peek(2).type == TokenType::LBrace;
+    }
+
+    FrontendResult<AstChainUse> parse_use_chain() {
+        auto use = expect(TokenType::Ident);
+        if (!use) return core::make_unexpected(use.error());
+        if (!use.value()->text.eq({"use", 3}))
+            return frontend_error(FrontendError::UnexpectedToken, span_from(*use.value()));
+        auto chain = expect(TokenType::Ident);
+        if (!chain) return core::make_unexpected(chain.error());
+        if (!chain.value()->text.eq({"chain", 5}))
+            return frontend_error(FrontendError::UnexpectedToken, span_from(*chain.value()));
+        auto name = expect(TokenType::Ident);
+        if (!name) return core::make_unexpected(name.error());
+        AstChainUse chain_use{};
+        chain_use.name = name.value()->text;
+        chain_use.span =
+            Span{use.value()->start, name.value()->end, use.value()->line, use.value()->col};
+        return chain_use;
+    }
+
+    FrontendResult<AstItem> parse_chain() {
+        auto kw = expect(TokenType::Ident);
+        if (!kw) return core::make_unexpected(kw.error());
+        if (!kw.value()->text.eq({"chain", 5}))
+            return frontend_error(FrontendError::UnexpectedToken, span_from(*kw.value()));
+        auto name = expect(TokenType::Ident);
+        if (!name) return core::make_unexpected(name.error());
+        auto lbrace = expect(TokenType::LBrace);
+        if (!lbrace) return core::make_unexpected(lbrace.error());
+
+        AstItem item{};
+        item.kind = AstItemKind::Chain;
+        item.chain.name = name.value()->text;
+        while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
+            AstChainDecl::Step step{};
+            const Token start = cur();
+            if (cur().type == TokenType::Ident && cur().text.eq({"before", 6})) {
+                pos++;
+                step.kind = AstChainStepKind::Before;
+            } else if (cur().type == TokenType::Ident && cur().text.eq({"after", 5})) {
+                pos++;
+                step.kind = AstChainStepKind::After;
+            } else {
+                return frontend_error(FrontendError::UnexpectedToken, span_from(cur()), cur().text);
+            }
+            auto call = parse_expr();
+            if (!call) return core::make_unexpected(call.error());
+            step.call = call.value();
+            if (step.kind == AstChainStepKind::Before) {
+                auto kw_else = expect(TokenType::KwElse);
+                if (!kw_else) return core::make_unexpected(kw_else.error());
+                auto status = expect(TokenType::IntLit);
+                if (!status) return core::make_unexpected(status.error());
+                u32 parsed_status = 0;
+                for (u32 i = 0; i < status.value()->text.len; i++) {
+                    const u32 digit = static_cast<u32>(status.value()->text.ptr[i] - '0');
+                    if (parsed_status > (0xffffffffu - digit) / 10)
+                        return frontend_error(FrontendError::InvalidInteger,
+                                              span_from(*status.value()));
+                    parsed_status = parsed_status * 10 + digit;
+                }
+                step.else_status = parsed_status;
+                step.span = Span{start.start, status.value()->end, start.line, start.col};
+            } else {
+                step.span = Span{start.start, call->span.end, start.line, start.col};
+            }
+            if (!item.chain.steps.push(step))
+                return frontend_error(FrontendError::TooManyItems, step.span);
+        }
+        auto rbrace = expect(TokenType::RBrace);
+        if (!rbrace) return core::make_unexpected(rbrace.error());
+        if (item.chain.steps.len == 0)
+            return frontend_error(FrontendError::UnexpectedToken, span_from(*rbrace.value()));
+        item.span = Span{kw.value()->start, rbrace.value()->end, kw.value()->line, kw.value()->col};
+        item.chain.span = item.span;
+        return item;
+    }
+
     static bool binding_matches(Str pattern, bool is_wildcard, Str path) {
         if (is_wildcard) return true;
         if (path.len < pattern.len) return false;
@@ -2224,6 +2311,12 @@ struct Parser {
         method = &toks->tokens[pos++];
         auto path = expect(TokenType::StringLit);
         if (!path) return core::make_unexpected(path.error());
+        while (is_use_chain_start()) {
+            auto chain_name = parse_use_chain();
+            if (!chain_name) return core::make_unexpected(chain_name.error());
+            if (!item.route.chains.push(chain_name.value()))
+                return frontend_error(FrontendError::TooManyItems, span_from(cur()));
+        }
         auto lbrace = expect(TokenType::LBrace);
         if (!lbrace) return core::make_unexpected(lbrace.error());
         while (cur().type != TokenType::RBrace && cur().type != TokenType::Eof) {
@@ -2270,19 +2363,35 @@ struct Parser {
         };
         static constexpr u32 kMaxBindings = AstRouteDecl::kMaxDecorators;
         FixedVec<PendingBinding, kMaxBindings> bindings;
+        FixedVec<AstChainUse, AstRouteDecl::kMaxChains> group_chains;
 
-        // Phase 1: bindings — `@ident "pattern"` while next-after-@ident is StringLit.
-        while (cur().type == TokenType::At && peek().type == TokenType::Ident &&
-               peek(2).type == TokenType::StringLit) {
-            auto deco = parse_decorator_atom();
-            if (!deco) return core::make_unexpected(deco.error());
-            auto pat = expect(TokenType::StringLit);
-            if (!pat) return core::make_unexpected(pat.error());
-            PendingBinding pb{};
-            pb.decorator = deco.value();
-            pb.pattern = pat.value()->text;
-            pb.is_wildcard = pb.pattern.len == 1 && pb.pattern.ptr[0] == '*';
-            if (!bindings.push(pb)) return frontend_error(FrontendError::TooManyItems, deco->span);
+        // Phase 1: route-block bindings. Decorator bindings use
+        // `@ident "pattern"`; core chains use `use chain name` and apply to
+        // every entry in the block.
+        bool parsing_bindings = true;
+        while (parsing_bindings) {
+            if (cur().type == TokenType::At && peek().type == TokenType::Ident &&
+                peek(2).type == TokenType::StringLit) {
+                auto deco = parse_decorator_atom();
+                if (!deco) return core::make_unexpected(deco.error());
+                auto pat = expect(TokenType::StringLit);
+                if (!pat) return core::make_unexpected(pat.error());
+                PendingBinding pb{};
+                pb.decorator = deco.value();
+                pb.pattern = pat.value()->text;
+                pb.is_wildcard = pb.pattern.len == 1 && pb.pattern.ptr[0] == '*';
+                if (!bindings.push(pb))
+                    return frontend_error(FrontendError::TooManyItems, deco->span);
+                continue;
+            }
+            if (is_use_chain_start()) {
+                auto chain_name = parse_use_chain();
+                if (!chain_name) return core::make_unexpected(chain_name.error());
+                if (!group_chains.push(chain_name.value()))
+                    return frontend_error(FrontendError::TooManyItems, span_from(cur()));
+                continue;
+            }
+            parsing_bindings = false;
         }
 
         // Phase 2: entries (with optional entry-prefix decorators).
@@ -2297,6 +2406,16 @@ struct Parser {
             }
             auto entry = parse_route_entry(*kw.value());
             if (!entry) return core::make_unexpected(entry.error());
+            FixedVec<AstChainUse, AstRouteDecl::kMaxChains> entry_chains = entry->route.chains;
+            entry->route.chains.len = 0;
+            for (u32 i = 0; i < group_chains.len; i++) {
+                if (!entry->route.chains.push(group_chains[i]))
+                    return frontend_error(FrontendError::TooManyItems, entry->span);
+            }
+            for (u32 i = 0; i < entry_chains.len; i++) {
+                if (!entry->route.chains.push(entry_chains[i]))
+                    return frontend_error(FrontendError::TooManyItems, entry->span);
+            }
             for (u32 i = 0; i < bindings.len; i++) {
                 if (binding_matches(
                         bindings[i].pattern, bindings[i].is_wildcard, entry->route.path)) {
@@ -2372,6 +2491,10 @@ FrontendResult<AstFile*> parse_file(const LexedTokens& tokens) {
                 item = p.parse_route();
                 break;
             default:
+                if (p.is_chain_decl_start()) {
+                    item = p.parse_chain();
+                    break;
+                }
                 if (p.cur().type == TokenType::Ident && p.cur().text.eq({"type", 4})) {
                     item = p.parse_type_alias();
                     break;

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -3332,6 +3332,238 @@ TEST(frontend, parse_route_block_legacy_form_still_works) {
     CHECK_EQ(ast->items[0].route.decorators.len, 0u);
 }
 
+TEST(frontend, parse_chain_and_route_use_chain_order) {
+    const char* src = R"rut(
+chain common {
+    before require_host(req) else 400
+}
+chain read {
+    before require_auth(req) else 401
+}
+route {
+    use chain common
+    GET "/users" use chain read { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 3u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].kind), static_cast<u8>(AstItemKind::Chain));
+    CHECK(ast->items[0].chain.name.eq(lit("common")));
+    REQUIRE_EQ(ast->items[0].chain.steps.len, 1u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].chain.steps[0].kind),
+             static_cast<u8>(AstChainStepKind::Before));
+    CHECK_EQ(ast->items[0].chain.steps[0].else_status, 400u);
+    CHECK_EQ(static_cast<u8>(ast->items[2].kind), static_cast<u8>(AstItemKind::Route));
+    REQUIRE_EQ(ast->items[2].route.chains.len, 2u);
+    CHECK(ast->items[2].route.chains[0].name.eq(lit("common")));
+    CHECK(ast->items[2].route.chains[1].name.eq(lit("read")));
+}
+
+TEST(frontend, parse_chain_step_words_remain_contextual_identifiers) {
+    const char* src = R"rut(
+func before(_ x: i32) -> bool => true
+func after(_ x: i32) -> bool => before(x)
+route GET "/users" {
+    guard after(1) else { return 403 }
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 3u);
+    CHECK(ast->items[0].func.name.eq(lit("before")));
+    CHECK(ast->items[1].func.name.eq(lit("after")));
+}
+
+TEST(frontend, parse_chain_named_type_impl_remains_contextual) {
+    const char* src = R"rut(
+struct chain { value: i32 }
+protocol Hashable {
+    func hash(_ self: Self) -> i32
+}
+chain impl Hashable {
+    func hash(_ self: chain) -> i32 => self.value
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    REQUIRE_EQ(ast->items.len, 3u);
+    CHECK_EQ(static_cast<u8>(ast->items[0].kind), static_cast<u8>(AstItemKind::Struct));
+    CHECK(ast->items[0].struct_decl.name.eq(lit("chain")));
+    CHECK_EQ(static_cast<u8>(ast->items[2].kind), static_cast<u8>(AstItemKind::Impl));
+}
+
+TEST(frontend, analyze_chain_before_lowers_to_guard) {
+    const char* src = R"rut(
+func require_auth(_ req: i32) -> bool {
+    if req.method == GET { true } else { false }
+}
+chain secure {
+    before require_auth(req) else 401
+}
+route {
+    use chain secure
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes.len, 1u);
+    REQUIRE_EQ(hir->routes[0].guards.len, 1u);
+    CHECK_EQ(hir->routes[0].guards[0].fail_term.status_code, 401);
+    CHECK_EQ(static_cast<u8>(hir->routes[0].guards[0].cond.kind),
+             static_cast<u8>(HirExprKind::IfElse));
+}
+
+TEST(frontend, analyze_unused_chain_does_not_mark_callee_as_magic_request) {
+    const char* src = R"rut(
+func future_auth(_ req: i32) -> bool {
+    if req.method == GET { true } else { false }
+}
+chain future {
+    before future_auth(req) else 401
+}
+route GET "/users" {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_chain_non_req_argument_does_not_mark_callee_as_magic_request) {
+    const char* src = R"rut(
+func check(_ req: i32) -> bool {
+    if req.method == GET { true } else { false }
+}
+chain secure {
+    before check(123) else 401
+}
+route GET "/users" use chain secure {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
+TEST(frontend, analyze_rejects_duplicate_chain_names) {
+    const char* src = R"rut(
+func first_auth(_ req: i32) -> bool {
+    if req.method == GET { true } else { false }
+}
+func shadowed_auth(_ req: i32) -> bool {
+    if req.method == GET { true } else { false }
+}
+chain secure {
+    before first_auth(req) else 401
+}
+chain secure {
+    before shadowed_auth(req) else 403
+}
+route GET "/users" use chain secure {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+    CHECK(hir.error().detail.eq(lit("secure")));
+}
+
+TEST(frontend, analyze_rejects_chain_before_optional_error_predicate) {
+    const char* src = R"rut(
+func maybe_auth(_ req: i32) -> bool {
+    if req.method == GET { true } else { error(.timeout) }
+}
+chain secure {
+    before maybe_auth(req) else 401
+}
+route GET "/users" use chain secure {
+    return 200
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+    CHECK_EQ(hir.error().code, FrontendError::UnsupportedSyntax);
+    CHECK(hir.error().detail.eq(lit("maybe_auth")));
+}
+
+TEST(frontend, mir_forward_declared_chain_guard_runs_before_route_wait) {
+    const char* src = R"rut(
+func require_auth(_ req: i32) -> bool {
+    if req.method == GET { true } else { false }
+}
+route GET "/users" use chain secure {
+    wait(50)
+    return 200
+}
+chain secure {
+    before require_auth(req) else 401
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    auto mir = build_mir_heap(hir.value());
+    REQUIRE(mir);
+    REQUIRE_EQ(mir->functions.len, 1u);
+    REQUIRE(mir->functions[0].blocks.len >= 2u);
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[0].term.kind),
+             static_cast<u8>(MirTerminatorKind::Branch));
+    CHECK_EQ(static_cast<u8>(mir->functions[0].blocks[1].term.kind),
+             static_cast<u8>(MirTerminatorKind::YieldTimer));
+}
+
+TEST(frontend, analyze_chain_after_is_reserved_until_lowering_exists) {
+    const char* src = R"rut(
+func access_log(_ req: i32) -> bool => true
+chain access {
+    after access_log(req)
+}
+route {
+    use chain access
+    GET "/users" { return 200 }
+}
+)rut";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(!hir);
+}
+
 TEST(frontend, parse_func_param_accepts_underscore_label) {
     const char* src = "func auth(_ req: i32) -> i32 => 0\n";
     auto lexed = lex(lit(src));


### PR DESCRIPTION
## Summary

- Add explicit `chain` syntax for route middleware-style before/after steps.
- Wire `before` chain steps into route analysis by lowering them to guards with explicit `else` status codes.
- Document the Rut Core direction: prefer explicit chains over decorator-style middleware, and narrow the recommended pipe surface for AI-generated code.

## Notes

`after` steps are parsed and documented as the intended shape, but analysis currently rejects them until response/after lowering support is added. This avoids silently accepting syntax with no runtime behavior.

## Validation

- `git diff --cached --check`
- `./build/tests/test_frontend` (`1153 passed, 0 failed`)