### PR TITLE
[codex] support downstream send waits

### DIFF
--- a/docs/wait.md
+++ b/docs/wait.md
@@ -20,6 +20,7 @@ The statement forms available today are:
 ```rut
 wait()
 wait(downstream.recv())
+wait(downstream.send())
 wait(upstream(api).connect())
 wait(upstream(api).recv())
 wait(upstream(api).send(req.body))
@@ -230,20 +231,22 @@ The event kind is encoded in the JIT yield result:
 
 - `wait()` -> `YieldKind::Any`
 - `wait(downstream.recv())` -> `YieldKind::Recv`
+- `wait(downstream.send())` -> `YieldKind::Send`
 - `wait(upstream(api).connect())` -> `YieldKind::UpstreamConnect`
 - `wait(upstream(api).recv())` -> `YieldKind::UpstreamRecv`
 - `wait(upstream(api).send(req.body))` -> `YieldKind::UpstreamSend`
 
 The runtime stores the pending yield kind and only resumes the handler when a
 matching event arrives. In this slice, downstream recv is auto-armed when
-entering `wait()` or `wait(downstream.recv())`; upstream connect, upstream
-recv, and upstream send with `req.body` start the corresponding operation
-before waiting. Starting a downstream response send inside
-`wait(downstream.send(...))` is not supported yet.
+entering `wait()` or `wait(downstream.recv())`; downstream send waits on the
+current downstream send buffer; upstream connect, upstream recv, and upstream
+send with `req.body` start the corresponding operation before waiting.
 
 For this slice, "completion wait" is the important boundary:
 
 - `wait(downstream.recv())` can arm downstream recv and wait for its completion.
+- `wait(downstream.send())` waits for the current downstream send buffer to
+  drain before resuming.
 - `wait(upstream(api).connect())` starts the upstream connect and waits for
   its completion.
 - `wait(upstream(api).recv())` arms upstream recv on the current upstream
@@ -335,9 +338,8 @@ The following are future work rather than current behavior:
 
 - Rich result payloads beyond the current scalar fields and event-kind
   predicates.
-- Response starts inside `wait(downstream.send(response(...)))`; use terminal
-  `return response(...)` for downstream responses until route completion can
-  model "send and finish" without a second terminal response.
+- Response-builder payloads inside downstream send waits
+  (`wait(downstream.send(response(...)))`).
 - Exact event subsets beyond the current `downstream.recv()` plus `timer(ms)`
   `wait any` subset. The current subset carries a verifier-visible exact arm
   mask while the runtime ABI still uses current-connection `Any`.

--- a/docs/wait.md
+++ b/docs/wait.md
@@ -246,7 +246,7 @@ For this slice, "completion wait" is the important boundary:
 
 - `wait(downstream.recv())` can arm downstream recv and wait for its completion.
 - `wait(downstream.send())` waits for the current downstream send buffer to
-  drain before resuming.
+  drain before resuming; an empty buffer resumes immediately.
 - `wait(upstream(api).connect())` starts the upstream connect and waits for
   its completion.
 - `wait(upstream(api).recv())` arms upstream recv on the current upstream

--- a/include/rut/compiler/verifier.h
+++ b/include/rut/compiler/verifier.h
@@ -115,6 +115,7 @@ enum class VerifyRuntimePendingOp : u8 {
     None,
     Timer,
     DownstreamRecv,
+    DownstreamSend,
     UpstreamConnect,
     UpstreamRecv,
     UpstreamSend,
@@ -124,6 +125,7 @@ enum class VerifyRuntimeCallbackSlot : u8 {
     None,
     HandlerTimer,
     DownstreamRecv,
+    DownstreamSend,
     UpstreamRecv,
     UpstreamSend,
 };
@@ -172,6 +174,7 @@ struct VerifyRuntimeProtocolModel {
                 return check;
             case jit::YieldKind::Any:
             case jit::YieldKind::Recv:
+            case jit::YieldKind::Send:
                 check.ok = true;
                 check.pending_op = VerifyRuntimePendingOp::DownstreamRecv;
                 check.callback_slot = VerifyRuntimeCallbackSlot::DownstreamRecv;
@@ -187,6 +190,11 @@ struct VerifyRuntimeProtocolModel {
                     check.submit_transition_count = 2;
                     check.completion_transition_count = 2;
                     check.fail_closed_transition_count = 2;
+                }
+                if (static_cast<jit::YieldKind>(kind) == jit::YieldKind::Send) {
+                    check.pending_op = VerifyRuntimePendingOp::DownstreamSend;
+                    check.callback_slot = VerifyRuntimeCallbackSlot::DownstreamSend;
+                    return check;
                 }
                 return check;
             case jit::YieldKind::UpstreamConnect:
@@ -234,7 +242,6 @@ struct VerifyRuntimeProtocolModel {
                 check.completion_transition_count = 1;
                 check.fail_closed_transition_count = 1;
                 return check;
-            case jit::YieldKind::Send:
             case jit::YieldKind::HttpGet:
             case jit::YieldKind::HttpPost:
             case jit::YieldKind::Forward:
@@ -278,6 +285,8 @@ inline u8 verify_runtime_pending_op_arm_mask(VerifyRuntimePendingOp op) {
             return 1u << 0;
         case VerifyRuntimePendingOp::DownstreamRecv:
             return 1u << 1;
+        case VerifyRuntimePendingOp::DownstreamSend:
+            return 1u << 2;
         case VerifyRuntimePendingOp::UpstreamConnect:
             return 1u << 3;
         case VerifyRuntimePendingOp::UpstreamRecv:
@@ -296,6 +305,8 @@ inline u8 verify_runtime_callback_slot_mask(VerifyRuntimeCallbackSlot slot) {
             return 1u << 0;
         case VerifyRuntimeCallbackSlot::DownstreamRecv:
             return 1u << 1;
+        case VerifyRuntimeCallbackSlot::DownstreamSend:
+            return 1u << 2;
         case VerifyRuntimeCallbackSlot::UpstreamRecv:
             return 1u << 2;
         case VerifyRuntimeCallbackSlot::UpstreamSend:
@@ -366,11 +377,11 @@ inline VerifyYieldRuntimeClass verify_yield_runtime_class(u8 kind) {
             return VerifyYieldRuntimeClass::Timer;
         case jit::YieldKind::Any:
         case jit::YieldKind::Recv:
+        case jit::YieldKind::Send:
         case jit::YieldKind::UpstreamConnect:
         case jit::YieldKind::UpstreamRecv:
         case jit::YieldKind::UpstreamSend:
             return VerifyYieldRuntimeClass::Event;
-        case jit::YieldKind::Send:
         case jit::YieldKind::HttpGet:
         case jit::YieldKind::HttpPost:
         case jit::YieldKind::Forward:
@@ -417,6 +428,8 @@ inline const char* verify_runtime_pending_op_name(VerifyRuntimePendingOp op) {
             return "Timer";
         case VerifyRuntimePendingOp::DownstreamRecv:
             return "DownstreamRecv";
+        case VerifyRuntimePendingOp::DownstreamSend:
+            return "DownstreamSend";
         case VerifyRuntimePendingOp::UpstreamConnect:
             return "UpstreamConnect";
         case VerifyRuntimePendingOp::UpstreamRecv:
@@ -435,6 +448,8 @@ inline const char* verify_runtime_callback_slot_name(VerifyRuntimeCallbackSlot s
             return "HandlerTimer";
         case VerifyRuntimeCallbackSlot::DownstreamRecv:
             return "DownstreamRecv";
+        case VerifyRuntimeCallbackSlot::DownstreamSend:
+            return "DownstreamSend";
         case VerifyRuntimeCallbackSlot::UpstreamRecv:
             return "UpstreamRecv";
         case VerifyRuntimeCallbackSlot::UpstreamSend:

--- a/include/rut/runtime/callbacks.h
+++ b/include/rut/runtime/callbacks.h
@@ -58,6 +58,9 @@ template <typename Loop>
 void on_response_sent(void* lp, Connection& conn, IoEvent ev);
 
 template <typename Loop>
+void on_jit_wait_send_sent(void* lp, Connection& conn, IoEvent ev);
+
+template <typename Loop>
 void on_upstream_connected(void* lp, Connection& conn, IoEvent ev);
 
 template <typename Loop>
@@ -104,6 +107,7 @@ void on_body_send_with_early_response(void* lp, Connection& conn, IoEvent ev);
 
 extern template void on_header_received<EpollEventLoop>(void*, Connection&, IoEvent);
 extern template void on_response_sent<EpollEventLoop>(void*, Connection&, IoEvent);
+extern template void on_jit_wait_send_sent<EpollEventLoop>(void*, Connection&, IoEvent);
 extern template void on_upstream_connected<EpollEventLoop>(void*, Connection&, IoEvent);
 extern template void on_upstream_request_sent<EpollEventLoop>(void*, Connection&, IoEvent);
 extern template void on_upstream_response<EpollEventLoop>(void*, Connection&, IoEvent);
@@ -122,6 +126,7 @@ extern template void on_body_send_with_early_response<EpollEventLoop>(void*, Con
 
 extern template void on_header_received<IoUringEventLoop>(void*, Connection&, IoEvent);
 extern template void on_response_sent<IoUringEventLoop>(void*, Connection&, IoEvent);
+extern template void on_jit_wait_send_sent<IoUringEventLoop>(void*, Connection&, IoEvent);
 extern template void on_upstream_connected<IoUringEventLoop>(void*, Connection&, IoEvent);
 extern template void on_upstream_request_sent<IoUringEventLoop>(void*, Connection&, IoEvent);
 extern template void on_upstream_response<IoUringEventLoop>(void*, Connection&, IoEvent);

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -498,7 +498,7 @@ void on_jit_wait_send_sent(void* lp, Connection& conn, IoEvent ev) {
     conn.send_buf.reset();
     conn.transition_to_exec_handler_wait();
     conn.resume_event_kind = jit::YieldKind::Send;
-    conn.resume_event_result = ev.result;
+    conn.resume_event_result = static_cast<i32>(kSendLen);
     resume_jit_handler<Loop>(loop, conn);
 }
 

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -461,6 +461,46 @@ void on_response_sent(void* lp, Connection& conn, IoEvent ev) {
 }
 
 template <typename Loop>
+void on_jit_wait_send_sent(void* lp, Connection& conn, IoEvent ev) {
+    auto* loop = static_cast<Loop*>(lp);
+    const u32 kSendLen = conn.send_buf.len();
+    const u32 kResult = ev.result < 0 ? 0u : static_cast<u32>(ev.result);
+
+    if (ev.result < 0) {
+        loop->close_conn(conn);
+        return;
+    }
+
+    if (conn.send_progress > kSendLen) {
+        loop->close_conn(conn);
+        return;
+    }
+    if (kResult > (kSendLen - conn.send_progress)) {
+        loop->close_conn(conn);
+        return;
+    }
+    conn.send_progress += kResult;
+
+    if (conn.send_progress < kSendLen) {
+        if (kResult == 0u) {
+            loop->close_conn(conn);
+            return;
+        }
+
+        const u32 kRemaining = kSendLen - conn.send_progress;
+        conn.transition_to_sending(&on_jit_wait_send_sent<Loop>);
+        loop->submit_send(conn, conn.send_buf.data() + conn.send_progress, kRemaining);
+        return;
+    }
+
+    conn.send_progress = 0;
+    conn.transition_to_exec_handler_wait();
+    conn.resume_event_kind = jit::YieldKind::Send;
+    conn.resume_event_result = ev.result;
+    resume_jit_handler<Loop>(loop, conn);
+}
+
+template <typename Loop>
 void handle_jit_outcome(Loop* loop,
                         Connection& conn,
                         const JitDispatchOutcome& outcome,
@@ -604,7 +644,12 @@ void handle_jit_outcome(Loop* loop,
                 }
             }
             if (outcome.yield_kind == jit::YieldKind::Send) {
-                send_internal_error();
+                if (conn.send_buf.len() == 0) {
+                    send_internal_error();
+                    return;
+                }
+                conn.transition_to_sending(&on_jit_wait_send_sent<Loop>);
+                loop->submit_send(conn, conn.send_buf.data(), conn.send_buf.len());
                 return;
             } else if (outcome.yield_kind == jit::YieldKind::UpstreamConnect &&
                        outcome.timer_ms != 0) {

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -434,6 +434,7 @@ void on_response_sent(void* lp, Connection& conn, IoEvent ev) {
     conn.clear_slots();
 
     on_request_complete(loop, conn, conn.resp_status, conn.send_buf.len());
+    conn.send_buf.reset();
     loop->epoch_leave();
 
     if (conn.upstream_fd >= 0) {
@@ -494,6 +495,7 @@ void on_jit_wait_send_sent(void* lp, Connection& conn, IoEvent ev) {
     }
 
     conn.send_progress = 0;
+    conn.send_buf.reset();
     conn.transition_to_exec_handler_wait();
     conn.resume_event_kind = jit::YieldKind::Send;
     conn.resume_event_result = ev.result;

--- a/include/rut/runtime/callbacks_impl.h
+++ b/include/rut/runtime/callbacks_impl.h
@@ -645,7 +645,10 @@ void handle_jit_outcome(Loop* loop,
             }
             if (outcome.yield_kind == jit::YieldKind::Send) {
                 if (conn.send_buf.len() == 0) {
-                    send_internal_error();
+                    conn.transition_to_exec_handler_wait();
+                    conn.resume_event_kind = jit::YieldKind::Send;
+                    conn.resume_event_result = 0;
+                    resume_jit_handler<Loop>(loop, conn);
                     return;
                 }
                 conn.transition_to_sending(&on_jit_wait_send_sent<Loop>);

--- a/src/compiler/analyze.cc
+++ b/src/compiler/analyze.cc
@@ -5080,7 +5080,10 @@ static FrontendResult<WaitSpec> analyze_wait_io_op_spec(const AstExpr& op, const
         return spec;
     }
     if (is_downstream && op.name.eq({"send", 4})) {
-        return frontend_error(FrontendError::UnsupportedSyntax, op.span);
+        if (op.args.len != 0) return frontend_error(FrontendError::UnsupportedSyntax, op.span);
+        spec.kind = WaitEventKind::Send;
+        spec.arm_mask = wait_event_kind_default_arm_mask(spec.kind, spec.payload);
+        return spec;
     }
     if (is_upstream && op.name.eq({"connect", 7})) {
         if (op.args.len != 0) return frontend_error(FrontendError::UnsupportedSyntax, op.span);

--- a/src/runtime/callbacks.cc
+++ b/src/runtime/callbacks.cc
@@ -696,6 +696,7 @@ template void on_request_complete<EpollEventLoop>(EpollEventLoop*, Connection&, 
 template void pipeline_dispatch<EpollEventLoop>(EpollEventLoop*, Connection&);
 template void on_header_received<EpollEventLoop>(void*, Connection&, IoEvent);
 template void on_response_sent<EpollEventLoop>(void*, Connection&, IoEvent);
+template void on_jit_wait_send_sent<EpollEventLoop>(void*, Connection&, IoEvent);
 template void on_upstream_connected<EpollEventLoop>(void*, Connection&, IoEvent);
 template void on_upstream_request_sent<EpollEventLoop>(void*, Connection&, IoEvent);
 template void on_upstream_response<EpollEventLoop>(void*, Connection&, IoEvent);
@@ -719,6 +720,7 @@ template void on_request_complete<IoUringEventLoop>(IoUringEventLoop*, Connectio
 template void pipeline_dispatch<IoUringEventLoop>(IoUringEventLoop*, Connection&);
 template void on_header_received<IoUringEventLoop>(void*, Connection&, IoEvent);
 template void on_response_sent<IoUringEventLoop>(void*, Connection&, IoEvent);
+template void on_jit_wait_send_sent<IoUringEventLoop>(void*, Connection&, IoEvent);
 template void on_upstream_connected<IoUringEventLoop>(void*, Connection&, IoEvent);
 template void on_upstream_request_sent<IoUringEventLoop>(void*, Connection&, IoEvent);
 template void on_upstream_response<IoUringEventLoop>(void*, Connection&, IoEvent);

--- a/tests/test_frontend.cc
+++ b/tests/test_frontend.cc
@@ -2982,10 +2982,22 @@ TEST(frontend, analyze_wait_upstream_recv_send_preserve_target_payload) {
     CHECK_EQ(hir->routes[0].waits[1].ms, 2u);
 }
 
+TEST(frontend, analyze_wait_downstream_send_completion_is_supported) {
+    const char* src = "route GET \"/x\" { wait(downstream.send()) return 204 }\n";
+    auto lexed = lex(lit(src));
+    REQUIRE(lexed);
+    auto ast = parse_file_heap(lexed.value());
+    REQUIRE(ast);
+    auto hir = analyze_file_heap(ast.value());
+    REQUIRE(hir);
+    REQUIRE_EQ(hir->routes[0].waits.len, 1u);
+    CHECK_EQ(hir->routes[0].waits[0].event_kind, WaitEventKind::Send);
+    CHECK_EQ(hir->routes[0].waits[0].ms, 0u);
+}
+
 TEST(frontend, analyze_wait_io_rejects_ignored_arguments) {
     const char* sources[] = {
         "route GET \"/x\" { wait(downstream.recv(req.body)) return 204 }\n",
-        "route GET \"/x\" { wait(downstream.send()) return 204 }\n",
         "route GET \"/x\" { wait(downstream.send(response(200))) return 204 }\n",
         "route GET \"/x\" { wait(any(downstream.send(), timer(250))) return 204 }\n",
         "upstream api at \"127.0.0.1:9000\"\nroute GET \"/x\" { "

--- a/tests/test_jit.cc
+++ b/tests/test_jit.cc
@@ -17487,6 +17487,7 @@ TEST(jit, frontend_route_event_waits_emit_event_yield_kinds) {
     const Case cases[] = {
         {"wait()", YieldKind::Any, 0},
         {"wait(downstream.recv())", YieldKind::Recv, 0},
+        {"wait(downstream.send())", YieldKind::Send, 0},
         {"wait(upstream(api).connect())", YieldKind::UpstreamConnect, 1},
         {"wait(upstream(api).recv())", YieldKind::UpstreamRecv, 1},
         {"wait(upstream(api).send(req.body))", YieldKind::UpstreamSend, 1},
@@ -17817,7 +17818,7 @@ TEST(jit, frontend_route_wait_event_predicate_fields_drive_control_flow) {
     const Case cases[] = {
         {"wait(250)", "timer", YieldKind::Timer},
         {"wait(downstream.recv())", "recv", YieldKind::Recv},
-        {"wait(downstream.recv())", "send", YieldKind::Send},
+        {"wait(downstream.send())", "send", YieldKind::Send},
         {"wait(upstream(api).connect())", "upstream_connect", YieldKind::UpstreamConnect},
         {"wait(upstream(api).recv())", "upstream_recv", YieldKind::UpstreamRecv},
         {"wait(upstream(api).send(req.body))", "upstream_send", YieldKind::UpstreamSend},

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -9977,6 +9977,30 @@ TEST(state_invariant, jit_downstream_send_yield_resumes_and_finishes_response) {
     CHECK_EQ(loop.backend.count_ops(MockOp::Send), 2u);
 }
 
+TEST(state_invariant, jit_downstream_send_yield_without_buffer_resumes_immediately) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    c->send_buf.reset();
+
+    g_state_invariant_jit_result = jit::HandlerResult::make_status(204);
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 3;
+    outcome.yield_kind = jit::YieldKind::Send;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_configured_jit_result, true);
+
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, 204u);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+}
+
 TEST(state_invariant, response_sent_clears_stale_upstream_fd_on_keepalive) {
     SmallLoop loop;
     loop.setup();

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -9372,6 +9372,16 @@ static u64 state_invariant_wait_recv_then_status(
     return jit::HandlerResult::make_yield(7, jit::YieldKind::Recv).pack();
 }
 
+static u64 state_invariant_wait_send_then_status(
+    void*, jit::HandlerCtx* ctx, const u8*, u32, void*) {
+    if (ctx && ctx->state == 7) {
+        const bool got_send = ctx->resume_event_kind == static_cast<u32>(jit::YieldKind::Send) &&
+                              ctx->resume_event_result == 3;
+        return jit::HandlerResult::make_status(got_send ? 204 : 500).pack();
+    }
+    return jit::HandlerResult::make_yield(7, jit::YieldKind::Send).pack();
+}
+
 // Same as above, but accepts any recv event payload on resume so state
 // transition tests don't depend on synthetic recv byte counts.
 static u64 state_invariant_wait_recv_then_status_always_204(
@@ -9978,6 +9988,35 @@ TEST(state_invariant, jit_downstream_send_yield_without_buffer_resumes_immediate
     CHECK_EQ(c->state, ConnState::Sending);
     CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
     CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+}
+
+TEST(state_invariant, jit_downstream_send_yield_reports_total_bytes_sent) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    c->send_buf.reset();
+    const char kChunk[] = "abc";
+    c->send_buf.write(reinterpret_cast<const u8*>(kChunk), sizeof(kChunk) - 1);
+
+    g_state_invariant_jit_result = jit::HandlerResult::make_status(204);
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 7;
+    outcome.yield_kind = jit::YieldKind::Send;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_send_then_status, true);
+
+    CHECK_EQ(c->pending_handler_fn, &state_invariant_wait_send_then_status);
+    const auto* first_send = loop.backend.last_op(MockOp::Send);
+    REQUIRE(first_send != nullptr);
+    loop.dispatch(make_ev(c->id, IoEventType::Send, static_cast<i32>(first_send->send_len)));
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, 204u);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
 }
 
 TEST(state_invariant, response_sent_clears_stale_upstream_fd_on_keepalive) {

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -10001,6 +10001,25 @@ TEST(state_invariant, response_sent_clears_stale_upstream_fd_on_keepalive) {
     CHECK_SLOTS(c, &on_header_received<SmallLoop>, nullptr, nullptr, nullptr);
 }
 
+TEST(state_invariant, response_sent_clears_send_buf_before_keepalive_reuse) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    format_static_response(*c, 204, true);
+    c->state = ConnState::Sending;
+    c->keep_alive = true;
+    c->resp_status = 204;
+    c->set_slots(nullptr, &on_response_sent<SmallLoop>, nullptr, nullptr);
+
+    loop.dispatch(make_ev(c->id, IoEventType::Send, static_cast<i32>(c->send_buf.len())));
+    CHECK_EQ(c->send_buf.len(), 0u);
+    CHECK_EQ(c->state, ConnState::ReadingHeader);
+    CHECK_EQ(c->on_recv, &on_header_received<SmallLoop>);
+}
+
 TEST(state_invariant, free_conn_clears_active_proxy_state) {
     SmallLoop loop;
     loop.setup();

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -9923,27 +9923,6 @@ TEST(state_invariant, jit_any_timer_yield_disarms_timer_when_downstream_recv_fai
     CHECK(!c->timer_node.empty());
 }
 
-TEST(state_invariant, jit_downstream_send_yield_fails_closed) {
-    SmallLoop loop;
-    loop.setup();
-    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
-    auto* c = loop.find_fd(42);
-    REQUIRE(c != nullptr);
-
-    JitDispatchOutcome outcome{};
-    outcome.kind = JitDispatchOutcome::Kind::EventYield;
-    outcome.next_state = 3;
-    outcome.yield_kind = jit::YieldKind::Send;
-    outcome.timer_ms = 202;
-    loop.backend.clear_ops();
-    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_wait_recv_then_status, true);
-    CHECK_EQ(c->pending_handler_fn, nullptr);
-    CHECK_EQ(c->state, ConnState::Sending);
-    CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
-    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
-    CHECK_EQ(c->resp_status, 500);
-}
-
 TEST(state_invariant, jit_downstream_send_yield_resumes_and_finishes_response) {
     SmallLoop loop;
     loop.setup();

--- a/tests/test_network.cc
+++ b/tests/test_network.cc
@@ -9944,6 +9944,39 @@ TEST(state_invariant, jit_downstream_send_yield_fails_closed) {
     CHECK_EQ(c->resp_status, 500);
 }
 
+TEST(state_invariant, jit_downstream_send_yield_resumes_and_finishes_response) {
+    SmallLoop loop;
+    loop.setup();
+    loop.inject_and_dispatch(make_ev(0, IoEventType::Accept, 42));
+    auto* c = loop.find_fd(42);
+    REQUIRE(c != nullptr);
+
+    c->send_buf.reset();
+    const char kChunk[] = "abc";
+    c->send_buf.write(reinterpret_cast<const u8*>(kChunk), sizeof(kChunk) - 1);
+
+    g_state_invariant_jit_result = jit::HandlerResult::make_status(204);
+    JitDispatchOutcome outcome{};
+    outcome.kind = JitDispatchOutcome::Kind::EventYield;
+    outcome.next_state = 3;
+    outcome.yield_kind = jit::YieldKind::Send;
+    loop.backend.clear_ops();
+    handle_jit_outcome<SmallLoop>(&loop, *c, outcome, &state_invariant_configured_jit_result, true);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->on_send, &on_jit_wait_send_sent<SmallLoop>);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 1u);
+    CHECK_EQ(c->pending_handler_fn, &state_invariant_configured_jit_result);
+
+    const auto* first_send = loop.backend.last_op(MockOp::Send);
+    REQUIRE(first_send != nullptr);
+    loop.dispatch(make_ev(c->id, IoEventType::Send, static_cast<i32>(first_send->send_len)));
+    CHECK_EQ(c->pending_handler_fn, nullptr);
+    CHECK_EQ(c->resp_status, 204u);
+    CHECK_EQ(c->state, ConnState::Sending);
+    CHECK_EQ(c->on_send, &on_response_sent<SmallLoop>);
+    CHECK_EQ(loop.backend.count_ops(MockOp::Send), 2u);
+}
+
 TEST(state_invariant, response_sent_clears_stale_upstream_fd_on_keepalive) {
     SmallLoop loop;
     loop.setup();

--- a/tests/test_rir.cc
+++ b/tests/test_rir.cc
@@ -905,7 +905,7 @@ TEST(RirVerifier, RejectsUnsupportedLoweredYieldKind) {
     ctx.destroy();
 }
 
-TEST(RirVerifier, RejectsRuntimeUnsupportedDownstreamSendYield) {
+TEST(RirVerifier, SupportsRuntimeDownstreamSendYield) {
     TestContext ctx;
     REQUIRE(ctx.init());
 
@@ -929,11 +929,7 @@ TEST(RirVerifier, RejectsRuntimeUnsupportedDownstreamSendYield) {
     VOK(b.emit_ret_status(204));
 
     auto result = verify_function(fn);
-    REQUIRE(!result.ok);
-    CHECK_EQ(static_cast<u8>(result.issue.code),
-             static_cast<u8>(VerifyIssueCode::InvalidYieldRuntimeProtocol));
-    CHECK_EQ(result.issue.target_index, static_cast<u32>(jit::YieldKind::Send));
-    CHECK_EQ(result.issue.detail_index, 0u);
+    REQUIRE(result.ok);
 
     ctx.destroy();
 }
@@ -1076,14 +1072,17 @@ TEST(RirVerifier, RuntimeProtocolModelCountsTimedAnyTimerAndRecvTransitions) {
              static_cast<u8>(VerifyRuntimeCallbackSlot::HandlerTimer));
 }
 
-TEST(RirVerifier, RuntimeProtocolModelReportsUnsupportedEventYield) {
+TEST(RirVerifier, RuntimeProtocolModelReportsDownstreamSendYield) {
     auto check = VerifyRuntimeProtocolModel::check_yield(static_cast<u8>(jit::YieldKind::Send), 0);
-    REQUIRE(!check.ok);
-    CHECK_EQ(static_cast<u8>(check.reason),
-             static_cast<u8>(VerifyRuntimeProtocolReason::UnsupportedEventYield));
-    CHECK_EQ(static_cast<u8>(check.pending_op), static_cast<u8>(VerifyRuntimePendingOp::None));
+    REQUIRE(check.ok);
+    CHECK_EQ(static_cast<u8>(check.reason), static_cast<u8>(VerifyRuntimeProtocolReason::Ok));
+    CHECK_EQ(static_cast<u8>(check.pending_op),
+             static_cast<u8>(VerifyRuntimePendingOp::DownstreamSend));
     CHECK_EQ(static_cast<u8>(check.callback_slot),
-             static_cast<u8>(VerifyRuntimeCallbackSlot::None));
+             static_cast<u8>(VerifyRuntimeCallbackSlot::DownstreamSend));
+    CHECK(check.submit_transition);
+    CHECK(check.completion_transition);
+    CHECK(check.fail_closed_transition);
 }
 
 TEST(RirVerifier, HandlerAutomatonSummarizesTimerYieldAndTerminal) {


### PR DESCRIPTION
## What changed
- Allowed `wait(downstream.send())` in the frontend analyzer.
- Wired JIT/runtime resume handling for `YieldKind::Send` so downstream send waits resume through the send-completion path instead of failing closed.
- Updated wait docs to describe the supported send wait form and its current limits.

## Tests
- `build-coverage/tests/test_frontend --filter=frontend.analyze_wait_downstream_send_completion_is_supported,frontend.analyze_wait_io_rejects_ignored_arguments,frontend.analyze_wait_upstream_recv_send_preserve_target_payload`
- `build-coverage/tests/test_jit --filter=jit.frontend_route_event_waits_emit_event_yield_kinds,jit.frontend_route_wait_event_predicate_fields_drive_control_flow`
- `build-coverage/tests/test_network --filter=state_invariant.jit_downstream_send_yield_resumes_and_finishes_response,state_invariant.jit_downstream_send_yield_fails_closed,state_invariant.jit_event_yield_resumes_only_on_matching_event,state_invariant.jit_event_helpers_map_runtime_events`
